### PR TITLE
feat(agent): Add unique graph ID generation for agent copies

### DIFF
--- a/app/dev/copy-agent/action.ts
+++ b/app/dev/copy-agent/action.ts
@@ -9,6 +9,7 @@ import { putGraph } from "../../(playground)/p/[agentId]/canary/actions";
 import {
 	buildFileFolderPath,
 	createFileId,
+	createGraphId,
 	pathJoin,
 	pathnameToFilename,
 } from "../../(playground)/p/[agentId]/canary/lib/utils";
@@ -101,7 +102,8 @@ export async function copyAgentAction(
 			} as Node;
 		}),
 	);
-	const { url } = await putGraph({ ...graph, nodes: newNodes });
+	const newGraphId = createGraphId();
+	const { url } = await putGraph({ ...graph, id: newGraphId, nodes: newNodes });
 	const newAgentId = `agnt_${createId()}` as AgentId;
 	const newAgent = await db.insert(agents).values({
 		id: newAgentId,


### PR DESCRIPTION
Modify copyAgentAction to generate new graph IDs when copying agents to ensure each copy has a distinct graph identity. This prevents potential conflicts and maintains data isolation between copied agents.

Changes:
- Import createGraphId utility
- Generate new graph ID during copy operation
- Pass new ID when creating graph copy
