### PR TITLE
fix(editor): Update default LLM to GPT-4

### DIFF
--- a/app/(playground)/p/[agentId]/components/editor.tsx
+++ b/app/(playground)/p/[agentId]/components/editor.tsx
@@ -273,7 +273,7 @@ export function Editor() {
 										type: "action",
 										content: {
 											type: "textGeneration",
-											llm: "anthropic:claude-3-5-sonnet-latest",
+											llm: "openai:gpt-4o",
 											temperature: 0.7,
 											topP: 1,
 											instruction: "Write a short story about a cat",


### PR DESCRIPTION
Change text generation model from Claude 3 Sonnet to OpenAI's GPT-4 in the playground editor's default configuration

- Replaces anthropic:claude-3-5-sonnet-latest with openai:gpt-4o
- Keeps other generation parameters (temperature, topP) unchanged
