### PR TITLE
[feat] Auto-open properties panel on node selection

### DIFF
--- a/app/(playground)/p/[agentId]/canary/components/editor.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/editor.tsx
@@ -83,7 +83,7 @@ export function Editor() {
 			),
 		);
 	}, [graph.connections, reactFlowInstance.setEdges]);
-	const { setTab } = usePropertiesPanel();
+	const { setTab, setOpen } = usePropertiesPanel();
 	return (
 		<div className="w-full h-screen">
 			<ReactFlow<Node, Edge>
@@ -113,6 +113,7 @@ export function Editor() {
 									},
 								});
 								if (nodeChange.selected) {
+									setOpen(true);
 									switch (node.content.type) {
 										case "textGeneration":
 											setTab("Prompt");

--- a/app/(playground)/p/[agentId]/canary/components/editor.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/editor.tsx
@@ -16,7 +16,7 @@ import { useGraph } from "../contexts/graph";
 import { useMousePosition } from "../contexts/mouse-position";
 import { usePropertiesPanel } from "../contexts/properties-panel";
 import { useToolbar } from "../contexts/toolbar";
-import type { ConnectionId, NodeId, Tool } from "../types";
+import type { NodeId, Tool } from "../types";
 import { createNodeId, isTextGeneration } from "../utils";
 import { Edge } from "./edge";
 import { Node, PreviewNode } from "./node";


### PR DESCRIPTION
## Changes
- Implemented automatic properties panel opening when selecting nodes
  - Added `setOpen` control from usePropertiesPanel
  - Connected node selection events to panel visibility
  - Preserved existing tab selection behavior
- Cleaned up code by removing unused ConnectionId type import

