### PR TITLE
[refactor] Optimize logger creation and usage tracking in canary actions

### DIFF
--- a/app/(playground)/p/[agentId]/canary/actions.ts
+++ b/app/(playground)/p/[agentId]/canary/actions.ts
@@ -317,7 +317,7 @@ export async function action(
 				},
 			});
 			(async () => {
-				const { partialObjectStream, object } = streamObject({
+				const { partialObjectStream, object, usage } = streamObject({
 					model,
 					prompt,
 					schema: jsonSchema<v.InferInput<typeof artifactSchema>>(

--- a/app/(playground)/p/[agentId]/canary/actions.ts
+++ b/app/(playground)/p/[agentId]/canary/actions.ts
@@ -137,8 +137,6 @@ export async function action(
 	if (node === undefined) {
 		throw new Error("Node not found");
 	}
-	const logger = createLogger(node.content.type);
-
 	/**
 	 * This function is a helper that retrieves a node from the graph
 	 * based on its NodeHandleId. It looks for a connection in the
@@ -343,7 +341,7 @@ export async function action(
 				const result = await object;
 
 				await withTokenMeasurement(
-					logger,
+					createLogger(node.content.type),
 					async () => {
 						generationTracer.end({ output: result });
 						await lf.shutdownAsync();

--- a/app/(playground)/p/[agentId]/canary/actions.ts
+++ b/app/(playground)/p/[agentId]/canary/actions.ts
@@ -88,14 +88,6 @@ const artifactSchema = v.object({
 			"Explanation of the Artifact and what the intention was in creating this Artifact. Add any suggestions for making it even better.",
 		),
 	),
-	usage: v.pipe(
-		v.object({
-			promptTokens: v.number(),
-			completionTokens: v.number(),
-			totalTokens: v.number(),
-		}),
-		v.description("Return from 'generateObject()' from @vercel/ai"),
-	),
 });
 
 interface ActionSourceBase {
@@ -346,15 +338,6 @@ export async function action(
 							plan: partialObject.plan ?? "",
 							description: partialObject.description ?? "",
 						},
-						...(partialObject.usage?.promptTokens !== undefined &&
-						partialObject.usage?.completionTokens !== undefined
-							? {
-									usage: {
-										promptTokens: partialObject.usage.promptTokens,
-										completionTokens: partialObject.usage.completionTokens,
-									},
-								}
-							: {}),
 					});
 				}
 				const result = await object;
@@ -365,7 +348,7 @@ export async function action(
 						generationTracer.end({ output: result });
 						await lf.shutdownAsync();
 						waitForTelemetryExport();
-						return result;
+						return { usage: await usage };
 					},
 					model,
 					startTime,

--- a/app/(playground)/p/[agentId]/canary/lib/graph.test.ts
+++ b/app/(playground)/p/[agentId]/canary/lib/graph.test.ts
@@ -121,6 +121,7 @@ const graph: Graph = {
 	artifacts: [],
 	version: "2024-12-09",
 	flows: [],
+	executionIndexes: [],
 };
 
 describe("deriveFlows", () => {


### PR DESCRIPTION
## Changes
- Streamline data flow for token usage tracking
- Remove usage metrics from artifact schema
- Move logger creation inside token measurement scope
- Update action response to handle LLM usage metrics directly

## Why
These changes improve the efficiency and accuracy of our usage tracking:
1. Usage metrics now come directly from the LLM instead of being calculated
   from tokens, providing more accurate measurements
2. Logger is only created when needed, preventing unnecessary instantiation
3. Separation of concerns between artifact data and usage metrics makes the
   code more maintainable

## Testing
- Verified LLM usage metrics are correctly returned
- Confirmed token measurement still works with delayed logger creation
- Tested artifact generation without usage schema
- Validated response structure changes

## Technical Details
- Modified artifactSchema to remove redundant usage object
- Moved createLogger call inside withTokenMeasurement for better scoping
- Updated action response structure to handle usage separately
- Maintained existing functionality while improving code organization
