### PR TITLE
feat(agents): Add loading state to New Agent button

### DIFF
--- a/app/(main)/agents-v2/components.tsx
+++ b/app/(main)/agents-v2/components.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useFormStatus } from "react-dom";
+
+export function CreateAgentButton() {
+	const { pending } = useFormStatus();
+	return (
+		<Button type="submit" disabled={pending} data-loading={pending}>
+			New Agent +
+		</Button>
+	);
+}

--- a/app/(main)/agents-v2/layout.tsx
+++ b/app/(main)/agents-v2/layout.tsx
@@ -7,6 +7,7 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { putGraph } from "../../(playground)/p/[agentId]/canary/actions";
 import { initGraph } from "../../(playground)/p/[agentId]/canary/utils";
+import { CreateAgentButton } from "./components";
 
 export default function Layout({
 	children,
@@ -46,7 +47,7 @@ export default function Layout({
 		<div className="flex h-full divide-x divide-black-80">
 			<div className="w-[200px] h-full p-[24px]">
 				<form action={createAgent}>
-					<Button type="submit">New Agent +</Button>
+					<CreateAgentButton />
 				</form>
 			</div>
 			<div className="p-[24px] flex-1">{children}</div>


### PR DESCRIPTION
https://github.com/user-attachments/assets/ea931ab0-8673-44e8-b3aa-30827226a88f




Add loading state feedback to the New Agent creation button:
- Create client-side button component with useFormStatus hook
- Show disabled state while form submission is pending
- Maintain consistent button styling and layout

This improves UX by providing visual feedback during agent creation and preventing duplicate submissions.
