### PR TITLE
Add agent time usage limit for free plan teams

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/flow/composite-actions.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/composite-actions.ts
@@ -16,15 +16,21 @@ export function executeFlow(finalNode: GiselleNode): CompositeAction {
 				},
 			}),
 		);
-		const { streamableValue } = await executeFlowOnServer(
-			getState().graph.agentId,
-			finalNode.id,
-		);
-		for await (const streamContent of readStreamableValue(streamableValue)) {
-			if (streamContent === undefined) {
-				continue;
+		try {
+			const { streamableValue } = await executeFlowOnServer(
+				getState().graph.agentId,
+				finalNode.id,
+			);
+			for await (const streamContent of readStreamableValue(streamableValue)) {
+				if (streamContent === undefined) {
+					continue;
+				}
+				dispatch(streamContent);
 			}
-			dispatch(streamContent);
+		} catch (error: unknown) {
+			if (error instanceof Error) {
+				global.alert(error.message);
+			}
 		}
 	};
 }

--- a/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
@@ -5,7 +5,6 @@ import {
 	AgentActivity,
 	hasEnoughAgentTimeCharge,
 } from "@/services/agents/activities";
-import { fetchCurrentTeam } from "@/services/teams";
 import { put } from "@vercel/blob";
 import { createStreamableValue } from "ai/rsc";
 import { eq } from "drizzle-orm";
