### PR TITLE
feat(file): Add pathnameToFilename utility for path handling

### DIFF
--- a/app/(playground)/p/[agentId]/canary/lib/utils.test.ts
+++ b/app/(playground)/p/[agentId]/canary/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { pathJoin } from "./utils";
+import { pathJoin, pathnameToFilename } from "./utils";
 
 describe("pathJoin", () => {
 	test("a, b, c", () => {
@@ -12,5 +12,26 @@ describe("pathJoin", () => {
 		const folder = pathJoin("a", "b");
 		const file = pathJoin(folder, "c.json");
 		expect(file).toBe("a/b/c.json");
+	});
+});
+
+describe("pathNameToFileName", () => {
+	test("articles/test.txt", () => {
+		expect(pathnameToFilename("articles/test.txt")).toBe("test.txt");
+	});
+	test("empty", () => {
+		expect(pathnameToFilename("")).toBe("");
+	});
+	test("just filename", () => {
+		expect(pathnameToFilename("test.txt")).toBe("test.txt");
+	});
+	test("nested path", () => {
+		expect(pathnameToFilename("path/to/nested/file.txt")).toBe("file.txt");
+	});
+	test("no extension", () => {
+		expect(pathnameToFilename("folder/file")).toBe("file");
+	});
+	test("with spaces", () => {
+		expect(pathnameToFilename("folder/my file.txt")).toBe("my file.txt");
 	});
 });

--- a/app/(playground)/p/[agentId]/canary/lib/utils.ts
+++ b/app/(playground)/p/[agentId]/canary/lib/utils.ts
@@ -366,3 +366,7 @@ export function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
 		return new Error(String(maybeError));
 	}
 }
+
+export function pathnameToFilename(pathname: string) {
+	return pathname.split("/").pop() ?? "";
+}

--- a/app/dev/copy-agent/action.ts
+++ b/app/dev/copy-agent/action.ts
@@ -10,6 +10,7 @@ import {
 	buildFileFolderPath,
 	createFileId,
 	pathJoin,
+	pathnameToFilename,
 } from "../../(playground)/p/[agentId]/canary/lib/utils";
 import type {
 	AgentId,
@@ -66,8 +67,12 @@ export async function copyAgentAction(
 						blobList.blobs.map(async (blob) => {
 							const copyResult = await copy(
 								blob.url,
-								buildFileFolderPath(newFileId),
+								pathJoin(
+									buildFileFolderPath(newFileId),
+									pathnameToFilename(blob.pathname),
+								),
 								{
+									addRandomSuffix: true,
 									access: "public",
 								},
 							);


### PR DESCRIPTION
Copy file feature does not work in current implementation. I add a new utility function to extract filenames from full paths and update file copy implementation to preserve original filenames with random suffixes.

- Add pathnameToFilename function to extract file name from path
- Add comprehensive test cases for different path scenarios
- Update copyAgentAction to maintain original file names during copy
- Add random suffix to prevent filename collisions
