### PR TITLE
Add function to report Agent time usage to Stripe

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/flow/save-agent-activity.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/save-agent-activity.ts
@@ -19,6 +19,6 @@ export async function saveAgentActivity(activity: AgentActivity) {
 		agentDbId,
 		startedAt: activity.startedAt,
 		endedAt: activity.endedAt,
-		aggregatedExecutionTimeMs: activity.totalDurationMs(),
+		totalDurationMs: activity.totalDurationMs(),
 	});
 }

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2,23 +2,22 @@
 
 
 ## Summary
-* 677 MIT
-* 130 Apache 2.0
-* 62 ISC
-* 24 New BSD
-* 13 Simplified BSD
+* 656 MIT
+* 122 Apache 2.0
+* 61 ISC
+* 23 New BSD
+* 12 Simplified BSD
 * 3 MIT OR Apache-2.0
 * 3 BlueOak-1.0.0
-* 2 LGPL-3.0-or-later
 * 2 BSD Zero Clause License
 * 2 The Unlicense
-* 1 (MIT AND Zlib)
-* 1 BSD
-* 1 CC0 1.0 Universal
-* 1 CC-BY-4.0
-* 1 (MIT OR CC0-1.0)
-* 1 (AFL-2.1 OR BSD-3-Clause)
+* 2 LGPL-3.0-or-later
 * 1 Apache 2.0, BSD Zero Clause License, ISC, MIT, Mozilla Public License 2.0, New BSD, Simplified BSD, The Unlicense, zlib/libpng license
+* 1 (AFL-2.1 OR BSD-3-Clause)
+* 1 (MIT OR CC0-1.0)
+* 1 CC-BY-4.0
+* 1 BSD
+* 1 (MIT AND Zlib)
 
 
 
@@ -26,7 +25,7 @@
 
 
 <a name="@ai-sdk/anthropic"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/anthropic</a> v0.0.56 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/anthropic</a> v1.0.5 (dependencies)
 #### 
 
 ##### Paths
@@ -37,7 +36,7 @@
 
 
 <a name="@ai-sdk/google"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/google</a> v1.0.7 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/google</a> v1.0.10 (dependencies)
 #### 
 
 ##### Paths
@@ -48,18 +47,7 @@
 
 
 <a name="@ai-sdk/openai"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/openai</a> v0.0.72 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-
-
-<a name="@ai-sdk/provider"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/provider</a> v0.0.26 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/openai</a> v1.0.8 (dependencies)
 #### 
 
 ##### Paths
@@ -81,17 +69,6 @@
 
 
 <a name="@ai-sdk/provider-utils"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/provider-utils</a> v1.0.22 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-
-
-<a name="@ai-sdk/provider-utils"></a>
 ### <a href="https://sdk.vercel.ai/docs">@ai-sdk/provider-utils</a> v2.0.4 (dependencies)
 #### 
 
@@ -103,29 +80,7 @@
 
 
 <a name="@ai-sdk/react"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/react</a> v0.0.70 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-
-
-<a name="@ai-sdk/solid"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/solid</a> v0.0.54 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-
-
-<a name="@ai-sdk/svelte"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/svelte</a> v0.0.57 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/react</a> v1.0.6 (dependencies)
 #### 
 
 ##### Paths
@@ -136,18 +91,7 @@
 
 
 <a name="@ai-sdk/ui-utils"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/ui-utils</a> v0.0.50 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-
-
-<a name="@ai-sdk/vue"></a>
-### <a href="https://sdk.vercel.ai/docs">@ai-sdk/vue</a> v0.0.59 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">@ai-sdk/ui-utils</a> v1.0.5 (dependencies)
 #### 
 
 ##### Paths
@@ -3589,105 +3533,6 @@ Connect to Vercel Postgres databases on the Edge
 
 Speed Insights is a tool for measuring web performance and providing suggestions for improvement.
 
-<a name="@vue/compiler-core"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/compiler-core#readme">@vue/compiler-core</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/compiler-core
-
-<a name="@vue/compiler-dom"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/compiler-dom#readme">@vue/compiler-dom</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/compiler-dom
-
-<a name="@vue/compiler-sfc"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/compiler-sfc#readme">@vue/compiler-sfc</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/compiler-sfc
-
-<a name="@vue/compiler-ssr"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/compiler-ssr#readme">@vue/compiler-ssr</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/compiler-ssr
-
-<a name="@vue/reactivity"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/reactivity#readme">@vue/reactivity</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/reactivity
-
-<a name="@vue/runtime-core"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/runtime-core#readme">@vue/runtime-core</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/runtime-core
-
-<a name="@vue/runtime-dom"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/runtime-dom#readme">@vue/runtime-dom</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/runtime-dom
-
-<a name="@vue/server-renderer"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/server-renderer#readme">@vue/server-renderer</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-@vue/server-renderer
-
-<a name="@vue/shared"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/shared#readme">@vue/shared</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-internal utils shared across @vue packages
-
 <a name="@webassemblyjs/ast"></a>
 ### @webassemblyjs/ast v1.12.1 (dependencies)
 #### 
@@ -3975,7 +3820,7 @@ Turn a function into an `http.Agent` instance
 Missing keepalive http.Agent
 
 <a name="ai"></a>
-### <a href="https://sdk.vercel.ai/docs">ai</a> v3.4.33 (dependencies)
+### <a href="https://sdk.vercel.ai/docs">ai</a> v4.0.16 (dependencies)
 #### 
 
 ##### Paths
@@ -4139,17 +3984,6 @@ Unopinionated, no-frills CLI argument parser
 
 Cast aria-hidden to everything, except...
 
-<a name="aria-query"></a>
-### <a href="https://github.com/A11yance/aria-query#readme">aria-query</a> v5.3.2 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-Programmatic access to the ARIA specification
-
 <a name="ast-types"></a>
 ### <a href="http://github.com/benjamn/ast-types">ast-types</a> v0.16.1 (dependencies)
 #### 
@@ -4226,17 +4060,6 @@ Promise based HTTP client for the browser and node.js
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 Promise based HTTP client for the browser and node.js
-
-<a name="axobject-query"></a>
-### <a href="https://github.com/A11yance/axobject-query#readme">axobject-query</a> v4.1.0 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-Programmatic access to information about the AXObject Model
 
 <a name="bail"></a>
 ### bail v2.0.2 (dependencies)
@@ -4733,17 +4556,6 @@ A tiny (239B) utility for constructing className strings conditionally.
 
 
 
-<a name="code-red"></a>
-### code-red v1.0.4 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-code-red
-
 <a name="color"></a>
 ### color v4.2.3 (dependencies)
 #### 
@@ -4919,17 +4731,6 @@ Standard library
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 Cross platform child_process#spawn and child_process#spawnSync
-
-<a name="css-tree"></a>
-### css-tree v2.3.1 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-A tool set for CSS: fast detailed parser (CSS → AST), walker (AST traversal), generator (AST → CSS) and lexer (validation and matching) based on specs and browser implementations
 
 <a name="cssesc"></a>
 ### <a href="https://mths.be/cssesc">cssesc</a> v3.0.0 (dependencies, devDependencies)
@@ -5305,17 +5106,6 @@ Call a callback when a readable/writable/duplex stream has completed or failed.
 
 Offers a async require.resolve function. It's highly configurable.
 
-<a name="entities"></a>
-### entities v4.5.0 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/bsd-license">Simplified BSD</a> permitted
-
-Encode & decode XML and HTML entities with ease & speed
-
 <a name="es-define-property"></a>
 ### <a href="https://github.com/ljharb/es-define-property#readme">es-define-property</a> v1.0.0 (dependencies)
 #### 
@@ -5470,17 +5260,6 @@ ECMAScript JS AST traversal functions
 
 Traverse an ESTree-compliant AST
 
