### PR TITLE
Send meterEvent to Stripe (Agent v1)

### DIFF
--- a/app/(playground)/p/[agentId]/beta-proto/flow/save-agent-activity.ts
+++ b/app/(playground)/p/[agentId]/beta-proto/flow/save-agent-activity.ts
@@ -19,6 +19,6 @@ export async function saveAgentActivity(activity: AgentActivity) {
 		agentDbId,
 		startedAt: activity.startedAt,
 		endedAt: activity.endedAt,
-		totalDurationMs: activity.totalDurationMs(),
+		totalDurationMs: activity.totalDurationMs().toString(),
 	});
 }

--- a/app/webhooks/stripe/billing-meter/route.ts
+++ b/app/webhooks/stripe/billing-meter/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Handle Stripe Billing Meter webhooks
+ *
+ * Error codes: https://docs.stripe.com/billing/subscriptions/usage-based/recording-usage-api#error-codes
+ */
+import { stripe } from "@/services/external/stripe";
+import { captureEvent, captureException } from "@sentry/nextjs";
+import type Stripe from "stripe";
+
+const relevantEvents = new Set([
+	"v1.billing.meter.error_report_triggered",
+	"v1.billing.meter.no_meter_found",
+]);
+
+export async function POST(req: Request) {
+	const body = await req.text();
+	const sig = req.headers.get("stripe-signature") as string;
+	const webhookSecret = process.env.STRIPE_BILLING_METER_WEBHOOK_SECRET;
+	let thinEvent: Stripe.ThinEvent;
+
+	try {
+		if (!sig || !webhookSecret)
+			return new Response("Webhook secret not found.", { status: 400 });
+		thinEvent = stripe.parseThinEvent(body, sig, webhookSecret);
+		console.log(`🔔  Webhook received: ${thinEvent.type}`);
+	} catch (err: unknown) {
+		console.log(`❌ Error: ${err}`);
+		captureException(err);
+		return new Response(`Webhook Error: ${err}`, { status: 400 });
+	}
+
+	if (!relevantEvents.has(thinEvent.type)) {
+		return new Response(`Unsupported event type: ${thinEvent.type}`, {
+			status: 400,
+		});
+	}
+
+	const event = await stripe.v2.core.events.retrieve(thinEvent.id);
+	try {
+		console.error(
+			`
+				Stripe Billing Meter Error Report:
+				Period: ${event.data.validation_start} - ${event.data.validation_end}
+				Summary: ${event.data.developer_message_summary}
+				Error Count: ${event.data.reason.error_count}`
+				.trim()
+				.replace(/^\s+/gm, "    "),
+		);
+
+		for (const errorType of event.data.reason.error_types) {
+			console.error(
+				`Error Type: ${errorType.code} (${errorType.error_count} occurrences)`,
+			);
+			for (const error of errorType.sample_errors) {
+				console.error(`  - ${error.error_message}`);
+			}
+		}
+		if ("related_object" in event && event.related_object != null) {
+			console.error(
+				`
+				Related Object:
+        ID: ${event.related_object.id}
+        Type: ${event.related_object.type}
+        URL: ${event.related_object.url}`
+					.trim()
+					.replace(/^\s+/gm, "    "),
+			);
+		}
+
+		captureEvent({
+			message: "Stripe Billing Meter Error",
+			level: "error",
+			extra: {
+				validationPeriod: {
+					start: event.data.validation_start,
+					end: event.data.validation_end,
+				},
+				summary: event.data.developer_message_summary,
+				errors: event.data.reason.error_types,
+				relatedObject: "related_object" in event ? event.related_object : null,
+			},
+		});
+	} catch (error) {
+		console.log(error);
+		return new Response(
+			"Webhook handler failed. View your Next.js function logs.",
+			{
+				status: 400,
+			},
+		);
+	}
+	return new Response(JSON.stringify({ received: true }));
+}

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -477,9 +477,7 @@ export const agentActivities = pgTable(
 			.references(() => agents.dbId, { onDelete: "cascade" }),
 		startedAt: timestamp("started_at").notNull(),
 		endedAt: timestamp("ended_at").notNull(),
-		// This would be greater than int32 max, but will not be greater than int64 max.
-		// so, we can safely use number type.
-		totalDurationMs: numeric("total_duration_ms").$type<number>().notNull(),
+		totalDurationMs: numeric("total_duration_ms").notNull(),
 		usageReportDbId: integer("usage_report_db_id").references(
 			() => agentTimeUsageReports.dbId,
 		),
@@ -497,11 +495,7 @@ export const agentTimeUsageReports = pgTable(
 		teamDbId: integer("team_db_id")
 			.notNull()
 			.references(() => teams.dbId, { onDelete: "cascade" }),
-		// This would be greater than int32 max, but will not be greater than int64 max.
-		// so, we can safely use number type.
-		accumulatedDurationMs: numeric("accumulated_duration_ms")
-			.$type<number>()
-			.notNull(),
+		accumulatedDurationMs: numeric("accumulated_duration_ms").notNull(),
 		minutesIncrement: integer("minutes_increment").notNull(),
 		stripeMeterEventId: text("stripe_meter_event_id").notNull(),
 		timestamp: timestamp("created_at").defaultNow().notNull(),


### PR DESCRIPTION
## Summary

Implement sending meter events to Stripe.
This functionality has been implemented only for Agent v1.
Implementation for Agent v2 will be done in a subsequent pull request.

----

This PR contains one bugfix: [Fix type issue](https://github.com/giselles-ai/giselle/commit/14581305fa6e077b0f4f224ba961fc955be8354b)

The `numeric` type in PostgreSQL is treated as `string` on TypeScript runtime.
Therefore, casting between numeric string and number type is necessary in both directions.

----

Additionally, I added /webhooks/stripe/billing-meter endpoint.
Since billing meter uses a thin event format that cannot be handled by existing webhook handlers, it requires a separate handler.
(While handling through the same router is possible, it would introduce unnecessary complexity.)

## Related Issue
- https://github.com/giselles-ai/giselle/pull/230

## Changes
- Bug fix: https://github.com/giselles-ai/giselle/commit/14581305fa6e077b0f4f224ba961fc955be8354b
- Reporting: https://github.com/giselles-ai/giselle/commit/7744c4e95f7b2ddaf5d4a831a06e2ac7ab228ed3
- Error webhook event handler: https://github.com/giselles-ai/giselle/commit/6e29980f705f310557d81aae789862a6431f31c1

## Testing
- [x] Verify free team usage is not reported
- [x] Verify usage is not reported until accumulated duration reaches 1 minute
- [x] Test error webhook handling using Stripe CLI's local receiver
- [x] When a team is upgraded to Pro, verify that usage during the free period is not included in reporting


## TODO
- [x] Setup a new webhook endpoint setting: Preview
- [ ] Setup a new webhook endpoint setting: Production

📝 After merging this pull request, I'll update `preview` branch.