### PR TITLE
Add GITHUB_APP_WEBHOOK_SECRET to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ FIRECRAWL_API_KEY=
 # @see https://vercel.com/docs/workflow-collaboration/feature-flags/supporting-feature-flags#flags_secret-environment-variable
 FLAGS_SECRET=
 
+# GitHub Apps
+# @see https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/using-webhooks-with-github-apps
+GITHUB_APP_WEBHOOK_SECRET="REPLACE_YOUR_SECRET"
+
 # Google Tag Manager https://tagmanager.google.com/
 # @see https://support.google.com/tagmanager/answer/6102821
 GTM_ID=


### PR DESCRIPTION
## Summary
Add GITHUB_APP_WEBHOOK_SECRET to .env.example

## Related Issue
- https://github.com/giselles-ai/giselle/pull/51

## Changes
Just added GITHUB_APP_WEBHOOK_SECRET to .env.example.

## Testing
Please set the environment variables below and confirm that `bun run dev` works correctly.

```
GITHUB_APP_WEBHOOK_SECRET="REPLACE_YOUR_SECRET"
```

## Other Information
<!-- Add any other relevant information for the reviewer. -->
