### PR TITLE
fix(shortcuts): Prevent keyboard shortcuts in form inputs

### DIFF
--- a/app/(playground)/p/[agentId]/canary/components/keyboard-shortcut.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/keyboard-shortcut.tsx
@@ -1,11 +1,19 @@
 import { type ReactNode, useEffect } from "react";
 import { useToolbar } from "../contexts/toolbar";
 
+const ignoredTags = ["INPUT", "TEXTAREA", "SELECT"];
+
 export function KeyboardShortcut() {
 	const { selectTool } = useToolbar();
 
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
+			const activeElement = document.activeElement;
+			const tagName = activeElement?.tagName;
+
+			if (tagName !== undefined && ignoredTags.includes(tagName)) {
+				return;
+			}
 			switch (event.key) {
 				case "v":
 					selectTool("move");


### PR DESCRIPTION
Add check to ignore keyboard shortcuts when focus is on input elements:
- Add list of ignored HTML tags (INPUT, TEXTAREA, SELECT)
- Check active element before triggering shortcuts
- Prevents unintended tool switching while typing

This fixes potential conflicts between keyboard shortcuts and text input, improving usability when editing text fields or forms.
