### PR TITLE
feat(ui): Add keyboard shortcuts for toolbar actions

### DIFF
--- a/app/(playground)/p/[agentId]/canary/components/editor.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/editor.tsx
@@ -19,6 +19,7 @@ import { useToolbar } from "../contexts/toolbar";
 import type { NodeId, Tool } from "../types";
 import { createNodeId, isTextGeneration } from "../utils";
 import { Edge } from "./edge";
+import { KeyboardShortcut } from "./keyboard-shortcut";
 import { Node, PreviewNode } from "./node";
 import { PropertiesPanel } from "./properties-panel";
 import { Toolbar } from "./toolbar";
@@ -31,7 +32,7 @@ const edgeTypes = {
 };
 export function Editor() {
 	const { graph, dispatch } = useGraph();
-	const { selectedTool, reset } = useToolbar();
+	const { selectTool, selectedTool, reset } = useToolbar();
 	const reactFlowInstance = useReactFlow<Node, Edge>();
 	const updateNodeInternals = useUpdateNodeInternals();
 	useEffect(() => {
@@ -301,6 +302,7 @@ export function Editor() {
 					<FloatingNodePreview tool={selectedTool} />
 				)}
 			</ReactFlow>
+			<KeyboardShortcut />
 		</div>
 	);
 }

--- a/app/(playground)/p/[agentId]/canary/components/keyboard-shortcut.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/keyboard-shortcut.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode, useEffect } from "react";
+import { useToolbar } from "../contexts/toolbar";
+
+export function KeyboardShortcut() {
+	const { selectTool } = useToolbar();
+
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			switch (event.key) {
+				case "v":
+					selectTool("move");
+					break;
+				case "t":
+					selectTool("addTextNode");
+					break;
+				case "f":
+					selectTool("addFileNode");
+					break;
+				case "g":
+					selectTool("addTextGenerationNode");
+					break;
+			}
+			if (event.code === "Escape") {
+				selectTool("move");
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [selectTool]);
+
+	return <></>;
+}

--- a/app/(playground)/p/[agentId]/canary/components/toolbar.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/toolbar.tsx
@@ -11,9 +11,13 @@ import type { Tool } from "../types";
 function ToggleGroupItem({
 	tooltip,
 	value,
+	shortcut,
 
 	...props
-}: ComponentProps<typeof ToggleGroup.Item> & { tooltip: string }) {
+}: ComponentProps<typeof ToggleGroup.Item> & {
+	tooltip: string;
+	shortcut?: string;
+}) {
 	const { selectedTool } = useToolbar();
 	return (
 		<TooltipPrimitive.Provider>
@@ -29,9 +33,10 @@ function ToggleGroupItem({
 				<TooltipPrimitive.Portal>
 					<TooltipPrimitive.Content
 						sideOffset={18}
-						className="z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+						className="z-50 overflow-hidden flex justify-between gap-[8px] rounded-[6px] bg-black-30 px-[8px] py-[2px] text-xs text-black-100 shadow-sm animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
 					>
-						{tooltip}
+						<p>{tooltip}</p>
+						<p className="uppercase text-black-70">{shortcut}</p>
 					</TooltipPrimitive.Content>
 				</TooltipPrimitive.Portal>
 			</TooltipPrimitive.Root>
@@ -52,27 +57,23 @@ export function Toolbar() {
 					onValueChange={(value) => {
 						selectTool(value as Tool["action"]);
 					}}
-					onKeyUp={(key) => {
-						if (key.code === "Escape") {
-							selectTool("move");
-						}
-					}}
 				>
 					<div className="flex gap-[12px]">
-						<ToggleGroupItem value="move" tooltip="Move">
+						<ToggleGroupItem value="move" tooltip="Move" shortcut="v">
 							<MousePointer2Icon
 								className={"w-[24px] h-[24px] text-black-30"}
 							/>
 						</ToggleGroupItem>
-						<ToggleGroupItem value="addTextNode" tooltip="Text">
+						<ToggleGroupItem value="addTextNode" tooltip="Text" shortcut="t">
 							<LetterTextIcon className={"w-[24px] h-[24px] text-black-30"} />
 						</ToggleGroupItem>
-						<ToggleGroupItem value="addFileNode" tooltip="File">
+						<ToggleGroupItem value="addFileNode" tooltip="File" shortcut="f">
 							<FileUpIcon className={"w-[24px] h-[24px] text-black-30 "} />
 						</ToggleGroupItem>
 						<ToggleGroupItem
 							value="addTextGenerationNode"
 							tooltip="Text Generator"
+							shortcut="g"
 						>
 							<TextGenerationIcon
 								className={"w-[24px] h-[24px] text-black-30 fill-current"}


### PR DESCRIPTION
Implement keyboard shortcuts for quick tool selection and enhance tooltip display to show available shortcuts.

- Add new KeyboardShortcut component to handle keyboard events
- Implement shortcuts:
  - v: Move tool
  - t: Text node
  - f: File node
  - g: Text Generator node
  - Escape: Reset to move tool
- Update tooltips to display shortcut hints
- Improve tooltip styling with better contrast and spacing

This improves workflow efficiency by allowing quick tool switching via keyboard commands while maintaining discoverability through visual hints.
