### PR TITLE
Prevent redirection of non-subscribed users when free plan flag is enabled

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { retrieveActiveStripeSubscriptionBySupabaseUserId } from "@/services/accounts/actions";
 import { NextResponse } from "next/server";
+import { freePlanFlag } from "./flags";
 import { supabaseMiddleware } from "./lib/supabase";
-import { isEmailFromRoute06 } from "./lib/utils";
 
 export default supabaseMiddleware(async (user, request) => {
 	if (user == null) {
@@ -11,8 +11,12 @@ export default supabaseMiddleware(async (user, request) => {
 		return NextResponse.redirect(url);
 	}
 
-	// Proceeding to check the user's subscription status since the email is not from the route06.co.jp
-	if (!isEmailFromRoute06(user.email ?? "")) {
+	// Users can use giselle without subscription if the free plan is enabled
+	const freePlanEnabled = await freePlanFlag();
+	if (!freePlanEnabled) {
+		// TODO: You can remove this block after the free plan is fully released.
+
+		// Proceeding to check the user's subscription status since the email is not from the route06.co.jp
 		const subscription = await retrieveActiveStripeSubscriptionBySupabaseUserId(
 			user.id,
 		);


### PR DESCRIPTION
## Summary
This PR enables users to use Giselle without a subscription.

- Limitations of the free plan will be implemented in other pull requests.
- Normal users won't be affected by this PR because of the feature flag.