### PR TITLE
[docs] Replaced route06inc with giselles-ai due to a GitHub organization transfer.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature request
-    url: https://github.com/route06inc/giselle/discussions/categories/ideas
+    url: https://github.com/giselles-ai/giselle/discussions/categories/ideas
     about: Share ideas for new features
   - name: Ask a question
-    url: https://github.com/route06inc/giselle/discussions/categories/q-a
+    url: https://github.com/giselles-ai/giselle/discussions/categories/q-a
     about: Ask questions and discuss with other community members

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To set up a development environment, please follow these steps:
 
 ### 1. Fork this repository and clone it
 
-1. [Fork this repository](https://github.com/route06inc/giselle/fork) to your own GitHub account
+1. [Fork this repository](https://github.com/giselles-ai/giselle/fork) to your own GitHub account
 2. [Clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 
 ### 2. Prerequisites
@@ -38,7 +38,7 @@ bun dev
 
 ## Issues and feature requests
 
-You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new feature? Take a look at [GitHub Discussions](https://github.com/route06inc/giselle/discussions) to see if it's already being discussed. You can help us by [submitting an issue on GitHub](https://github.com/route06inc/giselle/issues). Before you create an issue, make sure to search the issue archive -- your issue may have already been addressed!
+You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new feature? Take a look at [GitHub Discussions](https://github.com/giselles-ai/giselle/discussions) to see if it's already being discussed. You can help us by [submitting an issue on GitHub](https://github.com/giselles-ai/giselle/issues). Before you create an issue, make sure to search the issue archive -- your issue may have already been addressed!
 
 Please try to create bug reports that are:
 
@@ -51,9 +51,9 @@ Please try to create bug reports that are:
 
 ### How to submit a Pull Request
 
-1. Search our repository for open or closed [Pull Requests](https://github.com/route06inc/giselle/pulls) that relate to your submission. You don't want to duplicate effort.
+1. Search our repository for open or closed [Pull Requests](https://github.com/giselles-ai/giselle/pulls) that relate to your submission. You don't want to duplicate effort.
 2. Fork the project
 3. Create your feature branch (`git switch -c feat/amazing_feature`)
 4. Commit your changes (`git commit -m 'feat: add amazing_feature'`)
 5. Push to the branch (`git push origin feat/amazing_feature`)
-6. [Open a Pull Request](https://github.com/route06inc/giselle/compare?expand=1)
+6. [Open a Pull Request](https://github.com/giselles-ai/giselle/compare?expand=1)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ We welcome your contributions to help improve Giselle!
 
 Here are some ways you can contribute:
 
-- [Report a bug](https://github.com/route06inc/giselle/issues/new?template=1_bug_report.yml) you found while using Giselle
-- [Request a feature](https://github.com/route06inc/giselle/discussions/categories/ideas) that you believe would be helpful
+- [Report a bug](https://github.com/giselles-ai/giselle/issues/new?template=1_bug_report.yml) you found while using Giselle
+- [Request a feature](https://github.com/giselles-ai/giselle/discussions/categories/ideas) that you believe would be helpful
 - [Submit a pull request](CONTRIBUTING.md#how-to-submit-a-pull-request) if you'd like to add new features or fix bugs
 
 For more details, please see the [contributing guide](CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ If you discover a security vulnerability, please report it to us in the followin
 
 Out team and community take security bugs in seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/route06inc/giselle/security/advisories/new) tab. **Do not open up a GitHub issue.**
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/giselles-ai/giselle/security/advisories/new) tab. **Do not open up a GitHub issue.**
 
 Our team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 

--- a/config/dependency_decisions.yml
+++ b/config/dependency_decisions.yml
@@ -52,7 +52,7 @@
 - - :approve
   - "@vercel/flags"
   - :who:
-    :why: The license is none. Check https://github.com/route06inc/giselle/issues/12
+    :why: The license is none. Check https://github.com/giselles-ai/giselle/issues/12
       later
     :versions: []
     :when: 2024-10-08 09:38:17.316315298 Z

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -3038,7 +3038,7 @@ The Vercel Blob JavaScript API client
 
 unknown manually approved
 
->The license is none. Check https://github.com/route06inc/giselle/issues/12 later
+>The license is none. Check https://github.com/giselles-ai/giselle/issues/12 later
 
 ><cite>  2024-10-08</cite>
 

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -1,11 +1,11 @@
 # giselle
 
-As of November  5, 2024  8:23am. 824 total
+As of November  8, 2024  2:26am. 826 total
 
 ## Summary
 * 605 MIT
-* 107 Apache 2.0
-* 58 ISC
+* 108 Apache 2.0
+* 59 ISC
 * 23 New BSD
 * 12 Simplified BSD
 * 3 MIT OR Apache-2.0
@@ -26,8 +26,19 @@ As of November  5, 2024  8:23am. 824 total
 ## Items
 
 
+<a name="@ai-sdk/anthropic"></a>
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/anthropic</a> v0.0.56 (dependencies)
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
+
+
+
 <a name="@ai-sdk/openai"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/openai</a> v0.0.62 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/openai</a> v0.0.72 (dependencies)
 #### 
 
 ##### Paths
@@ -38,7 +49,7 @@ As of November  5, 2024  8:23am. 824 total
 
 
 <a name="@ai-sdk/provider"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/provider</a> v0.0.23 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/provider</a> v0.0.26 (dependencies)
 #### 
 
 ##### Paths
@@ -49,7 +60,7 @@ As of November  5, 2024  8:23am. 824 total
 
 
 <a name="@ai-sdk/provider-utils"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/provider-utils</a> v1.0.19 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/provider-utils</a> v1.0.22 (dependencies)
 #### 
 
 ##### Paths
@@ -60,7 +71,7 @@ As of November  5, 2024  8:23am. 824 total
 
 
 <a name="@ai-sdk/react"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/react</a> v0.0.60 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/react</a> v0.0.70 (dependencies)
 #### 
 
 ##### Paths
@@ -71,7 +82,7 @@ As of November  5, 2024  8:23am. 824 total
 
 
 <a name="@ai-sdk/solid"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/solid</a> v0.0.47 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/solid</a> v0.0.54 (dependencies)
 #### 
 
 ##### Paths
@@ -82,7 +93,7 @@ As of November  5, 2024  8:23am. 824 total
 
 
 <a name="@ai-sdk/svelte"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/svelte</a> v0.0.49 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/svelte</a> v0.0.57 (dependencies)
 #### 
 
 ##### Paths
@@ -93,7 +104,7 @@ As of November  5, 2024  8:23am. 824 total
 
 
 <a name="@ai-sdk/ui-utils"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/ui-utils</a> v0.0.44 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/ui-utils</a> v0.0.50 (dependencies)
 #### 
 
 ##### Paths
@@ -104,7 +115,7 @@ As of November  5, 2024  8:23am. 824 total
 
 
 <a name="@ai-sdk/vue"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/vue</a> v0.0.51 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/vue</a> v0.0.59 (dependencies)
 #### 
 
 ##### Paths
@@ -3452,7 +3463,7 @@ Turn a function into an `http.Agent` instance
 Missing keepalive http.Agent
 
 <a name="ai"></a>
-### <a href="https://sdk.vercel.ai/docs">ai</a> v3.4.3 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">ai</a> v3.4.33 (dependencies)
 #### 
 
 ##### Paths
@@ -6565,17 +6576,6 @@ Bytes go in, but they don't come out (when muted).
 modernize node.js to current ECMAScript standards
 
 <a name="nanoid"></a>
-### nanoid v3.3.6 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-A tiny (116 bytes), secure URL-friendly unique string ID generator
-
-<a name="nanoid"></a>
 ### nanoid v3.3.7 (dependencies, devDependencies)
 #### 
 
@@ -8291,6 +8291,17 @@ Promisifies all the selected functions in an object
 
 
 
+<a name="throttleit"></a>
+### throttleit v2.1.0 (dependencies)
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+Throttle a function to limit its execution rate
+
 <a name="through"></a>
 ### <a href="https://github.com/dominictarr/through">through</a> v2.3.8 (dependencies)
 #### 
@@ -9063,6 +9074,17 @@ TypeScript-first schema declaration and validation library with static type infe
 
 <a name="zod-to-json-schema"></a>
 ### zod-to-json-schema v3.23.2 (dependencies)
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://en.wikipedia.org/wiki/ISC_license">ISC</a> permitted
+
+Converts Zod schemas to Json Schemas
+
+<a name="zod-to-json-schema"></a>
+### zod-to-json-schema v3.23.5 (dependencies)
 #### 
 
 ##### Paths


### PR DESCRIPTION
## Summary
I replaced route06inc with giselles-ai due to a GitHub organization transfer.

## Related Issue
None

## Changes
I replaced route06inc with giselles-ai due to a GitHub organization transfer.

## Testing
Please check if all the modified URLs are accessible.

## Other Information
None
