### PR TITLE
[refactor] Simplify action execution by removing explicit graph URL parameter

### DIFF
--- a/app/(playground)/p/[agentId]/canary/contexts/execution.tsx
+++ b/app/(playground)/p/[agentId]/canary/contexts/execution.tsx
@@ -20,7 +20,6 @@ interface ExecutionProviderProps {
 	children: ReactNode;
 	executeAction: (
 		artifactId: ArtifactId,
-		graphUrl: string,
 		nodeId: NodeId,
 	) => Promise<StreamableValue<TextArtifactObject, unknown>>;
 }
@@ -56,9 +55,9 @@ export function ExecutionProvider({
 				},
 			});
 			setTab("Result");
-			const latestGraphUrl = await flush();
+			await flush();
 			try {
-				const stream = await executeAction(artifactId, latestGraphUrl, nodeId);
+				const stream = await executeAction(artifactId, nodeId);
 
 				let textArtifactObject: TextArtifactObject = {
 					type: "text",

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -4,7 +4,6 @@ import { del, list } from "@vercel/blob";
 import { ReactFlowProvider } from "@xyflow/react";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
-import type { AgentId } from "../beta-proto/types";
 import { action, putGraph } from "./actions";
 import { Editor } from "./components/editor";
 import { AgentNameProvider } from "./contexts/agent-name";
@@ -16,7 +15,7 @@ import { PropertiesPanelProvider } from "./contexts/properties-panel";
 import { ToastProvider } from "./contexts/toast";
 import { ToolbarContextProvider } from "./contexts/toolbar";
 import { isLatestVersion, migrateGraph } from "./graph";
-import type { ArtifactId, Graph, NodeId } from "./types";
+import type { AgentId, ArtifactId, Graph, NodeId } from "./types";
 import { buildGraphFolderPath } from "./utils";
 
 // Extend the max duration of the server actions from this page to 5 minutes
@@ -94,7 +93,7 @@ export default async function Page({
 		nodeId: NodeId,
 	) {
 		"use server";
-		return await action(artifactId, graphUrl, nodeId);
+		return await action(artifactId, agentId, nodeId);
 	}
 
 	return (

--- a/app/(playground)/p/[agentId]/canary/page.tsx
+++ b/app/(playground)/p/[agentId]/canary/page.tsx
@@ -87,11 +87,7 @@ export default async function Page({
 		return agentName;
 	}
 
-	async function execute(
-		artifactId: ArtifactId,
-		graphUrl: string,
-		nodeId: NodeId,
-	) {
+	async function execute(artifactId: ArtifactId, nodeId: NodeId) {
 		"use server";
 		return await action(artifactId, agentId, nodeId);
 	}

--- a/app/(playground)/p/[agentId]/canary/types.ts
+++ b/app/(playground)/p/[agentId]/canary/types.ts
@@ -212,3 +212,5 @@ export interface SubGraph {
 	nodes: Set<NodeId>;
 	connections: Set<ConnectionId>;
 }
+
+export type AgentId = `agnt_${string}`;


### PR DESCRIPTION
## Changes
- Remove `graphUrl` parameter from execute action signature
- Update execution context to no longer manage graph URLs
- Simplify execution flow in execution provider component
- Adjust server action to handle graph URL fetch internally

## Why
This change streamlines the execution flow by removing the need to pass graph URLs through the client. The graph URL is now managed entirely server-side through database lookups using the agent ID, which:
- Improves security by preventing client-side URL manipulation
- Reduces complexity in the execution context
- Ensures single source of truth for graph URLs in the database
