### PR TITLE
Retry step

### DIFF
--- a/app/(playground)/p/[agentId]/components/viewer.tsx
+++ b/app/(playground)/p/[agentId]/components/viewer.tsx
@@ -152,18 +152,28 @@ function ExecutionViewer({
 									<Markdown>{stepExecution.artifact?.object.content}</Markdown>
 								))}
 							{stepExecution.artifact?.type === "generatedArtifact" && (
-								<div className="mt-[10px] flex gap-[12px]">
+								<div className="mt-[10px] flex gap-[12px] items-center">
 									<div className="text-[14px] font-bold text-black-70 ">
 										Generated{" "}
 										{formatTimestamp.toRelativeTime(
 											stepExecution.artifact.createdAt,
 										)}
 									</div>
-									<div className="text-black-30">
+									<div className="text-black-30 flex items-center">
 										<ClipboardButton
 											text={stepExecution.artifact.object.content}
 											sizeClassName="w-[16px] h-[16px]"
 										/>
+									</div>
+									<div className="text-black-30 text-[14px]">
+										<button
+											type="button"
+											onClick={() => {
+												retryFlowExecution(execution.id, stepExecution.stepId);
+											}}
+										>
+											Retry
+										</button>
 									</div>
 								</div>
 							)}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8d4f5456-1b45-40e9-bcff-4a2952c68547)

> [!NOTE]
> Adjust separately so that the Copy button and UI are aligned.

Enhance flow execution system with ability to retry specific steps while maintaining execution context. Key changes:

- Add buildExecutionsFromSnapshot helper to reconstruct execution state
- Modify retryFlowExecution to accept optional forceRetryStepId parameter
- Filter artifacts by creator node when retrying steps
- Preserve completed steps while resetting targeted step and dependencies

This change allows for more efficient debugging and error recovery by retrying only failed or specified steps rather than the entire flow.

Breaking changes:
- retryFlowExecution API now accepts additional forceRetryStepId parameter
