### PR TITLE
Exclude Files from Deployments with .vercelignore

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+.github
+.zed
+*.md
+LICENSE
+scripts


### PR DESCRIPTION
## Summary
Exclude Files from Deployments with .vercelignore

## Related Issue
None

## Changes
Exclude Files from Deployments with .vercelignore

```
.github
.zed
*.md
LICENSE
scripts
```

## Testing
Please check that the build was successful at [Vercel Deployment Details](https://vercel.com/r06-edge/giselle/5YHqLFRY7ECzmFD2DbeU6DeSHwPL).

## Other Information
- doc: https://vercel.com/docs/deployments/vercel-ignore
