### PR TITLE
Release pro plan

### DIFF
--- a/flags.ts
+++ b/flags.ts
@@ -95,7 +95,8 @@ export const googleOauthFlag = flag<boolean>({
 export const proTeamPlanFlag = flag<boolean>({
 	key: "pro-team-plan",
 	async decide() {
-		return takeLocalEnv("PRO_TEAM_PLAN_FLAG");
+		return true;
+		// return takeLocalEnv("PRO_TEAM_PLAN_FLAG");
 	},
 	description: "Enable Pro Team Plan",
 	defaultValue: false,
@@ -108,7 +109,8 @@ export const proTeamPlanFlag = flag<boolean>({
 export const teamCreationFlag = flag<boolean>({
 	key: "team-creation",
 	async decide() {
-		return takeLocalEnv("TEAM_CREATION_FLAG");
+		return true;
+		// return takeLocalEnv("TEAM_CREATION_FLAG");
 	},
 	description: "Enable Team Creation",
 	defaultValue: false,

--- a/services/agents/activities/constants.ts
+++ b/services/agents/activities/constants.ts
@@ -1,4 +1,4 @@
 export const AGENT_TIME_CHARGE_LIMIT_MINUTES = {
 	FREE: 30,
-	PRO: 120,
+	PRO: 60,
 } as const;


### PR DESCRIPTION
## Summary
This PR activates the Pro plan and a team creation.
Also, the agent time included in the Pro plan is changed from 120 to 60 minutes.

## Related Issue
- https://github.com/giselles-ai/giselle/pull/271

## Changes
- Activate `proTeamPlanFlag` by default
- Activate `teamCreationFlag` by default
- Change `AGENT_TIME_CHARGE_LIMIT_MINUTES` for `PRO`

## Testing
- [x] Create a new Giselle account
- [x] Upgrade the default team to Pro
- [x] Included Agent time with Pro plan is 60
- [x] Create and run Agent
- [x] Create only one Free team
- [x] Create a Pro team
- [x] Add a member to a Pro team
- [x] Remove a member from a Pro team
- [x] Change a member’s role in a Pro team
- [x] Ensure that you cannot add a member to a Free team

## Other Information
<!-- Add any other relevant information for the reviewer. -->
