### PR TITLE
Allow only pro plan and admin role to edit team member

### DIFF
--- a/app/(main)/settings/team/team-members-list-item.tsx
+++ b/app/(main)/settings/team/team-members-list-item.tsx
@@ -30,6 +30,7 @@ type TeamMemberListItemProps = {
 	email: string | null;
 	role: TeamRole;
 	currentUserRole: TeamRole;
+	isProPlan: boolean;
 };
 
 export function TeamMemberListItem({
@@ -38,6 +39,7 @@ export function TeamMemberListItem({
 	email,
 	role: initialRole,
 	currentUserRole,
+	isProPlan,
 }: TeamMemberListItemProps) {
 	const [isEditingRole, setIsEditingRole] = useState(false);
 	const [role, setRole] = useState<TeamRole>(initialRole);
@@ -45,7 +47,7 @@ export function TeamMemberListItem({
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string>("");
 
-	const canEditRole = currentUserRole === "admin";
+	const canEdit = currentUserRole === "admin" && isProPlan;
 	const handleRoleChange = (value: TeamRole) => {
 		setTempRole(value);
 	};
@@ -152,7 +154,7 @@ export function TeamMemberListItem({
 					) : (
 						<>
 							<span className="text-zinc-400 capitalize w-[100px]">{role}</span>
-							{canEditRole && (
+							{canEdit && (
 								<>
 									<Button
 										className="shrink-0 h-8 w-8 rounded-full p-0"

--- a/app/(main)/settings/team/team-members-list.tsx
+++ b/app/(main)/settings/team/team-members-list.tsx
@@ -10,12 +10,14 @@ type TeamMembersListProps = {
 		role: TeamRole;
 	}[];
 	currentUserRole: TeamRole;
+	isProPlan: boolean;
 };
 
 export function TeamMembersList({
 	teamDbId,
 	members,
 	currentUserRole,
+	isProPlan,
 }: TeamMembersListProps) {
 	return (
 		<div className="font-avenir rounded-[16px]">
@@ -33,6 +35,7 @@ export function TeamMembersList({
 						email={member.email}
 						role={member.role}
 						currentUserRole={currentUserRole}
+						isProPlan={isProPlan}
 					/>
 				))}
 			</div>

--- a/app/(main)/settings/team/team-members.tsx
+++ b/app/(main)/settings/team/team-members.tsx
@@ -30,11 +30,14 @@ export async function TeamMembers() {
 		);
 	}
 
+	const hasProPlan = isProPlan(team);
+
 	return (
 		<Card title="Team members">
-			{isProPlan(team) && currentUserRole === "admin" && <TeamMembersForm />}
+			{hasProPlan && currentUserRole === "admin" && <TeamMembersForm />}
 			<TeamMembersList
 				teamDbId={team.dbId}
+				isProPlan={hasProPlan}
 				members={members}
 				currentUserRole={currentUserRole}
 			/>


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Allow only pro plan and admin role to edit team member.

### Free Plan and Admin role
<img width="1434" alt="スクリーンショット 2025-01-04 15 19 10" src="https://github.com/user-attachments/assets/be870011-6482-495d-a978-e19bfd069b2e" />

### Pro Plan and Admin role
<img width="1436" alt="スクリーンショット 2025-01-04 15 19 47" src="https://github.com/user-attachments/assets/36f26880-269b-421d-9afb-cecba283a50d" />


## Related Issue
<!-- Mention the related issue number if applicable. -->
https://github.com/giselles-ai/giselle/issues/262

## Changes
<!-- List the main changes made in this PR. -->
- Previous: If you are in the Admin role,  you can edit team members.
- Currently: If you are in the Admin role and have subscribed to a Pro Plan, you can edit team members.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
