### PR TITLE
Postpone introduction of parser pipeline by sending input/output token consumed as two separated attributes

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -81,10 +81,8 @@ ${sourcesToText(sources)}
 					logger.info(
 						{
 							externalServiceName: "openai",
-							tokenConsumed: {
-								input: result.usage.promptTokens,
-								output: result.usage.completionTokens,
-							},
+							tokenConsumedInput: result.usage.promptTokens,
+							tokenConsumedOutput: result.usage.completionTokens,
 							duration,
 							measurementScope,
 							isR06User,

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -92,10 +92,8 @@ ${sourcesToText(sources)}
 				logger.info(
 					{
 						externalServiceName: "openai",
-						tokenConsumed: {
-							input: result.usage.promptTokens,
-							output: result.usage.completionTokens,
-						},
+						tokenConsumedInput: result.usage.promptTokens,
+						tokenConsumedOutput: result.usage.completionTokens,
 						duration,
 						measurementScope,
 						isR06User,

--- a/lib/opentelemetry/types.ts
+++ b/lib/opentelemetry/types.ts
@@ -17,10 +17,8 @@ const BaseMetricsSchema = z.object({
 });
 
 const TokenConsumedSchema = BaseMetricsSchema.extend({
-	tokenConsumed: z.object({
-		input: z.number(), // Number of tokens used in the prompt/input sent to the model
-		output: z.number(), // Number of tokens used in the response/output received from the model
-	}),
+	tokenConsumedInput: z.number(), // Number of tokens used in the prompt/input sent to the model
+	tokenConsumedOutput: z.number(), // Number of tokens used in the response/output received from the model
 });
 
 const RequestCountSchema = BaseMetricsSchema.extend({


### PR DESCRIPTION
## Summary

Send `tokenConsumedInput` and `tokenConsumedOutput` as two flat attributes and quit using preprocessing pipeline on telemetry backend (private environment)

## Related Issue

- this PR closes #188 

## Changes

- fixed schema of `tokenConsumed`
- fixed instrumentation on token consumption

## Testing

Using corresponding preview environment (private environment), numbers of token consumed are recognized as numeric attributes without preprocessing pipeline:
![image](https://github.com/user-attachments/assets/e1d32033-41fd-4ae0-835d-cc94037c03eb)

## Additional information

Although we can use nested object when we use `body` field  (described in https://github.com/giselles-ai/giselle/issues/188), I think simpler solution adopted in this PR is better for us in current situation.
