### PR TITLE
fix(execution): Update execution state during flow processing

### DIFF
--- a/app/(playground)/p/[agentId]/contexts/execution.tsx
+++ b/app/(playground)/p/[agentId]/contexts/execution.tsx
@@ -217,7 +217,7 @@ export function ExecutionProvider({
 			const flowRunStartedAt = Date.now();
 
 			// Initialize flow execution
-			const initialExecution: Execution = {
+			let initialExecution: Execution = {
 				id: executionId,
 				status: "running",
 				flowId,
@@ -229,6 +229,10 @@ export function ExecutionProvider({
 
 			const finalExecution = await performFlowExecution({
 				initialExecution,
+				onExecutionChange: (execution) => {
+					setExecution(execution);
+					initialExecution = execution;
+				},
 				executeStepFn: (stepId) =>
 					executeStepAction(
 						flowId,


### PR DESCRIPTION
Modify flow execution to maintain current state by updating the initialExecution reference when execution changes. This ensures the execution context remains synchronized throughout the flow processing.

- Add onExecutionChange callback to update both state and reference
- Change initialExecution from const to let to allow updates
