### PR TITLE
Create agent(v2)

### DIFF
--- a/app/(main)/agents/v2.tsx
+++ b/app/(main)/agents/v2.tsx
@@ -44,7 +44,12 @@ async function AgentList({
 		);
 	}
 	return (
-		<div>
+		<div className="mt-[24px] px-[16px]">
+			<div className="flex justify-end">
+				<Button type="button" onClick={createAgentAction} className="w-[200px]">
+					Create an agent
+				</Button>
+			</div>
 			{dbAgents.map((agent) => (
 				<div key={agent.id}>
 					<Link href={`/p/${agent.id}/canary`}>

--- a/app/(main)/agents/v2.tsx
+++ b/app/(main)/agents/v2.tsx
@@ -1,21 +1,95 @@
+import { getCurrentTeam } from "@/app/(auth)/lib";
+import { Button } from "@/components/ui/button";
 import { agents, db, supabaseUserMappings, teamMemberships } from "@/drizzle";
 import { getUser } from "@/lib/supabase";
-import { eq } from "drizzle-orm";
+import { createId } from "@paralleldrive/cuid2";
+import { put } from "@vercel/blob";
+import { and, eq, isNotNull } from "drizzle-orm";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { vercelBlobGraphFolder } from "../../(playground)/p/[agentId]/canary/constants";
+import {
+	initGraph,
+	pathJoin,
+} from "../../(playground)/p/[agentId]/canary/utils";
 
-async function getAgents(userId: string) {
-	return await db
-		.select({ agents })
+async function AgentList({
+	userId,
+	createAgentAction,
+}: { userId: string; createAgentAction: () => void }) {
+	const dbAgents = await db
+		.select({ id: agents.id, name: agents.name })
 		.from(agents)
 		.innerJoin(teamMemberships, eq(agents.teamDbId, teamMemberships.teamDbId))
 		.innerJoin(
 			supabaseUserMappings,
 			eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
 		)
-		.where(eq(supabaseUserMappings.supabaseUserId, userId));
+		.where(
+			and(
+				eq(supabaseUserMappings.supabaseUserId, userId),
+				isNotNull(agents.graphUrl),
+			),
+		);
+	if (dbAgents.length === 0) {
+		return (
+			<div className="flex justify-center items-center h-full">
+				<div className="grid gap-[12px] justify-center text-center">
+					<div>No agents found</div>
+					<Button type="button" onClick={createAgentAction}>
+						Create an agent
+					</Button>
+				</div>
+			</div>
+		);
+	}
+	return (
+		<div>
+			{dbAgents.map((agent) => (
+				<div key={agent.id}>
+					<Link href={`/p/${agent.id}/canary`}>
+						{agent.name ?? "Unname Agent"}
+					</Link>
+				</div>
+			))}
+		</div>
+	);
 }
 export async function AgentListV2() {
 	const user = await getUser();
-	const agents = await getAgents(user.id);
+	async function createAgentAction() {
+		"use server";
 
-	return <div>{agents.length}</div>;
+		const graph = initGraph();
+		const agentId = `agnt_${createId()}` as const;
+		const { url } = await put(
+			pathJoin(vercelBlobGraphFolder, `${graph.id}.json`),
+			JSON.stringify(graph),
+			{
+				access: "public",
+			},
+		);
+		const team = await getCurrentTeam();
+		await db.insert(agents).values({
+			id: agentId,
+			teamDbId: team.dbId,
+			graphUrl: url,
+			graphv2: {
+				agentId,
+				nodes: [],
+				xyFlow: {
+					nodes: [],
+					edges: [],
+				},
+				connectors: [],
+				artifacts: [],
+				webSearches: [],
+				mode: "edit",
+				flowIndexes: [],
+			},
+		});
+		redirect(`/p/${agentId}`);
+	}
+
+	return <AgentList userId={user.id} createAgentAction={createAgentAction} />;
 }

--- a/app/(playground)/p/[agentId]/canary/constants.ts
+++ b/app/(playground)/p/[agentId]/canary/constants.ts
@@ -1,1 +1,2 @@
 export const vercelBlobFileFolder = "canary/files";
+export const vercelBlobGraphFolder = "canary/graphs";

--- a/app/(playground)/p/[agentId]/canary/loading.tsx
+++ b/app/(playground)/p/[agentId]/canary/loading.tsx
@@ -1,0 +1,15 @@
+import bg from "./components/bg.png";
+
+export default function Loading() {
+	return (
+		<div
+			className="w-screen h-screen bg-black-100"
+			style={{
+				backgroundImage: `url(${bg.src})`,
+				backgroundPositionX: "center",
+				backgroundPositionY: "center",
+				backgroundSize: "cover",
+			}}
+		/>
+	);
+}

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -1,16 +1,35 @@
+import { db } from "@/drizzle";
 import { playgroundV2Flag } from "@/flags";
 import { notFound } from "next/navigation";
+import type { AgentId } from "../beta-proto/types";
 import { Editor } from "./components/editor";
 import { artifacts, connections, nodes } from "./mockData";
+import type { Graph } from "./types";
 import { createGraphId } from "./utils";
 
 // This page is experimental. it requires PlaygroundV2Flag to show this page
-export default async function Page() {
-	const playgroundV2 = await playgroundV2Flag();
+export default async function Page({
+	params,
+}: {
+	params: Promise<{ agentId: AgentId }>;
+}) {
+	const [playgroundV2, { agentId }] = await Promise.all([
+		playgroundV2Flag(),
+		params,
+	]);
 	if (!playgroundV2) {
 		return notFound();
 	}
-	return (
-		<Editor graph={{ id: createGraphId(), nodes, connections, artifacts }} />
+	const agent = await db.query.agents.findFirst({
+		where: (agents, { eq }) => eq(agents.id, agentId),
+	});
+	// TODO: Remove graphUrl null check when add notNull constrain to graphUrl column
+	if (agent === undefined || agent.graphUrl === null) {
+		throw new Error("Agent not found");
+	}
+	// TODO: Add schema validation to verify parsed graph matches expected shape
+	const graph = await fetch(agent.graphUrl).then(
+		(res) => res.json() as unknown as Graph,
 	);
+	return <Editor graph={graph} />;
 }

--- a/app/(playground)/p/[agentId]/canary/utils.ts
+++ b/app/(playground)/p/[agentId]/canary/utils.ts
@@ -7,6 +7,7 @@ import type {
 	ConnectionId,
 	File,
 	FileId,
+	Graph,
 	GraphId,
 	Node,
 	NodeHandleId,
@@ -145,4 +146,13 @@ export function pathJoin(...parts: string[]): string {
 	});
 
 	return processedParts.join("/");
+}
+
+export function initGraph(): Graph {
+	return {
+		id: createGraphId(),
+		nodes: [],
+		connections: [],
+		artifacts: [],
+	};
 }

--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/services/external/github";
 import "@xyflow/react/dist/style.css";
 import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { Playground } from "./beta-proto/component";
 import type { Repository } from "./beta-proto/github-integration/context";
 import type { Graph } from "./beta-proto/graph/types";
@@ -135,7 +135,7 @@ export default async function AgentPlaygroundPage({
 	const gitHubIntegrationFlag = await getGitHubIntegrationFlag();
 	const playgroundV2Flag = await getPlaygroundV2Flag();
 	if (playgroundV2Flag) {
-		return <PlaygroundV2Page />;
+		return redirect(`/p/${agentId}/canary`);
 	}
 
 	const agent = await getAgent(agentId);


### PR DESCRIPTION
- `/agents`.

    - Only agents with a graphUrl are displayed.
    - Enabled to create agents.
      
- `/p/:id/canary`.

    - Display the graphUrl initially by fetching it.