### PR TITLE
add error handling to text generation

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -108,7 +108,6 @@ ${sourcesToText(sources)}
 			}
 
 			const result = await object;
-
 		} catch (error) {
 			stream.append(`${error}`);
 		}

--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -61,53 +61,57 @@ ${sourcesToText(sources)}
 				temperature: params.modelConfiguration.temperature,
 			},
 		});
-		const { partialObjectStream, object } = await streamObject({
-			model,
-			system,
-			temperature: params.modelConfiguration.temperature,
-			topP: params.modelConfiguration.topP,
-			prompt: params.userPrompt,
-			schema: artifactSchema,
-			onFinish: async (result) => {
-				const meter = metrics.getMeter(params.modelConfiguration.provider);
-				const tokenCounter = meter.createCounter("token_consumed", {
-					description: "Number of OpenAI API tokens consumed by each request",
-				});
-				const subscriptionId = await getUserSubscriptionId();
-				const isR06User = await isRoute06User();
-				tokenCounter.add(result.usage.totalTokens, {
-					subscriptionId,
-					isR06User,
-				});
-				generation.end({
-					output: result,
-				});
+		try {
+			const { partialObjectStream, object } = await streamObject({
+				model,
+				system,
+				temperature: params.modelConfiguration.temperature,
+				topP: params.modelConfiguration.topP,
+				prompt: params.userPrompt,
+				schema: artifactSchema,
+				onFinish: async (result) => {
+					const meter = metrics.getMeter(params.modelConfiguration.provider);
+					const tokenCounter = meter.createCounter("token_consumed", {
+						description: "Number of OpenAI API tokens consumed by each request",
+					});
+					const subscriptionId = await getUserSubscriptionId();
+					const isR06User = await isRoute06User();
+					tokenCounter.add(result.usage.totalTokens, {
+						subscriptionId,
+						isR06User,
+					});
+					generation.end({
+						output: result,
+					});
 
-				logger.debug(
-					{ tokenConsumed: result.usage.totalTokens },
-					"response obtained",
-				);
+					logger.debug(
+						{ tokenConsumed: result.usage.totalTokens },
+						"response obtained",
+					);
 
-				await lf.shutdownAsync();
-				waitUntil(
-					new Promise((resolve) =>
-						setTimeout(
-							resolve,
-							Number.parseInt(
-								process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000",
+					await lf.shutdownAsync();
+					waitUntil(
+						new Promise((resolve) =>
+							setTimeout(
+								resolve,
+								Number.parseInt(
+									process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000",
+								),
 							),
 						),
-					),
-				); // wait until telemetry sent
-			},
-		});
+					); // wait until telemetry sent
+				},
+			});
 
-		for await (const partialObject of partialObjectStream) {
-			stream.update(partialObject);
+			for await (const partialObject of partialObjectStream) {
+				stream.update(partialObject);
+			}
+
+			const result = await object;
+
+		} catch (error) {
+			stream.append(`${error}`);
 		}
-
-		const result = await object;
-
 		stream.done();
 	})();
 

--- a/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
@@ -481,6 +481,7 @@ export const generateText =
 					sourceIndexes,
 					modelConfiguration: resolveModelConfiguration(node),
 				});
+
 				let content: PartialGeneratedObject = {};
 				for await (const streamContent of readStreamableValue(object)) {
 					if (
@@ -495,17 +496,39 @@ export const generateText =
 								},
 							}),
 						);
+						dispatch(
+							setTextGenerationNodeOutput({
+								node: {
+									id: args.textGeneratorNode.id,
+									output:
+										streamContent as PartialGeneratedObject /** @todo type assertion */,
+								},
+							}),
+						);
+					} else if (typeof streamContent === "string") {
+						dispatch(
+							setTextGenerationNodeOutput({
+								node: {
+									id: args.textGeneratorNode.id,
+									output: {
+										thinking: 'Sorry, a temporary issue has occurred.\nPlease try again after a while.'
+									}
+								},
+							}),
+						);
 					}
+					content = streamContent as PartialGeneratedObject;
+				}
+				if (typeof content === "string") {
 					dispatch(
-						setTextGenerationNodeOutput({
+						updateNodeState({
 							node: {
 								id: args.textGeneratorNode.id,
-								output:
-									streamContent as PartialGeneratedObject /** @todo type assertion */,
+								state: giselleNodeState.completed,
 							},
 						}),
 					);
-					content = streamContent as PartialGeneratedObject;
+					break;
 				}
 				dispatch(
 					setTextGenerationNodeOutput({

--- a/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/graph/actions.ts
@@ -511,8 +511,9 @@ export const generateText =
 								node: {
 									id: args.textGeneratorNode.id,
 									output: {
-										thinking: 'Sorry, a temporary issue has occurred.\nPlease try again after a while.'
-									}
+										thinking:
+											"Sorry, a temporary issue has occurred.\nPlease try again after a while.",
+									},
 								},
 							}),
 						);


### PR DESCRIPTION
## Summary
Added temporal error handling for LLM API calls in text generation node processing.
This is a temporary solution because there is a slightly high possibility that an Overloaded error will occur when calling Claude 3.5 Sonnet's API.
Web scraping node uses gpt, so will not support it at this time.

## Changes
- Catch an exception when calling streamObject().
- Display error messages in the right output panel.

## Testing
I confirmed that setting an incorrect value to the LLM API key causes an error message to be output to the right panel.