-<a name="estree-walker"></a>
-### estree-walker v3.0.3 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Traverse an ESTree-compliant AST
-
 <a name="event-target-shim"></a>
 ### <a href="https://github.com/mysticatea/event-target-shim">event-target-shim</a> v5.0.1 (dependencies)
 #### 
@@ -5502,17 +5281,6 @@ An implementation of WHATWG EventTarget interface.
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 Node's event emitter for all engines.
-
-<a name="eventsource-parser"></a>
-### <a href="https://github.com/rexxars/eventsource-parser#readme">eventsource-parser</a> v1.1.2 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Streaming, source-agnostic EventSource/Server-Sent Events parser
 
 <a name="eventsource-parser"></a>
 ### <a href="https://github.com/rexxars/eventsource-parser#readme">eventsource-parser</a> v3.0.0 (dependencies)
@@ -6383,17 +6151,6 @@ Returns true if an object was created by the `Object` constructor, or Object.cre
 
 Determine whether an AST node is a reference
 
-<a name="is-reference"></a>
-### <a href="https://github.com/Rich-Harris/is-reference#readme">is-reference</a> v3.0.2 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Determine whether an AST node is a reference
-
 <a name="is-stream"></a>
 ### is-stream v2.0.1 (dependencies)
 #### 
@@ -6735,17 +6492,6 @@ Runs (webpack) loaders
 
 Offline storage, improved.
 
-<a name="locate-character"></a>
-### <a href="https://gitlab.com/Rich-Harris/locate-character#README">locate-character</a> v3.0.0 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Get the line and column number of a specific character in a string
-
 <a name="locate-path"></a>
 ### locate-path v6.0.0 (dependencies)
 #### 
@@ -6965,17 +6711,6 @@ mdast utility to serialize markdown
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 mdast utility to get the plain text content of a node
-
-<a name="mdn-data"></a>
-### <a href="https://developer.mozilla.org">mdn-data</a> v2.0.30 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://creativecommons.org/publicdomain/zero/1.0">CC0 1.0 Universal</a> permitted
-
-Open Web data by the Mozilla Developer Network
 
 <a name="merge-stream"></a>
 ### merge-stream v2.0.0 (dependencies)
@@ -7747,17 +7482,6 @@ walk paths fast and efficiently
 
 Create and modify PDF files with JavaScript
 
-<a name="periscopic"></a>
-### periscopic v3.1.0 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-periscopic
-
 <a name="pg-int8"></a>
 ### pg-int8 v1.0.1 (dependencies)
 #### 
@@ -7815,17 +7539,6 @@ Query result type converters for node-postgres
 
 <a name="picocolors"></a>
 ### picocolors v1.0.1 (dependencies, devDependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://en.wikipedia.org/wiki/ISC_license">ISC</a> permitted
-
-The tiniest and the fastest library for terminal output formatting with ANSI colors
-
-<a name="picocolors"></a>
-### picocolors v1.1.0 (dependencies, devDependencies)
 #### 
 
 ##### Paths
@@ -7936,17 +7649,6 @@ Tool for transforming styles with JS plugins
 
 <a name="postcss"></a>
 ### <a href="https://postcss.org/">postcss</a> v8.4.41 (dependencies, devDependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Tool for transforming styles with JS plugins
-
-<a name="postcss"></a>
-### <a href="https://postcss.org/">postcss</a> v8.4.47 (dependencies, devDependencies)
 #### 
 
 ##### Paths
@@ -8891,17 +8593,6 @@ Generates and consumes source maps
 
 Generates and consumes source maps
 
-<a name="source-map-js"></a>
-### <a href="https://github.com/7rulnik/source-map-js">source-map-js</a> v1.2.1 (dependencies, devDependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/BSD-3-Clause">New BSD</a> permitted
-
-Generates and consumes source maps
-
 <a name="source-map-support"></a>
 ### source-map-support v0.5.21 (dependencies, devDependencies)
 #### 
@@ -8934,17 +8625,6 @@ Parse and stringify space separated tokens
 <a href="http://en.wikipedia.org/wiki/ISC_license">ISC</a> permitted
 
 split a Text Stream into a Line Stream, using Stream 3
-
-<a name="sswr"></a>
-### sswr v2.1.0 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Svelte stale while revalidate (SWR) data fetching strategy
 
 <a name="stacktrace-parser"></a>
 ### <a href="https://github.com/errwischt/stacktrace-parser">stacktrace-parser</a> v0.1.10 (dependencies)
@@ -9079,7 +8759,7 @@ Strip ANSI escape codes from a string
 Strip comments from JSON. Lets you use comments in your JSON files!
 
 <a name="stripe"></a>
-### <a href="https://github.com/stripe/stripe-node">stripe</a> v16.10.0 (dependencies)
+### <a href="https://github.com/stripe/stripe-node">stripe</a> v17.4.0 (dependencies)
 #### 
 
 ##### Paths
@@ -9155,17 +8835,6 @@ Detect whether a terminal supports color
 
 Determine if the current node version supports the `--preserve-symlinks` flag.
 
-<a name="svelte"></a>
-### <a href="https://svelte.dev">svelte</a> v4.2.19 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Cybernetically enhanced web apps
-
 <a name="swr"></a>
 ### <a href="https://swr.vercel.app">swr</a> v2.2.5 (dependencies)
 #### 
@@ -9176,28 +8845,6 @@ Cybernetically enhanced web apps
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 React Hooks library for remote data fetching
-
-<a name="swrev"></a>
-### swrev v4.0.0 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-Framework agnostic stale while revalidate (SWR) data fetching strategy
-
-<a name="swrv"></a>
-### swrv v1.0.4 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
-
-
 
 <a name="tailwind-merge"></a>
 ### <a href="https://github.com/dcastil/tailwind-merge">tailwind-merge</a> v2.5.2 (dependencies)
