### PR TITLE
Skip checking subscription if freePlanFlag is enabled

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { retrieveActiveStripeSubscriptionBySupabaseUserId } from "@/services/accounts/actions";
 import { NextResponse } from "next/server";
+import { freePlanFlag } from "./flags";
 import { supabaseMiddleware } from "./lib/supabase";
 import { isEmailFromRoute06 } from "./lib/utils";
 
@@ -9,6 +10,12 @@ export default supabaseMiddleware(async (user, request) => {
 		const url = request.nextUrl.clone();
 		url.pathname = "/login";
 		return NextResponse.redirect(url);
+	}
+
+	// Users can use giselle without subscription if the free plan is enabled
+	const freePlanEnabled = await freePlanFlag();
+	if (freePlanEnabled) {
+		return;
 	}
 
 	// Proceeding to check the user's subscription status since the email is not from the route06.co.jp


### PR DESCRIPTION
## Summary
Fix https://github.com/giselles-ai/giselle/pull/126 logic bug.

I've deleted `!isEmailFromRoute06` condition unintentionally.

## Related Issue
- https://github.com/giselles-ai/giselle/pull/126
- https://github.com/giselles-ai/giselle/pull/133

## Testing

#### FreePlanFlag => on
- [x] User: `@route06.co.jp`, subscription: no -> no redirection
- [x] User: `@giselles.ai`, subscription: yes -> no redirection
- [x] User: `@giselles.ai`, subscription: no -> no redirection

#### FreePlanFlag => off
- [x] User: `@route06.co.jp`, subscription: no -> no redirection
- [x] User: `@giselles.ai`, subscription: no -> redirect
- [x] User: `@giselles.ai`, subscription: yes -> no redirection
