### PR TITLE
Update `serverActions.bodySizeLimit` to 4.5mb for fix the error FUNCTION_PAYLOAD_TOO_LARGE

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/add-source-dialog.tsx
+++ b/app/(playground)/p/[agentId]/beta-proto/giselle-node/components/panel/add-source-dialog.tsx
@@ -162,7 +162,7 @@ export function AddSourceDialog(props: AddSourceDialogProps) {
 											<p>
 												No contents added yet. Click to upload or drag and drop
 												files here (supports images, documents, and more; max
-												10MB per file).
+												4.5MB per file).
 											</p>
 											<div className="flex gap-[8px] justify-center items-center">
 												<span>or</span>

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig: NextConfig = {
 	},
 	experimental: {
 		serverActions: {
-			bodySizeLimit: "10mb",
+			bodySizeLimit: "4.5mb",
 		},
 	},
 	serverExternalPackages: ["@opentelemetry/sdk-node", "pino", "pino-pretty"],

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig: NextConfig = {
 	},
 	experimental: {
 		serverActions: {
-			bodySizeLimit: "2mb",
+			bodySizeLimit: "10mb",
 		},
 	},
 	serverExternalPackages: ["@opentelemetry/sdk-node", "pino", "pino-pretty"],


### PR DESCRIPTION
## Summary
I updated `serverActions.bodySizeLimit` to 4.5mb to allow file uploads of up to 4.5MB.

## Related Issue
None.

## Changes
- Update `serverActions.bodySizeLimit` to "4.5mb"

## Testing
- Please upload a PDF file of around 4.5 MB to test it.

## Other Information

### Fix errors

#### Error1: `Error: Body exceeded 2mb limit.`

```
 ⨯ uncaughtException: Error: Body exceeded 2mb limit.
                To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit
    at Transform.transform [as _transform] (file:///Users/shige/giselle/node_modules/next/dist/compiled/next-server/dist/src/server/app-render/action-handler.ts:744:18) {
  statusCode: 413
}
```

docs:
- https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit

#### Error2: `413 (Payload Too Large)`

docs:
- https://vercel.com/docs/errors/FUNCTION_PAYLOAD_TOO_LARGE
- https://vercel.com/docs/functions/runtimes#size-limits
