### PR TITLE
refactor(execution): Extract node execution logic into dedicated context

### DIFF
--- a/app/(playground)/p/[agentId]/canary/contexts/execution.tsx
+++ b/app/(playground)/p/[agentId]/canary/contexts/execution.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { type StreamableValue, readStreamableValue } from "ai/rsc";
+import { type ReactNode, createContext, useCallback, useContext } from "react";
+import type { ArtifactId, NodeId, TextArtifactObject } from "../types";
+import { createArtifactId } from "../utils";
+import { useGraph } from "./graph";
+import { usePropertiesPanel } from "./properties-panel";
+
+interface ExecutionContextType {
+	execute: (nodeId: NodeId) => Promise<void>;
+}
+
+const ExecutionContext = createContext<ExecutionContextType | undefined>(
+	undefined,
+);
+
+interface ExecutionProviderProps {
+	children: ReactNode;
+	executeAction: (
+		artifactId: ArtifactId,
+		graphUrl: string,
+		nodeId: NodeId,
+	) => Promise<StreamableValue<TextArtifactObject, unknown>>;
+}
+
+export function ExecutionProvider({
+	children,
+	executeAction,
+}: ExecutionProviderProps) {
+	const { dispatch, flush } = useGraph();
+	const { setTab } = usePropertiesPanel();
+	const execute = useCallback(
+		async (nodeId: NodeId) => {
+			const artifactId = createArtifactId();
+			dispatch({
+				type: "upsertArtifact",
+				input: {
+					nodeId,
+					artifact: {
+						id: artifactId,
+						type: "streamArtifact",
+						creatorNodeId: nodeId,
+						object: {
+							type: "text",
+							title: "",
+							content: "",
+							messages: {
+								plan: "",
+								description: "",
+							},
+						},
+					},
+				},
+			});
+			setTab("Result");
+			const latestGraphUrl = await flush();
+			const stream = await executeAction(artifactId, latestGraphUrl, nodeId);
+
+			let textArtifactObject: TextArtifactObject = {
+				type: "text",
+				title: "",
+				content: "",
+				messages: {
+					plan: "",
+					description: "",
+				},
+			};
+			for await (const streamContent of readStreamableValue(stream)) {
+				if (streamContent === undefined) {
+					continue;
+				}
+				dispatch({
+					type: "upsertArtifact",
+					input: {
+						nodeId,
+						artifact: {
+							id: artifactId,
+							type: "streamArtifact",
+							creatorNodeId: nodeId,
+							object: streamContent,
+						},
+					},
+				});
+				textArtifactObject = {
+					...textArtifactObject,
+					...streamContent,
+				};
+			}
+			dispatch({
+				type: "upsertArtifact",
+				input: {
+					nodeId,
+					artifact: {
+						id: artifactId,
+						type: "generatedArtifact",
+						creatorNodeId: nodeId,
+						createdAt: Date.now(),
+						object: textArtifactObject,
+					},
+				},
+			});
+		},
+		[executeAction, dispatch, flush, setTab],
+	);
+	return (
+		<ExecutionContext.Provider value={{ execute }}>
+			{children}
+		</ExecutionContext.Provider>
+	);
+}
+
+export function useExecution() {
+	const context = useContext(ExecutionContext);
+	if (!context) {
+		throw new Error("useExecution must be used within an ExecutionProvider");
+	}
+	return context.execute;
+}

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -5,15 +5,16 @@ import { ReactFlowProvider } from "@xyflow/react";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import type { AgentId } from "../beta-proto/types";
-import { putGraph } from "./actions";
+import { action, putGraph } from "./actions";
 import { Editor } from "./components/editor";
 import { AgentNameProvider } from "./contexts/agent-name";
+import { ExecutionProvider } from "./contexts/execution";
 import { GraphContextProvider } from "./contexts/graph";
 import { MousePositionProvider } from "./contexts/mouse-position";
 import { PropertiesPanelProvider } from "./contexts/properties-panel";
 import { ToastProvider } from "./contexts/toast";
 import { ToolbarContextProvider } from "./contexts/toolbar";
-import type { Graph } from "./types";
+import type { ArtifactId, Graph, NodeId } from "./types";
 import { buildGraphFolderPath } from "./utils";
 
 // This page is experimental. it requires PlaygroundV2Flag to show this page
@@ -74,6 +75,15 @@ export default async function Page({
 		return agentName;
 	}
 
+	async function execute(
+		artifactId: ArtifactId,
+		graphUrl: string,
+		nodeId: NodeId,
+	) {
+		"use server";
+		return await action(artifactId, graphUrl, nodeId);
+	}
+
 	return (
 		<GraphContextProvider
 			defaultGraph={graph}
@@ -89,7 +99,9 @@ export default async function Page({
 									defaultValue={agent.name ?? "Unnamed Agent"}
 									updateAgentNameAction={updateAgentName}
 								>
-									<Editor />
+									<ExecutionProvider executeAction={execute}>
+										<Editor />
+									</ExecutionProvider>
 								</AgentNameProvider>
 							</ToastProvider>
 						</MousePositionProvider>


### PR DESCRIPTION
Centralize text generation execution logic from properties panel into a new ExecutionContext to improve code reusability and maintainability.

- Move duplicate execution code into ExecutionProvider component
- Add useExecution hook for accessing execution functionality
- Update properties panel to use new execution context
- Handle server-side execution through action prop
