### PR TITLE
Stop git commit only timestamp update in license report

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -88,6 +88,7 @@ jobs:
           && steps.determine.outputs.files_changed == 'true'
           && github.ref_name != github.event.repository.default_branch
         run: |
+          mkdir -p "$(dirname "$LICENSE_REPORT")"
           license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
           # Delete the timestamp line because there will be a difference even if there is no change in licenses
           sed -e '/^As of /d' -i "$LICENSE_REPORT"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -87,13 +87,20 @@ jobs:
           steps.fork-check.outputs.is_fork != 'true'
           && steps.determine.outputs.files_changed == 'true'
           && github.ref_name != github.event.repository.default_branch
-        run: license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
+        run: |
+          license_finder report --format=markdown | tail -n +2 > "$LICENSE_REPORT"
+          # Delete the timestamp line because there will be a difference even if there is no change in licenses
+          sed -e '/^As of /d' -i "$LICENSE_REPORT"
       - name: Commit license report and push
         if: |
           steps.fork-check.outputs.is_fork != 'true'
           && steps.determine.outputs.files_changed == 'true'
           && github.ref_name != github.event.repository.default_branch
         run: |
+          if git diff --quiet; then
+            echo 'No changes to commit'
+            exit 0
+          fi
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add "$LICENSE_REPORT"

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -1,6 +1,5 @@
 # giselle
 
-As of December 10, 2024  3:40am. 920 total
 
 ## Summary
 * 675 MIT


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Stop git commit only timestamp update in license report.
e.g. https://github.com/giselles-ai/giselle/commit/67f5ff7571fe332b441780c76b3b0ee405f2c7ad

## Related Issue
<!-- Mention the related issue number if applicable. -->
N/A

## Changes
<!-- List the main changes made in this PR. -->
Removed the timestamp line from license report in GitHub Actions workflow.

## Testing
<!-- Briefly describe the testing steps or results. -->
✅ This job removed the timestamp line.
https://github.com/giselles-ai/giselle/actions/runs/12269896633/job/34234219729
