### PR TITLE
Provide google login

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -4,11 +4,12 @@ import { getAuthCallbackUrl } from "@/app/(auth)/lib";
 import { createClient } from "@/lib/supabase";
 import { redirect } from "next/navigation";
 
-export async function authorizeGitHub() {
-	const supabase = await createClient();
+type OAuthProvider = "github" | "google";
 
+async function authorizeOAuth(provider: OAuthProvider) {
+	const supabase = await createClient();
 	const { data, error } = await supabase.auth.signInWithOAuth({
-		provider: "github",
+		provider,
 		options: {
 			redirectTo: getAuthCallbackUrl(),
 		},
@@ -18,27 +19,16 @@ export async function authorizeGitHub() {
 		const { code, message, name, status } = error;
 		throw new Error(`${name} occurred: ${code} (${status}): ${message}`);
 	}
+
 	if (data.url) {
 		redirect(data.url);
 	}
 }
 
+export async function authorizeGitHub() {
+	return authorizeOAuth("github");
+}
+
 export async function authorizeGoogle() {
-	const supabase = await createClient();
-
-	const { data, error } = await supabase.auth.signInWithOAuth({
-		provider: "google",
-		options: {
-			redirectTo: getAuthCallbackUrl(),
-		},
-	});
-
-	if (error != null) {
-		const { code, message, name, status } = error;
-		throw new Error(`${name} occurred: ${code} (${status}): ${message}`);
-	}
-
-	if (data.url) {
-		redirect(data.url);
-	}
+	return authorizeOAuth("google");
 }

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -1,10 +1,8 @@
 "use server";
 
-import { getAuthCallbackUrl } from "@/app/(auth)/lib";
+import { type OAuthProvider, getAuthCallbackUrl } from "@/app/(auth)/lib";
 import { createClient } from "@/lib/supabase";
 import { redirect } from "next/navigation";
-
-type OAuthProvider = "github" | "google";
 
 async function authorizeOAuth(provider: OAuthProvider) {
 	const supabase = await createClient();

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -22,3 +22,23 @@ export async function authorizeGitHub() {
 		redirect(data.url);
 	}
 }
+
+export async function authorizeGoogle() {
+	const supabase = await createClient();
+
+	const { data, error } = await supabase.auth.signInWithOAuth({
+		provider: "google",
+		options: {
+			redirectTo: getAuthCallbackUrl(),
+		},
+	});
+
+	if (error != null) {
+		const { code, message, name, status } = error;
+		throw new Error(`${name} occurred: ${code} (${status}): ${message}`);
+	}
+
+	if (data.url) {
+		redirect(data.url);
+	}
+}

--- a/app/(auth)/auth/callback/route.ts
+++ b/app/(auth)/auth/callback/route.ts
@@ -84,6 +84,9 @@ async function storeProviderTokens(user: User, session: Session) {
 	if (provider_token.startsWith("ghu_")) {
 		provider = "github";
 	}
+	if (session.user.app_metadata.providers.includes("google")) {
+		provider = "google";
+	}
 	// TODO: add another logic for other providers
 	if (provider === "") {
 		throw new Error("No provider found");

--- a/app/(auth)/components/oauth-providers.tsx
+++ b/app/(auth)/components/oauth-providers.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { googleOauthFlag } from "@/flags";
 import { SiGithub, SiGoogle } from "@icons-pack/react-simple-icons";
 import type { FC } from "react";
 import { authorizeGitHub, authorizeGoogle } from "../actions";
@@ -7,30 +8,31 @@ type OauthProvidersProps = {
 	labelPrefix: string;
 };
 
-export const OAuthProviders: FC<OauthProvidersProps> = ({ labelPrefix }) => (
-	<div className="space-y-2">
-		<Button asChild variant="link">
-			<form>
-				<SiGoogle className="h-[20px] w-[20px]" />
-				<button type="submit" formAction={authorizeGoogle}>
-					{labelPrefix} with Google
-				</button>
-			</form>
-		</Button>
-		{/**<button
-							className="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500"
-							type="button"
-						>
-							<Microsoft className="h-5 w-5 mr-2" /> Sign up with Microsoft
-						</button>**/}
+export const OAuthProviders: FC<OauthProvidersProps> = async ({
+	labelPrefix,
+}) => {
+	const displayGoogleOauth = await googleOauthFlag();
 
-		<Button asChild variant="link">
-			<form>
-				<SiGithub className="h-[20px] w-[20px]" />
-				<button type="submit" formAction={authorizeGitHub}>
-					{labelPrefix} with GitHub
-				</button>
-			</form>
-		</Button>
-	</div>
-);
+	return (
+		<div className="space-y-2">
+			{displayGoogleOauth && (
+				<Button asChild variant="link">
+					<form>
+						<SiGoogle className="h-[20px] w-[20px]" />
+						<button type="submit" formAction={authorizeGoogle}>
+							{labelPrefix} with Google
+						</button>
+					</form>
+				</Button>
+			)}
+			<Button asChild variant="link">
+				<form>
+					<SiGithub className="h-[20px] w-[20px]" />
+					<button type="submit" formAction={authorizeGitHub}>
+						{labelPrefix} with GitHub
+					</button>
+				</form>
+			</Button>
+		</div>
+	);
+};

--- a/app/(auth)/components/oauth-providers.tsx
+++ b/app/(auth)/components/oauth-providers.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
-import { SiGithub } from "@icons-pack/react-simple-icons";
+import { SiGithub, SiGoogle } from "@icons-pack/react-simple-icons";
 import type { FC } from "react";
-import { authorizeGitHub } from "../actions";
+import { authorizeGitHub, authorizeGoogle } from "../actions";
 
 type OauthProvidersProps = {
 	labelPrefix: string;
@@ -9,12 +9,14 @@ type OauthProvidersProps = {
 
 export const OAuthProviders: FC<OauthProvidersProps> = ({ labelPrefix }) => (
 	<div className="space-y-2">
-		{/* <Button asChild variant="link">
-			<Link href="/signup/google">
+		<Button asChild variant="link">
+			<form>
 				<SiGoogle className="h-[20px] w-[20px]" />
-				<p>Sign up with Google</p>
-			</Link>
-		</Button> */}
+				<button type="submit" formAction={authorizeGoogle}>
+					{labelPrefix} with Google
+				</button>
+			</form>
+		</Button>
 		{/**<button
 							className="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500"
 							type="button"

--- a/app/(auth)/lib/index.ts
+++ b/app/(auth)/lib/index.ts
@@ -6,3 +6,4 @@ export { getCurrentTeam } from "./get-current-team";
 export { getOauthCredential } from "./get-oauth-credential";
 export { isRoute06User } from "./is-route06-user";
 export { refreshOauthCredential } from "./refresh-oauth-credential";
+export type { OAuthProvider } from "./provider";

--- a/app/(auth)/lib/provider.ts
+++ b/app/(auth)/lib/provider.ts
@@ -1,0 +1,1 @@
+export type OAuthProvider = "github" | "google";

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 import { ClickableText } from "@/components/ui/clicable-text";
 import Link from "next/link";
+import { Suspense } from "react";
 import { ActionPrompt } from "../components/action-prompt";
 import { Divider } from "../components/divider";
 import { OAuthProviders } from "../components/oauth-providers";
@@ -13,7 +14,9 @@ export default function Page() {
 				<div className="mx-auto grid w-[350px] gap-[24px]">
 					<PageTitle>Log in to Giselle</PageTitle>
 					<div className="grid gap-[16px]">
-						<OAuthProviders labelPrefix="Continue" />
+						<Suspense fallback={<div>Loading...</div>}>
+							<OAuthProviders labelPrefix="Continue" />
+						</Suspense>
 						<Divider />
 						<LoginForm />
 

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { ClickableText } from "@/components/ui/clicable-text";
 import { MailIcon } from "lucide-react";
 import Link from "next/link";
+import { Suspense } from "react";
 import { ActionPrompt } from "../components/action-prompt";
 import { Divider } from "../components/divider";
 import { LegalConsent } from "../components/legal-consent";
@@ -24,7 +25,9 @@ export default function SignupPage() {
 			</div>
 			<div className="mt-8 space-y-6 w-[320px]">
 				<PageHeader title="Get Started" />
-				<OAuthProviders labelPrefix="Sign up" />
+				<Suspense fallback={<div>Loading...</div>}>
+					<OAuthProviders labelPrefix="Continue" />
+				</Suspense>
 				<Divider label="or" />
 				<Button asChild>
 					<Link href="/signup/email">

--- a/flags.ts
+++ b/flags.ts
@@ -51,3 +51,16 @@ export const githubIntegrationFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const googleOauthFlag = flag<boolean>({
+	key: "google-oauth",
+	async decide() {
+		return takeLocalEnv("GOOGLE_OAUTH_FLAG");
+	},
+	description: "Enable Google OAuth",
+	defaultValue: false,
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});


### PR DESCRIPTION
## Summary

Enables user to login using Google account

## Related Issue

- #53 

## Changes

- add "Google" type social login button
- unify provider detection logic between GitHub and Google

## Testing

- [x] "Sign in with Google" button is absent by default
- [x] "Sign in with Google" button is available with its feature flag on
- [x] "Sign in with Google" login works
- [x] preexistent "Sign in with GitHub" works

## Other Information

