### PR TITLE
Measure usage of Unstructured in file upload feature

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -84,7 +84,10 @@ ${sourcesToText(sources)}
 										resolve,
 										Number.parseInt(
 											process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000",
-										),
+										) +
+											Number.parseInt(
+												process.env.WAITUNTIL_OFFSET_MILLIS ?? "0",
+											),
 									),
 								),
 							); // wait until telemetry sent

--- a/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
@@ -74,11 +74,11 @@ export async function parseFile(args: ParseFileInput) {
 		new Promise((resolve) =>
 			setTimeout(
 				resolve,
-				Number.parseInt(process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000"),
+				Number.parseInt(process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000") +
+					Number.parseInt(process.env.WAITUNTIL_OFFSET_MILLIS ?? "0"),
 			),
 		),
 	); // wait until telemetry sent
-
 	const jsonString = JSON.stringify(partitionResponse.elements, null, 2);
 	const blob = new Blob([jsonString], { type: "application/json" });
 

--- a/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
@@ -1,6 +1,12 @@
 "use server";
 
+import {
+	ExternalServiceName,
+	createLogger,
+	withCountMeasurement,
+} from "@/lib/opentelemetry";
 import { put } from "@vercel/blob";
+import { waitUntil } from "@vercel/functions";
 import { UnstructuredClient } from "unstructured-client";
 import { Strategy } from "unstructured-client/sdk/models/shared";
 import { elementsToMarkdown } from "../utils/unstructured";
@@ -28,6 +34,8 @@ type ParseFileInput = {
 	blobUrl: string;
 };
 export async function parseFile(args: ParseFileInput) {
+	const startTime = performance.now();
+	const logger = createLogger("files");
 	if (process.env.UNSTRUCTURED_API_KEY === undefined) {
 		throw new Error("UNSTRUCTURED_API_KEY is not set");
 	}
@@ -38,21 +46,39 @@ export async function parseFile(args: ParseFileInput) {
 	});
 	const response = await fetch(args.blobUrl);
 	const content = await response.blob();
-	const partitionResponse = await client.general.partition({
-		partitionParameters: {
-			files: {
-				fileName: args.name,
-				content,
-			},
-			strategy: Strategy.Fast,
-			splitPdfPage: false,
-			splitPdfConcurrencyLevel: 1,
-		},
-	});
+	const strategy = Strategy.Fast;
+	const partitionResponse = await withCountMeasurement(
+		logger,
+		() =>
+			client.general.partition({
+				partitionParameters: {
+					files: {
+						fileName: args.name,
+						content,
+					},
+					strategy,
+					splitPdfPage: false,
+					splitPdfConcurrencyLevel: 1,
+				},
+			}),
+		ExternalServiceName.Unstructured,
+		startTime,
+		strategy,
+	);
 	if (partitionResponse.statusCode !== 200) {
 		console.error(partitionResponse.rawResponse);
 		throw new Error(`Failed to parse file: ${partitionResponse.statusCode}`);
 	}
+
+	waitUntil(
+		new Promise((resolve) =>
+			setTimeout(
+				resolve,
+				Number.parseInt(process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000"),
+			),
+		),
+	); // wait until telemetry sent
+
 	const jsonString = JSON.stringify(partitionResponse.elements, null, 2);
 	const blob = new Blob([jsonString], { type: "application/json" });
 

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -1,7 +1,12 @@
 "use server";
 
 import { langfuseModel } from "@/lib/llm";
-import { ExternalServiceName, createLogger, withCountMeasurement, withTokenMeasurement } from "@/lib/opentelemetry";
+import {
+	ExternalServiceName,
+	createLogger,
+	withCountMeasurement,
+	withTokenMeasurement,
+} from "@/lib/opentelemetry";
 import { fetchCurrentUser } from "@/services/accounts/fetch-current-user";
 import { openai } from "@ai-sdk/openai";
 import FirecrawlApp from "@mendable/firecrawl-js";
@@ -192,14 +197,15 @@ ${sourcesToText(sources)}
 			chunkedArray.map(async (webSearchItems) => {
 				for (const webSearchItem of webSearchItems) {
 					try {
-						const scrapeResponse = await withCountMeasurement<FirecrawlResponse>(
-							logger,
-							() =>
-								app.scrapeUrl(webSearchItem.url, {
-									formats: ["markdown"],
-								}),
-							ExternalServiceName.Firecrawl,
-						);
+						const scrapeResponse =
+							await withCountMeasurement<FirecrawlResponse>(
+								logger,
+								() =>
+									app.scrapeUrl(webSearchItem.url, {
+										formats: ["markdown"],
+									}),
+								ExternalServiceName.Firecrawl,
+							);
 
 						if (scrapeResponse.success) {
 							const blob = await put(

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -100,7 +100,8 @@ ${sourcesToText(sources)}
 									resolve,
 									Number.parseInt(
 										process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000",
-									),
+									) +
+										Number.parseInt(process.env.WAITUNTIL_OFFSET_MILLIS ?? "0"),
 								),
 							),
 						); // wait until telemetry sent

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -1,8 +1,7 @@
 "use server";
 
-import { getCurrentMeasurementScope, isRoute06User } from "@/app/(auth)/lib";
 import { langfuseModel } from "@/lib/llm";
-import { ExternalServiceName, createLogger, withCountMeasurement } from "@/lib/opentelemetry";
+import { ExternalServiceName, createLogger, withCountMeasurement, withTokenMeasurement } from "@/lib/opentelemetry";
 import { fetchCurrentUser } from "@/services/accounts/fetch-current-user";
 import { openai } from "@ai-sdk/openai";
 import FirecrawlApp from "@mendable/firecrawl-js";
@@ -85,23 +84,24 @@ ${sourcesToText(sources)}
 			prompt: inputs.userPrompt,
 			schema: webSearchSchema,
 			onFinish: async (result) => {
-				const duration = performance.now() - startTime;
-				const measurementScope = await getCurrentMeasurementScope();
-				const isR06User = await isRoute06User();
-				generation.end({
-					output: result,
-				});
-
-				logger.info(
-					{
-						externalServiceName: "openai",
-						tokenConsumedInput: result.usage.promptTokens,
-						tokenConsumedOutput: result.usage.completionTokens,
-						duration,
-						measurementScope,
-						isR06User,
+				await withTokenMeasurement(
+					logger,
+					async () => {
+						generation.end({ output: result });
+						await lf.shutdownAsync();
+						waitUntil(
+							new Promise((resolve) =>
+								setTimeout(
+									resolve,
+									Number.parseInt(
+										process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000",
+									),
+								),
+							),
+						); // wait until telemetry sent
+						return result;
 					},
-					"[openai] search keywords generated",
+					startTime,
 				);
 			},
 		});

--- a/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/web-search/server-action.ts
@@ -2,7 +2,7 @@
 
 import { getCurrentMeasurementScope, isRoute06User } from "@/app/(auth)/lib";
 import { langfuseModel } from "@/lib/llm";
-import { createLogger, withMeasurement } from "@/lib/opentelemetry";
+import { ExternalServiceName, createLogger, withCountMeasurement } from "@/lib/opentelemetry";
 import { fetchCurrentUser } from "@/services/accounts/fetch-current-user";
 import { openai } from "@ai-sdk/openai";
 import FirecrawlApp from "@mendable/firecrawl-js";
@@ -120,10 +120,10 @@ ${sourcesToText(sources)}
 
 		const searchResults = await Promise.all(
 			result.keywords.map((keyword) =>
-				withMeasurement<WebSearchResult[]>(
+				withCountMeasurement<WebSearchResult[]>(
 					logger,
 					() => search(keyword),
-					"tavily",
+					ExternalServiceName.Tavily,
 				),
 			),
 		)
@@ -192,13 +192,13 @@ ${sourcesToText(sources)}
 			chunkedArray.map(async (webSearchItems) => {
 				for (const webSearchItem of webSearchItems) {
 					try {
-						const scrapeResponse = await withMeasurement<FirecrawlResponse>(
+						const scrapeResponse = await withCountMeasurement<FirecrawlResponse>(
 							logger,
 							() =>
 								app.scrapeUrl(webSearchItem.url, {
 									formats: ["markdown"],
 								}),
-							"firecrawl",
+							ExternalServiceName.Firecrawl,
 						);
 
 						if (scrapeResponse.success) {

--- a/lib/opentelemetry/wrapper.ts
+++ b/lib/opentelemetry/wrapper.ts
@@ -22,7 +22,7 @@ async function withMeasurement<T>(
 	measurement: MeasurementSchema<T>,
 	measurementStartTime?: number,
 ): Promise<T> {
-	const startTime = measurementStartTime ?? performance.now();
+	const startTime = measurementStartTime ?? performance.now(); // set `startTime` for each call in parallel process
 	try {
 		// business logic: error should be thrown
 		const result = await operation();


### PR DESCRIPTION
## Summary

This PR enables:
- counting API calls for Unstructured in file upload feature
- sending it to telemetry backend

## Related Issue

- this PR closes #198 
  - as subtask of #197

## Changes

- instrument to API call for Unstructured
- refactor preexistent wrapper function and instrumentations

## Testing

- confirmed that telemetry data arrived after uploading a file ✅ 

![image](https://github.com/user-attachments/assets/149eb92a-db25-4501-8bfb-329c6b7530d3)

## Note

Although we still need to instrument for Vercel Blob to record usages along file-uploading feature, I did not include it in this PR because the amount of changes is already large at this point.