### PR TITLE
Update @vercel/flags

### DIFF
--- a/config/dependency_decisions.yml
+++ b/config/dependency_decisions.yml
@@ -49,13 +49,6 @@
     :why:
     :versions: []
     :when: 2024-09-18 06:46:06.140937000 Z
-- - :approve
-  - "@vercel/flags"
-  - :who:
-    :why: The license is none. Check https://github.com/giselles-ai/giselle/issues/12
-      later
-    :versions: []
-    :when: 2024-10-08 09:38:17.316315298 Z
 - - :permit
   - Zlib
   - :who:

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -1,6 +1,6 @@
 # giselle
 
-As of December  5, 2024  6:33am. 920 total
+As of December  5, 2024  6:53am. 920 total
 
 ## Summary
 * 675 MIT
@@ -3509,11 +3509,7 @@ The Vercel Blob JavaScript API client
 ##### Paths
 * /home/runner/work/giselle/giselle
 
-<a href="http://opensource.org/licenses/mit-license">MIT</a> manually approved
-
->The license is none. Check https://github.com/giselles-ai/giselle/issues/12 later
-
-><cite>  2024-10-08</cite>
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 Make the Vercel Toolbar aware of your feature flags and read overrides set by it
 

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -1,9 +1,9 @@
 # giselle
 
-As of December  4, 2024  3:26am. 919 total
+As of December  5, 2024  6:33am. 920 total
 
 ## Summary
-* 673 MIT
+* 675 MIT
 * 127 Apache 2.0
 * 62 ISC
 * 24 New BSD
@@ -16,7 +16,6 @@ As of December  4, 2024  3:26am. 919 total
 * 1 (MIT AND Zlib)
 * 1 BSD
 * 1 CC0 1.0 Universal
-* 1 unknown
 * 1 CC-BY-4.0
 * 1 (MIT OR CC0-1.0)
 * 1 (AFL-2.1 OR BSD-3-Clause)
@@ -2513,6 +2512,17 @@ Radix UI React Icon Set
 
 
 
+<a name="@radix-ui/react-toast"></a>
+### <a href="https://radix-ui.com/primitives">@radix-ui/react-toast</a> v1.2.2 (dependencies)
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
 <a name="@radix-ui/react-toggle"></a>
 ### <a href="https://radix-ui.com/primitives">@radix-ui/react-toggle</a> v1.1.0 (dependencies)
 #### 
@@ -3493,13 +3503,13 @@ The official JSON schema converter for Valibot
 The Vercel Blob JavaScript API client
 
 <a name="@vercel/flags"></a>
-### @vercel/flags v2.6.1 (dependencies)
+### @vercel/flags v2.6.3 (dependencies)
 #### 
 
 ##### Paths
 * /home/runner/work/giselle/giselle
 
-unknown manually approved
+<a href="http://opensource.org/licenses/mit-license">MIT</a> manually approved
 
 >The license is none. Check https://github.com/giselles-ai/giselle/issues/12 later
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"@supabase/supabase-js": "2.45.0",
 		"@valibot/to-json-schema": "1.0.0-beta.3",
 		"@vercel/blob": "0.23.4",
-		"@vercel/flags": "2.6.1",
+		"@vercel/flags": "2.6.3",
 		"@vercel/functions": "1.5.0",
 		"@vercel/otel": "1.10.0",
 		"@vercel/postgres": "0.9.0",


### PR DESCRIPTION
## Summary
To supress warning message like this: 

```
[Error: Route "/" used `cookies().get('vercel-flag-overrides')`. `cookies()` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis]
```

## Related Issue
- https://github.com/giselles-ai/giselle/issues/12