### PR TITLE
[feat] Add flow retry capability with state preservation

### DIFF
--- a/app/(playground)/p/[agentId]/components/header.tsx
+++ b/app/(playground)/p/[agentId]/components/header.tsx
@@ -1,15 +1,31 @@
 import { GiselleLogo } from "@/components/giselle-logo";
 import Link from "next/link";
-import type { ReactNode } from "react";
+import type { ButtonHTMLAttributes, DetailedHTMLProps, ReactNode } from "react";
 import { useExecution } from "../contexts/execution";
 import { useGraph } from "../contexts/graph";
 import {
 	type PlaygroundMode,
 	usePlaygroundMode,
 } from "../contexts/playground-mode";
-// import { RunButton } from "./flow/components/run-button";
 import { SparklesIcon } from "./icons/sparkles";
-import { Button } from "./ui/button";
+
+function Button({
+	className,
+	...props
+}: DetailedHTMLProps<
+	ButtonHTMLAttributes<HTMLButtonElement>,
+	HTMLButtonElement
+>) {
+	return (
+		<button
+			className="px-[16px] py-[8px] rounded-[8px] flex items-center gap-[2px] bg-[hsla(207,19%,77%,0.3)] font-rosart"
+			style={{
+				boxShadow: "0px 0px 3px 0px hsla(0, 0%, 100%, 0.25) inset",
+			}}
+			{...props}
+		/>
+	);
+}
 
 function SelectionIndicator() {
 	return (

--- a/app/(playground)/p/[agentId]/components/ui/button.tsx
+++ b/app/(playground)/p/[agentId]/components/ui/button.tsx
@@ -11,10 +11,11 @@ export function Button({
 	return (
 		<button
 			className={clsx(
-				"px-[16px] py-[8px] rounded-[8px] flex items-center gap-[2px] bg-[hsla(207,19%,77%,0.3)] font-rosart",
+				"px-[16px] h-[36px] rounded-full flex items-center gap-[2px] font-rosart text-black-30",
+				className,
 			)}
 			style={{
-				boxShadow: "0px 0px 3px 0px hsla(0, 0%, 100%, 0.25) inset",
+				boxShadow: "0px 0px 3px 0px hsla(0, 0%, 100%, 0.4) inset",
 			}}
 			{...props}
 		/>

--- a/app/(playground)/p/[agentId]/components/viewer.tsx
+++ b/app/(playground)/p/[agentId]/components/viewer.tsx
@@ -14,6 +14,7 @@ import ClipboardButton from "./clipboard-button";
 import { ContentTypeIcon } from "./content-type-icon";
 import { Header } from "./header";
 import { Markdown } from "./markdown";
+import { Button } from "./ui/button";
 import { EmptyState } from "./ui/empty-state";
 
 interface StepExecutionButtonProps
@@ -68,6 +69,7 @@ function ExecutionViewer({
 	execution: tmpExecution,
 }: { execution: Execution }) {
 	const { graph } = useGraph();
+	const { retryFlowExecution } = useExecution();
 	const execution = useMemo(
 		() => ({
 			...tmpExecution,
@@ -79,6 +81,7 @@ function ExecutionViewer({
 							(node) => node.id === stepExecution.nodeId,
 						);
 						if (node === undefined) {
+							console.log(`${stepExecution.nodeId} not found`);
 							return null;
 						}
 						const artifact = tmpExecution.artifacts.find((artifact) => {
@@ -130,7 +133,19 @@ function ExecutionViewer({
 						<Tabs.Content key={stepExecution.id} value={stepExecution.id}>
 							{stepExecution.status === "pending" && <p>Pending</p>}
 							{stepExecution.status === "failed" && (
-								<p>{stepExecution.error}</p>
+								<div className="flex flex-col gap-[8px]">
+									<p>{stepExecution.error}</p>
+									<div>
+										<Button
+											type="button"
+											onClick={() => {
+												retryFlowExecution(execution.id);
+											}}
+										>
+											Retry
+										</Button>
+									</div>
+								</div>
 							)}
 							{stepExecution.status === "running" ||
 								(stepExecution.status === "completed" && (

--- a/app/(playground)/p/[agentId]/lib/utils.ts
+++ b/app/(playground)/p/[agentId]/lib/utils.ts
@@ -4,6 +4,7 @@ import type {
 	ArtifactId,
 	ConnectionId,
 	ExecutionId,
+	ExecutionSnapshotId,
 	File,
 	FileId,
 	Files,
@@ -68,6 +69,9 @@ export function createJobExecutionId(): JobExecutionId {
 
 export function createExecutionId(): ExecutionId {
 	return `exct_${createId()}`;
+}
+export function createExecutionSnapshotId(): ExecutionSnapshotId {
+	return `excs_${createId()}`;
 }
 
 export function isTextGeneration(node: Node): node is TextGeneration {

--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -24,7 +24,7 @@ import { PlaygroundModeProvider } from "./contexts/playground-mode";
 import { PropertiesPanelProvider } from "./contexts/properties-panel";
 import { ToastProvider } from "./contexts/toast";
 import { ToolbarContextProvider } from "./contexts/toolbar";
-import { executeStep } from "./lib/execution";
+import { executeStep, retryStep } from "./lib/execution";
 import { isLatestVersion, migrateGraph } from "./lib/graph";
 import { buildGraphExecutionPath, buildGraphFolderPath } from "./lib/utils";
 import type {
@@ -182,6 +182,21 @@ export default async function Page({
 		return { blobUrl: result.url };
 	}
 
+	async function retryStepAction(
+		retryExecutionSnapshotUrl: string,
+		executionId: ExecutionId,
+		stepId: StepId,
+		artifacts: Artifact[],
+	) {
+		"use server";
+		return await retryStep(
+			retryExecutionSnapshotUrl,
+			executionId,
+			stepId,
+			artifacts,
+		);
+	}
+
 	return (
 		<DeveloperModeProvider developerMode={developerMode}>
 			<GraphContextProvider
@@ -203,6 +218,7 @@ export default async function Page({
 												executeAction={execute}
 												executeStepAction={executeStepAction}
 												putExecutionAction={putExecutionAction}
+												retryStepAction={retryStepAction}
 											>
 												<Playground />
 											</ExecutionProvider>

--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -86,6 +86,7 @@ export default async function Page({
 			async () => {
 				const result = await list({
 					prefix: buildGraphFolderPath(graph.id),
+					mode: "folded",
 				});
 				const size = result.blobs.reduce((sum, blob) => sum + blob.size, 0);
 				return {

--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -33,6 +33,7 @@ import type {
 	ArtifactId,
 	Execution,
 	ExecutionId,
+	ExecutionSnapshot,
 	FlowId,
 	Graph,
 	NodeId,
@@ -153,15 +154,15 @@ export default async function Page({
 		"use server";
 		return await executeStep(agentId, flowId, executionId, stepId, artifacts);
 	}
-	async function putExecutionAction(execution: Execution) {
+	async function putExecutionAction(executionSnapshot: ExecutionSnapshot) {
 		"use server";
 		const startTime = Date.now();
 		const result = await withCountMeasurement(
 			createLogger("putExecutionAction"),
 			async () => {
-				const stringifiedExecution = JSON.stringify(execution);
+				const stringifiedExecution = JSON.stringify(executionSnapshot);
 				const result = await put(
-					buildGraphExecutionPath(graph.id, execution.id),
+					buildGraphExecutionPath(graph.id, executionSnapshot.execution.id),
 					stringifiedExecution,
 					{
 						access: "public",

--- a/app/(playground)/p/[agentId]/types.ts
+++ b/app/(playground)/p/[agentId]/types.ts
@@ -344,6 +344,15 @@ export type Execution =
 	| CompletedExecution
 	| FailedExecution;
 
+export type ExecutionSnapshotId = `excs_${string}`;
+export interface ExecutionSnapshot {
+	id: ExecutionSnapshotId;
+	execution: Execution;
+	nodes: Node[];
+	connections: Connection[];
+	flow: Flow;
+}
+
 export interface ExecutionIndex {
 	executionId: ExecutionId;
 	blobUrl: string;


### PR DESCRIPTION
https://github.com/user-attachments/assets/29d6136b-87bc-4847-af8f-518a09db7931


## Changes
- Add retry button to failed execution steps
- Implement execution snapshot system to preserve graph state
- Add retry flow execution functionality that maintains execution history
- Refactor execution state management for better reliability
- Optimize blob listing with folded mode

## Testing

> [!NOTE]
> It is difficult to artificially cause an error and then succeed with a further retry, so it is OK if the normal case can be confirmed.
 
### Execute a node on the playground

- [ ] Visit `/p/:agentId`
- [ ] Open playground
- [ ] Put on node
- [ ] Generate text with Text generator node

### Execute a flow on the playground
- [ ] Visit `/p/:agentId`
- [ ] Open playground
- [ ] Put on nodes
- [ ] Connect the nodes
- [ ] Execute flow with connected nodes
