### PR TITLE
[feat] Enhance GitHub workflow integration with dynamic node selection

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/left-menu/github-integration/github-integration.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/left-menu/github-integration/github-integration.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { XIcon } from "lucide-react";
 import Link from "next/link";
+import { useMemo } from "react";
 import { Label } from "../../components/label";
 import {
 	Select,
@@ -11,6 +12,7 @@ import {
 	SelectValue,
 } from "../../components/select";
 import { useGitHubIntegration } from "../../github-integration/context";
+import { useGraph } from "../../graph/context";
 import {
 	Section,
 	SectionFormField,
@@ -28,16 +30,6 @@ const mockEvents = [
 	},
 ];
 
-const mockNodes = [
-	{
-		id: "f-1",
-		name: "Untitled node - 1 → Untitle node - 6",
-	},
-	{
-		id: "f-2",
-		name: "Untitled node - 3 → Untitle node - 4",
-	},
-];
 const mockNextActions = [
 	{
 		id: "r-1",
@@ -97,6 +89,18 @@ interface GitHubIntegrationFormProps {
 	}>;
 }
 function GithubIntegrationForm({ repositories }: GitHubIntegrationFormProps) {
+	const { state } = useGraph();
+	const startNodes = useMemo(
+		() =>
+			state.graph.nodes.filter(
+				(node) =>
+					!state.graph.connectors.some(
+						(connector) => connector.target === node.id,
+					),
+			),
+		[state.graph],
+	);
+
 	return (
 		<div className="grid gap-[16px]">
 			<Section>
@@ -151,13 +155,13 @@ function GithubIntegrationForm({ repositories }: GitHubIntegrationFormProps) {
 			<Section>
 				<SectionHeader title="Action" />
 				<SectionFormField>
-					<Label htmlFor="event">Run flow</Label>
-					<Select name="event">
+					<Label>Start flow from</Label>
+					<Select name="start">
 						<SelectTrigger>
-							<SelectValue placeholder="Choose value" />
+							<SelectValue placeholder="Choose node" />
 						</SelectTrigger>
 						<SelectContent>
-							{mockNodes.map((node) => (
+							{startNodes.map((node) => (
 								<SelectItem value={node.id} key={node.id}>
 									{node.name}
 								</SelectItem>

--- a/app/(playground)/p/[agentId]/beta-proto/left-menu/github-integration/github-integration.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/left-menu/github-integration/github-integration.tsx
@@ -107,7 +107,7 @@ function GithubIntegrationForm({ repositories }: GitHubIntegrationFormProps) {
 				<SectionHeader title="Repository" />
 				<Select>
 					<SelectTrigger>
-						<SelectValue placeholder="Choose value" />
+						<SelectValue placeholder="Choose repository" />
 					</SelectTrigger>
 					<SelectContent>
 						{repositories.map((repository) => (
@@ -124,7 +124,7 @@ function GithubIntegrationForm({ repositories }: GitHubIntegrationFormProps) {
 					<Label htmlFor="event">Event</Label>
 					<Select name="event">
 						<SelectTrigger>
-							<SelectValue placeholder="Choose value" />
+							<SelectValue placeholder="Choose event" />
 						</SelectTrigger>
 						<SelectContent>
 							{mockEvents.map((event) => (
@@ -170,10 +170,10 @@ function GithubIntegrationForm({ repositories }: GitHubIntegrationFormProps) {
 					</Select>
 				</SectionFormField>
 				<SectionFormField>
-					<Label htmlFor="event">Then</Label>
-					<Select name="event">
+					<Label>Then</Label>
+					<Select name="nextAction">
 						<SelectTrigger>
-							<SelectValue placeholder="Choose value" />
+							<SelectValue placeholder="Choose next action" />
 						</SelectTrigger>
 						<SelectContent>
 							{mockNextActions.map((nextAction) => (


### PR DESCRIPTION
## Changes
- Add dynamic start node selection based on graph topology
- Filter and display only valid workflow entry points (nodes without incoming connections)
- Improve form field labels and placeholders across GitHub integration form
- Fix form component properties for better accessibility and data handling
- Remove redundant HTML attributes and standardize naming conventions

## Why
The GitHub workflow integration needed improvements in both functionality and usability:
1. Start node selection was previously static, now dynamically filtered based on graph structure
2. Form fields lacked clear context and had inconsistent properties
3. User experience needed enhancement with more descriptive labels and placeholders

These changes make the integration more intuitive while ensuring valid workflow configurations.

## Technical Details
- Implemented useMemo hook for efficient node filtering
- Added logic to identify valid start nodes (those without incoming connections)
- Standardized form component properties (htmlFor, name attributes)
- Integrated with graph context for accessing node data

## Testing
- Verified dynamic start node filtering works correctly
- Confirmed only valid entry points are displayed in selection
- Tested form submission with updated field properties
- Validated accessibility improvements
- Checked compatibility with existing graph context

