### PR TITLE
Enable capture PostHog Pageleave event

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -31,6 +31,7 @@ function PHProviderEnabled({ children }: { children: React.ReactNode }) {
 				api_host: posthog_host,
 				person_profiles: "identified_only",
 				capture_pageview: false,
+				capture_pageleave: true,
 			});
 		} catch (error) {
 			Sentry.captureException(error);


### PR DESCRIPTION
## Summary
Enabled Pageleave event capture to accurately capture session duration, etc.

In Next.js, `capture_pageview` needs to be `false`. That setting disables `capture_pageleave`, so we need to enable it explicitly.

ref. https://posthog.com/docs/web-analytics/installation#pageleave-events-optional

> To capture pageleave events, we need to set capture_pageleave: true in the initialization because setting capture_pageview: false disables it.

## Changes
Set `capture_pageleave` to `true` explicitly at initiazing.

## Testing
Checked the capture in the development environment and confirmed that it was not degraded.
