### PR TITLE
[feat] Implement versioned graph persistence with UI improvements

### DIFF
--- a/app/(main)/agents/v2.tsx
+++ b/app/(main)/agents/v2.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { vercelBlobGraphFolder } from "../../(playground)/p/[agentId]/canary/constants";
 import {
+	buildGraphPath,
 	initGraph,
 	pathJoin,
 } from "../../(playground)/p/[agentId]/canary/utils";
@@ -67,13 +68,10 @@ export async function AgentListV2() {
 
 		const graph = initGraph();
 		const agentId = `agnt_${createId()}` as const;
-		const { url } = await put(
-			pathJoin(vercelBlobGraphFolder, `${graph.id}.json`),
-			JSON.stringify(graph),
-			{
-				access: "public",
-			},
-		);
+		const { url } = await put(buildGraphPath(graph.id), JSON.stringify(graph), {
+			access: "public",
+			addRandomSuffix: false,
+		});
 		const team = await getCurrentTeam();
 		await db.insert(agents).values({
 			id: agentId,

--- a/app/(main)/agents/v2.tsx
+++ b/app/(main)/agents/v2.tsx
@@ -1,4 +1,5 @@
 import { getCurrentTeam } from "@/app/(auth)/lib";
+import { putGraph } from "@/app/(playground)/p/[agentId]/canary/actions";
 import { Button } from "@/components/ui/button";
 import { agents, db, supabaseUserMappings, teamMemberships } from "@/drizzle";
 import { getUser } from "@/lib/supabase";
@@ -68,10 +69,7 @@ export async function AgentListV2() {
 
 		const graph = initGraph();
 		const agentId = `agnt_${createId()}` as const;
-		const { url } = await put(buildGraphPath(graph.id), JSON.stringify(graph), {
-			access: "public",
-			addRandomSuffix: false,
-		});
+		const { url } = await putGraph(graph);
 		const team = await getCurrentTeam();
 		await db.insert(agents).values({
 			id: agentId,

--- a/app/(playground)/p/[agentId]/canary/actions.ts
+++ b/app/(playground)/p/[agentId]/canary/actions.ts
@@ -8,7 +8,7 @@ import HandleBars from "handlebars";
 import { UnstructuredClient } from "unstructured-client";
 import { Strategy } from "unstructured-client/sdk/models/shared";
 import * as v from "valibot";
-import { vercelBlobFileFolder } from "./constants";
+import { vercelBlobFileFolder, vercelBlobGraphFolder } from "./constants";
 import { textGenerationPrompt } from "./prompts";
 import type {
 	FileId,

--- a/app/(playground)/p/[agentId]/canary/actions.ts
+++ b/app/(playground)/p/[agentId]/canary/actions.ts
@@ -20,7 +20,12 @@ import type {
 	TextArtifactObject,
 	TextGenerateActionContent,
 } from "./types";
-import { elementsToMarkdown, pathJoin, resolveLanguageModel } from "./utils";
+import {
+	buildGraphPath,
+	elementsToMarkdown,
+	pathJoin,
+	resolveLanguageModel,
+} from "./utils";
 
 const artifactSchema = v.object({
 	plan: v.pipe(
@@ -256,4 +261,10 @@ export async function parse(id: FileId, name: string, blobUrl: string) {
 	);
 
 	return vercelBlob;
+}
+
+export async function putGraph(graph: Graph) {
+	return await put(buildGraphPath(graph.id), JSON.stringify(graph), {
+		access: "public",
+	});
 }

--- a/app/(playground)/p/[agentId]/canary/components/editor.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/editor.tsx
@@ -30,31 +30,13 @@ import { Node, PreviewNode } from "./node";
 import { PropertiesPanel } from "./properties-panel";
 import { Toolbar } from "./toolbar";
 
-interface EditorProps {
-	graph: Graph;
-}
-export function Editor(props: EditorProps) {
-	return (
-		<GraphContextProvider defaultGraph={props.graph}>
-			<PropertiesPanelProvider>
-				<ReactFlowProvider>
-					<ToolbarContextProvider>
-						<MousePositionProvider>
-							<EditorInner />
-						</MousePositionProvider>
-					</ToolbarContextProvider>
-				</ReactFlowProvider>
-			</PropertiesPanelProvider>
-		</GraphContextProvider>
-	);
-}
 const nodeTypes = {
 	giselleNode: Node,
 };
 const edgeTypes = {
 	giselleEdge: Edge,
 };
-function EditorInner() {
+export function Editor() {
 	const { graph, dispatch } = useGraph();
 	const { selectedTool, reset } = useToolbar();
 	const reactFlowInstance = useReactFlow<Node, Edge>();

--- a/app/(playground)/p/[agentId]/canary/components/properties-panel.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/properties-panel.tsx
@@ -22,6 +22,7 @@ import {
 import { DocumentIcon } from "../../beta-proto/components/icons/document";
 import { PanelCloseIcon } from "../../beta-proto/components/icons/panel-close";
 import { PanelOpenIcon } from "../../beta-proto/components/icons/panel-open";
+import { WilliIcon } from "../../beta-proto/components/icons/willi";
 import { action, parse } from "../actions";
 import { vercelBlobFileFolder } from "../constants";
 import {
@@ -1357,6 +1358,14 @@ function TabContentGenerateTextResult({
 				</Dialog>
 			)}
 			<div>{artifact.object.messages.description}</div>
+
+			{artifact.type === "streamArtifact" && (
+				<div className="flex gap-[12px]">
+					<WilliIcon className="w-[20px] h-[20px] fill-black-40 animate-[pop-pop_1.8s_steps(1)_infinite]" />
+					<WilliIcon className="w-[20px] h-[20px] fill-black-40 animate-[pop-pop_1.8s_steps(1)_0.6s_infinite]" />
+					<WilliIcon className="w-[20px] h-[20px] fill-black-40 animate-[pop-pop_1.8s_steps(1)_1.2s_infinite]" />
+				</div>
+			)}
 
 			{artifact.type === "generatedArtifact" && (
 				<div>

--- a/app/(playground)/p/[agentId]/canary/components/properties-panel.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/properties-panel.tsx
@@ -260,7 +260,7 @@ function DialogFooter(props: HTMLAttributes<HTMLDivElement>) {
 DialogFooter.displayName = "DialogHeader";
 
 export function PropertiesPanel() {
-	const { graph, dispatch } = useGraph();
+	const { graph, dispatch, flush } = useGraph();
 	const selectedNode = useSelectedNode();
 	const { open, setOpen, tab, setTab } = usePropertiesPanel();
 	return (
@@ -350,8 +350,10 @@ export function PropertiesPanel() {
 												},
 											});
 											setTab("Result");
+											const latestGraphUrl = await flush();
+											console.log(latestGraphUrl);
 											const stream = await action(
-												"https://aj9qps90wwygtg5h.public.blob.vercel-storage.com/canary/mockData-sf23dFVJkNoaXv3Di56N40Pt83JBSr.json",
+												latestGraphUrl,
 												selectedNode.id,
 											);
 

--- a/app/(playground)/p/[agentId]/canary/contexts/graph.tsx
+++ b/app/(playground)/p/[agentId]/canary/contexts/graph.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
 	type ReactNode,
 	createContext,
@@ -178,11 +180,11 @@ function graphReducer(graph: Graph, action: GraphAction): Graph {
 export function GraphContextProvider({
 	children,
 	defaultGraph,
-	onPersist,
+	onPersistAction,
 }: {
 	children: ReactNode;
 	defaultGraph: Graph;
-	onPersist: (graph: Graph) => Promise<void>;
+	onPersistAction: (graph: Graph) => Promise<void>;
 }) {
 	const graphRef = useRef(defaultGraph);
 	const [graph, setGraph] = useState(graphRef.current);
@@ -191,11 +193,11 @@ export function GraphContextProvider({
 	const persist = useCallback(async () => {
 		isPendingPersistRef.current = false;
 		try {
-			await onPersist(graphRef.current);
+			await onPersistAction(graphRef.current);
 		} catch (error) {
 			console.error("Failed to persist graph:", error);
 		}
-	}, [onPersist]);
+	}, [onPersistAction]);
 
 	const flush = useCallback(async () => {
 		if (persistTimeoutRef.current) {

--- a/app/(playground)/p/[agentId]/canary/contexts/mouse-position.tsx
+++ b/app/(playground)/p/[agentId]/canary/contexts/mouse-position.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, useEffect, useState } from "react";
 
 interface MousePosition {

--- a/app/(playground)/p/[agentId]/canary/contexts/properties-panel.tsx
+++ b/app/(playground)/p/[agentId]/canary/contexts/properties-panel.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type ReactNode, createContext, useContext, useState } from "react";
 
 interface PropertiesPanelContextType {

--- a/app/(playground)/p/[agentId]/canary/contexts/toolbar.tsx
+++ b/app/(playground)/p/[agentId]/canary/contexts/toolbar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type ReactNode, createContext, useContext, useState } from "react";
 import type { Tool } from "../types";
 

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -5,6 +5,7 @@ import { ReactFlowProvider } from "@xyflow/react";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import type { AgentId } from "../beta-proto/types";
+import { putGraph } from "./actions";
 import { Editor } from "./components/editor";
 import { GraphContextProvider } from "./contexts/graph";
 import { MousePositionProvider } from "./contexts/mouse-position";
@@ -45,9 +46,7 @@ export default async function Page({
 
 	async function persistGraph(graph: Graph) {
 		"use server";
-		const { url } = await put(buildGraphPath(graph.id), JSON.stringify(graph), {
-			access: "public",
-		});
+		const { url } = await putGraph(graph);
 		await db
 			.update(agents)
 			.set({

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -1,11 +1,17 @@
-import { db } from "@/drizzle";
+import { agents, db } from "@/drizzle";
 import { playgroundV2Flag } from "@/flags";
+import { del, list, put } from "@vercel/blob";
+import { ReactFlowProvider } from "@xyflow/react";
+import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import type { AgentId } from "../beta-proto/types";
 import { Editor } from "./components/editor";
-import { artifacts, connections, nodes } from "./mockData";
+import { GraphContextProvider } from "./contexts/graph";
+import { MousePositionProvider } from "./contexts/mouse-position";
+import { PropertiesPanelProvider } from "./contexts/properties-panel";
+import { ToolbarContextProvider } from "./contexts/toolbar";
 import type { Graph } from "./types";
-import { createGraphId } from "./utils";
+import { buildGraphPath, createGraphId, pathJoin } from "./utils";
 
 // This page is experimental. it requires PlaygroundV2Flag to show this page
 export default async function Page({
@@ -31,5 +37,41 @@ export default async function Page({
 	const graph = await fetch(agent.graphUrl).then(
 		(res) => res.json() as unknown as Graph,
 	);
-	return <Editor graph={graph} />;
+
+	async function persistGraph(graph: Graph) {
+		"use server";
+		const { url } = await put(buildGraphPath(graph.id), JSON.stringify(graph), {
+			access: "public",
+		});
+		await db
+			.update(agents)
+			.set({
+				graphUrl: url,
+			})
+			.where(eq(agents.id, agentId));
+		const blobList = await list({
+			prefix: buildGraphPath(graph.id),
+		});
+
+		const oldBlobUrls = blobList.blobs
+			.filter((blob) => blob.url !== url)
+			.map((blob) => blob.url);
+		if (oldBlobUrls.length > 0) {
+			await del(oldBlobUrls);
+		}
+	}
+
+	return (
+		<GraphContextProvider defaultGraph={graph} onPersistAction={persistGraph}>
+			<PropertiesPanelProvider>
+				<ReactFlowProvider>
+					<ToolbarContextProvider>
+						<MousePositionProvider>
+							<Editor />
+						</MousePositionProvider>
+					</ToolbarContextProvider>
+				</ReactFlowProvider>
+			</PropertiesPanelProvider>
+		</GraphContextProvider>
+	);
 }

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -1,6 +1,6 @@
 import { agents, db } from "@/drizzle";
 import { playgroundV2Flag } from "@/flags";
-import { del, list, put } from "@vercel/blob";
+import { del, list } from "@vercel/blob";
 import { ReactFlowProvider } from "@xyflow/react";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
@@ -12,12 +12,7 @@ import { MousePositionProvider } from "./contexts/mouse-position";
 import { PropertiesPanelProvider } from "./contexts/properties-panel";
 import { ToolbarContextProvider } from "./contexts/toolbar";
 import type { Graph } from "./types";
-import {
-	buildGraphFolderPath,
-	buildGraphPath,
-	createGraphId,
-	pathJoin,
-} from "./utils";
+import { buildGraphFolderPath } from "./utils";
 
 // This page is experimental. it requires PlaygroundV2Flag to show this page
 export default async function Page({

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -11,7 +11,12 @@ import { MousePositionProvider } from "./contexts/mouse-position";
 import { PropertiesPanelProvider } from "./contexts/properties-panel";
 import { ToolbarContextProvider } from "./contexts/toolbar";
 import type { Graph } from "./types";
-import { buildGraphPath, createGraphId, pathJoin } from "./utils";
+import {
+	buildGraphFolderPath,
+	buildGraphPath,
+	createGraphId,
+	pathJoin,
+} from "./utils";
 
 // This page is experimental. it requires PlaygroundV2Flag to show this page
 export default async function Page({
@@ -50,7 +55,7 @@ export default async function Page({
 			})
 			.where(eq(agents.id, agentId));
 		const blobList = await list({
-			prefix: buildGraphPath(graph.id),
+			prefix: buildGraphFolderPath(graph.id),
 		});
 
 		const oldBlobUrls = blobList.blobs

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -58,10 +58,15 @@ export default async function Page({
 		if (oldBlobUrls.length > 0) {
 			await del(oldBlobUrls);
 		}
+		return url;
 	}
 
 	return (
-		<GraphContextProvider defaultGraph={graph} onPersistAction={persistGraph}>
+		<GraphContextProvider
+			defaultGraph={graph}
+			onPersistAction={persistGraph}
+			defaultGraphUrl={agent.graphUrl}
+		>
 			<PropertiesPanelProvider>
 				<ReactFlowProvider>
 					<ToolbarContextProvider>

--- a/app/(playground)/p/[agentId]/canary/utils.test.ts
+++ b/app/(playground)/p/[agentId]/canary/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { pathJoin } from "./utils";
+
+describe("pathJoin", () => {
+	test("a, b, c", () => {
+		expect(pathJoin("a", "b", "c")).toBe("a/b/c");
+	});
+	test("a, b/, /c", () => {
+		expect(pathJoin("a", "b/", "/c")).toBe("a/b/c");
+	});
+	test("nested", () => {
+		const folder = pathJoin("a", "b");
+		const file = pathJoin(folder, "c.json");
+		expect(file).toBe("a/b/c.json");
+	});
+});

--- a/app/(playground)/p/[agentId]/canary/utils.ts
+++ b/app/(playground)/p/[agentId]/canary/utils.ts
@@ -2,6 +2,7 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { openai } from "@ai-sdk/openai";
 import { createId } from "@paralleldrive/cuid2";
 import type { LanguageModelV1 } from "ai";
+import { vercelBlobGraphFolder } from "./constants";
 import type {
 	ArtifactId,
 	ConnectionId,
@@ -155,4 +156,8 @@ export function initGraph(): Graph {
 		connections: [],
 		artifacts: [],
 	};
+}
+
+export function buildGraphPath(graphId: GraphId) {
+	return pathJoin(vercelBlobGraphFolder, graphId, "graph.json");
 }

--- a/app/(playground)/p/[agentId]/canary/utils.ts
+++ b/app/(playground)/p/[agentId]/canary/utils.ts
@@ -158,6 +158,9 @@ export function initGraph(): Graph {
 	};
 }
 
+export function buildGraphFolderPath(graphId: GraphId) {
+	return pathJoin(vercelBlobGraphFolder, graphId);
+}
 export function buildGraphPath(graphId: GraphId) {
-	return pathJoin(vercelBlobGraphFolder, graphId, "graph.json");
+	return pathJoin(buildGraphFolderPath(graphId), "graph.json");
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/f9dda6eb-2d8d-4652-9359-6be4f7508886


## Changes
- Add versioned graph storage with automatic cleanup of old versions
- Implement auto-save behavior with debounced persistence (500ms)
- Add loading animations for stream artifacts
- Centralize graph persistence logic in server actions
- Improve graph path handling with dedicated utilities
- Enhance GraphContext with persistence capabilities
- Clean up unused imports and improve code organization

## Why
These changes significantly improve the graph system's reliability and user experience:
1. Versioned storage provides better data management and recovery options
2. Auto-save prevents data loss while optimizing storage operations
3. Loading animations give users clear feedback during stream processing
4. Centralized persistence logic reduces code duplication and improves maintainability

## Testing

> [!NOTE]
> Please turn `playground-v2` flag on to verify the following steps

- [ ] Visit agents list `/agents`
- [ ] Click the `Create an agent` button and transition to the Playground page
- [ ] Add Text Generator node
- [ ] Open the Property Panel and Click `Generate` button
- [ ] Streaming generate text

## Technical Details

### Graph Persistence
- Graph states are automatically saved after a 500ms debounce period
- Manual flush capability available for immediate persistence
- Server-side actions handle all storage operations
- Old versions are automatically cleaned up

### UI Improvements
- Added animated Willi icons for stream artifact feedback
- Implemented pop-pop animation with staggered timing
- Maintained consistent styling with existing UI elements

## Breaking Changes
None. All changes maintain backwards compatibility with existing implementations.
