### PR TITLE
Count API calls for Vercel Blob

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -4,7 +4,11 @@ import { streamObject } from "ai";
 import { createStreamableValue } from "ai/rsc";
 
 import { langfuseModel } from "@/lib/llm";
-import {createLogger, waitForTelemetryExport, withTokenMeasurement} from "@/lib/opentelemetry";
+import {
+	createLogger,
+	waitForTelemetryExport,
+	withTokenMeasurement,
+} from "@/lib/opentelemetry";
 import { fetchCurrentUser } from "@/services/accounts/fetch-current-user";
 import { Langfuse } from "langfuse";
 import { schema as artifactSchema } from "../artifact/schema";

--- a/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/artifact/server-actions.ts
@@ -4,9 +4,8 @@ import { streamObject } from "ai";
 import { createStreamableValue } from "ai/rsc";
 
 import { langfuseModel } from "@/lib/llm";
-import { createLogger, withTokenMeasurement } from "@/lib/opentelemetry";
+import {createLogger, waitForTelemetryExport, withTokenMeasurement} from "@/lib/opentelemetry";
 import { fetchCurrentUser } from "@/services/accounts/fetch-current-user";
-import { waitUntil } from "@vercel/functions";
 import { Langfuse } from "langfuse";
 import { schema as artifactSchema } from "../artifact/schema";
 import { buildLanguageModel } from "../flow/server-actions/generate-text";
@@ -78,19 +77,7 @@ ${sourcesToText(sources)}
 						async () => {
 							generation.end({ output: result });
 							await lf.shutdownAsync();
-							waitUntil(
-								new Promise((resolve) =>
-									setTimeout(
-										resolve,
-										Number.parseInt(
-											process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000",
-										) +
-											Number.parseInt(
-												process.env.WAITUNTIL_OFFSET_MILLIS ?? "0",
-											),
-									),
-								),
-							); // wait until telemetry sent
+							waitForTelemetryExport();
 							return result;
 						},
 						startTime,

--- a/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
@@ -17,15 +17,31 @@ type UploadFileInput = {
 	file: File;
 };
 export async function uploadFile({ input }: { input: UploadFileInput }) {
-	const blob = await put(
-		`files/${input.fileId}/${input.file.name}`,
-		input.file,
-		{
-			access: "public",
-			contentType: input.file.type,
+	const startTime = performance.now();
+	const logger = createLogger("files");
+	const result = await withCountMeasurement(
+		logger,
+		async () => {
+			const result = await put(
+				`files/${input.fileId}/${input.file.name}`,
+				input.file,
+				{
+					access: "public",
+					contentType: input.file.type,
+				},
+			);
+			return {
+				blob: result,
+				size: input.file.size,
+			};
 		},
+		ExternalServiceName.VercelBlob,
+		startTime,
+		"put",
 	);
-	return blob;
+	waitForTelemetryExport();
+
+	return result.blob;
 }
 
 type ParseFileInput = {
@@ -44,8 +60,22 @@ export async function parseFile(args: ParseFileInput) {
 			apiKeyAuth: process.env.UNSTRUCTURED_API_KEY,
 		},
 	});
-	const response = await fetch(args.blobUrl);
-	const content = await response.blob();
+	const response = await withCountMeasurement(
+		logger,
+		async () => {
+			const response = await fetch(args.blobUrl);
+			const blob = await response.blob();
+			return {
+				blob,
+				size: blob.size,
+			};
+		},
+		ExternalServiceName.VercelBlob,
+		startTime,
+		"fetch",
+	);
+
+	const content = await response.blob;
 	const strategy = Strategy.Fast;
 	const partitionResponse = await withCountMeasurement(
 		logger,
@@ -70,15 +100,20 @@ export async function parseFile(args: ParseFileInput) {
 		throw new Error(`Failed to parse file: ${partitionResponse.statusCode}`);
 	}
 
-	waitForTelemetryExport();
-
 	const jsonString = JSON.stringify(partitionResponse.elements, null, 2);
 	const blob = new Blob([jsonString], { type: "application/json" });
 
-	await put(`files/${args.id}/partition.json`, blob, {
-		access: "public",
-		contentType: blob.type,
-	});
+	await withCountMeasurement(
+		logger,
+		() =>
+			put(`files/${args.id}/partition.json`, blob, {
+				access: "public",
+				contentType: blob.type,
+			}),
+		ExternalServiceName.VercelBlob,
+		startTime,
+		"put",
+	);
 
 	const markdown = elementsToMarkdown(partitionResponse.elements ?? []);
 	const markdownBlob = new Blob([markdown], { type: "text/markdown" });
@@ -86,6 +121,8 @@ export async function parseFile(args: ParseFileInput) {
 		access: "public",
 		contentType: markdownBlob.type,
 	});
+
+	waitForTelemetryExport();
 
 	return vercelBlob;
 }

