### PR TITLE
Fix instrumentation on external service usage

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -81,7 +81,10 @@ ${sourcesToText(sources)}
 					logger.info(
 						{
 							externalServiceName: "openai",
-							tokenConsumed: result.usage.totalTokens,
+							tokenConsumed: {
+								input: result.usage.promptTokens,
+								output: result.usage.completionTokens,
+	                                                },
 							duration,
 							measurementScope,
 							isR06User,

--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -84,7 +84,7 @@ ${sourcesToText(sources)}
 							tokenConsumed: {
 								input: result.usage.promptTokens,
 								output: result.usage.completionTokens,
-	                                                },
+							},
 							duration,
 							measurementScope,
 							isR06User,

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -95,7 +95,7 @@ ${sourcesToText(sources)}
 						tokenConsumed: {
 							input: result.usage.promptTokens,
 							output: result.usage.completionTokens,
-                                                },
+						},
 						duration,
 						measurementScope,
 						isR06User,
@@ -119,7 +119,11 @@ ${sourcesToText(sources)}
 
 		const searchResults = await Promise.all(
 			result.keywords.map((keyword) =>
-				withMeasurement<WebSearchResult[]>(logger, () => search(keyword), "tavily"),
+				withMeasurement<WebSearchResult[]>(
+					logger,
+					() => search(keyword),
+					"tavily",
+				),
 			),
 		)
 			.then((results) => [...new Set(results.flat())] as WebSearchResult[])

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -116,7 +116,7 @@ ${sourcesToText(sources)}
 
 		const searchResults = await Promise.all(
 			result.keywords.map((keyword) =>
-				withMeasurement<WebSearchResult[]>(() => search(keyword), "tavily"),
+				withMeasurement<WebSearchResult[]>(logger, () => search(keyword), "tavily"),
 			),
 		)
 			.then((results) => [...new Set(results.flat())] as WebSearchResult[])
@@ -185,6 +185,7 @@ ${sourcesToText(sources)}
 				for (const webSearchItem of webSearchItems) {
 					try {
 						const scrapeResponse = await withMeasurement<FirecrawlResponse>(
+							logger,
 							() =>
 								app.scrapeUrl(webSearchItem.url, {
 									formats: ["markdown"],

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -92,7 +92,10 @@ ${sourcesToText(sources)}
 				logger.info(
 					{
 						externalServiceName: "openai",
-						tokenConsumed: result.usage.totalTokens,
+						tokenConsumed: {
+							input: result.usage.promptTokens,
+							output: result.usage.completionTokens,
+                                                },
 						duration,
 						measurementScope,
 						isR06User,

--- a/lib/opentelemetry/log.ts
+++ b/lib/opentelemetry/log.ts
@@ -2,7 +2,7 @@ import { logger as pinoLogger } from "@/lib/logger";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { captureException } from "@sentry/nextjs";
-import type { RequestCountSchema, TokenConsumedSchema } from "./types";
+import type { LogSchema, OtelLoggerWrapper } from "./types";
 
 import type { AnyValue, Logger } from "@opentelemetry/api-logs";
 import { Resource } from "@opentelemetry/resources";
@@ -90,14 +90,6 @@ function getOrCreateLoggerProvider() {
 		sharedLoggerProvider.addLogRecordProcessor(pinoLogRecordProcessor);
 	}
 	return sharedLoggerProvider;
-}
-
-type LogSchema = TokenConsumedSchema | RequestCountSchema;
-
-interface OtelLoggerWrapper {
-	info: (obj: LogSchema, msg?: string) => void;
-	error: (obj: LogSchema | Error, msg?: string) => void;
-	debug: (obj: LogSchema, msg?: string) => void;
 }
 
 function createEmitLog(otelLogger: Logger) {

--- a/lib/opentelemetry/types.ts
+++ b/lib/opentelemetry/types.ts
@@ -26,3 +26,10 @@ const RequestCountSchema = BaseMetricsSchema.extend({
 
 export type TokenConsumedSchema = z.infer<typeof TokenConsumedSchema>;
 export type RequestCountSchema = z.infer<typeof RequestCountSchema>;
+export type LogSchema = TokenConsumedSchema | RequestCountSchema;
+
+export interface OtelLoggerWrapper {
+	info: (obj: LogSchema, msg?: string) => void;
+	error: (obj: LogSchema | Error, msg?: string) => void;
+	debug: (obj: LogSchema, msg?: string) => void;
+}

--- a/lib/opentelemetry/types.ts
+++ b/lib/opentelemetry/types.ts
@@ -17,7 +17,10 @@ const BaseMetricsSchema = z.object({
 });
 
 const TokenConsumedSchema = BaseMetricsSchema.extend({
-	tokenConsumed: z.number(), // Number of tokens consumed by the API request
+	tokenConsumed: z.object({
+		input: z.number(), // Number of tokens used in the prompt/input sent to the model
+		output: z.number(), // Number of tokens used in the response/output received from the model
+	}),
 });
 
 const RequestCountSchema = BaseMetricsSchema.extend({

--- a/lib/opentelemetry/wrapper.ts
+++ b/lib/opentelemetry/wrapper.ts
@@ -1,12 +1,12 @@
 import { getCurrentMeasurementScope, isRoute06User } from "@/app/(auth)/lib";
-import { captureError, createLogger } from "./log";
-import type { ExternalServiceName, RequestCountSchema } from "./types";
+import { captureError } from "./log";
+import type { ExternalServiceName, RequestCountSchema, OtelLoggerWrapper } from "./types";
 
 export async function withMeasurement<T>(
+	logger: OtelLoggerWrapper,
 	operation: () => Promise<T>,
 	externalServiceName: ExternalServiceName,
 ): Promise<T> {
-	const logger = createLogger(externalServiceName);
 	const startTime = performance.now();
 
 	try {

--- a/lib/opentelemetry/wrapper.ts
+++ b/lib/opentelemetry/wrapper.ts
@@ -1,6 +1,10 @@
 import { getCurrentMeasurementScope, isRoute06User } from "@/app/(auth)/lib";
 import { captureError } from "./log";
-import type { ExternalServiceName, RequestCountSchema, OtelLoggerWrapper } from "./types";
+import type {
+	ExternalServiceName,
+	OtelLoggerWrapper,
+	RequestCountSchema,
+} from "./types";
 
 export async function withMeasurement<T>(
 	logger: OtelLoggerWrapper,


### PR DESCRIPTION
## Summary

- token consumption will be measured separately by input/output to calculate cost correctly
- wrong value in `scope_name` attribute will be fixed

## Related Issue

- close #168

## Changes

- get input/output token consumption by using `promptTokens` and `completionTokens` of AI SDK response
- Quit creating multiple logger in single use case to avoid enbugging to common attribute

## Testing

- [x] confirmed the problems listed in #168 is fixed in the corresponding preview (private) environment ✅ 

## Other Information

- simple log parsing is needed to access input/output tokens in telemetry backend
![image](https://github.com/user-attachments/assets/e50a60b8-0d80-4074-ba14-9c5447b5d019)


