### PR TITLE
feat(playground): Add customizable system prompt for text generation

### DIFF
--- a/app/(playground)/p/[agentId]/canary/actions.ts
+++ b/app/(playground)/p/[agentId]/canary/actions.ts
@@ -243,7 +243,9 @@ export async function action(
 			const actionSources = await resolveSources(node.content.sources);
 			const requirement = resolveRequirement(node.content.requirement);
 			const model = resolveLanguageModel(node.content.llm);
-			const promptTemplate = HandleBars.compile(textGenerationPrompt);
+			const promptTemplate = HandleBars.compile(
+				node.content.system ?? textGenerationPrompt,
+			);
 			const prompt = promptTemplate({
 				instruction: node.content.instruction,
 				requirement,

--- a/app/(playground)/p/[agentId]/canary/prompts.ts
+++ b/app/(playground)/p/[agentId]/canary/prompts.ts
@@ -1,8 +1,7 @@
 import HandleBars from "handlebars";
 HandleBars.registerHelper("eq", (arg1, arg2) => arg1 === arg2);
 
-export const textGenerationPrompt = `
-You are tasked with generating text based on specific instructions, requirements, and sources provided by the user. Follow these steps carefully:
+export const textGenerationPrompt = `You are tasked with generating text based on specific instructions, requirements, and sources provided by the user. Follow these steps carefully:
 
 1. Read and analyze the following inputs:
 

--- a/app/(playground)/p/[agentId]/canary/types.ts
+++ b/app/(playground)/p/[agentId]/canary/types.ts
@@ -26,6 +26,7 @@ export interface TextGenerateActionContent extends ActionContentBase {
 	topP: number;
 	instruction: string;
 	requirement?: NodeHandle;
+	system?: string;
 	sources: NodeHandle[];
 }
 export interface TextGeneration extends Action {


### PR DESCRIPTION


https://github.com/user-attachments/assets/a4932471-2ee5-4da8-9fad-47b0990dae01


> [!NOTE]
> The fact that the text is not changed when “Revert to Return” is pressed is an unnatural behavior and should be corrected separately.

Add ability to customize and reset system prompts in text generation nodes:
- Add system prompt field to TextGenerateActionContent type
- Create collapsible system prompt editor with persistence
- Add revert to default functionality with visual feedback
- Use default prompt when system is undefined

This gives users more control over LLM behavior while maintaining the ability to return to default settings.