@@ -9840,17 +9487,6 @@ Virtual file format for text processing
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 vfile utility to create a virtual message
-
-<a name="vue"></a>
-### <a href="https://github.com/vuejs/core/tree/main/packages/vue#readme">vue</a> v3.5.8 (dependencies)
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-The progressive JavaScript framework for building modern web UI.
 
 <a name="watchpack"></a>
 ### <a href="https://github.com/webpack/watchpack">watchpack</a> v2.4.2 (dependencies)

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -497,8 +497,6 @@ export const agentTimeUsageReports = pgTable(
 		teamDbId: integer("team_db_id")
 			.notNull()
 			.references(() => teams.dbId, { onDelete: "cascade" }),
-		periodStart: timestamp("period_start").notNull(),
-		periodEnd: timestamp("period_end").notNull(),
 		// This would be greater than int32 max, but will not be greater than int64 max.
 		// so, we can safely use number type.
 		accumulatedDurationMs: numeric("accumulated_duration_ms")
@@ -506,11 +504,11 @@ export const agentTimeUsageReports = pgTable(
 			.notNull(),
 		minutesIncrement: integer("minutes_increment").notNull(),
 		stripeMeterEventId: text("stripe_meter_event_id").notNull(),
-		createdAt: timestamp("created_at").defaultNow().notNull(),
+		timestamp: timestamp("created_at").defaultNow().notNull(),
 	},
 	(table) => ({
 		teamDbIdIdx: index().on(table.teamDbId),
-		periodIdx: index().on(table.periodStart, table.periodEnd),
+		timestampIdx: index().on(table.timestamp),
 		stripeMeterEventIdIdx: index().on(table.stripeMeterEventId),
 	}),
 );

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -476,7 +476,7 @@ export const agentActivities = pgTable(
 			.references(() => agents.dbId, { onDelete: "cascade" }),
 		startedAt: timestamp("started_at").notNull(),
 		endedAt: timestamp("ended_at").notNull(),
-		aggregatedExecutionTimeMs: integer("total_duration_ms").notNull(),
+		totalDurationMs: integer("total_duration_ms").notNull(),
 	},
 	(table) => ({
 		agentDbIdIdx: index().on(table.agentDbId),

--- a/migrations/0017_lying_dexter_bennett.sql
+++ b/migrations/0017_lying_dexter_bennett.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS "agent_time_usage_reports" (
+	"db_id" serial PRIMARY KEY NOT NULL,
+	"team_db_id" integer NOT NULL,
+	"accumulated_duration_ms" numeric NOT NULL,
+	"minutes_increment" integer NOT NULL,
+	"stripe_meter_event_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agent_activities" ALTER COLUMN "total_duration_ms" SET DATA TYPE numeric;--> statement-breakpoint
+ALTER TABLE "agent_activities" ADD COLUMN "usage_report_db_id" integer;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_time_usage_reports" ADD CONSTRAINT "agent_time_usage_reports_team_db_id_teams_db_id_fk" FOREIGN KEY ("team_db_id") REFERENCES "public"."teams"("db_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_time_usage_reports_team_db_id_index" ON "agent_time_usage_reports" USING btree ("team_db_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_time_usage_reports_created_at_index" ON "agent_time_usage_reports" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_time_usage_reports_stripe_meter_event_id_index" ON "agent_time_usage_reports" USING btree ("stripe_meter_event_id");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_activities" ADD CONSTRAINT "agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk" FOREIGN KEY ("usage_report_db_id") REFERENCES "public"."agent_time_usage_reports"("db_id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/migrations/meta/0017_snapshot.json
+++ b/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1950 @@
+{
+	"id": "c54aa12f-01f2-406f-ad65-a16ef01e0f03",
+	"prevId": "235651a6-37f8-41f8-ac21-0de905112023",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.agent_activities": {
+			"name": "agent_activities",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_duration_ms": {
+					"name": "total_duration_ms",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"usage_report_db_id": {
+					"name": "usage_report_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"agent_activities_agent_db_id_index": {
+					"name": "agent_activities_agent_db_id_index",
+					"columns": [
+						{
+							"expression": "agent_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agent_activities_ended_at_index": {
+					"name": "agent_activities_ended_at_index",
+					"columns": [
+						{
+							"expression": "ended_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agent_activities_agent_db_id_agents_db_id_fk": {
+					"name": "agent_activities_agent_db_id_agents_db_id_fk",
+					"tableFrom": "agent_activities",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk": {
+					"name": "agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk",
+					"tableFrom": "agent_activities",
+					"tableTo": "agent_time_usage_reports",
+					"columnsFrom": ["usage_report_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.agent_time_usage_reports": {
+			"name": "agent_time_usage_reports",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"accumulated_duration_ms": {
+					"name": "accumulated_duration_ms",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"minutes_increment": {
+					"name": "minutes_increment",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_meter_event_id": {
+					"name": "stripe_meter_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"agent_time_usage_reports_team_db_id_index": {
+					"name": "agent_time_usage_reports_team_db_id_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agent_time_usage_reports_created_at_index": {
+					"name": "agent_time_usage_reports_created_at_index",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agent_time_usage_reports_stripe_meter_event_id_index": {
+					"name": "agent_time_usage_reports_stripe_meter_event_id_index",
+					"columns": [
+						{
+							"expression": "stripe_meter_event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agent_time_usage_reports_team_db_id_teams_db_id_fk": {
+					"name": "agent_time_usage_reports_team_db_id_teams_db_id_fk",
+					"tableFrom": "agent_time_usage_reports",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.agents": {
+			"name": "agents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"graph_url": {
+					"name": "graph_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"graphv2": {
+					"name": "graphv2",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"graph": {
+					"name": "graph",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{\"nodes\":[],\"edges\":[],\"viewport\":{\"x\":0,\"y\":0,\"zoom\":1}}'::jsonb"
+				},
+				"graph_hash": {
+					"name": "graph_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"creator_db_id": {
+					"name": "creator_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"agents_team_db_id_index": {
+					"name": "agents_team_db_id_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agents_team_db_id_teams_db_id_fk": {
+					"name": "agents_team_db_id_teams_db_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"agents_creator_db_id_users_db_id_fk": {
+					"name": "agents_creator_db_id_users_db_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "users",
+					"columnsFrom": ["creator_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"agents_id_unique": {
+					"name": "agents_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"agents_graph_hash_unique": {
+					"name": "agents_graph_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["graph_hash"]
+				}
+			}
+		},
+		"public.builds": {
+			"name": "builds",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"graph": {
+					"name": "graph",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"graph_hash": {
+					"name": "graph_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"before_id": {
+					"name": "before_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"after_id": {
+					"name": "after_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"builds_agent_db_id_agents_db_id_fk": {
+					"name": "builds_agent_db_id_agents_db_id_fk",
+					"tableFrom": "builds",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"builds_id_unique": {
+					"name": "builds_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"builds_graph_hash_unique": {
+					"name": "builds_graph_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["graph_hash"]
+				}
+			}
+		},
+		"public.edges": {
+			"name": "edges",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_port_db_id": {
+					"name": "target_port_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_port_db_id": {
+					"name": "source_port_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"edges_build_db_id_builds_db_id_fk": {
+					"name": "edges_build_db_id_builds_db_id_fk",
+					"tableFrom": "edges",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"edges_target_port_db_id_ports_db_id_fk": {
+					"name": "edges_target_port_db_id_ports_db_id_fk",
+					"tableFrom": "edges",
+					"tableTo": "ports",
+					"columnsFrom": ["target_port_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"edges_source_port_db_id_ports_db_id_fk": {
+					"name": "edges_source_port_db_id_ports_db_id_fk",
+					"tableFrom": "edges",
+					"tableTo": "ports",
+					"columnsFrom": ["source_port_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"edges_target_port_db_id_source_port_db_id_unique": {
+					"name": "edges_target_port_db_id_source_port_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["target_port_db_id", "source_port_db_id"]
+				},
+				"edges_id_build_db_id_unique": {
+					"name": "edges_id_build_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id", "build_db_id"]
+				}
+			}
+		},
+		"public.file_openai_file_representations": {
+			"name": "file_openai_file_representations",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"file_db_id": {
+					"name": "file_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_file_id": {
+					"name": "openai_file_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"file_openai_file_representations_file_db_id_files_db_id_fk": {
+					"name": "file_openai_file_representations_file_db_id_files_db_id_fk",
+					"tableFrom": "file_openai_file_representations",
+					"tableTo": "files",
+					"columnsFrom": ["file_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"file_openai_file_representations_openai_file_id_unique": {
+					"name": "file_openai_file_representations_openai_file_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["openai_file_id"]
+				}
+			}
+		},
+		"public.files": {
+			"name": "files",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_type": {
+					"name": "file_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_size": {
+					"name": "file_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"blob_url": {
+					"name": "blob_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"files_id_unique": {
+					"name": "files_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.github_integrations": {
+			"name": "github_integrations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"repository_full_name": {
+					"name": "repository_full_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"call_sign": {
+					"name": "call_sign",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event": {
+					"name": "event",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"start_node_id": {
+					"name": "start_node_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_node_id": {
+					"name": "end_node_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_action": {
+					"name": "next_action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"github_integrations_repository_full_name_index": {
+					"name": "github_integrations_repository_full_name_index",
+					"columns": [
+						{
+							"expression": "repository_full_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"github_integrations_agent_db_id_agents_db_id_fk": {
+					"name": "github_integrations_agent_db_id_agents_db_id_fk",
+					"tableFrom": "github_integrations",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"github_integrations_id_unique": {
+					"name": "github_integrations_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.knowledge_content_openai_vector_store_file_representations": {
+			"name": "knowledge_content_openai_vector_store_file_representations",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"knowledge_content_db_id": {
+					"name": "knowledge_content_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_vector_store_file_id": {
+					"name": "openai_vector_store_file_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_vector_store_status": {
+					"name": "openai_vector_store_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk": {
+					"name": "knowledge_content_openai_vector_store_file_representations_knowledge_content_db_id_knowledge_contents_db_id_fk",
+					"tableFrom": "knowledge_content_openai_vector_store_file_representations",
+					"tableTo": "knowledge_contents",
+					"columnsFrom": ["knowledge_content_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"kcovsfr_knowledge_content_db_id_unique": {
+					"name": "kcovsfr_knowledge_content_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["knowledge_content_db_id"]
+				},
+				"kcovsfr_openai_vector_store_file_id_unique": {
+					"name": "kcovsfr_openai_vector_store_file_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["openai_vector_store_file_id"]
+				}
+			}
+		},
+		"public.knowledge_contents": {
+			"name": "knowledge_contents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"knowledge_content_type": {
+					"name": "knowledge_content_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"knowledge_db_id": {
+					"name": "knowledge_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_db_id": {
+					"name": "file_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledge_contents_knowledge_db_id_knowledges_db_id_fk": {
+					"name": "knowledge_contents_knowledge_db_id_knowledges_db_id_fk",
+					"tableFrom": "knowledge_contents",
+					"tableTo": "knowledges",
+					"columnsFrom": ["knowledge_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"knowledge_contents_file_db_id_files_db_id_fk": {
+					"name": "knowledge_contents_file_db_id_files_db_id_fk",
+					"tableFrom": "knowledge_contents",
+					"tableTo": "files",
+					"columnsFrom": ["file_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"knowledge_contents_id_unique": {
+					"name": "knowledge_contents_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"knowledge_contents_file_db_id_knowledge_db_id_unique": {
+					"name": "knowledge_contents_file_db_id_knowledge_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["file_db_id", "knowledge_db_id"]
+				}
+			}
+		},
+		"public.knowledge_openai_vector_store_representations": {
+			"name": "knowledge_openai_vector_store_representations",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"knowledge_db_id": {
+					"name": "knowledge_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"openai_vector_store_id": {
+					"name": "openai_vector_store_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk": {
+					"name": "knowledge_openai_vector_store_representations_knowledge_db_id_knowledges_db_id_fk",
+					"tableFrom": "knowledge_openai_vector_store_representations",
+					"tableTo": "knowledges",
+					"columnsFrom": ["knowledge_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"knowledge_openai_vector_store_representations_openai_vector_store_id_unique": {
+					"name": "knowledge_openai_vector_store_representations_openai_vector_store_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["openai_vector_store_id"]
+				}
+			}
+		},
+		"public.knowledges": {
+			"name": "knowledges",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"knowledges_agent_db_id_agents_db_id_fk": {
+					"name": "knowledges_agent_db_id_agents_db_id_fk",
+					"tableFrom": "knowledges",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"knowledges_id_unique": {
+					"name": "knowledges_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.nodes": {
+			"name": "nodes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"graph": {
+					"name": "graph",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"nodes_build_db_id_builds_db_id_fk": {
+					"name": "nodes_build_db_id_builds_db_id_fk",
+					"tableFrom": "nodes",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"nodes_id_build_db_id_unique": {
+					"name": "nodes_id_build_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id", "build_db_id"]
+				}
+			}
+		},
+		"public.oauth_credentials": {
+			"name": "oauth_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_account_id": {
+					"name": "provider_account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_credentials_user_id_users_db_id_fk": {
+					"name": "oauth_credentials_user_id_users_db_id_fk",
+					"tableFrom": "oauth_credentials",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_credentials_user_id_provider_provider_account_id_unique": {
+					"name": "oauth_credentials_user_id_provider_provider_account_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_id", "provider", "provider_account_id"]
+				}
+			}
+		},
+		"public.ports": {
+			"name": "ports",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"node_db_id": {
+					"name": "node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"ports_node_db_id_nodes_db_id_fk": {
+					"name": "ports_node_db_id_nodes_db_id_fk",
+					"tableFrom": "ports",
+					"tableTo": "nodes",
+					"columnsFrom": ["node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"ports_id_node_db_id_unique": {
+					"name": "ports_id_node_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id", "node_db_id"]
+				}
+			}
+		},
+		"public.request_port_messages": {
+			"name": "request_port_messages",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"port_db_id": {
+					"name": "port_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"message": {
+					"name": "message",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_port_messages_request_db_id_requests_db_id_fk": {
+					"name": "request_port_messages_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_port_messages",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_port_messages_port_db_id_ports_db_id_fk": {
+					"name": "request_port_messages_port_db_id_ports_db_id_fk",
+					"tableFrom": "request_port_messages",
+					"tableTo": "ports",
+					"columnsFrom": ["port_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_port_messages_request_db_id_port_db_id_unique": {
+					"name": "request_port_messages_request_db_id_port_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["request_db_id", "port_db_id"]
+				}
+			}
+		},
+		"public.request_results": {
+			"name": "request_results",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"text": {
+					"name": "text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_results_request_db_id_requests_db_id_fk": {
+					"name": "request_results_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_results",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_results_request_db_id_unique": {
+					"name": "request_results_request_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["request_db_id"]
+				}
+			}
+		},
+		"public.request_runners": {
+			"name": "request_runners",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"runner_id": {
+					"name": "runner_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_runners_request_db_id_requests_db_id_fk": {
+					"name": "request_runners_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_runners",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_runners_runner_id_unique": {
+					"name": "request_runners_runner_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["runner_id"]
+				}
+			}
+		},
+		"public.request_stack_runners": {
+			"name": "request_stack_runners",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_stack_db_id": {
+					"name": "request_stack_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"runner_id": {
+					"name": "runner_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_stack_runners_request_stack_db_id_request_stacks_db_id_fk": {
+					"name": "request_stack_runners_request_stack_db_id_request_stacks_db_id_fk",
+					"tableFrom": "request_stack_runners",
+					"tableTo": "request_stacks",
+					"columnsFrom": ["request_stack_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_stack_runners_runner_id_unique": {
+					"name": "request_stack_runners_runner_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["runner_id"]
+				}
+			}
+		},
+		"public.request_stacks": {
+			"name": "request_stacks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_db_id": {
+					"name": "request_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"start_node_db_id": {
+					"name": "start_node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"end_node_db_id": {
+					"name": "end_node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_stacks_request_db_id_requests_db_id_fk": {
+					"name": "request_stacks_request_db_id_requests_db_id_fk",
+					"tableFrom": "request_stacks",
+					"tableTo": "requests",
+					"columnsFrom": ["request_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_stacks_start_node_db_id_nodes_db_id_fk": {
+					"name": "request_stacks_start_node_db_id_nodes_db_id_fk",
+					"tableFrom": "request_stacks",
+					"tableTo": "nodes",
+					"columnsFrom": ["start_node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_stacks_end_node_db_id_nodes_db_id_fk": {
+					"name": "request_stacks_end_node_db_id_nodes_db_id_fk",
+					"tableFrom": "request_stacks",
+					"tableTo": "nodes",
+					"columnsFrom": ["end_node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_stacks_id_unique": {
+					"name": "request_stacks_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.request_steps": {
+			"name": "request_steps",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_stack_db_id": {
+					"name": "request_stack_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"node_db_id": {
+					"name": "node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'in_progress'"
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"request_steps_request_stack_db_id_request_stacks_db_id_fk": {
+					"name": "request_steps_request_stack_db_id_request_stacks_db_id_fk",
+					"tableFrom": "request_steps",
+					"tableTo": "request_stacks",
+					"columnsFrom": ["request_stack_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"request_steps_node_db_id_nodes_db_id_fk": {
+					"name": "request_steps_node_db_id_nodes_db_id_fk",
+					"tableFrom": "request_steps",
+					"tableTo": "nodes",
+					"columnsFrom": ["node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"request_steps_id_unique": {
+					"name": "request_steps_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.requests": {
+			"name": "requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"requests_build_db_id_builds_db_id_fk": {
+					"name": "requests_build_db_id_builds_db_id_fk",
+					"tableFrom": "requests",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"requests_id_unique": {
+					"name": "requests_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.stripe_user_mappings": {
+			"name": "stripe_user_mappings",
+			"schema": "",
+			"columns": {
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_customer_id": {
+					"name": "stripe_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"stripe_user_mappings_user_db_id_users_db_id_fk": {
+					"name": "stripe_user_mappings_user_db_id_users_db_id_fk",
+					"tableFrom": "stripe_user_mappings",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"stripe_user_mappings_user_db_id_unique": {
+					"name": "stripe_user_mappings_user_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id"]
+				},
+				"stripe_user_mappings_stripe_customer_id_unique": {
+					"name": "stripe_user_mappings_stripe_customer_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["stripe_customer_id"]
+				}
+			}
+		},
+		"public.subscriptions": {
+			"name": "subscriptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cancel_at_period_end": {
+					"name": "cancel_at_period_end",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cancel_at": {
+					"name": "cancel_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"canceled_at": {
+					"name": "canceled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_period_start": {
+					"name": "current_period_start",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"current_period_end": {
+					"name": "current_period_end",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created": {
+					"name": "created",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_start": {
+					"name": "trial_start",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_end": {
+					"name": "trial_end",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"subscriptions_team_db_id_teams_db_id_fk": {
+					"name": "subscriptions_team_db_id_teams_db_id_fk",
+					"tableFrom": "subscriptions",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"subscriptions_id_unique": {
+					"name": "subscriptions_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.supabase_user_mappings": {
+			"name": "supabase_user_mappings",
+			"schema": "",
+			"columns": {
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"supabase_user_id": {
+					"name": "supabase_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"supabase_user_mappings_user_db_id_users_db_id_fk": {
+					"name": "supabase_user_mappings_user_db_id_users_db_id_fk",
+					"tableFrom": "supabase_user_mappings",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"supabase_user_mappings_user_db_id_unique": {
+					"name": "supabase_user_mappings_user_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id"]
+				},
+				"supabase_user_mappings_supabase_user_id_unique": {
+					"name": "supabase_user_mappings_supabase_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["supabase_user_id"]
+				}
+			}
+		},
+		"public.team_memberships": {
+			"name": "team_memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"team_memberships_user_db_id_users_db_id_fk": {
+					"name": "team_memberships_user_db_id_users_db_id_fk",
+					"tableFrom": "team_memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"team_memberships_team_db_id_teams_db_id_fk": {
+					"name": "team_memberships_team_db_id_teams_db_id_fk",
+					"tableFrom": "team_memberships",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"team_memberships_user_db_id_team_db_id_unique": {
+					"name": "team_memberships_user_db_id_team_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id", "team_db_id"]
+				}
+			}
+		},
+		"public.teams": {
+			"name": "teams",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'customer'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.trigger_nodes": {
+			"name": "trigger_nodes",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"build_db_id": {
+					"name": "build_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"node_db_id": {
+					"name": "node_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"trigger_nodes_build_db_id_builds_db_id_fk": {
+					"name": "trigger_nodes_build_db_id_builds_db_id_fk",
+					"tableFrom": "trigger_nodes",
+					"tableTo": "builds",
+					"columnsFrom": ["build_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"trigger_nodes_node_db_id_nodes_db_id_fk": {
+					"name": "trigger_nodes_node_db_id_nodes_db_id_fk",
+					"tableFrom": "trigger_nodes",
+					"tableTo": "nodes",
+					"columnsFrom": ["node_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"trigger_nodes_build_db_id_unique": {
+					"name": "trigger_nodes_build_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["build_db_id"]
+				}
+			}
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_id_unique": {
+					"name": "users_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			}
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
 			"when": 1733811412858,
 			"tag": "0016_short_madelyne_pryor",
 			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1734079652838,
+			"tag": "0017_lying_dexter_bennett",
+			"breakpoints": true
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"react-dom": "19.0.0-rc-4d577fd2-20241104",
 		"remark": "15.0.1",
 		"remark-html": "16.0.1",
-		"stripe": "16.10.0",
+		"stripe": "17.4.0",
 		"swr": "2.2.5",
 		"tailwind-merge": "^2.4.0",
 		"tailwindcss-animate": "^1.0.7",

--- a/services/agents/activities/agent-time-usage.ts
+++ b/services/agents/activities/agent-time-usage.ts
@@ -72,7 +72,7 @@ async function agentTimeUsageMs(
 ) {
 	const result = await db
 		.select({
-			value: sql<number>`sum(${agentActivities.aggregatedExecutionTimeMs})`,
+			value: sql<number>`sum(${agentActivities.totalDurationMs})`,
 		})
 		.from(agentActivities)
 		.innerJoin(agents, eq(agents.dbId, agentActivities.agentDbId))

--- a/services/agents/activities/index.ts
+++ b/services/agents/activities/index.ts
@@ -2,3 +2,4 @@ export { calculateAgentTimeUsageMs } from "./agent-time-usage";
 export { AGENT_TIME_CHARGE_LIMIT_MINUTES } from "./constants";
 export { hasEnoughAgentTimeCharge } from "./has-enough-agent-time-charge";
 export { AgentActivity } from "./types";
+export { getMonthlyBillingCycle } from "./utils";

--- a/services/external/stripe/config.ts
+++ b/services/external/stripe/config.ts
@@ -2,5 +2,5 @@ import { Stripe } from "stripe";
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
 	// https://github.com/stripe/stripe-node#configuration
-	apiVersion: "2024-06-20",
+	apiVersion: "2024-11-20.acacia",
 });

--- a/services/usage-based-billing/agent-time-usage-dao.ts
+++ b/services/usage-based-billing/agent-time-usage-dao.ts
@@ -1,0 +1,141 @@
+import {
+	agentActivities,
+	agentTimeUsageReports,
+	agents,
+	type db as drizzleDb,
+	subscriptions,
+} from "@/drizzle";
+import { and, desc, eq, gt, inArray, isNull, lte } from "drizzle-orm";
+import type {
+	AgentActivity,
+	AgentTimeUsageDataAccess,
+	AgentTimeUsageReport,
+} from "./types";
+
+export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
+	constructor(private readonly db: typeof drizzleDb) {}
+
+	async transaction<T>(
+		fn: (dao: AgentTimeUsageDataAccess) => Promise<T>,
+	): Promise<T> {
+		return await this.db.transaction(async (tx) => {
+			const transactionDao = new AgentTimeUsageDAO(tx);
+			return await fn(transactionDao);
+		});
+	}
+
+	async fetchCurrentSubscription(teamDbId: number) {
+		const records = await this.db
+			.select({
+				id: subscriptions.id,
+				periodStart: subscriptions.currentPeriodStart,
+				periodEnd: subscriptions.currentPeriodEnd,
+			})
+			.from(subscriptions)
+			.where(
+				and(
+					eq(subscriptions.teamDbId, teamDbId),
+					eq(subscriptions.status, "active"),
+				),
+			)
+			.limit(1);
+		if (records.length === 0) {
+			throw new Error(`No active subscription found for team ${teamDbId}`);
+		}
+		if (records.length > 1) {
+			throw new Error(
+				`Multiple active subscriptions found for team ${teamDbId}`,
+			);
+		}
+		const currentSubscription = records[0];
+		return {
+			subscriptionId: currentSubscription.id,
+			periodStart: currentSubscription.periodStart,
+			periodEnd: currentSubscription.periodEnd,
+		};
+	}
+
+	async findUnprocessedActivities(
+		teamDbId: number,
+		periodStart: Date,
+		periodEnd: Date,
+	): Promise<AgentActivity[]> {
+		const activities = await this.db
+			.select({
+				dbId: agentActivities.dbId,
+				totalDurationMs: agentActivities.totalDurationMs,
+				endedAt: agentActivities.endedAt,
+				usageReportDbId: agentActivities.usageReportDbId,
+			})
+			.from(agentActivities)
+			.innerJoin(agents, eq(agentActivities.agentDbId, agents.dbId))
+			.where(
+				and(
+					eq(agents.teamDbId, teamDbId),
+					isNull(agentActivities.usageReportDbId),
+					gt(agentActivities.endedAt, periodStart),
+					lte(agentActivities.endedAt, periodEnd),
+				),
+			)
+			.orderBy(agentActivities.endedAt);
+
+		return activities;
+	}
+
+	async findLastUsageReport(
+		teamDbId: number,
+		periodStart: Date,
+	): Promise<AgentTimeUsageReport | null> {
+		const reports = await this.db
+			.select()
+			.from(agentTimeUsageReports)
+			.where(
+				and(
+					eq(agentTimeUsageReports.teamDbId, teamDbId),
+					eq(agentTimeUsageReports.periodStart, periodStart),
+				),
+			)
+			.orderBy(desc(agentTimeUsageReports.createdAt))
+			.limit(1);
+
+		return reports[0] || null;
+	}
+
+	async createUsageReport(params: {
+		teamDbId: number;
+		periodStart: Date;
+		periodEnd: Date;
+		accumulatedDurationMs: number;
+		minutesIncrement: number;
+		stripeMeterEventId: string;
+	}): Promise<AgentTimeUsageReport> {
+		const [report] = await this.db
+			.insert(agentTimeUsageReports)
+			.values({
+				teamDbId: params.teamDbId,
+				periodStart: params.periodStart,
+				periodEnd: params.periodEnd,
+				accumulatedDurationMs: params.accumulatedDurationMs,
+				minutesIncrement: params.minutesIncrement,
+				stripeMeterEventId: params.stripeMeterEventId,
+			})
+			.returning();
+		return report;
+	}
+
+	async markActivitiesAsProcessed(
+		activityIds: number[],
+		usageReportId: number,
+	): Promise<void> {
+		if (activityIds.length === 0) {
+			return;
+		}
+
+		await this.db
+			.update(agentActivities)
+			.set({
+				usageReportDbId: usageReportId,
+			})
+			.where(inArray(agentActivities.dbId, activityIds));
+	}
+}

--- a/services/usage-based-billing/agent-time-usage-dao.ts
+++ b/services/usage-based-billing/agent-time-usage-dao.ts
@@ -28,8 +28,8 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 		const records = await this.db
 			.select({
 				id: subscriptions.id,
-				periodStart: subscriptions.currentPeriodStart,
-				periodEnd: subscriptions.currentPeriodEnd,
+				currentPeriodStart: subscriptions.currentPeriodStart,
+				currentPeriodEnd: subscriptions.currentPeriodEnd,
 			})
 			.from(subscriptions)
 			.where(
@@ -50,8 +50,8 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 		const currentSubscription = records[0];
 		return {
 			subscriptionId: currentSubscription.id,
-			periodStart: currentSubscription.periodStart,
-			periodEnd: currentSubscription.periodEnd,
+			currentPeriodStart: currentSubscription.currentPeriodStart,
+			currentPeriodEnd: currentSubscription.currentPeriodEnd,
 		};
 	}
 
@@ -78,7 +78,7 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 					lte(agentActivities.endedAt, periodEnd),
 				),
 			)
-			.orderBy(agentActivities.endedAt);
+			.orderBy(agentActivities.dbId);
 		return activities;
 	}
 

--- a/services/usage-based-billing/agent-time-usage-dao.ts
+++ b/services/usage-based-billing/agent-time-usage-dao.ts
@@ -68,6 +68,7 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 				usageReportDbId: agentActivities.usageReportDbId,
 			})
 			.from(agentActivities)
+			.for("update")
 			.innerJoin(agents, eq(agentActivities.agentDbId, agents.dbId))
 			.where(
 				and(
@@ -78,7 +79,6 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 				),
 			)
 			.orderBy(agentActivities.endedAt);
-
 		return activities;
 	}
 
@@ -97,8 +97,10 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 			)
 			.orderBy(desc(agentTimeUsageReports.createdAt))
 			.limit(1);
-
-		return reports[0] || null;
+		if (reports.length === 0) {
+			return null;
+		}
+		return reports[0];
 	}
 
 	async createUsageReport(params: {
@@ -120,6 +122,9 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 				stripeMeterEventId: params.stripeMeterEventId,
 			})
 			.returning();
+		if (report == null) {
+			throw new Error("Failed to create usage report");
+		}
 		return report;
 	}
 
@@ -130,7 +135,6 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 		if (activityIds.length === 0) {
 			return;
 		}
-
 		await this.db
 			.update(agentActivities)
 			.set({

--- a/services/usage-based-billing/agent-time-usage.test.ts
+++ b/services/usage-based-billing/agent-time-usage.test.ts
@@ -130,12 +130,10 @@ describe("processUnreportedActivities", () => {
 		createUsageReport: mock(async () => ({
 			dbId: 1,
 			teamDbId: 123,
-			periodStart: new Date("2024-01-01"),
-			periodEnd: new Date("2024-01-31"),
 			accumulatedDurationMs: 60000,
 			minutesIncrement: 1,
 			stripeMeterEventId: "meter_123",
-			createdAt: new Date(),
+			timestamp: new Date(),
 		})),
 		markActivitiesAsProcessed: mock(async () => {}),
 	};

--- a/services/usage-based-billing/agent-time-usage.test.ts
+++ b/services/usage-based-billing/agent-time-usage.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	calculateAgentTimeUsage,
+	processUnreportedActivities,
+} from "./agent-time-usage";
+
+describe("calculateAgentTimeUsage", () => {
+	test("when there are only new activities", () => {
+		const result = calculateAgentTimeUsage(
+			[{ totalDurationMs: 60 * 1000 }, { totalDurationMs: 30 * 1000 }],
+			null,
+		);
+
+		expect(result.accumulatedDurationMs).toBe(90000);
+		expect(result.minutesIncrement).toBe(1);
+	});
+
+	test("when there is existing accumulated time", () => {
+		const result = calculateAgentTimeUsage([{ totalDurationMs: 60 * 1000 }], {
+			accumulatedDurationMs: 90 * 1000,
+		});
+
+		expect(result.accumulatedDurationMs).toBe(150000);
+		expect(result.minutesIncrement).toBe(1); // 1 minute previously, 2 minutes now, difference is 1 minute
+	});
+
+	test("with empty activity list", () => {
+		const result = calculateAgentTimeUsage([], null);
+
+		expect(result.accumulatedDurationMs).toBe(0);
+		expect(result.minutesIncrement).toBe(0);
+	});
+
+	test("handling over int32 max numbers", () => {
+		const result = calculateAgentTimeUsage(
+			[
+				{ totalDurationMs: 2147483647 }, // About 35.8 minutes (int32 max)
+				{ totalDurationMs: 2147483647 },
+			],
+			null,
+		);
+
+		expect(result.accumulatedDurationMs).toBe(2147483647 + 2147483647);
+		expect(result.minutesIncrement).toBe(71582);
+	});
+
+	test("when current usage is less than previous report (increment should be 0)", () => {
+		const result = calculateAgentTimeUsage([{ totalDurationMs: 30 * 1000 }], {
+			accumulatedDurationMs: 60 * 1000,
+		});
+
+		expect(result.accumulatedDurationMs).toBe(90000);
+		expect(result.minutesIncrement).toBe(0); // Same minute as previous report, so no increment
+	});
+
+	test("edge case: 59.9 seconds should count as 0 minutes", () => {
+		const result = calculateAgentTimeUsage(
+			[{ totalDurationMs: 59.9 * 1000 }],
+			null,
+		);
+
+		expect(result.accumulatedDurationMs).toBe(59900);
+		expect(result.minutesIncrement).toBe(0);
+	});
+
+	test("edge case: exactly 60 seconds should count as 1 minute", () => {
+		const result = calculateAgentTimeUsage(
+			[{ totalDurationMs: 60 * 1000 }],
+			null,
+		);
+
+		expect(result.accumulatedDurationMs).toBe(60000);
+		expect(result.minutesIncrement).toBe(1);
+	});
+
+	test("edge case: 59.9 + incoming 0.1 seconds should count as 1 minutes", () => {
+		const result = calculateAgentTimeUsage([{ totalDurationMs: 0.1 * 1000 }], {
+			accumulatedDurationMs: 59.9 * 1000,
+		});
+
+		expect(result.accumulatedDurationMs).toBe(60000);
+		expect(result.minutesIncrement).toBe(1);
+	});
+
+	test("lastReported = 30 min, incoming 60 seconds should count as 1 minutes", () => {
+		const result = calculateAgentTimeUsage([{ totalDurationMs: 60 * 1000 }], {
+			accumulatedDurationMs: 30 * 60 * 1000, // 30 min
+		});
+
+		expect(result.accumulatedDurationMs).toBe(30 * 60 * 1000 + 60 * 1000);
+		expect(result.minutesIncrement).toBe(1);
+	});
+});
+
+describe("processUnreportedActivities", () => {
+	const mockStripe = {
+		subscriptions: {
+			retrieve: mock(async () => ({
+				customer: "cust_123",
+			})),
+		},
+		v2: {
+			billing: {
+				meterEvents: {
+					create: mock(async () => ({
+						identifier: "meter_123",
+					})),
+				},
+			},
+		},
+	};
+
+	const mockDao = {
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		transaction: async (fn: any) => fn(mockDao),
+		fetchCurrentSubscription: mock(async () => ({
+			subscriptionId: "sub_123",
+			periodStart: new Date("2024-01-01"),
+			periodEnd: new Date("2024-01-31"),
+		})),
+		findUnprocessedActivities: mock(async () => [
+			{
+				dbId: 1,
+				totalDurationMs: 60000,
+				endedAt: new Date("2024-01-15"),
+				usageReportDbId: null,
+			},
+		]),
+		findLastUsageReport: mock(async () => null),
+		createUsageReport: mock(async () => ({
+			dbId: 1,
+			teamDbId: 123,
+			periodStart: new Date("2024-01-01"),
+			periodEnd: new Date("2024-01-31"),
+			accumulatedDurationMs: 60000,
+			minutesIncrement: 1,
+			stripeMeterEventId: "meter_123",
+			createdAt: new Date(),
+		})),
+		markActivitiesAsProcessed: mock(async () => {}),
+	};
+
+	test("successful processing flow", async () => {
+		const result = await processUnreportedActivities(
+			{
+				teamDbId: 123,
+			},
+			{
+				dao: mockDao,
+				// biome-ignore lint/suspicious/noExplicitAny: mock
+				stripe: mockStripe as any,
+			},
+		);
+
+		expect(result.processedReportId).toBe(1);
+		expect(mockStripe.v2.billing.meterEvents.create).toHaveBeenCalled();
+		expect(mockDao.createUsageReport).toHaveBeenCalled();
+		expect(mockDao.markActivitiesAsProcessed).toHaveBeenCalled();
+	});
+
+	test("when there are no unprocessed activities", async () => {
+		mockDao.findUnprocessedActivities.mockImplementation(async () => []);
+
+		const result = await processUnreportedActivities(
+			{
+				teamDbId: 123,
+			},
+			{
+				dao: mockDao,
+				// biome-ignore lint/suspicious/noExplicitAny: mock
+				stripe: mockStripe as any,
+			},
+		);
+
+		expect(result.processedReportId).toBeNull();
+	});
+});

--- a/services/usage-based-billing/agent-time-usage.ts
+++ b/services/usage-based-billing/agent-time-usage.ts
@@ -1,0 +1,125 @@
+import { createId } from "@paralleldrive/cuid2";
+import type Stripe from "stripe";
+import type { AgentTimeUsageDataAccess } from "./types";
+
+const AGENT_TIME_USAGE_METER_NAME = "agent_time_charge";
+
+/**
+ * Pure function for calculating usage time
+ */
+export function calculateAgentTimeUsage(
+	activities: { totalDurationMs: number }[],
+	lastReport: {
+		accumulatedDurationMs: number;
+	} | null,
+) {
+	// Total duration of new activities (milliseconds)
+	const newDurationMs = activities.reduce(
+		(sum, activity) => sum + activity.totalDurationMs,
+		0,
+	);
+
+	// Add new duration to the accumulated duration
+	const accumulatedDurationMs =
+		(lastReport?.accumulatedDurationMs ?? 0) + newDurationMs;
+
+	// Convert milliseconds to minutes (round down)
+	// If accumulatedDurationMs will over Number.MAX_SAFE_INTEGER, we should use Bigint but, we may not need to worry about it
+	// Number.MAX_SAFE_INTEGER = 9007199254740991 = 104,249,991 days
+	const totalMinutes = Math.floor(accumulatedDurationMs / 1000 / 60);
+
+	const lastReportedTotalMinutes = Math.floor(
+		(lastReport?.accumulatedDurationMs ?? 0) / 1000 / 60,
+	);
+	const minutesIncrement = totalMinutes - lastReportedTotalMinutes;
+
+	return {
+		accumulatedDurationMs,
+		minutesIncrement,
+	};
+}
+
+/**
+ * Function to process unreported agent usage time for current period
+ */
+export async function processUnreportedActivities(
+	params: {
+		teamDbId: number;
+	},
+	deps: {
+		dao: AgentTimeUsageDataAccess;
+		stripe: Stripe;
+	},
+) {
+	const { dao, stripe } = deps;
+	const { subscriptionId, periodStart, periodEnd } =
+		await dao.fetchCurrentSubscription(params.teamDbId);
+	// FIXME: if we have customer id in subscriptions table, we can use it directly
+	const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+	const customerId =
+		typeof subscription.customer === "string"
+			? subscription.customer
+			: subscription.customer.id;
+
+	return await dao.transaction(async (tx) => {
+		// Retrieve unprocessed activities
+		const unprocessedActivities = await tx.findUnprocessedActivities(
+			params.teamDbId,
+			periodStart,
+			periodEnd,
+		);
+
+		if (unprocessedActivities.length === 0) {
+			return { processedReportId: null };
+		}
+
+		// Retrieve the latest report
+		const lastReport = await tx.findLastUsageReport(
+			params.teamDbId,
+			periodStart,
+		);
+
+		// Calculate usage time
+		const { accumulatedDurationMs, minutesIncrement } = calculateAgentTimeUsage(
+			unprocessedActivities,
+			lastReport,
+		);
+
+		// Do not report if the increment is less than 1 minute
+		if (minutesIncrement < 1) {
+			return { processedReportId: null };
+		}
+
+		const meterEventId = createId();
+		const currentTimestamp = new Date().toISOString();
+
+		// Report usage to Stripe
+		const stripeEvent = await stripe.v2.billing.meterEvents.create({
+			event_name: AGENT_TIME_USAGE_METER_NAME,
+			payload: {
+				value: minutesIncrement.toString(),
+				stripe_customer_id: customerId,
+			},
+			identifier: meterEventId,
+			timestamp: currentTimestamp,
+		});
+
+		// Create usage report
+		const report = await tx.createUsageReport({
+			teamDbId: params.teamDbId,
+			periodStart,
+			periodEnd,
+			accumulatedDurationMs,
+			minutesIncrement,
+			stripeMeterEventId: stripeEvent.identifier,
+		});
+
+		// Update activities
+		await tx.markActivitiesAsProcessed(
+			unprocessedActivities.map((a) => a.dbId),
+			report.dbId,
+		);
+
+		return { processedReportId: report.dbId };
+	});
+}

--- a/services/usage-based-billing/index.ts
+++ b/services/usage-based-billing/index.ts
@@ -1,0 +1,1 @@
+export { processUnreportedActivities } from "./agent-time-usage";

--- a/services/usage-based-billing/types.ts
+++ b/services/usage-based-billing/types.ts
@@ -1,0 +1,54 @@
+export type AgentActivity = {
+	dbId: number;
+	totalDurationMs: number;
+	endedAt: Date;
+	usageReportDbId: number | null;
+};
+
+export type AgentTimeUsageReport = {
+	dbId: number;
+	teamDbId: number;
+	periodStart: Date;
+	periodEnd: Date;
+	accumulatedDurationMs: number;
+	minutesIncrement: number;
+	stripeMeterEventId: string;
+	createdAt: Date;
+};
+
+export type Subscription = {
+	subscriptionId: string;
+	periodStart: Date;
+	periodEnd: Date;
+};
+
+export interface AgentTimeUsageDataAccess {
+	transaction<T>(fn: (dao: AgentTimeUsageDataAccess) => Promise<T>): Promise<T>;
+
+	fetchCurrentSubscription(teamDbId: number): Promise<Subscription>;
+
+	findUnprocessedActivities(
+		teamDbId: number,
+		periodStart: Date,
+		periodEnd: Date,
+	): Promise<AgentActivity[]>;
+
+	findLastUsageReport(
+		teamDbId: number,
+		periodStart: Date,
+	): Promise<AgentTimeUsageReport | null>;
+
+	createUsageReport(params: {
+		teamDbId: number;
+		periodStart: Date;
+		periodEnd: Date;
+		accumulatedDurationMs: number;
+		minutesIncrement: number;
+		stripeMeterEventId: string;
+	}): Promise<AgentTimeUsageReport>;
+
+	markActivitiesAsProcessed(
+		activityIds: number[],
+		usageReportId: number,
+	): Promise<void>;
+}

--- a/services/usage-based-billing/types.ts
+++ b/services/usage-based-billing/types.ts
@@ -16,8 +16,8 @@ export type AgentTimeUsageReport = {
 
 export type Subscription = {
 	subscriptionId: string;
-	periodStart: Date;
-	periodEnd: Date;
+	currentPeriodStart: Date;
+	currentPeriodEnd: Date;
 };
 
 export interface AgentTimeUsageDataAccess {

--- a/services/usage-based-billing/types.ts
+++ b/services/usage-based-billing/types.ts
@@ -8,12 +8,10 @@ export type AgentActivity = {
 export type AgentTimeUsageReport = {
 	dbId: number;
 	teamDbId: number;
-	periodStart: Date;
-	periodEnd: Date;
 	accumulatedDurationMs: number;
 	minutesIncrement: number;
 	stripeMeterEventId: string;
-	createdAt: Date;
+	timestamp: Date;
 };
 
 export type Subscription = {
@@ -36,15 +34,15 @@ export interface AgentTimeUsageDataAccess {
 	findLastUsageReport(
 		teamDbId: number,
 		periodStart: Date,
+		periodEnd: Date,
 	): Promise<AgentTimeUsageReport | null>;
 
 	createUsageReport(params: {
 		teamDbId: number;
-		periodStart: Date;
-		periodEnd: Date;
 		accumulatedDurationMs: number;
 		minutesIncrement: number;
 		stripeMeterEventId: string;
+		timestamp: Date;
 	}): Promise<AgentTimeUsageReport>;
 
 	markActivitiesAsProcessed(


### PR DESCRIPTION
## Summary

This PR introduces a new mechanism to report usage-based billing metrics to Stripe.

**Key changes:**

1. **Database Schema Updates**  
   - Changed the column type from `integer` to `numeric` in `agentActivities` to handle larger values that may exceed the 32-bit integer limit.
     - And the column's name in TypeScript was wrong, I've fixed.
   - Introduced a new `agent_time_usage_reports` table to track accumulated agent usage time on a per-team, per-billing-cycle basis.

2. **Usage-based Billing Logic**  
   - Added a new `AgentTimeUsageDAO` class that encapsulates database operations related to agent time usage, including transactional updates.
   - Implemented the `processUnreportedActivities` function that identifies unprocessed agent activities within a given billing cycle, calculates the incremental usage in minutes, and reports those increments to Stripe via their `v2.billing.meterEvents` API.

3. **Integration with Stripe**  
   - Upgraded the Stripe API version and library version to ensure compatibility with the new events API.
     - `stripe.v2.billing.meterEvents.` was not in previous version.
   - When new usage increments are detected, we create a meter event in Stripe to reflect the additional chargeable minutes.

4. **Unit Tests**  
   - Added unit tests (`agent-time-usage.test.ts`) to cover edge cases, including boundaries at exactly 60 seconds and slightly under a full minute.
   - Tested scenarios such as no unreported activities, increments less than a minute (which results in no billing update), and handling data across multiple billing periods.

---

### The `processUnreportedActivities` Function Explained

`processUnreportedActivities` is the core of this PR and is responsible for tying together the data retrieval, calculation, and reporting logic.

**What does it do?**

- Determines the correct billing cycle based on the current subscription data and a given `targetDate`.
- Fetches all agent activities that have not yet been associated with a usage report within that billing cycle.
- Calculates the total accumulated duration of all these activities and determines how many **additional whole minutes** have accrued since the last report.  
  *(We track usage in whole minutes because our Stripe product is configured to bill on a per-minute basis.)*
- If there are new billable increments, creates a usage report, marks activities as processed, and reports the increment to Stripe as a meter event.

**How does it work?**

```mermaid
flowchart TD
    A[Determine Billing Cycle] --> B[Fetch Unreported Activities]
    B --> |Activities Found| C[Calculate Total Usage Duration]
    B --> |No Activities| J[Return no changes]
    C --> D[Get Last Usage Report]
    D --> E[Calculate Increment in Whole Minutes]
    E --> |Increment > 0| F[Create Stripe Meter Event]
    E --> |Increment = 0| J[Return no changes]
    F --> G[Create Usage Report in DB]
    G --> H[Mark Activities as Processed]
    H --> I[Return Report ID]
```


**Key Points in the Flow:**
- Accumulate Duration: Sums totalDurationMs from all unreported activities.
- Determine Increment: Converts the accumulated duration into whole minutes and compares it to the previously reported total minutes.
- Meter Event Creation: If there’s at least a 1-minute increment, we send that increment to Stripe.
- Database Consistency: Creates a usage report and updates activities to ensure no double counting in subsequent runs.

----

## Additional Notes
- We currently retrieve the customerId from Stripe subscriptions each time. In the future, we may store it in our DB to reduce external API calls.
- Using numeric for totalDurationMs avoids overflow issues with extremely large durations.
- The included tests cover various edge cases, ensuring that increments are calculated accurately.


## What I didn't do
- This function is not called anywhere.
- I will implement it in the following PRs.

## TODO
- [x] Ensure the Stripe update does not affect other areas.
- [x] Run migration for Preview
- [ ] Run migration for Production