### PR TITLE
fix(a11y): Add required DialogTitle to improve dialog accessibility

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/artifact-block.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/artifact-block.tsx
@@ -2,6 +2,7 @@ import { CopyIcon } from "lucide-react";
 import {
 	Dialog,
 	DialogContent,
+	DialogTitle,
 	DialogTrigger,
 } from "../../../components/dialog";
 import { DocumentIcon } from "../../../components/icons/document";
@@ -43,14 +44,14 @@ export function ArtifactBlock(props: ArtifactBlockProps) {
 			</DialogTrigger>
 			<DialogContent>
 				<div className="flex flex-col h-full overflow-hidden z-10">
-					<div
+					<DialogTitle
 						className="px-[32px] py-[16px] font-rosart text-[22px] text-black--30 drop-shadow-[0px_0px_20px_0px_hsla(207,_100%,_48%,_1)]"
 						style={{
 							textShadow: "0px 0px 20px hsla(207, 100%, 48%, 1)",
 						}}
 					>
 						{title}
-					</div>
+					</DialogTitle>
 					<div className="border-t border-black-40" />
 					<div className="overflow-x-hidden overflow-y-auto flex-1">
 						<div className="px-[32px] py-[16px] font-rosart text-[18px] text-black-30">

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/websearch-block.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/websearch-block.tsx
@@ -1,5 +1,10 @@
 import { CopyIcon } from "lucide-react";
-import { Dialog, DialogContent, DialogTrigger } from "../components/dialog";
+import {
+	Dialog,
+	DialogContent,
+	DialogTitle,
+	DialogTrigger,
+} from "../components/dialog";
 import { CircleCheckIcon } from "../components/icons/circle-check";
 import { CircleXIcon } from "../components/icons/circle-x";
 import { DocumentIcon } from "../components/icons/document";
@@ -33,14 +38,14 @@ export function WebSearchBlock(props: WebSearchBlockProps) {
 			</DialogTrigger>
 			<DialogContent>
 				<div className="flex flex-col h-full overflow-hidden z-10">
-					<div
+					<DialogTitle
 						className="px-[32px] py-[16px] font-rosart text-[22px] text-black--30 drop-shadow-[0px_0px_20px_0px_hsla(207,_100%,_48%,_1)]"
 						style={{
 							textShadow: "0px 0px 20px hsla(207, 100%, 48%, 1)",
 						}}
 					>
 						{title}
-					</div>
+					</DialogTitle>
 					<div className="border-t border-black-40" />
 					<div className="overflow-x-hidden overflow-y-auto flex-1">
 						<div className="px-[16px] py-[16px] font-rosart text-[18px] text-black-30">


### PR DESCRIPTION
Add missing DialogTitle components to dialog implementations to ensure proper accessibility for screen reader users, following Radix UI Dialog requirements.

- Replace div headers with DialogTitle in artifact-block
- Replace div headers in websearch-block
- Maintain existing styling while improving ARIA compliance

Fixes accessibility issues with Dialog component implementation per Radix UI documentation requirements.
