### PR TITLE
fix(playground): Add onChange handlers for temperature and top-p sliders

### DIFF
--- a/app/(playground)/p/[agentId]/components/properties-panel.tsx
+++ b/app/(playground)/p/[agentId]/components/properties-panel.tsx
@@ -907,6 +907,12 @@ function TabsContentPrompt({
 								max={2.0}
 								min={0.0}
 								step={0.01}
+								onChange={(value) => {
+									onContentChange?.({
+										...content,
+										temperature: value,
+									});
+								}}
 							/>
 						</div>
 						<Slider
@@ -915,6 +921,12 @@ function TabsContentPrompt({
 							max={1.0}
 							min={0.0}
 							step={0.01}
+							onChange={(value) => {
+								onContentChange?.({
+									...content,
+									topP: value,
+								});
+							}}
 						/>
 					</div>
 				</div>

--- a/app/(playground)/p/[agentId]/components/slider.tsx
+++ b/app/(playground)/p/[agentId]/components/slider.tsx
@@ -30,7 +30,7 @@ interface SliderProps
 	> {
 	label: string;
 	value: number;
-	onChange?: (topP: number) => void;
+	onChange?: (value: number) => void;
 }
 export function Slider(props: SliderProps) {
 	const [value, setValue] = useState(props.value);


### PR DESCRIPTION
Update slider component to properly propagate value changes to parent component. This enables real-time updates of temperature and top-p parameters in the properties panel for agent configuration.

- Implement missing onChange handlers for temperature slider
- Implement missing onChange handlers for top-p slider
- Refactor slider prop type from 'topP' to generic 'value' for reusability
