### PR TITLE
refactor(webhook): Extract GitHub workflow logic into separate function

### DIFF
--- a/app/webhooks/github/route.ts
+++ b/app/webhooks/github/route.ts
@@ -1,13 +1,16 @@
 import type { GenerateResult } from "@/app/(playground)/p/[agentId]/beta-proto/flow/types";
+import type { GiselleNodeId } from "@/app/(playground)/p/[agentId]/beta-proto/giselle-node/types";
 import { db, gitHubIntegrations } from "@/drizzle";
 import {
 	buildAppInstallationClient,
 	needsAdditionalPermissions,
 	webhooks,
 } from "@/services/external/github";
+import type { GitHubNextAction } from "@/services/external/github/types";
 import type { EmitterWebhookEvent } from "@octokit/webhooks";
 import type { WebhookEventName } from "@octokit/webhooks-types";
 import { captureException } from "@sentry/nextjs";
+import { waitUntil } from "@vercel/functions";
 import type { NextRequest } from "next/server";
 import {
 	buildTextArtifact,
@@ -96,10 +99,16 @@ async function issueCommentHandler(
 ) {
 	const payload = event.payload;
 
+	if (payload.installation === undefined) {
+		return;
+	}
+
 	const issueNumber = payload.issue.number;
-	const repoName = payload.repository.name;
-	const repoOwner = payload.repository.owner.login;
+	const repo = payload.repository.name;
+	const owner = payload.repository.owner.login;
 	const repositoryFullName = payload.repository.full_name;
+	const installationId = payload.installation.id;
+
 	const command = parseCommand(payload.comment.body);
 	if (command === null) {
 		return;
@@ -108,133 +117,161 @@ async function issueCommentHandler(
 		repositoryFullName,
 		command.callSign,
 	);
-	await Promise.all(
-		integrations.map(async (integration) => {
-			const agent = await db.query.agents.findFirst({
-				where: (agents, { eq }) => eq(agents.dbId, integration.agentDbId),
-			});
-			if (agent === undefined) {
-				return;
-			}
-			const flow = await buildFlow({
-				input: {
-					agentId: agent.id,
-					finalNodeId: integration.endNodeId,
-					graph: agent.graphv2,
-				},
-			});
-
-			const generateResults: GenerateResult[] = [];
-			for (const job of flow.jobs) {
-				await Promise.all(
-					job.steps.map(async (step) => {
-						const relevanceResults = step.sourceNodeIds
-							.map((sourceNodeId) => {
-								const sourceArtifact = generateResults.find(
-									(generateResult) =>
-										generateResult.generator.nodeId === sourceNodeId,
-								);
-								/** @todo log warning */
-								if (sourceArtifact === undefined) {
-									return null;
-								}
-								return sourceArtifact;
-							})
-							.filter((sourceArtifact) => sourceArtifact !== null);
-						switch (step.action) {
-							case "generate-text": {
-								const prompt =
-									integration.startNodeId === step.node.id
-										? command.content
-										: step.prompt;
-								const artifactObject = await generateArtifactObject({
-									input: {
-										prompt,
-										model: step.modelConfiguration,
-										sources: [
-											...step.sources,
-											...relevanceResults.map((result) => result.artifact),
-										],
-									},
-								});
-								generateResults.push(
-									buildGenerateResult({
-										generator: buildGeneratorNode({
-											nodeId: step.node.id,
-											archetype: step.node.archetype,
-											name: step.node.name,
-										}),
-										artifact: buildTextArtifact({
-											title: artifactObject.artifact.title,
-											content: artifactObject.artifact.content,
-										}),
-									}),
-								);
-								break;
-							}
-							case "search-web": {
-								const webSearchArtifact = await generateWebSearchArtifactObject(
-									{
-										input: {
-											prompt: step.prompt,
-											sources: [
-												...step.sources,
-												...relevanceResults.map((result) => result.artifact),
-											],
-										},
-									},
-								);
-								generateResults.push(
-									buildGenerateResult({
-										generator: buildGeneratorNode({
-											nodeId: step.node.id,
-											archetype: step.node.archetype,
-											name: step.node.name,
-										}),
-										artifact: buildWebSearchArtifact({
-											keywords: webSearchArtifact.keywords,
-											scrapingTasks: webSearchArtifact.scrapingTasks,
-										}),
-									}),
-								);
-								break;
-							}
-						}
+	waitUntil(
+		Promise.all(
+			integrations.map(
+				async (integration) =>
+					await run({
+						agentDbId: integration.agentDbId,
+						startNodeId: integration.startNodeId,
+						endNodeId: integration.endNodeId,
+						prompt: command.content,
+						gitHubAppInstallationId: installationId,
+						nextAction: {
+							type: integration.nextAction,
+							issueNumber,
+							repo,
+							owner,
+						},
 					}),
-				);
-			}
-
-			const output = generateResults.find(
-				(generateResult) =>
-					generateResult.generator.nodeId === integration.endNodeId,
-			);
-			if (
-				output === undefined ||
-				output.artifact.object === "artifact.webSearch"
-			) {
-				/** @todo log */
-				return;
-			}
-
-			if (integration.nextAction === "github.issue_comment.reply") {
-				const commentBody = output.artifact.content;
-
-				const installation = payload.installation;
-				if (!installation) {
-					throw new Error("No installation found in payload");
-				}
-				const octokit = await buildAppInstallationClient(installation.id);
-
-				await octokit.request(
-					"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-					{
-						owner: repoOwner,
-						repo: repoName,
-						issue_number: issueNumber,
-						body: commentBody,
-					},
-				);
-			}
-		}),
+			),
+		),
 	);
+	return new Response("Accepted", { status: 202 });
+}
+
+interface NextActionBase {
+	type: GitHubNextAction;
+}
+interface ReplyIssueCommentAction extends NextActionBase {
+	type: "github.issue_comment.reply";
+	owner: string;
+	repo: string;
+	issueNumber: number;
+}
+type NextAction = ReplyIssueCommentAction;
+interface RunInput {
+	agentDbId: number;
+	startNodeId: GiselleNodeId;
+	prompt: string;
+	endNodeId: GiselleNodeId;
+	gitHubAppInstallationId: number;
+	nextAction: NextAction;
+}
+async function run(input: RunInput) {
+	const agent = await db.query.agents.findFirst({
+		where: (agents, { eq }) => eq(agents.dbId, input.agentDbId),
+	});
+	if (agent === undefined) {
+		return;
+	}
+	const flow = await buildFlow({
+		input: {
+			agentId: agent.id,
+			finalNodeId: input.endNodeId,
+			graph: agent.graphv2,
+		},
+	});
+
+	const generateResults: GenerateResult[] = [];
+	for (const job of flow.jobs) {
+		await Promise.all(
+			job.steps.map(async (step) => {
+				const relevanceResults = step.sourceNodeIds
+					.map((sourceNodeId) => {
+						const sourceArtifact = generateResults.find(
+							(generateResult) =>
+								generateResult.generator.nodeId === sourceNodeId,
+						);
+						/** @todo log warning */
+						if (sourceArtifact === undefined) {
+							return null;
+						}
+						return sourceArtifact;
+					})
+					.filter((sourceArtifact) => sourceArtifact !== null);
+				switch (step.action) {
+					case "generate-text": {
+						const prompt =
+							input.startNodeId === step.node.id ? input.prompt : step.prompt;
+						const artifactObject = await generateArtifactObject({
+							input: {
+								prompt,
+								model: step.modelConfiguration,
+								sources: [
+									...step.sources,
+									...relevanceResults.map((result) => result.artifact),
+								],
+							},
+						});
+						generateResults.push(
+							buildGenerateResult({
+								generator: buildGeneratorNode({
+									nodeId: step.node.id,
+									archetype: step.node.archetype,
+									name: step.node.name,
+								}),
+								artifact: buildTextArtifact({
+									title: artifactObject.artifact.title,
+									content: artifactObject.artifact.content,
+								}),
+							}),
+						);
+						break;
+					}
+					case "search-web": {
+						const webSearchArtifact = await generateWebSearchArtifactObject({
+							input: {
+								prompt: step.prompt,
+								sources: [
+									...step.sources,
+									...relevanceResults.map((result) => result.artifact),
+								],
+							},
+						});
+						generateResults.push(
+							buildGenerateResult({
+								generator: buildGeneratorNode({
+									nodeId: step.node.id,
+									archetype: step.node.archetype,
+									name: step.node.name,
+								}),
+								artifact: buildWebSearchArtifact({
+									keywords: webSearchArtifact.keywords,
+									scrapingTasks: webSearchArtifact.scrapingTasks,
+								}),
+							}),
+						);
+						break;
+					}
+				}
+			}),
+		);
+	}
+
+	const output = generateResults.find(
+		(generateResult) => generateResult.generator.nodeId === input.endNodeId,
+	);
+	if (output === undefined || output.artifact.object === "artifact.webSearch") {
+		/** @todo log */
+		return;
+	}
+
+	if (input.nextAction.type === "github.issue_comment.reply") {
+		const commentBody = output.artifact.content;
+
+		const octokit = await buildAppInstallationClient(
+			input.gitHubAppInstallationId,
+		);
+
+		await octokit.request(
+			"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+			{
+				owner: input.nextAction.owner,
+				repo: input.nextAction.repo,
+				issue_number: input.nextAction.issueNumber,
+				body: commentBody,
+			},
+		);
+	}
 }


### PR DESCRIPTION
Refactors the GitHub webhook handler to improve maintainability and error handling by:
- Moving core workflow logic into dedicated `run` function
- Adding proper typing for GitHub next actions
- Implementing background processing with Vercel's waitUntil
- Improving installation ID validation

The changes make the code more modular and easier to test while maintaining the same functionality. Webhook responses now return immediately while processing continues in the background.
