### PR TITLE
Introduce team creation flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ GITHUB_INTEGRATION_FLAG="true"
 PLAYGROUND_V2_FLAG="true"
 FREE_PLAN_FLAG="true"
 PRO_TEAM_PLAN_FLAG="true"
+TEAM_CREATION_FLAG="true"
 
 # @vercel/blob https://vercel.com/docs/storage/vercel-blob/using-blob-sdk
 # @see https://vercel.com/docs/storage/vercel-blob/client-upload#prepare-your-local-project

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,5 +1,5 @@
 import { GiselleLogo } from "@/components/giselle-logo";
-import { proTeamPlanFlag } from "@/flags";
+import { proTeamPlanFlag, teamCreationFlag } from "@/flags";
 import { UserButton } from "@/services/accounts/components";
 import TeamCreation from "@/services/teams/components/team-creation";
 import { TeamSelection } from "@/services/teams/components/team-selection";
@@ -9,6 +9,7 @@ import { Nav } from "./nav";
 
 export default async function Layout({ children }: { children: ReactNode }) {
 	const proTeamPlan = await proTeamPlanFlag();
+	const teamCreation = await teamCreationFlag();
 
 	return (
 		<div className="h-screen overflow-y-hidden bg-black-100 divide-y divide-black-80 flex flex-col">
@@ -23,7 +24,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
 					{proTeamPlan && (
 						<>
 							<TeamSelection />
-							<TeamCreation />
+							{teamCreation && <TeamCreation />}
 						</>
 					)}
 					<UserButton />

--- a/flags.ts
+++ b/flags.ts
@@ -103,3 +103,16 @@ export const proTeamPlanFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const teamCreationFlag = flag<boolean>({
+	key: "team-creation",
+	async decide() {
+		return takeLocalEnv("TEAM_CREATION_FLAG");
+	},
+	description: "Enable Team Creation",
+	defaultValue: false,
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});


### PR DESCRIPTION
## Summary
Hide team creation functionality behind a feature flag until Stripe product setup is complete

## Background
- Team creation feature requires proper Stripe product configuration
- Need to temporarily disable team creation UI while Stripe setup is in progress

## Changes
### Feature Flags
- Add `teamCreation` flag to control UI visibility
- Default value: `false` (disabled)
- Flag location: `flags/index.ts`

### UI Changes
- Conditionally render team creation button in header
- Implement flag check in `layout.tsx`
