### PR TITLE
Add team name edit functionality in settings

### DIFF
--- a/app/(main)/settings/team/actions.ts
+++ b/app/(main)/settings/team/actions.ts
@@ -23,8 +23,7 @@ export async function getTeamName() {
 			supabaseUserMappings,
 			eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
 		)
-		.where(eq(supabaseUserMappings.supabaseUserId, user.id))
-		.execute();
+		.where(eq(supabaseUserMappings.supabaseUserId, user.id));
 
 	return _teams[0].name;
 }
@@ -42,8 +41,7 @@ export async function updateTeamName(formData: FormData) {
 				supabaseUserMappings,
 				eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
 			)
-			.where(eq(supabaseUserMappings.supabaseUserId, user.id))
-			.execute();
+			.where(eq(supabaseUserMappings.supabaseUserId, user.id));
 
 		if (team.length === 0) {
 			throw new Error("Team not found");

--- a/app/(main)/settings/team/actions.ts
+++ b/app/(main)/settings/team/actions.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import {
+	UserId,
+	db,
+	supabaseUserMappings,
+	teamMemberships,
+	teams,
+} from "@/drizzle";
+import { getUser } from "@/lib/supabase";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+export async function getTeamName() {
+	const user = await getUser();
+
+	// TODO: In the future, this query will be changed to retrieve from the selected team ID
+	const _teams = await db
+		.select({ dbId: teams.dbId, name: teams.name })
+		.from(teams)
+		.innerJoin(teamMemberships, eq(teams.dbId, teamMemberships.teamDbId))
+		.innerJoin(
+			supabaseUserMappings,
+			eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
+		)
+		.where(eq(supabaseUserMappings.supabaseUserId, user.id))
+		.execute();
+
+	return _teams[0].name;
+}
+
+export async function updateTeamName(formData: FormData) {
+	const newName = formData.get("name") as string;
+	const user = await getUser();
+
+	try {
+		const team = await db
+			.select({ dbId: teams.dbId })
+			.from(teams)
+			.innerJoin(teamMemberships, eq(teams.dbId, teamMemberships.teamDbId))
+			.innerJoin(
+				supabaseUserMappings,
+				eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
+			)
+			.where(eq(supabaseUserMappings.supabaseUserId, user.id))
+			.execute();
+
+		if (team.length === 0) {
+			throw new Error("Team not found");
+		}
+
+		await db
+			.update(teams)
+			.set({ name: newName })
+			.where(eq(teams.dbId, team[0].dbId))
+			.execute();
+
+		revalidatePath("/settings/team");
+
+		return { success: true };
+	} catch (error) {
+		console.error("Failed to update team name:", error);
+		return { success: false, error };
+	}
+}

--- a/app/(main)/settings/team/page.tsx
+++ b/app/(main)/settings/team/page.tsx
@@ -12,7 +12,13 @@ export default function TeamPage() {
 				Team
 			</h3>
 
-			<Suspense fallback={<Skeleton className="h-full w-full" />}>
+			<Suspense
+				fallback={
+					<div className="w-full h-24">
+						<Skeleton className="h-full w-full" />
+					</div>
+				}
+			>
 				<TeamName />
 			</Suspense>
 		</div>

--- a/app/(main)/settings/team/page.tsx
+++ b/app/(main)/settings/team/page.tsx
@@ -1,3 +1,7 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Suspense } from "react";
+import { TeamName } from "./team-name";
+
 export default function TeamPage() {
 	return (
 		<div className="grid gap-[16px]">
@@ -7,6 +11,10 @@ export default function TeamPage() {
 			>
 				Team
 			</h3>
+
+			<Suspense fallback={<Skeleton className="h-full w-full" />}>
+				<TeamName />
+			</Suspense>
 		</div>
 	);
 }

--- a/app/(main)/settings/team/team-name-form.tsx
+++ b/app/(main)/settings/team/team-name-form.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Card } from "@/app/(main)/settings/components/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { teams } from "@/drizzle";
+import { Check, Pencil, X } from "lucide-react";
+import { useState } from "react";
+import {
+	type InferInput,
+	maxLength,
+	minLength,
+	parse,
+	pipe,
+	string,
+} from "valibot";
+import { updateTeamName } from "./actions";
+
+const TeamNameSchema = pipe(
+	string(),
+	minLength(1, "Team name is required"),
+	maxLength(256, "Team name must be 256 characters or less"),
+);
+
+type TeamNameSchema = InferInput<typeof TeamNameSchema>;
+
+export function TeamNameForm({
+	name,
+}: { name: typeof teams.$inferSelect.name }) {
+	const [isEditingName, setIsEditingName] = useState(false);
+	const [teamName, setTeamName] = useState(name);
+	const [tempTeamName, setTempTeamName] = useState(teamName);
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<string>("");
+
+	const handleSaveTeamName = async () => {
+		setError("");
+
+		try {
+			const validatedName = parse(TeamNameSchema, tempTeamName);
+
+			setIsLoading(true);
+
+			const formData = new FormData();
+			formData.append("name", validatedName);
+
+			const result = await updateTeamName(formData);
+
+			if (result.success) {
+				setTeamName(validatedName);
+				setIsEditingName(false);
+			} else {
+				setError("Failed to update team name");
+				console.error("Failed to update team name");
+			}
+		} catch (error) {
+			if (error instanceof Error) {
+				setError(error.message);
+			}
+			console.error("Error:", error);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	const handleCancelTeamName = () => {
+		setTempTeamName(teamName);
+		setIsEditingName(false);
+		setError("");
+	};
+
+	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setError("");
+		setTempTeamName(e.target.value);
+	};
+
+	return (
+		<Card title="Team name">
+			<div className="flex flex-col gap-2">
+				<div className="flex items-center gap-2">
+					{isEditingName ? (
+						<>
+							<Input
+								value={tempTeamName}
+								onChange={handleChange}
+								className="w-full"
+								disabled={isLoading}
+							/>
+							<Button
+								className="shrink-0 h-8 w-8 rounded-full p-0"
+								onClick={handleSaveTeamName}
+								disabled={isLoading || !!error}
+							>
+								<Check className="h-4 w-4" />
+							</Button>
+							<Button
+								className="shrink-0 h-8 w-8 rounded-full p-0"
+								onClick={handleCancelTeamName}
+								disabled={isLoading}
+							>
+								<X className="h-4 w-4" />
+							</Button>
+						</>
+					) : (
+						<>
+							<span className="text-lg">{teamName}</span>
+							<Button
+								className="shrink-0 h-8 w-8 rounded-full p-0"
+								onClick={() => setIsEditingName(true)}
+							>
+								<Pencil className="h-4 w-4" />
+							</Button>
+						</>
+					)}
+				</div>
+
+				{error && <p className="text-sm text-destructive">{error}</p>}
+			</div>
+		</Card>
+	);
+}

--- a/app/(main)/settings/team/team-name.tsx
+++ b/app/(main)/settings/team/team-name.tsx
@@ -1,0 +1,8 @@
+import { getTeamName } from "./actions";
+import { TeamNameForm } from "./team-name-form";
+
+export async function TeamName() {
+	const teamName = await getTeamName();
+
+	return <TeamNameForm name={teamName} />;
+}


### PR DESCRIPTION
## Summary
Added interactive team name editing functionality in the settings page. This includes real-time validation, error handling, and server-side updates using Server Actions.

## Related Issue
N/A

## Changes
- Added `actions.ts` for server-side operations
  - Implemented `getTeamName` action for fetching team data
  - Implemented `updateTeamName` action with revalidation
- Added team name editing components
  - Created `team-name.tsx` for interactive editing UI
  - Implemented input validation (1-256 characters)
  - Added real-time error feedback
- Updated settings page layout to include team name editing section

## Testing
- Verified team name updates successfully persist in database
- Confirmed validation works for:
  - Empty input (shows error)
  - Input exceeding 256 characters (shows error)
  - Valid input (updates successfully)
- Tested revalidation functionality after updates

## Other Information
- Uses valibot for input validation
- Implements optimistic updates with error handling
- Uses Server Actions for data mutations
- Maintains consistent UI/UX with the existing components