### PR TITLE
fix Langfuse model id

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -5,6 +5,7 @@ import { streamObject } from "ai";
 import { createStreamableValue } from "ai/rsc";
 
 import { getUserSubscriptionId, isRoute06User } from "@/app/(auth)/lib";
+import { langfuseModel } from "@/lib/llm"
 import { logger } from "@/lib/logger";
 import { metrics } from "@opentelemetry/api";
 import { waitUntil } from "@vercel/functions";
@@ -54,7 +55,7 @@ ${sourcesToText(sources)}
 		const model = buildLanguageModel(params.modelConfiguration);
 		const generation = trace.generation({
 			input: params.userPrompt,
-			model: params.modelConfiguration.modelId,
+			model: langfuseModel(params.modelConfiguration.modelId),
 			modelParameters: {
 				topP: params.modelConfiguration.topP,
 				temperature: params.modelConfiguration.temperature,

--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -5,7 +5,7 @@ import { streamObject } from "ai";
 import { createStreamableValue } from "ai/rsc";
 
 import { getUserSubscriptionId, isRoute06User } from "@/app/(auth)/lib";
-import { langfuseModel } from "@/lib/llm"
+import { langfuseModel } from "@/lib/llm";
 import { logger } from "@/lib/logger";
 import { metrics } from "@opentelemetry/api";
 import { waitUntil } from "@vercel/functions";

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { getUserSubscriptionId, isRoute06User } from "@/app/(auth)/lib";
-import { langfuseModel } from "@/lib/llm"
+import { langfuseModel } from "@/lib/llm";
 import { openai } from "@ai-sdk/openai";
 import FirecrawlApp from "@mendable/firecrawl-js";
 import { metrics } from "@opentelemetry/api";

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { getUserSubscriptionId, isRoute06User } from "@/app/(auth)/lib";
+import { langfuseModel } from "@/lib/llm"
 import { openai } from "@ai-sdk/openai";
 import FirecrawlApp from "@mendable/firecrawl-js";
 import { metrics } from "@opentelemetry/api";
@@ -69,7 +70,7 @@ ${sourcesToText(sources)}
 		const model = "gpt-4o-mini";
 		const generation = trace.generation({
 			input: inputs.userPrompt,
-			model,
+			model: langfuseModel(model),
 		});
 		const { partialObjectStream, object } = await streamObject({
 			model: openai(model),

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,10 +1,10 @@
 export function langfuseModel(modelId: string) {
-    switch (modelId) {
-        case 'gpt-4o':
-            return 'gpt-4o'
-        case 'gpt-4o-mini':
-            return 'gpt-4o-mini'
-        case 'claude-3.5-sonnet':
-            return 'claude-3-5-sonnet-20241022'
-    }
+	switch (modelId) {
+		case "gpt-4o":
+			return "gpt-4o";
+		case "gpt-4o-mini":
+			return "gpt-4o-mini";
+		case "claude-3.5-sonnet":
+			return "claude-3-5-sonnet-20241022";
+	}
 }

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,0 +1,10 @@
+export function langfuseModel(modelId: string) {
+    switch (modelId) {
+        case 'gpt-4o':
+            return 'gpt-4o'
+        case 'gpt-4o-mini':
+            return 'gpt-4o-mini'
+        case 'claude-3.5-sonnet':
+            return 'claude-3-5-sonnet-20241022'
+    }
+}


### PR DESCRIPTION
## Summary
When using Claude 3.5 Sonnet, Langfuse cannot calculate the number of tokens etc.
The model id specified for Langfuse's generation() is incorrect, so correct it so that it is an appropriate model id.

## Changes
- Added a function `langfuseModel()` to convert Giselle model id to Langfuse model id.
- Pass the model id output by that function to Langfuse's generation().

## Testing
- Confirmed that all models work in the local dev environment.
  - gpt-4o
  - gpt-4o-mini
  - claude-3.5-sonnet

Test result displayed in Langfuse.

![スクリーンショット 2024-11-21 17 27 03](https://github.com/user-attachments/assets/c6aea081-b5c1-428f-9d0a-b5b896d19422)

