### PR TITLE
fix(components): Add key prop to text panel TabsContent

### DIFF
--- a/packages/components/properties-panel.tsx
+++ b/packages/components/properties-panel.tsx
@@ -491,7 +491,7 @@ export function PropertiesPanel() {
 						</TabsContent>
 					)}
 					{selectedNode && isText(selectedNode) && (
-						<TabsContent value="Text" className="flex-1">
+						<TabsContent value="Text" className="flex-1" key={selectedNode.id}>
 							<TabContentText
 								content={selectedNode.content}
 								onContentChange={(content) => {


### PR DESCRIPTION
Adds missing key prop to TabsContent component in properties panel when rendering text node content. This prevents React re-render issues and improves component stability when switching between different text nodes.
