### PR TITLE
security(headers): Add X-Frame-Options header to prevent clickjacking

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,19 @@ const nextConfig: NextConfig = {
 			},
 		];
 	},
+	async headers() {
+		return [
+			{
+				source: "/:path*",
+				headers: [
+					{
+						key: "X-Frame-Options",
+						value: "DENY",
+					},
+				],
+			},
+		];
+	},
 };
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
Add security header configuration to Next.js to protect against clickjacking attacks by setting X-Frame-Options: DENY for all paths matching /path*. This prevents the application from being embedded in iframes on other domains.

Security: This is a recommended security best practice to mitigate cross-frame scripting attacks.
