### PR TITLE
Change the default setting of the some feature flags to true.

### DIFF
--- a/flags.ts
+++ b/flags.ts
@@ -70,7 +70,7 @@ export const chooseModelFlag = flag<boolean>({
 		return takeLocalEnv("CHOOSE_MODEL_FLAG");
 	},
 	description: "Enable choose model",
-	defaultValue: false,
+	defaultValue: true,
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },
@@ -83,7 +83,7 @@ export const anthropicFlag = flag<boolean>({
 		return takeLocalEnv("ANTHROPIC_FLAG");
 	},
 	description: "Enable anthropic",
-	defaultValue: false,
+	defaultValue: true,
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },

--- a/flags.ts
+++ b/flags.ts
@@ -31,7 +31,7 @@ export const webSearchNodeFlag = flag<boolean>({
 		return takeLocalEnv("WEB_SEARCH_NODE_FLAG");
 	},
 	description: "User can use a web search node",
-	defaultValue: false,
+	defaultValue: true,
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },

--- a/flags.ts
+++ b/flags.ts
@@ -18,7 +18,7 @@ export const uploadFileToPromptNodeFlag = flag<boolean>({
 		return takeLocalEnv("UPLOAD_FILE_TO_PROMPT_NODE_FLAG");
 	},
 	description: "User can upload a file to the prompt node",
-	defaultValue: false,
+	defaultValue: true,
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },


### PR DESCRIPTION
## Summary
Change the default setting of the some feature flags to true.

- upload-file-to-prompt-node
- web-search-node
- choose-model
- anthropic

## Related Issue
- https://github.com/giselles-ai/giselle/issues/44
- https://github.com/giselles-ai/giselle/issues/63
- https://github.com/giselles-ai/giselle/pull/77#pullrequestreview-2418059719

## Changes
I have changed the default value of the following feature flags to true. 
The related code for the feature flags has not been removed yet.

- upload-file-to-prompt-node
- web-search-node
- choose-model
- anthropic

## Testing
Please use [Vercel Feature Flags](https://vercel.com/docs/workflow-collaboration/feature-flags).

## Other Information
<!-- Add any other relevant information for the reviewer. -->
