### PR TITLE
style(tabs): Add backdrop blur effect and adjust background color

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/left-menu/components/tabs.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/left-menu/components/tabs.tsx
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
 	<TabsPrimitive.Content
 		ref={ref}
 		className={cn(
-			"absolute w-[400px] rounded-[24px] bg-[hsla(233,93%,5%,0.8)] overflow-hidden shadow-[0px_0px_3px_0px_hsla(0,_0%,_100%,_0.25)_inset] top-[0px] bottom-[20px] left-[84px] mt-[60px]",
+			"absolute w-[400px] rounded-[24px] bg-[hsla(234,91%,5%,0.8)] overflow-hidden shadow-[0px_0px_3px_0px_hsla(0,_0%,_100%,_0.25)_inset] top-[0px] bottom-[20px] left-[84px] mt-[60px] backdrop-blur-[16px]",
 			className,
 		)}
 		{...props}


### PR DESCRIPTION
Enhances visual styling of tab content panel by adding blur effect and slightly adjusting the background color for better depth perception.

Changes:
- Add backdrop-blur-[16px] for frosted glass effect
- Update background HSL value for subtle color refinement
