### PR TITLE
Save agent activities to the database

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/flow/save-agent-activity.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/save-agent-activity.ts
@@ -1,0 +1,24 @@
+import { agentActivities, agents, db } from "@/drizzle";
+import type { AgentActivity } from "@/services/agents/activities";
+import { eq } from "drizzle-orm";
+
+export async function saveAgentActivity(activity: AgentActivity) {
+	if (activity.endedAt == null) {
+		throw new Error("Activity must be ended before saving");
+	}
+	const records = await db
+		.select({ agentDbId: agents.dbId })
+		.from(agents)
+		.where(eq(agents.id, activity.agentId));
+	if (records.length === 0) {
+		throw new Error(`Agent with id ${activity.agentId} not found`);
+	}
+	const agentDbId = records[0].agentDbId;
+
+	await db.insert(agentActivities).values({
+		agentDbId,
+		startedAt: activity.startedAt,
+		endedAt: activity.endedAt,
+		aggregatedExecutionTimeMs: activity.totalDurationMs(),
+	});
+}

--- a/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
@@ -8,6 +8,7 @@ import { eq } from "drizzle-orm";
 import type { GiselleNodeId } from "../giselle-node/types";
 import type { AgentId } from "../types";
 import { type V2FlowAction, setFlow, updateStep } from "./action";