--- a/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/files/server-actions.ts
@@ -3,10 +3,10 @@
 import {
 	ExternalServiceName,
 	createLogger,
+	waitForTelemetryExport,
 	withCountMeasurement,
 } from "@/lib/opentelemetry";
 import { put } from "@vercel/blob";
-import { waitUntil } from "@vercel/functions";
 import { UnstructuredClient } from "unstructured-client";
 import { Strategy } from "unstructured-client/sdk/models/shared";
 import { elementsToMarkdown } from "../utils/unstructured";
@@ -70,15 +70,8 @@ export async function parseFile(args: ParseFileInput) {
 		throw new Error(`Failed to parse file: ${partitionResponse.statusCode}`);
 	}
 
-	waitUntil(
-		new Promise((resolve) =>
-			setTimeout(
-				resolve,
-				Number.parseInt(process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000") +
-					Number.parseInt(process.env.WAITUNTIL_OFFSET_MILLIS ?? "0"),
-			),
-		),
-	); // wait until telemetry sent
+	waitForTelemetryExport();
+
 	const jsonString = JSON.stringify(partitionResponse.elements, null, 2);
 	const blob = new Blob([jsonString], { type: "application/json" });
 

--- a/lib/opentelemetry/types.ts
+++ b/lib/opentelemetry/types.ts
@@ -6,6 +6,7 @@ export const ExternalServiceName = {
 	OpenAI: "openai",
 	Tavily: "tavily",
 	Unstructured: "unstructured",
+	VercelBlob: "vercel_blob",
 } as const;
 
 export type ExternalServiceName = // Name of the service to which agent requests
@@ -39,9 +40,27 @@ const UnstructuredRequestCountSchema = RequestCount.extend({
 	strategy: z.nativeEnum(Strategy),
 });
 
+const VercelBlobPutSchema = RequestCount.extend({
+	externalServiceName: z.literal(ExternalServiceName.VercelBlob),
+	operationType: z.literal("put"),
+	blobSizeStored: z.number(),
+});
+
+const VercelBlobFetchSchema = RequestCount.extend({
+	externalServiceName: z.literal(ExternalServiceName.VercelBlob),
+	operationType: z.literal("fetch"),
+	blobSizeTransfered: z.number(),
+});
+
+const VercelBlobRequestCountSchema = z.discriminatedUnion("operationType", [
+	VercelBlobPutSchema,
+	VercelBlobFetchSchema,
+]);
+
 const RequestCountSchema = z.union([
 	BasicRequestCountSchema,
 	UnstructuredRequestCountSchema,
+	VercelBlobRequestCountSchema,
 ]);
 
 export type TokenConsumedSchema = z.infer<typeof TokenConsumedSchema>;

--- a/lib/opentelemetry/wrapper.ts
+++ b/lib/opentelemetry/wrapper.ts
@@ -1,4 +1,5 @@
 import { getCurrentMeasurementScope, isRoute06User } from "@/app/(auth)/lib";
+import { waitUntil } from "@vercel/functions";
 import type { LanguageModelUsage } from "ai";
 import type { Strategy } from "unstructured-client/sdk/models/shared";
 import { captureError } from "./log";
@@ -148,4 +149,16 @@ export function withTokenMeasurement<T extends { usage: LanguageModelUsage }>(
 	});
 
 	return withMeasurement(logger, operation, measurements, measurementStartTime);
+}
+
+export function waitForTelemetryExport() {
+	waitUntil(
+		new Promise((resolve) =>
+			setTimeout(
+				resolve,
+				Number.parseInt(process.env.OTEL_EXPORT_INTERVAL_MILLIS ?? "1000") +
+					Number.parseInt(process.env.WAITUNTIL_OFFSET_MILLIS ?? "0"),
+			),
+		),
+	);
 }


### PR DESCRIPTION
## Summary

This PR enables:
- counting API calls for Vercel Blob in file upload feature
- sending it to telemetry backend

## Related Issue

- this PR closes https://github.com/giselles-ai/giselle/issues/199
  - as subtask of https://github.com/giselles-ai/giselle/issues/197

## Changes

- instrument to API call for Vercel Blob
- reduce lines of preexistent workaround codes (`waitUntil()`) by using wrapper function

## Testing

Confirmed usage data arrived to our telemetry backend when I uploaded a file in corresponding preview environment (private env):
![image](https://github.com/user-attachments/assets/3c28cb37-7aac-499a-b089-d4b0d0bb29ed)

### At the first upload
![image](https://github.com/user-attachments/assets/0278b21e-ae25-4648-9b8f-98872a842e72)
![image](https://github.com/user-attachments/assets/114f4d29-9a40-4fc8-92fc-a22022a66592)

### At implicit download (to send to Unstructured)
![image](https://github.com/user-attachments/assets/6cbeb9b2-be13-477e-804f-9a7eb186ceca)
![image](https://github.com/user-attachments/assets/32c3c7d3-793a-4eff-ba0e-4f176e65d690)
