### PR TITLE
Add caching to `getUser` to reduce repeated fetch requests

### DIFF
--- a/lib/supabase/get-user.ts
+++ b/lib/supabase/get-user.ts
@@ -13,32 +13,32 @@ import { createClient } from "./server";
  * Make sure the user is logged in before calling this function.
  */
 const getUser = cache(async () => {
-  const supabase = await createClient();
+	const supabase = await createClient();
 
-  const getUserFunc = async () => {
-    const { data, error } = await supabase.auth.getUser();
+	const getUserFunc = async () => {
+		const { data, error } = await supabase.auth.getUser();
 
-    if (error != null) {
-      throw error;
-    }
-    if (data.user == null) {
-      throw new Error("No user returned");
-    }
-    return data.user;
-  };
+		if (error != null) {
+			throw error;
+		}
+		if (data.user == null) {
+			throw new Error("No user returned");
+		}
+		return data.user;
+	};
 
-  const user = await withRetry(getUserFunc, {
-    useExponentialBackoff: true,
-    onRetry: (retryCount, error) => {
-      console.error(`getUser failed, retrying (${retryCount})`, error);
-    },
-    shouldAbort: (error) => {
-      // retry if the error is a retryable fetch error
-      return !isAuthRetryableFetchError(error);
-    },
-  });
+	const user = await withRetry(getUserFunc, {
+		useExponentialBackoff: true,
+		onRetry: (retryCount, error) => {
+			console.error(`getUser failed, retrying (${retryCount})`, error);
+		},
+		shouldAbort: (error) => {
+			// retry if the error is a retryable fetch error
+			return !isAuthRetryableFetchError(error);
+		},
+	});
 
-  return user;
+	return user;
 });
 
 export { getUser };

--- a/lib/supabase/get-user.ts
+++ b/lib/supabase/get-user.ts
@@ -12,35 +12,33 @@ import { createClient } from "./server";
  * IMPORTANT: This function will throw an error if executed while the user is not authenticated.
  * Make sure the user is logged in before calling this function.
  */
-const getUser = async () => {
-	const supabase = await createClient();
+const getUser = cache(async () => {
+  const supabase = await createClient();
 
-	const getUserFunc = async () => {
-		const { data, error } = await supabase.auth.getUser();
+  const getUserFunc = async () => {
+    const { data, error } = await supabase.auth.getUser();
 
-		if (error != null) {
-			throw error;
-		}
-		if (data.user == null) {
-			throw new Error("No user returned");
-		}
-		return data.user;
-	};
+    if (error != null) {
+      throw error;
+    }
+    if (data.user == null) {
+      throw new Error("No user returned");
+    }
+    return data.user;
+  };
 
-	const user = await withRetry(getUserFunc, {
-		useExponentialBackoff: true,
-		onRetry: (retryCount, error) => {
-			console.error(`getUser failed, retrying (${retryCount})`, error);
-		},
-		shouldAbort: (error) => {
-			// retry if the error is a retryable fetch error
-			return !isAuthRetryableFetchError(error);
-		},
-	});
+  const user = await withRetry(getUserFunc, {
+    useExponentialBackoff: true,
+    onRetry: (retryCount, error) => {
+      console.error(`getUser failed, retrying (${retryCount})`, error);
+    },
+    shouldAbort: (error) => {
+      // retry if the error is a retryable fetch error
+      return !isAuthRetryableFetchError(error);
+    },
+  });
 
-	return user;
-};
+  return user;
+});
 
-const cachedGetUser = cache(getUser);
-
-export { cachedGetUser as getUser };
+export { getUser };


### PR DESCRIPTION
## Summary
This PR introduces caching for the `getUser` function. By using React's `cache()` API, it prevents repeated fetch requests for the user data, thereby reducing unnecessary network calls and mitigating recurring `isAuthRetryableFetchError` issues.

## Related Issue
https://github.com/giselles-ai/giselle/issues/130

## Changes
- Wrapped the `getUser` function with `cache()` to memoize results.

## Testing
- manual test