+import { saveAgentActivity } from "./save-agent-activity";
 import {
 	buildTextArtifact,
 	generateArtifactObject,
@@ -30,7 +31,7 @@ export async function executeFlow(
 ) {
 	const agentActivity = new AgentActivity(agentId, new Date());
 	const stream = createStreamableValue<V2FlowAction>();
-	(async () => {
+	await (async () => {
 		const agent = await db.query.agents.findFirst({
 			where: eq(agents.id, agentId),
 		});
@@ -181,6 +182,7 @@ export async function executeFlow(
 		stream.done();
 		agentActivity.end();
 	})();
+	await saveAgentActivity(agentActivity);
 
 	return { streamableValue: stream.value };
 }

--- a/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
@@ -31,7 +31,7 @@ export async function executeFlow(
 ) {
 	const agentActivity = new AgentActivity(agentId, new Date());
 	const stream = createStreamableValue<V2FlowAction>();
-	await (async () => {
+	(async () => {
 		const agent = await db.query.agents.findFirst({
 			where: eq(agents.id, agentId),
 		});
@@ -181,8 +181,8 @@ export async function executeFlow(
 
 		stream.done();
 		agentActivity.end();
+		await saveAgentActivity(agentActivity);
 	})();
-	await saveAgentActivity(agentActivity);
 
 	return { streamableValue: stream.value };
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -460,3 +460,19 @@ export const gitHubIntegrations = pgTable(
 		};
 	},
 );
+
+export const agentActivities = pgTable(
+	"agent_activities",
+	{
+		dbId: serial("db_id").primaryKey(),
+		agentDbId: integer("agent_db_id")
+			.notNull()
+			.references(() => agents.dbId, { onDelete: "cascade" }),
+		startedAt: timestamp("started_at").notNull(),
+		endedAt: timestamp("ended_at").notNull(),
+		aggregatedExecutionTimeMs: integer("total_duration_ms").notNull(),
+	},
+	(table) => ({
+		agentDbIdIdx: index().on(table.agentDbId),
+	}),
+);

--- a/migrations/0015_parched_talon.sql
+++ b/migrations/0015_parched_talon.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "agent_activities" (
+	"db_id" serial PRIMARY KEY NOT NULL,
+	"agent_db_id" integer NOT NULL,
+	"started_at" timestamp NOT NULL,
+	"ended_at" timestamp NOT NULL,
+	"total_duration_ms" integer NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_activities" ADD CONSTRAINT "agent_activities_agent_db_id_agents_db_id_fk" FOREIGN KEY ("agent_db_id") REFERENCES "public"."agents"("db_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_activities_agent_db_id_index" ON "agent_activities" USING btree ("agent_db_id");

--- a/migrations/meta/0015_snapshot.json
+++ b/migrations/meta/0015_snapshot.json
@@ -1,0 +1,2018 @@
+{
+  "id": "d4dc5fcf-b9a2-4446-b6a2-4f40e06e24e6",
+  "prevId": "d9bf892e-0113-42b0-9b91-925468406bc7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_activities": {
+      "name": "agent_activities",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_activities_agent_db_id_index": {
+          "name": "agent_activities_agent_db_id_index",
+          "columns": [
+            {
+              "expression": "agent_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_activities_agent_db_id_agents_db_id_fk": {
+          "name": "agent_activities_agent_db_id_agents_db_id_fk",
+          "tableFrom": "agent_activities",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_url": {
+          "name": "graph_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graphv2": {
+          "name": "graphv2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[],\"viewport\":{\"x\":0,\"y\":0,\"zoom\":1}}'::jsonb"
+        },
+        "graph_hash": {
+          "name": "graph_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_db_id": {
+          "name": "creator_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_team_db_id_teams_db_id_fk": {
+          "name": "agents_team_db_id_teams_db_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_creator_db_id_users_db_id_fk": {
+          "name": "agents_creator_db_id_users_db_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_id_unique": {
+          "name": "agents_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "agents_graph_hash_unique": {
+          "name": "agents_graph_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "graph_hash"
+          ]
+        }
+      }
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_hash": {
+          "name": "graph_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_id": {
+          "name": "before_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_id": {
+          "name": "after_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_agent_db_id_agents_db_id_fk": {
+          "name": "builds_agent_db_id_agents_db_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "builds_id_unique": {
+          "name": "builds_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "builds_graph_hash_unique": {
+          "name": "builds_graph_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "graph_hash"
+          ]
+        }
+      }
+    },
+    "public.edges": {
+      "name": "edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "build_db_id": {
+          "name": "build_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_port_db_id": {
+          "name": "target_port_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_port_db_id": {
+          "name": "source_port_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "edges_build_db_id_builds_db_id_fk": {
+          "name": "edges_build_db_id_builds_db_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_target_port_db_id_ports_db_id_fk": {
+          "name": "edges_target_port_db_id_ports_db_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "ports",
+          "columnsFrom": [
+            "target_port_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "edges_source_port_db_id_ports_db_id_fk": {
+          "name": "edges_source_port_db_id_ports_db_id_fk",
+          "tableFrom": "edges",
+          "tableTo": "ports",
+          "columnsFrom": [
+            "source_port_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edges_target_port_db_id_source_port_db_id_unique": {
+          "name": "edges_target_port_db_id_source_port_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "target_port_db_id",
+            "source_port_db_id"
+          ]
+        },
+        "edges_id_build_db_id_unique": {
+          "name": "edges_id_build_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "build_db_id"
+          ]
+        }
+      }
+    },
+    "public.file_openai_file_representations": {
+      "name": "file_openai_file_representations",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_db_id": {
+          "name": "file_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openai_file_id": {
+          "name": "openai_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_openai_file_representations_file_db_id_files_db_id_fk": {
+          "name": "file_openai_file_representations_file_db_id_files_db_id_fk",
+          "tableFrom": "file_openai_file_representations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_openai_file_representations_openai_file_id_unique": {
+          "name": "file_openai_file_representations_openai_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openai_file_id"
+          ]
+        }
+      }
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_url": {
+          "name": "blob_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_id_unique": {
+          "name": "files_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.github_integrations": {
+      "name": "github_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_sign": {
+          "name": "call_sign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_node_id": {
+          "name": "start_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_node_id": {
+          "name": "end_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_integrations_repository_full_name_index": {
+          "name": "github_integrations_repository_full_name_index",
+          "columns": [
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_integrations_agent_db_id_agents_db_id_fk": {
+          "name": "github_integrations_agent_db_id_agents_db_id_fk",
+          "tableFrom": "github_integrations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_integrations_id_unique": {
+          "name": "github_integrations_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.knowledge_content_openai_vector_store_file_representations": {
+      "name": "knowledge_content_openai_vector_store_file_representations",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledge_content_db_id": {
+          "name": "knowledge_content_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openai_vector_store_file_id": {
+          "name": "openai_vector_store_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openai_vector_store_status": {
+          "name": "openai_vector_store_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk": {
+          "name": "knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk",
+          "tableFrom": "knowledge_content_openai_vector_store_file_representations",
+          "tableTo": "knowledge_contents",
+          "columnsFrom": [
+            "knowledge_content_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kcovsfr_knowledge_content_db_id_unique": {
+          "name": "kcovsfr_knowledge_content_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "knowledge_content_db_id"
+          ]
+        },
+        "kcovsfr_openai_vector_store_file_id_unique": {
+          "name": "kcovsfr_openai_vector_store_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openai_vector_store_file_id"
+          ]
+        }
+      }
+    },
+    "public.knowledge_contents": {
+      "name": "knowledge_contents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledge_content_type": {
+          "name": "knowledge_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledge_db_id": {
+          "name": "knowledge_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_db_id": {
+          "name": "file_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_contents_knowledge_db_id_knowledges_db_id_fk": {
+          "name": "knowledge_contents_knowledge_db_id_knowledges_db_id_fk",
+          "tableFrom": "knowledge_contents",
+          "tableTo": "knowledges",
+          "columnsFrom": [
+            "knowledge_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_contents_file_db_id_files_db_id_fk": {
+          "name": "knowledge_contents_file_db_id_files_db_id_fk",
+          "tableFrom": "knowledge_contents",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_contents_id_unique": {
+          "name": "knowledge_contents_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "knowledge_contents_file_db_id_knowledge_db_id_unique": {
+          "name": "knowledge_contents_file_db_id_knowledge_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_db_id",
+            "knowledge_db_id"
+          ]
+        }
+      }
+    },
+    "public.knowledge_openai_vector_store_representations": {
+      "name": "knowledge_openai_vector_store_representations",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledge_db_id": {
+          "name": "knowledge_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openai_vector_store_id": {
+          "name": "openai_vector_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk": {
+          "name": "knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk",
+          "tableFrom": "knowledge_openai_vector_store_representations",
+          "tableTo": "knowledges",
+          "columnsFrom": [
+            "knowledge_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_openai_vector_store_representations_openai_vector_store_id_unique": {
+          "name": "knowledge_openai_vector_store_representations_openai_vector_store_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openai_vector_store_id"
+          ]
+        }
+      }
+    },
+    "public.knowledges": {
+      "name": "knowledges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledges_agent_db_id_agents_db_id_fk": {
+          "name": "knowledges_agent_db_id_agents_db_id_fk",
+          "tableFrom": "knowledges",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledges_id_unique": {
+          "name": "knowledges_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "build_db_id": {
+          "name": "build_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_name": {
+          "name": "class_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nodes_build_db_id_builds_db_id_fk": {
+          "name": "nodes_build_db_id_builds_db_id_fk",
+          "tableFrom": "nodes",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nodes_id_build_db_id_unique": {
+          "name": "nodes_id_build_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "build_db_id"
+          ]
+        }
+      }
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_credentials_user_id_users_db_id_fk": {
+          "name": "oauth_credentials_user_id_users_db_id_fk",
+          "tableFrom": "oauth_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_credentials_user_id_provider_provider_account_id_unique": {
+          "name": "oauth_credentials_user_id_provider_provider_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      }
+    },
+    "public.ports": {
+      "name": "ports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "node_db_id": {
+          "name": "node_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ports_node_db_id_nodes_db_id_fk": {
+          "name": "ports_node_db_id_nodes_db_id_fk",
+          "tableFrom": "ports",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ports_id_node_db_id_unique": {
+          "name": "ports_id_node_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "node_db_id"
+          ]
+        }
+      }
+    },
+    "public.request_port_messages": {
+      "name": "request_port_messages",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_db_id": {
+          "name": "request_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port_db_id": {
+          "name": "port_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_port_messages_request_db_id_requests_db_id_fk": {
+          "name": "request_port_messages_request_db_id_requests_db_id_fk",
+          "tableFrom": "request_port_messages",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "request_port_messages_port_db_id_ports_db_id_fk": {
+          "name": "request_port_messages_port_db_id_ports_db_id_fk",
+          "tableFrom": "request_port_messages",
+          "tableTo": "ports",
+          "columnsFrom": [
+            "port_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_port_messages_request_db_id_port_db_id_unique": {
+          "name": "request_port_messages_request_db_id_port_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_db_id",
+            "port_db_id"
+          ]
+        }
+      }
+    },
+    "public.request_results": {
+      "name": "request_results",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_db_id": {
+          "name": "request_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_results_request_db_id_requests_db_id_fk": {
+          "name": "request_results_request_db_id_requests_db_id_fk",
+          "tableFrom": "request_results",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_results_request_db_id_unique": {
+          "name": "request_results_request_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_db_id"
+          ]
+        }
+      }
+    },
+    "public.request_runners": {
+      "name": "request_runners",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_db_id": {
+          "name": "request_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_runners_request_db_id_requests_db_id_fk": {
+          "name": "request_runners_request_db_id_requests_db_id_fk",
+          "tableFrom": "request_runners",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_runners_runner_id_unique": {
+          "name": "request_runners_runner_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "runner_id"
+          ]
+        }
+      }
+    },
+    "public.request_stack_runners": {
+      "name": "request_stack_runners",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_stack_db_id": {
+          "name": "request_stack_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_stack_runners_request_stack_db_id_request_stacks_db_id_fk": {
+          "name": "request_stack_runners_request_stack_db_id_request_stacks_db_id_fk",
+          "tableFrom": "request_stack_runners",
+          "tableTo": "request_stacks",
+          "columnsFrom": [
+            "request_stack_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_stack_runners_runner_id_unique": {
+          "name": "request_stack_runners_runner_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "runner_id"
+          ]
+        }
+      }
+    },
+    "public.request_stacks": {
+      "name": "request_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_db_id": {
+          "name": "request_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_node_db_id": {
+          "name": "start_node_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_node_db_id": {
+          "name": "end_node_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_stacks_request_db_id_requests_db_id_fk": {
+          "name": "request_stacks_request_db_id_requests_db_id_fk",
+          "tableFrom": "request_stacks",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "request_stacks_start_node_db_id_nodes_db_id_fk": {
+          "name": "request_stacks_start_node_db_id_nodes_db_id_fk",
+          "tableFrom": "request_stacks",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "start_node_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "request_stacks_end_node_db_id_nodes_db_id_fk": {
+          "name": "request_stacks_end_node_db_id_nodes_db_id_fk",
+          "tableFrom": "request_stacks",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "end_node_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_stacks_id_unique": {
+          "name": "request_stacks_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.request_steps": {
+      "name": "request_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_stack_db_id": {
+          "name": "request_stack_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_db_id": {
+          "name": "node_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_steps_request_stack_db_id_request_stacks_db_id_fk": {
+          "name": "request_steps_request_stack_db_id_request_stacks_db_id_fk",
+          "tableFrom": "request_steps",
+          "tableTo": "request_stacks",
+          "columnsFrom": [
+            "request_stack_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "request_steps_node_db_id_nodes_db_id_fk": {
+          "name": "request_steps_node_db_id_nodes_db_id_fk",
+          "tableFrom": "request_steps",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_steps_id_unique": {
+          "name": "request_steps_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.requests": {
+      "name": "requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "build_db_id": {
+          "name": "build_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_build_db_id_builds_db_id_fk": {
+          "name": "requests_build_db_id_builds_db_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "requests_id_unique": {
+          "name": "requests_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.stripe_user_mappings": {
+      "name": "stripe_user_mappings",
+      "schema": "",
+      "columns": {
+        "user_db_id": {
+          "name": "user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_user_mappings_user_db_id_users_db_id_fk": {
+          "name": "stripe_user_mappings_user_db_id_users_db_id_fk",
+          "tableFrom": "stripe_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_user_mappings_user_db_id_unique": {
+          "name": "stripe_user_mappings_user_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_db_id"
+          ]
+        },
+        "stripe_user_mappings_stripe_customer_id_unique": {
+          "name": "stripe_user_mappings_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      }
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_start": {
+          "name": "trial_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_team_db_id_teams_db_id_fk": {
+          "name": "subscriptions_team_db_id_teams_db_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_id_unique": {
+          "name": "subscriptions_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.supabase_user_mappings": {
+      "name": "supabase_user_mappings",
+      "schema": "",
+      "columns": {
+        "user_db_id": {
+          "name": "user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supabase_user_mappings_user_db_id_users_db_id_fk": {
+          "name": "supabase_user_mappings_user_db_id_users_db_id_fk",
+          "tableFrom": "supabase_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supabase_user_mappings_user_db_id_unique": {
+          "name": "supabase_user_mappings_user_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_db_id"
+          ]
+        },
+        "supabase_user_mappings_supabase_user_id_unique": {
+          "name": "supabase_user_mappings_supabase_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "supabase_user_id"
+          ]
+        }
+      }
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_db_id": {
+          "name": "user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_memberships_user_db_id_users_db_id_fk": {
+          "name": "team_memberships_user_db_id_users_db_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_team_db_id_teams_db_id_fk": {
+          "name": "team_memberships_team_db_id_teams_db_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_memberships_user_db_id_team_db_id_unique": {
+          "name": "team_memberships_user_db_id_team_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_db_id",
+            "team_db_id"
+          ]
+        }
+      }
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.trigger_nodes": {
+      "name": "trigger_nodes",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "build_db_id": {
+          "name": "build_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_db_id": {
+          "name": "node_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trigger_nodes_build_db_id_builds_db_id_fk": {
+          "name": "trigger_nodes_build_db_id_builds_db_id_fk",
+          "tableFrom": "trigger_nodes",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_nodes_node_db_id_nodes_db_id_fk": {
+          "name": "trigger_nodes_node_db_id_nodes_db_id_fk",
+          "tableFrom": "trigger_nodes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "node_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trigger_nodes_build_db_id_unique": {
+          "name": "trigger_nodes_build_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "build_db_id"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0015_snapshot.json
+++ b/migrations/meta/0015_snapshot.json
@@ -1,2018 +1,1801 @@
 {
-  "id": "d4dc5fcf-b9a2-4446-b6a2-4f40e06e24e6",
-  "prevId": "d9bf892e-0113-42b0-9b91-925468406bc7",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.agent_activities": {
-      "name": "agent_activities",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "agent_db_id": {
-          "name": "agent_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ended_at": {
-          "name": "ended_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "total_duration_ms": {
-          "name": "total_duration_ms",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "agent_activities_agent_db_id_index": {
-          "name": "agent_activities_agent_db_id_index",
-          "columns": [
-            {
-              "expression": "agent_db_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "agent_activities_agent_db_id_agents_db_id_fk": {
-          "name": "agent_activities_agent_db_id_agents_db_id_fk",
-          "tableFrom": "agent_activities",
-          "tableTo": "agents",
-          "columnsFrom": [
-            "agent_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {}
-    },
-    "public.agents": {
-      "name": "agents",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "team_db_id": {
-          "name": "team_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "graph_url": {
-          "name": "graph_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "graphv2": {
-          "name": "graphv2",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "graph": {
-          "name": "graph",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{\"nodes\":[],\"edges\":[],\"viewport\":{\"x\":0,\"y\":0,\"zoom\":1}}'::jsonb"
-        },
-        "graph_hash": {
-          "name": "graph_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "creator_db_id": {
-          "name": "creator_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "agents_team_db_id_teams_db_id_fk": {
-          "name": "agents_team_db_id_teams_db_id_fk",
-          "tableFrom": "agents",
-          "tableTo": "teams",
-          "columnsFrom": [
-            "team_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "agents_creator_db_id_users_db_id_fk": {
-          "name": "agents_creator_db_id_users_db_id_fk",
-          "tableFrom": "agents",
-          "tableTo": "users",
-          "columnsFrom": [
-            "creator_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "agents_id_unique": {
-          "name": "agents_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        },
-        "agents_graph_hash_unique": {
-          "name": "agents_graph_hash_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "graph_hash"
-          ]
-        }
-      }
-    },
-    "public.builds": {
-      "name": "builds",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "graph": {
-          "name": "graph",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "graph_hash": {
-          "name": "graph_hash",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "agent_db_id": {
-          "name": "agent_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "before_id": {
-          "name": "before_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "after_id": {
-          "name": "after_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "builds_agent_db_id_agents_db_id_fk": {
-          "name": "builds_agent_db_id_agents_db_id_fk",
-          "tableFrom": "builds",
-          "tableTo": "agents",
-          "columnsFrom": [
-            "agent_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "builds_id_unique": {
-          "name": "builds_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        },
-        "builds_graph_hash_unique": {
-          "name": "builds_graph_hash_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "graph_hash"
-          ]
-        }
-      }
-    },
-    "public.edges": {
-      "name": "edges",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "build_db_id": {
-          "name": "build_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "target_port_db_id": {
-          "name": "target_port_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source_port_db_id": {
-          "name": "source_port_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "edges_build_db_id_builds_db_id_fk": {
-          "name": "edges_build_db_id_builds_db_id_fk",
-          "tableFrom": "edges",
-          "tableTo": "builds",
-          "columnsFrom": [
-            "build_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "edges_target_port_db_id_ports_db_id_fk": {
-          "name": "edges_target_port_db_id_ports_db_id_fk",
-          "tableFrom": "edges",
-          "tableTo": "ports",
-          "columnsFrom": [
-            "target_port_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "edges_source_port_db_id_ports_db_id_fk": {
-          "name": "edges_source_port_db_id_ports_db_id_fk",
-          "tableFrom": "edges",
-          "tableTo": "ports",
-          "columnsFrom": [
-            "source_port_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "edges_target_port_db_id_source_port_db_id_unique": {
-          "name": "edges_target_port_db_id_source_port_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "target_port_db_id",
-            "source_port_db_id"
-          ]
-        },
-        "edges_id_build_db_id_unique": {
-          "name": "edges_id_build_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id",
-            "build_db_id"
-          ]
-        }
-      }
-    },
-    "public.file_openai_file_representations": {
-      "name": "file_openai_file_representations",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "file_db_id": {
-          "name": "file_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "openai_file_id": {
-          "name": "openai_file_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "file_openai_file_representations_file_db_id_files_db_id_fk": {
-          "name": "file_openai_file_representations_file_db_id_files_db_id_fk",
-          "tableFrom": "file_openai_file_representations",
-          "tableTo": "files",
-          "columnsFrom": [
-            "file_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "file_openai_file_representations_openai_file_id_unique": {
-          "name": "file_openai_file_representations_openai_file_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "openai_file_id"
-          ]
-        }
-      }
-    },
-    "public.files": {
-      "name": "files",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_type": {
-          "name": "file_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_size": {
-          "name": "file_size",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "blob_url": {
-          "name": "blob_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "files_id_unique": {
-          "name": "files_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      }
-    },
-    "public.github_integrations": {
-      "name": "github_integrations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "agent_db_id": {
-          "name": "agent_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "repository_full_name": {
-          "name": "repository_full_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "call_sign": {
-          "name": "call_sign",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "event": {
-          "name": "event",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "start_node_id": {
-          "name": "start_node_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "end_node_id": {
-          "name": "end_node_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "next_action": {
-          "name": "next_action",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "github_integrations_repository_full_name_index": {
-          "name": "github_integrations_repository_full_name_index",
-          "columns": [
-            {
-              "expression": "repository_full_name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "github_integrations_agent_db_id_agents_db_id_fk": {
-          "name": "github_integrations_agent_db_id_agents_db_id_fk",
-          "tableFrom": "github_integrations",
-          "tableTo": "agents",
-          "columnsFrom": [
-            "agent_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "github_integrations_id_unique": {
-          "name": "github_integrations_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      }
-    },
-    "public.knowledge_content_openai_vector_store_file_representations": {
-      "name": "knowledge_content_openai_vector_store_file_representations",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "knowledge_content_db_id": {
-          "name": "knowledge_content_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "openai_vector_store_file_id": {
-          "name": "openai_vector_store_file_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "openai_vector_store_status": {
-          "name": "openai_vector_store_status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk": {
-          "name": "knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk",
-          "tableFrom": "knowledge_content_openai_vector_store_file_representations",
-          "tableTo": "knowledge_contents",
-          "columnsFrom": [
-            "knowledge_content_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "kcovsfr_knowledge_content_db_id_unique": {
-          "name": "kcovsfr_knowledge_content_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "knowledge_content_db_id"
-          ]
-        },
-        "kcovsfr_openai_vector_store_file_id_unique": {
-          "name": "kcovsfr_openai_vector_store_file_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "openai_vector_store_file_id"
-          ]
-        }
-      }
-    },
-    "public.knowledge_contents": {
-      "name": "knowledge_contents",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "knowledge_content_type": {
-          "name": "knowledge_content_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "knowledge_db_id": {
-          "name": "knowledge_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_db_id": {
-          "name": "file_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "knowledge_contents_knowledge_db_id_knowledges_db_id_fk": {
-          "name": "knowledge_contents_knowledge_db_id_knowledges_db_id_fk",
-          "tableFrom": "knowledge_contents",
-          "tableTo": "knowledges",
-          "columnsFrom": [
-            "knowledge_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "knowledge_contents_file_db_id_files_db_id_fk": {
-          "name": "knowledge_contents_file_db_id_files_db_id_fk",
-          "tableFrom": "knowledge_contents",
-          "tableTo": "files",
-          "columnsFrom": [
-            "file_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "knowledge_contents_id_unique": {
-          "name": "knowledge_contents_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        },
-        "knowledge_contents_file_db_id_knowledge_db_id_unique": {
-          "name": "knowledge_contents_file_db_id_knowledge_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "file_db_id",
-            "knowledge_db_id"
-          ]
-        }
-      }
-    },
-    "public.knowledge_openai_vector_store_representations": {
-      "name": "knowledge_openai_vector_store_representations",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "knowledge_db_id": {
-          "name": "knowledge_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "openai_vector_store_id": {
-          "name": "openai_vector_store_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk": {
-          "name": "knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk",
-          "tableFrom": "knowledge_openai_vector_store_representations",
-          "tableTo": "knowledges",
-          "columnsFrom": [
-            "knowledge_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "knowledge_openai_vector_store_representations_openai_vector_store_id_unique": {
-          "name": "knowledge_openai_vector_store_representations_openai_vector_store_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "openai_vector_store_id"
-          ]
-        }
-      }
-    },
-    "public.knowledges": {
-      "name": "knowledges",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "agent_db_id": {
-          "name": "agent_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "knowledges_agent_db_id_agents_db_id_fk": {
-          "name": "knowledges_agent_db_id_agents_db_id_fk",
-          "tableFrom": "knowledges",
-          "tableTo": "agents",
-          "columnsFrom": [
-            "agent_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "knowledges_id_unique": {
-          "name": "knowledges_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      }
-    },
-    "public.nodes": {
-      "name": "nodes",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "build_db_id": {
-          "name": "build_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "class_name": {
-          "name": "class_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "graph": {
-          "name": "graph",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "nodes_build_db_id_builds_db_id_fk": {
-          "name": "nodes_build_db_id_builds_db_id_fk",
-          "tableFrom": "nodes",
-          "tableTo": "builds",
-          "columnsFrom": [
-            "build_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "nodes_id_build_db_id_unique": {
-          "name": "nodes_id_build_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id",
-            "build_db_id"
-          ]
-        }
-      }
-    },
-    "public.oauth_credentials": {
-      "name": "oauth_credentials",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider_account_id": {
-          "name": "provider_account_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "token_type": {
-          "name": "token_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_credentials_user_id_users_db_id_fk": {
-          "name": "oauth_credentials_user_id_users_db_id_fk",
-          "tableFrom": "oauth_credentials",
-          "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_credentials_user_id_provider_provider_account_id_unique": {
-          "name": "oauth_credentials_user_id_provider_provider_account_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "user_id",
-            "provider",
-            "provider_account_id"
-          ]
-        }
-      }
-    },
-    "public.ports": {
-      "name": "ports",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "node_db_id": {
-          "name": "node_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "direction": {
-          "name": "direction",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "ports_node_db_id_nodes_db_id_fk": {
-          "name": "ports_node_db_id_nodes_db_id_fk",
-          "tableFrom": "ports",
-          "tableTo": "nodes",
-          "columnsFrom": [
-            "node_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "ports_id_node_db_id_unique": {
-          "name": "ports_id_node_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id",
-            "node_db_id"
-          ]
-        }
-      }
-    },
-    "public.request_port_messages": {
-      "name": "request_port_messages",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_db_id": {
-          "name": "request_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "port_db_id": {
-          "name": "port_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "message": {
-          "name": "message",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "request_port_messages_request_db_id_requests_db_id_fk": {
-          "name": "request_port_messages_request_db_id_requests_db_id_fk",
-          "tableFrom": "request_port_messages",
-          "tableTo": "requests",
-          "columnsFrom": [
-            "request_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "request_port_messages_port_db_id_ports_db_id_fk": {
-          "name": "request_port_messages_port_db_id_ports_db_id_fk",
-          "tableFrom": "request_port_messages",
-          "tableTo": "ports",
-          "columnsFrom": [
-            "port_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "request_port_messages_request_db_id_port_db_id_unique": {
-          "name": "request_port_messages_request_db_id_port_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "request_db_id",
-            "port_db_id"
-          ]
-        }
-      }
-    },
-    "public.request_results": {
-      "name": "request_results",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_db_id": {
-          "name": "request_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "text": {
-          "name": "text",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "request_results_request_db_id_requests_db_id_fk": {
-          "name": "request_results_request_db_id_requests_db_id_fk",
-          "tableFrom": "request_results",
-          "tableTo": "requests",
-          "columnsFrom": [
-            "request_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "request_results_request_db_id_unique": {
-          "name": "request_results_request_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "request_db_id"
-          ]
-        }
-      }
-    },
-    "public.request_runners": {
-      "name": "request_runners",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_db_id": {
-          "name": "request_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "runner_id": {
-          "name": "runner_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "request_runners_request_db_id_requests_db_id_fk": {
-          "name": "request_runners_request_db_id_requests_db_id_fk",
-          "tableFrom": "request_runners",
-          "tableTo": "requests",
-          "columnsFrom": [
-            "request_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "request_runners_runner_id_unique": {
-          "name": "request_runners_runner_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "runner_id"
-          ]
-        }
-      }
-    },
-    "public.request_stack_runners": {
-      "name": "request_stack_runners",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_stack_db_id": {
-          "name": "request_stack_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "runner_id": {
-          "name": "runner_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "request_stack_runners_request_stack_db_id_request_stacks_db_id_fk": {
-          "name": "request_stack_runners_request_stack_db_id_request_stacks_db_id_fk",
-          "tableFrom": "request_stack_runners",
-          "tableTo": "request_stacks",
-          "columnsFrom": [
-            "request_stack_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "request_stack_runners_runner_id_unique": {
-          "name": "request_stack_runners_runner_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "runner_id"
-          ]
-        }
-      }
-    },
-    "public.request_stacks": {
-      "name": "request_stacks",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_db_id": {
-          "name": "request_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "start_node_db_id": {
-          "name": "start_node_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "end_node_db_id": {
-          "name": "end_node_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "request_stacks_request_db_id_requests_db_id_fk": {
-          "name": "request_stacks_request_db_id_requests_db_id_fk",
-          "tableFrom": "request_stacks",
-          "tableTo": "requests",
-          "columnsFrom": [
-            "request_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "request_stacks_start_node_db_id_nodes_db_id_fk": {
-          "name": "request_stacks_start_node_db_id_nodes_db_id_fk",
-          "tableFrom": "request_stacks",
-          "tableTo": "nodes",
-          "columnsFrom": [
-            "start_node_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "request_stacks_end_node_db_id_nodes_db_id_fk": {
-          "name": "request_stacks_end_node_db_id_nodes_db_id_fk",
-          "tableFrom": "request_stacks",
-          "tableTo": "nodes",
-          "columnsFrom": [
-            "end_node_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "request_stacks_id_unique": {
-          "name": "request_stacks_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      }
-    },
-    "public.request_steps": {
-      "name": "request_steps",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_stack_db_id": {
-          "name": "request_stack_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "node_db_id": {
-          "name": "node_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'in_progress'"
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "finished_at": {
-          "name": "finished_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "request_steps_request_stack_db_id_request_stacks_db_id_fk": {
-          "name": "request_steps_request_stack_db_id_request_stacks_db_id_fk",
-          "tableFrom": "request_steps",
-          "tableTo": "request_stacks",
-          "columnsFrom": [
-            "request_stack_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "request_steps_node_db_id_nodes_db_id_fk": {
-          "name": "request_steps_node_db_id_nodes_db_id_fk",
-          "tableFrom": "request_steps",
-          "tableTo": "nodes",
-          "columnsFrom": [
-            "node_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "request_steps_id_unique": {
-          "name": "request_steps_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      }
-    },
-    "public.requests": {
-      "name": "requests",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "build_db_id": {
-          "name": "build_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'queued'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "finished_at": {
-          "name": "finished_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "requests_build_db_id_builds_db_id_fk": {
-          "name": "requests_build_db_id_builds_db_id_fk",
-          "tableFrom": "requests",
-          "tableTo": "builds",
-          "columnsFrom": [
-            "build_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "requests_id_unique": {
-          "name": "requests_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      }
-    },
-    "public.stripe_user_mappings": {
-      "name": "stripe_user_mappings",
-      "schema": "",
-      "columns": {
-        "user_db_id": {
-          "name": "user_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stripe_customer_id": {
-          "name": "stripe_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "stripe_user_mappings_user_db_id_users_db_id_fk": {
-          "name": "stripe_user_mappings_user_db_id_users_db_id_fk",
-          "tableFrom": "stripe_user_mappings",
-          "tableTo": "users",
-          "columnsFrom": [
-            "user_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "stripe_user_mappings_user_db_id_unique": {
-          "name": "stripe_user_mappings_user_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "user_db_id"
-          ]
-        },
-        "stripe_user_mappings_stripe_customer_id_unique": {
-          "name": "stripe_user_mappings_stripe_customer_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "stripe_customer_id"
-          ]
-        }
-      }
-    },
-    "public.subscriptions": {
-      "name": "subscriptions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "team_db_id": {
-          "name": "team_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "cancel_at_period_end": {
-          "name": "cancel_at_period_end",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "cancel_at": {
-          "name": "cancel_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "canceled_at": {
-          "name": "canceled_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_period_start": {
-          "name": "current_period_start",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "current_period_end": {
-          "name": "current_period_end",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created": {
-          "name": "created",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "ended_at": {
-          "name": "ended_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "trial_start": {
-          "name": "trial_start",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "trial_end": {
-          "name": "trial_end",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "subscriptions_team_db_id_teams_db_id_fk": {
-          "name": "subscriptions_team_db_id_teams_db_id_fk",
-          "tableFrom": "subscriptions",
-          "tableTo": "teams",
-          "columnsFrom": [
-            "team_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "subscriptions_id_unique": {
-          "name": "subscriptions_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      }
-    },
-    "public.supabase_user_mappings": {
-      "name": "supabase_user_mappings",
-      "schema": "",
-      "columns": {
-        "user_db_id": {
-          "name": "user_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "supabase_user_id": {
-          "name": "supabase_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "supabase_user_mappings_user_db_id_users_db_id_fk": {
-          "name": "supabase_user_mappings_user_db_id_users_db_id_fk",
-          "tableFrom": "supabase_user_mappings",
-          "tableTo": "users",
-          "columnsFrom": [
-            "user_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "supabase_user_mappings_user_db_id_unique": {
-          "name": "supabase_user_mappings_user_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "user_db_id"
-          ]
-        },
-        "supabase_user_mappings_supabase_user_id_unique": {
-          "name": "supabase_user_mappings_supabase_user_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "supabase_user_id"
-          ]
-        }
-      }
-    },
-    "public.team_memberships": {
-      "name": "team_memberships",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "user_db_id": {
-          "name": "user_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "team_db_id": {
-          "name": "team_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "role": {
-          "name": "role",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "team_memberships_user_db_id_users_db_id_fk": {
-          "name": "team_memberships_user_db_id_users_db_id_fk",
-          "tableFrom": "team_memberships",
-          "tableTo": "users",
-          "columnsFrom": [
-            "user_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "team_memberships_team_db_id_teams_db_id_fk": {
-          "name": "team_memberships_team_db_id_teams_db_id_fk",
-          "tableFrom": "team_memberships",
-          "tableTo": "teams",
-          "columnsFrom": [
-            "team_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "team_memberships_user_db_id_team_db_id_unique": {
-          "name": "team_memberships_user_db_id_team_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "user_db_id",
-            "team_db_id"
-          ]
-        }
-      }
-    },
-    "public.teams": {
-      "name": "teams",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'customer'"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {}
-    },
-    "public.trigger_nodes": {
-      "name": "trigger_nodes",
-      "schema": "",
-      "columns": {
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "build_db_id": {
-          "name": "build_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "node_db_id": {
-          "name": "node_db_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "trigger_nodes_build_db_id_builds_db_id_fk": {
-          "name": "trigger_nodes_build_db_id_builds_db_id_fk",
-          "tableFrom": "trigger_nodes",
-          "tableTo": "builds",
-          "columnsFrom": [
-            "build_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "trigger_nodes_node_db_id_nodes_db_id_fk": {
-          "name": "trigger_nodes_node_db_id_nodes_db_id_fk",
-          "tableFrom": "trigger_nodes",
-          "tableTo": "nodes",
-          "columnsFrom": [
-            "node_db_id"
-          ],
-          "columnsTo": [
-            "db_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "trigger_nodes_build_db_id_unique": {
-          "name": "trigger_nodes_build_db_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "build_db_id"
-          ]
-        }
-      }
-    },
-    "public.users": {
-      "name": "users",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "display_name": {
-          "name": "display_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "db_id": {
-          "name": "db_id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "users_id_unique": {
-          "name": "users_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        },
-        "users_email_unique": {
-          "name": "users_email_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
-        }
-      }
-    }
-  },
-  "enums": {},
-  "schemas": {},
-  "sequences": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "d4dc5fcf-b9a2-4446-b6a2-4f40e06e24e6",
+	"prevId": "d9bf892e-0113-42b0-9b91-925468406bc7",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.agent_activities": {
+			"name": "agent_activities",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_duration_ms": {
+					"name": "total_duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"agent_activities_agent_db_id_index": {
+					"name": "agent_activities_agent_db_id_index",
+					"columns": [
+						{
+							"expression": "agent_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agent_activities_agent_db_id_agents_db_id_fk": {
+					"name": "agent_activities_agent_db_id_agents_db_id_fk",
+					"tableFrom": "agent_activities",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.agents": {
+			"name": "agents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"graph_url": {
+					"name": "graph_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"graphv2": {
+					"name": "graphv2",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"graph": {
+					"name": "graph",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"nodes\":[],\"edges\":[],\"viewport\":{\"x\":0,\"y\":0,\"zoom\":1}}'::jsonb"
+				},
+				"graph_hash": {
+					"name": "graph_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"creator_db_id": {
+					"name": "creator_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"agents_team_db_id_teams_db_id_fk": {
+					"name": "agents_team_db_id_teams_db_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"agents_creator_db_id_users_db_id_fk": {
+					"name": "agents_creator_db_id_users_db_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "users",
+					"columnsFrom": ["creator_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"agents_id_unique": {
+					"name": "agents_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"agents_graph_hash_unique": {
+					"name": "agents_graph_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["graph_hash"]
+				}
+			}
+		},
+		"public.builds": {
+			"name": "builds",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"graph": {
+					"name": "graph",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"graph_hash": {
+					"name": "graph_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"before_id": {
+					"name": "before_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"after_id": {
+					"name": "after_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"builds_agent_db_id_agents_db_id_fk": {
+					"name": "builds_agent_db_id_agents_db_id_fk",
+					"tableFrom": "builds",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"builds_id_unique": {
+					"name": "builds_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"builds_graph_hash_unique": {
+					"name": "builds_graph_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["graph_hash"]
+				}
+			}
+		},
+		"public.edges": {
+			"name": "edges",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_port_db_id": {
+					"name": "target_port_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_port_db_id": {
+					"name": "source_port_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"edges_build_db_id_builds_db_id_fk": {
+					"name": "edges_build_db_id_builds_db_id_fk",
+					"tableFrom": "edges",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"edges_target_port_db_id_ports_db_id_fk": {
+					"name": "edges_target_port_db_id_ports_db_id_fk",
+					"tableFrom": "edges",
+					"tableTo": "ports",
+					"columnsFrom": ["target_port_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"edges_source_port_db_id_ports_db_id_fk": {
+					"name": "edges_source_port_db_id_ports_db_id_fk",
+					"tableFrom": "edges",
+					"tableTo": "ports",
+					"columnsFrom": ["source_port_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"edges_target_port_db_id_source_port_db_id_unique": {
+					"name": "edges_target_port_db_id_source_port_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["target_port_db_id", "source_port_db_id"]
+				},
+				"edges_id_build_db_id_unique": {
+					"name": "edges_id_build_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id", "build_db_id"]
+				}
+			}
+		},
+		"public.file_openai_file_representations": {
+			"name": "file_openai_file_representations",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"file_db_id": {
+					"name": "file_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_file_id": {
+					"name": "openai_file_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"file_openai_file_representations_file_db_id_files_db_id_fk": {
+					"name": "file_openai_file_representations_file_db_id_files_db_id_fk",
+					"tableFrom": "file_openai_file_representations",
+					"tableTo": "files",
+					"columnsFrom": ["file_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"file_openai_file_representations_openai_file_id_unique": {
+					"name": "file_openai_file_representations_openai_file_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["openai_file_id"]
+				}
+			}
+		},
+		"public.files": {
+			"name": "files",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_type": {
+					"name": "file_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_size": {
+					"name": "file_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blob_url": {
+					"name": "blob_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"files_id_unique": {
+					"name": "files_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.github_integrations": {
+			"name": "github_integrations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"repository_full_name": {
+					"name": "repository_full_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"call_sign": {
+					"name": "call_sign",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event": {
+					"name": "event",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"start_node_id": {
+					"name": "start_node_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_node_id": {
+					"name": "end_node_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_action": {
+					"name": "next_action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"github_integrations_repository_full_name_index": {
+					"name": "github_integrations_repository_full_name_index",
+					"columns": [
+						{
+							"expression": "repository_full_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"github_integrations_agent_db_id_agents_db_id_fk": {
+					"name": "github_integrations_agent_db_id_agents_db_id_fk",
+					"tableFrom": "github_integrations",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"github_integrations_id_unique": {
+					"name": "github_integrations_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.knowledge_content_openai_vector_store_file_representations": {
+			"name": "knowledge_content_openai_vector_store_file_representations",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"knowledge_content_db_id": {
+					"name": "knowledge_content_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_vector_store_file_id": {
+					"name": "openai_vector_store_file_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_vector_store_status": {
+					"name": "openai_vector_store_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk": {
+					"name": "knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk",
+					"tableFrom": "knowledge_content_openai_vector_store_file_representations",
+					"tableTo": "knowledge_contents",
+					"columnsFrom": ["knowledge_content_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"kcovsfr_knowledge_content_db_id_unique": {
+					"name": "kcovsfr_knowledge_content_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["knowledge_content_db_id"]
+				},
+				"kcovsfr_openai_vector_store_file_id_unique": {
+					"name": "kcovsfr_openai_vector_store_file_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["openai_vector_store_file_id"]
+				}
+			}
+		},
+		"public.knowledge_contents": {
+			"name": "knowledge_contents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"knowledge_content_type": {
+					"name": "knowledge_content_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"knowledge_db_id": {
+					"name": "knowledge_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_db_id": {
+					"name": "file_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledge_contents_knowledge_db_id_knowledges_db_id_fk": {
+					"name": "knowledge_contents_knowledge_db_id_knowledges_db_id_fk",
+					"tableFrom": "knowledge_contents",
+					"tableTo": "knowledges",
+					"columnsFrom": ["knowledge_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"knowledge_contents_file_db_id_files_db_id_fk": {
+					"name": "knowledge_contents_file_db_id_files_db_id_fk",
+					"tableFrom": "knowledge_contents",
+					"tableTo": "files",
+					"columnsFrom": ["file_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"knowledge_contents_id_unique": {
+					"name": "knowledge_contents_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"knowledge_contents_file_db_id_knowledge_db_id_unique": {
+					"name": "knowledge_contents_file_db_id_knowledge_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["file_db_id", "knowledge_db_id"]
+				}
+			}
+		},
+		"public.knowledge_openai_vector_store_representations": {
+			"name": "knowledge_openai_vector_store_representations",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"knowledge_db_id": {
+					"name": "knowledge_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_vector_store_id": {
+					"name": "openai_vector_store_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk": {
+					"name": "knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk",
+					"tableFrom": "knowledge_openai_vector_store_representations",
+					"tableTo": "knowledges",
+					"columnsFrom": ["knowledge_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"knowledge_openai_vector_store_representations_openai_vector_store_id_unique": {
+					"name": "knowledge_openai_vector_store_representations_openai_vector_store_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["openai_vector_store_id"]
+				}
+			}
+		},
+		"public.knowledges": {
+			"name": "knowledges",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledges_agent_db_id_agents_db_id_fk": {
+					"name": "knowledges_agent_db_id_agents_db_id_fk",
+					"tableFrom": "knowledges",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"knowledges_id_unique": {
+					"name": "knowledges_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.nodes": {
+			"name": "nodes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"graph": {
+					"name": "graph",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"nodes_build_db_id_builds_db_id_fk": {
+					"name": "nodes_build_db_id_builds_db_id_fk",
+					"tableFrom": "nodes",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"nodes_id_build_db_id_unique": {
+					"name": "nodes_id_build_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id", "build_db_id"]
+				}
+			}
+		},
+		"public.oauth_credentials": {
+			"name": "oauth_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_account_id": {
+					"name": "provider_account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_credentials_user_id_users_db_id_fk": {
+					"name": "oauth_credentials_user_id_users_db_id_fk",
+					"tableFrom": "oauth_credentials",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_credentials_user_id_provider_provider_account_id_unique": {
+					"name": "oauth_credentials_user_id_provider_provider_account_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_id", "provider", "provider_account_id"]
+				}
+			}
+		},
+		"public.ports": {
+			"name": "ports",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"node_db_id": {
+					"name": "node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"ports_node_db_id_nodes_db_id_fk": {
+					"name": "ports_node_db_id_nodes_db_id_fk",
+					"tableFrom": "ports",
+					"tableTo": "nodes",
+					"columnsFrom": ["node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"ports_id_node_db_id_unique": {
+					"name": "ports_id_node_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id", "node_db_id"]
+				}
+			}
+		},
+		"public.request_port_messages": {
+			"name": "request_port_messages",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"port_db_id": {
+					"name": "port_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"message": {
+					"name": "message",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_port_messages_request_db_id_requests_db_id_fk": {
+					"name": "request_port_messages_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_port_messages",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_port_messages_port_db_id_ports_db_id_fk": {
+					"name": "request_port_messages_port_db_id_ports_db_id_fk",
+					"tableFrom": "request_port_messages",
+					"tableTo": "ports",
+					"columnsFrom": ["port_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_port_messages_request_db_id_port_db_id_unique": {
+					"name": "request_port_messages_request_db_id_port_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["request_db_id", "port_db_id"]
+				}
+			}
+		},
+		"public.request_results": {
+			"name": "request_results",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"text": {
+					"name": "text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_results_request_db_id_requests_db_id_fk": {
+					"name": "request_results_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_results",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_results_request_db_id_unique": {
+					"name": "request_results_request_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["request_db_id"]
+				}
+			}
+		},
+		"public.request_runners": {
+			"name": "request_runners",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"runner_id": {
+					"name": "runner_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_runners_request_db_id_requests_db_id_fk": {
+					"name": "request_runners_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_runners",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_runners_runner_id_unique": {
+					"name": "request_runners_runner_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["runner_id"]
+				}
+			}
+		},
+		"public.request_stack_runners": {
+			"name": "request_stack_runners",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_stack_db_id": {
+					"name": "request_stack_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"runner_id": {
+					"name": "runner_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_stack_runners_request_stack_db_id_request_stacks_db_id_fk": {
+					"name": "request_stack_runners_request_stack_db_id_request_stacks_db_id_fk",
+					"tableFrom": "request_stack_runners",
+					"tableTo": "request_stacks",
+					"columnsFrom": ["request_stack_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_stack_runners_runner_id_unique": {
+					"name": "request_stack_runners_runner_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["runner_id"]
+				}
+			}
+		},
+		"public.request_stacks": {
+			"name": "request_stacks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"start_node_db_id": {
+					"name": "start_node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_node_db_id": {
+					"name": "end_node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_stacks_request_db_id_requests_db_id_fk": {
+					"name": "request_stacks_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_stacks",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_stacks_start_node_db_id_nodes_db_id_fk": {
+					"name": "request_stacks_start_node_db_id_nodes_db_id_fk",
+					"tableFrom": "request_stacks",
+					"tableTo": "nodes",
+					"columnsFrom": ["start_node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_stacks_end_node_db_id_nodes_db_id_fk": {
+					"name": "request_stacks_end_node_db_id_nodes_db_id_fk",
+					"tableFrom": "request_stacks",
+					"tableTo": "nodes",
+					"columnsFrom": ["end_node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_stacks_id_unique": {
+					"name": "request_stacks_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.request_steps": {
+			"name": "request_steps",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_stack_db_id": {
+					"name": "request_stack_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"node_db_id": {
+					"name": "node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'in_progress'"
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_steps_request_stack_db_id_request_stacks_db_id_fk": {
+					"name": "request_steps_request_stack_db_id_request_stacks_db_id_fk",
+					"tableFrom": "request_steps",
+					"tableTo": "request_stacks",
+					"columnsFrom": ["request_stack_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_steps_node_db_id_nodes_db_id_fk": {
+					"name": "request_steps_node_db_id_nodes_db_id_fk",
+					"tableFrom": "request_steps",
+					"tableTo": "nodes",
+					"columnsFrom": ["node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_steps_id_unique": {
+					"name": "request_steps_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.requests": {
+			"name": "requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"requests_build_db_id_builds_db_id_fk": {
+					"name": "requests_build_db_id_builds_db_id_fk",
+					"tableFrom": "requests",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"requests_id_unique": {
+					"name": "requests_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.stripe_user_mappings": {
+			"name": "stripe_user_mappings",
+			"schema": "",
+			"columns": {
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_customer_id": {
+					"name": "stripe_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"stripe_user_mappings_user_db_id_users_db_id_fk": {
+					"name": "stripe_user_mappings_user_db_id_users_db_id_fk",
+					"tableFrom": "stripe_user_mappings",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"stripe_user_mappings_user_db_id_unique": {
+					"name": "stripe_user_mappings_user_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id"]
+				},
+				"stripe_user_mappings_stripe_customer_id_unique": {
+					"name": "stripe_user_mappings_stripe_customer_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["stripe_customer_id"]
+				}
+			}
+		},
+		"public.subscriptions": {
+			"name": "subscriptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cancel_at_period_end": {
+					"name": "cancel_at_period_end",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cancel_at": {
+					"name": "cancel_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"canceled_at": {
+					"name": "canceled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_period_start": {
+					"name": "current_period_start",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"current_period_end": {
+					"name": "current_period_end",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created": {
+					"name": "created",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_start": {
+					"name": "trial_start",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_end": {
+					"name": "trial_end",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"subscriptions_team_db_id_teams_db_id_fk": {
+					"name": "subscriptions_team_db_id_teams_db_id_fk",
+					"tableFrom": "subscriptions",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"subscriptions_id_unique": {
+					"name": "subscriptions_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.supabase_user_mappings": {
+			"name": "supabase_user_mappings",
+			"schema": "",
+			"columns": {
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"supabase_user_id": {
+					"name": "supabase_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"supabase_user_mappings_user_db_id_users_db_id_fk": {
+					"name": "supabase_user_mappings_user_db_id_users_db_id_fk",
+					"tableFrom": "supabase_user_mappings",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"supabase_user_mappings_user_db_id_unique": {
+					"name": "supabase_user_mappings_user_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id"]
+				},
+				"supabase_user_mappings_supabase_user_id_unique": {
+					"name": "supabase_user_mappings_supabase_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["supabase_user_id"]
+				}
+			}
+		},
+		"public.team_memberships": {
+			"name": "team_memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"team_memberships_user_db_id_users_db_id_fk": {
+					"name": "team_memberships_user_db_id_users_db_id_fk",
+					"tableFrom": "team_memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"team_memberships_team_db_id_teams_db_id_fk": {
+					"name": "team_memberships_team_db_id_teams_db_id_fk",
+					"tableFrom": "team_memberships",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"team_memberships_user_db_id_team_db_id_unique": {
+					"name": "team_memberships_user_db_id_team_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id", "team_db_id"]
+				}
+			}
+		},
+		"public.teams": {
+			"name": "teams",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'customer'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.trigger_nodes": {
+			"name": "trigger_nodes",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"node_db_id": {
+					"name": "node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"trigger_nodes_build_db_id_builds_db_id_fk": {
+					"name": "trigger_nodes_build_db_id_builds_db_id_fk",
+					"tableFrom": "trigger_nodes",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"trigger_nodes_node_db_id_nodes_db_id_fk": {
+					"name": "trigger_nodes_node_db_id_nodes_db_id_fk",
+					"tableFrom": "trigger_nodes",
+					"tableTo": "nodes",
+					"columnsFrom": ["node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"trigger_nodes_build_db_id_unique": {
+					"name": "trigger_nodes_build_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["build_db_id"]
+				}
+			}
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_id_unique": {
+					"name": "users_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			}
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,118 +1,118 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1727672114041,
-      "tag": "0000_aberrant_stardust",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1727751238434,
-      "tag": "0001_glorious_mathemanic",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1727759326160,
-      "tag": "0002_mighty_zarek",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1729227804577,
-      "tag": "0003_messy_fabian_cortez",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1729759218608,
-      "tag": "0004_handy_kylun",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1730368916214,
-      "tag": "0005_smart_vapor",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1731571831614,
-      "tag": "0006_demonic_morlocks",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1731653065873,
-      "tag": "0007_breezy_bromley",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1731653081961,
-      "tag": "0008_cloudy_squadron_supreme",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1732504730844,
-      "tag": "0009_fuzzy_santa_claus",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1732514526781,
-      "tag": "0010_classy_jackpot",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1732852967369,
-      "tag": "0011_thin_ink",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1733113434236,
-      "tag": "0012_military_talisman",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1733117334658,
-      "tag": "0013_nosy_whiplash",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1733382854673,
-      "tag": "0014_lucky_sabretooth",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1733719570344,
-      "tag": "0015_parched_talon",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1727672114041,
+			"tag": "0000_aberrant_stardust",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1727751238434,
+			"tag": "0001_glorious_mathemanic",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1727759326160,
+			"tag": "0002_mighty_zarek",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1729227804577,
+			"tag": "0003_messy_fabian_cortez",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1729759218608,
+			"tag": "0004_handy_kylun",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1730368916214,
+			"tag": "0005_smart_vapor",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1731571831614,
+			"tag": "0006_demonic_morlocks",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1731653065873,
+			"tag": "0007_breezy_bromley",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1731653081961,
+			"tag": "0008_cloudy_squadron_supreme",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1732504730844,
+			"tag": "0009_fuzzy_santa_claus",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1732514526781,
+			"tag": "0010_classy_jackpot",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1732852967369,
+			"tag": "0011_thin_ink",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1733113434236,
+			"tag": "0012_military_talisman",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1733117334658,
+			"tag": "0013_nosy_whiplash",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1733382854673,
+			"tag": "0014_lucky_sabretooth",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1733719570344,
+			"tag": "0015_parched_talon",
+			"breakpoints": true
+		}
+	]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,111 +1,118 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1727672114041,
-			"tag": "0000_aberrant_stardust",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1727751238434,
-			"tag": "0001_glorious_mathemanic",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1727759326160,
-			"tag": "0002_mighty_zarek",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1729227804577,
-			"tag": "0003_messy_fabian_cortez",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1729759218608,
-			"tag": "0004_handy_kylun",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1730368916214,
-			"tag": "0005_smart_vapor",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1731571831614,
-			"tag": "0006_demonic_morlocks",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1731653065873,
-			"tag": "0007_breezy_bromley",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1731653081961,
-			"tag": "0008_cloudy_squadron_supreme",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1732504730844,
-			"tag": "0009_fuzzy_santa_claus",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1732514526781,
-			"tag": "0010_classy_jackpot",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1732852967369,
-			"tag": "0011_thin_ink",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1733113434236,
-			"tag": "0012_military_talisman",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1733117334658,
-			"tag": "0013_nosy_whiplash",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1733382854673,
-			"tag": "0014_lucky_sabretooth",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1727672114041,
+      "tag": "0000_aberrant_stardust",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1727751238434,
+      "tag": "0001_glorious_mathemanic",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1727759326160,
+      "tag": "0002_mighty_zarek",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1729227804577,
+      "tag": "0003_messy_fabian_cortez",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1729759218608,
+      "tag": "0004_handy_kylun",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1730368916214,
+      "tag": "0005_smart_vapor",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1731571831614,
+      "tag": "0006_demonic_morlocks",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1731653065873,
+      "tag": "0007_breezy_bromley",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1731653081961,
+      "tag": "0008_cloudy_squadron_supreme",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1732504730844,
+      "tag": "0009_fuzzy_santa_claus",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1732514526781,
+      "tag": "0010_classy_jackpot",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1732852967369,
+      "tag": "0011_thin_ink",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1733113434236,
+      "tag": "0012_military_talisman",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1733117334658,
+      "tag": "0013_nosy_whiplash",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1733382854673,
+      "tag": "0014_lucky_sabretooth",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1733719570344,
+      "tag": "0015_parched_talon",
+      "breakpoints": true
+    }
+  ]
 }

--- a/services/agents/activities/index.ts
+++ b/services/agents/activities/index.ts
@@ -1,1 +1,1 @@
-export { AgentActivityAction, AgentActivity } from "./types";
+export { AgentActivity } from "./types";

--- a/services/agents/activities/index.ts
+++ b/services/agents/activities/index.ts
@@ -1,0 +1,1 @@
+export { AgentActivityAction, AgentActivities } from "./types";

--- a/services/agents/activities/index.ts
+++ b/services/agents/activities/index.ts
@@ -1,1 +1,1 @@
-export { AgentActivityAction, AgentActivities } from "./types";
+export { AgentActivityAction, AgentActivity } from "./types";

--- a/services/agents/activities/types.ts
+++ b/services/agents/activities/types.ts
@@ -4,7 +4,7 @@ export class AgentActivity {
 	private actions: AgentActivityAction[] = [];
 	public agentId: AgentId;
 	public startedAt: Date;
-	public endedAt: Date | null;
+	public endedAt: Date | null = null;
 
 	constructor(agentId: AgentId, startedAt: Date) {
 		this.agentId = agentId;

--- a/services/agents/activities/types.ts
+++ b/services/agents/activities/types.ts
@@ -1,13 +1,23 @@
 import type { AgentId } from "../types";
 
-export class AgentActivities {
+export class AgentActivity {
 	private actions: AgentActivityAction[] = [];
+	public agentId: AgentId;
+	public startedAt: Date;
+	public endedAt: Date | null;
 
-	constructor(public agentId: AgentId) {}
+	constructor(agentId: AgentId, startedAt: Date) {
+		this.agentId = agentId;
+		this.startedAt = startedAt;
+	}
 
 	collectAction(action: string, startedAt: Date, completedAt: Date) {
 		const record = new AgentActivityAction(action, startedAt, completedAt);
 		this.actions.push(record);
+	}
+
+	end(endedAt: Date = new Date()) {
+		this.endedAt = endedAt;
 	}
 
 	totalDurationMs() {
@@ -15,7 +25,7 @@ export class AgentActivities {
 	}
 }
 
-export class AgentActivityAction {
+class AgentActivityAction {
 	constructor(
 		public action: string,
 		public startedAt: Date,

--- a/services/agents/activities/types.ts
+++ b/services/agents/activities/types.ts
@@ -1,0 +1,28 @@
+import type { AgentId } from "../types";
+
+export class AgentActivities {
+	private actions: AgentActivityAction[] = [];
+
+	constructor(public agentId: AgentId) {}
+
+	collectAction(action: string, startedAt: Date, completedAt: Date) {
+		const record = new AgentActivityAction(action, startedAt, completedAt);
+		this.actions.push(record);
+	}
+
+	totalDurationMs() {
+		return this.actions.reduce((acc, action) => acc + action.durationMs, 0);
+	}
+}
+
+export class AgentActivityAction {
+	constructor(
+		public action: string,
+		public startedAt: Date,
+		public completedAt: Date,
+	) {}
+
+	get durationMs() {
+		return this.completedAt.getTime() - this.startedAt.getTime();
+	}
+}


### PR DESCRIPTION
## Summary
Add functionality to track and store agent execution times in the database.

### Purpose
- For Giselle: Enable accurate calculation of billable agent execution time
- For users: Provide transparency into agent usage and associated costs within current billing cycle

## Changes
- Add new `agent_activities` table with columns:
  - `agent_db_id` (references agents table)
  - `started_at` (timestamp)
  - `ended_at` (timestamp)
  - `aggregated_execution_time_ms` (tracks total execution time including parallel tasks)
- Implement database operations for activity tracking
- Add cascade delete constraint to maintain referential integrity

> [!Note]
> - `aggregated_execution_time_ms` accounts for parallel task execution times
> - Foreign key constraint ensures cleanup of related activities when an agent is deleted

## TODO
- [x] Run migrate on Preview
- [ ] Run migrate on Production
