### PR TITLE
feat(ui): Add Gemini 2.0 Flash Exp model to LLM selection

### DIFF
--- a/app/(playground)/p/[agentId]/canary/components/properties-panel.tsx
+++ b/app/(playground)/p/[agentId]/canary/components/properties-panel.tsx
@@ -906,6 +906,9 @@ function TabsContentPrompt({
 									<SelectItem value="google:gemini-1.5-pro">
 										Gemini 1.5 Pro
 									</SelectItem>
+									<SelectItem value="google:gemini-2.0-flash-exp">
+										Gemini 2.0 Flash Exp
+									</SelectItem>
 								</SelectGroup>
 								{developerMode && (
 									<SelectGroup>


### PR DESCRIPTION
Add Google's Gemini 2.0 Flash Exp model as a new option in the language model selection dropdown. This experimental model is available for developer testing alongside existing Gemini, OpenAI, and Anthropic models.