@@ -33,8 +32,7 @@ export async function executeFlow(
 	agentId: AgentId,
 	finalNodeId: GiselleNodeId,
 ) {
-	const currentTeam = await fetchCurrentTeam();
-	const canExecute = await hasEnoughAgentTimeCharge(currentTeam.dbId);
+	const canExecute = await hasEnoughAgentTimeCharge();
 	if (!canExecute) {
 		throw new Error(
 			"Your agent time has been depleted. Please upgrade your plan to continue using this feature.",

--- a/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/server-action.ts
@@ -1,7 +1,11 @@
 "use server";
 
 import { agents, db } from "@/drizzle";
-import { AgentActivity } from "@/services/agents/activities";
+import {
+	AgentActivity,
+	hasEnoughAgentTimeCharge,
+} from "@/services/agents/activities";
+import { fetchCurrentTeam } from "@/services/teams";
 import { put } from "@vercel/blob";
 import { createStreamableValue } from "ai/rsc";
 import { eq } from "drizzle-orm";
@@ -29,6 +33,13 @@ export async function executeFlow(
 	agentId: AgentId,
 	finalNodeId: GiselleNodeId,
 ) {
+	const currentTeam = await fetchCurrentTeam();
+	const canExecute = await hasEnoughAgentTimeCharge(currentTeam.dbId);
+	if (!canExecute) {
+		throw new Error(
+			"Your agent time has been depleted. Please upgrade your plan to continue using this feature.",
+		);
+	}
 	const agentActivity = new AgentActivity(agentId, new Date());
 	const stream = createStreamableValue<V2FlowAction>();
 	(async () => {

--- a/services/agents/activities/has-enough-agent-time-charge.ts
+++ b/services/agents/activities/has-enough-agent-time-charge.ts
@@ -1,45 +1,20 @@
-import { db, subscriptions, teams } from "@/drizzle";
-import { isProPlan } from "@/services/teams";
-import { and, eq } from "drizzle-orm";
+import { fetchCurrentTeam, isProPlan } from "@/services/teams";
 import { calculateAgentTimeUsageMs } from "./agent-time-usage";
 import { AGENT_TIME_CHARGE_LIMIT_MINUTES } from "./constants";
 
-export async function hasEnoughAgentTimeCharge(teamDbId: number) {
-	const team = await getTeam(teamDbId);
+export async function hasEnoughAgentTimeCharge() {
+	const curerntTeam = await fetchCurrentTeam();
 	// if team is pro plan, go ahead
-	if (isProPlan(team)) {
+	if (isProPlan(curerntTeam)) {
 		return true;
 	}
 
 	// if team is free plan, check agent time usage
-	const timeUsageMs = await calculateAgentTimeUsageMs(teamDbId);
+	const timeUsageMs = await calculateAgentTimeUsageMs(curerntTeam.dbId);
 	const limitsInMs = AGENT_TIME_CHARGE_LIMIT_MINUTES.FREE * 60 * 1000;
 	if (timeUsageMs >= limitsInMs) {
 		return false;
 	}
 
 	return true;
-}
-
-async function getTeam(teamDbId: number) {
-	const result = await db
-		.select({
-			dbId: teams.dbId,
-			name: teams.name,
-			type: teams.type,
-			activeSubscriptionId: subscriptions.id,
-		})
-		.from(teams)
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(subscriptions.teamDbId, teams.dbId),
-				eq(subscriptions.status, "active"),
-			),
-		)
-		.where(eq(teams.dbId, teamDbId));
-	if (result.length === 0) {
-		throw new Error(`Team with dbId ${teamDbId} not found`);
-	}
-	return result[0];
 }

--- a/services/agents/activities/has-enough-agent-time-charge.ts
+++ b/services/agents/activities/has-enough-agent-time-charge.ts
@@ -1,0 +1,45 @@
+import { db, subscriptions, teams } from "@/drizzle";
+import { isProPlan } from "@/services/teams";
+import { and, eq } from "drizzle-orm";
+import { calculateAgentTimeUsageMs } from "./agent-time-usage";
+import { AGENT_TIME_CHARGE_LIMIT_MINUTES } from "./constants";
+
+export async function hasEnoughAgentTimeCharge(teamDbId: number) {
+	const team = await getTeam(teamDbId);
+	// if team is pro plan, go ahead
+	if (isProPlan(team)) {
+		return true;
+	}
+
+	// if team is free plan, check agent time usage
+	const timeUsageMs = await calculateAgentTimeUsageMs(teamDbId);
+	const limitsInMs = AGENT_TIME_CHARGE_LIMIT_MINUTES.FREE * 60 * 1000;
+	if (timeUsageMs >= limitsInMs) {
+		return false;
+	}
+
+	return true;
+}
+
+async function getTeam(teamDbId: number) {
+	const result = await db
+		.select({
+			dbId: teams.dbId,
+			name: teams.name,
+			type: teams.type,
+			activeSubscriptionId: subscriptions.id,
+		})
+		.from(teams)
+		.leftJoin(
+			subscriptions,
+			and(
+				eq(subscriptions.teamDbId, teams.dbId),
+				eq(subscriptions.status, "active"),
+			),
+		)
+		.where(eq(teams.dbId, teamDbId));
+	if (result.length === 0) {
+		throw new Error(`Team with dbId ${teamDbId} not found`);
+	}
+	return result[0];
+}

--- a/services/agents/activities/has-enough-agent-time-charge.ts
+++ b/services/agents/activities/has-enough-agent-time-charge.ts
@@ -4,12 +4,12 @@ import { AGENT_TIME_CHARGE_LIMIT_MINUTES } from "./constants";
 
 export async function hasEnoughAgentTimeCharge() {
 	const curerntTeam = await fetchCurrentTeam();
-	// if team is pro plan, go ahead
+	// If team is on a pro plan, proceed
 	if (isProPlan(curerntTeam)) {
 		return true;
 	}
 
-	// if team is free plan, check agent time usage
+	// If team is on a free plan, check agent time usage
 	const timeUsageMs = await calculateAgentTimeUsageMs(curerntTeam.dbId);
 	const limitsInMs = AGENT_TIME_CHARGE_LIMIT_MINUTES.FREE * 60 * 1000;
 	if (timeUsageMs >= limitsInMs) {

--- a/services/agents/activities/index.ts
+++ b/services/agents/activities/index.ts
@@ -1,3 +1,4 @@
 export { calculateAgentTimeUsageMs } from "./agent-time-usage";
 export { AGENT_TIME_CHARGE_LIMIT_MINUTES } from "./constants";
+export { hasEnoughAgentTimeCharge } from "./has-enough-agent-time-charge";
 export { AgentActivity } from "./types";


### PR DESCRIPTION
## Summary
Added limitation that prevents free plan teams from running workflows when their agent time charge has been depleted.

## Changes
- Added `hasEnoughAgentTimeCharge()` function to check if a team has enough agent time remaining
- If the limit is exceeded, `executeFlow()` will throw an error with a user-friendly message
  - Instead of adding a simple alert it would be better to use toast notifications or error states. However, since v2 playground development is ongoing, it makes more sense to implement improved error notifications in v2.

## Screenshots
<img width="803" alt="スクリーンショット 2024-12-11 14 50 48" src="https://github.com/user-attachments/assets/a88ea7b9-94b7-4f91-99d6-999da2c6bda7">
