### PR TITLE
[refactor] Standardize agent name fallback handling and improve null safety

### DIFF
--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -155,7 +155,7 @@ export default async function Page({
 		graphUrl = await persistGraph(graph);
 	}
 
-	async function updateAgentName(agentName: string) {
+	async function updateAgentName(agentName: string | null) {
 		"use server";
 		await db
 			.update(agents)
@@ -366,7 +366,7 @@ export default async function Page({
 								<MousePositionProvider>
 									<ToastProvider>
 										<AgentNameProvider
-											defaultValue={agent.name ?? "Unnamed Agent"}
+											defaultValue={agent.name}
 											updateAgentNameAction={updateAgentName}
 										>
 											<PlaygroundModeProvider>

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -442,6 +442,7 @@ export function ContentPanelSectionFormField(props: { children: ReactNode }) {
 	return <div className="grid gap-[2px]">{props.children}</div>;
 }
 
+const fallbackAgentName = "Untitled Agent";
 export function Overview() {
 	const [editTitle, setEditTitle] = useState(false);
 	const { agentName, updateAgentName } = useAgentName();
@@ -453,7 +454,7 @@ export function Overview() {
 				<input
 					type="text"
 					className="text-[16px] text-black-30 p-[4px] text-left outline-black-70 rounded-[8px]"
-					defaultValue={agentName ?? "Unnamed Agent"}
+					defaultValue={agentName ?? fallbackAgentName}
 					ref={(ref) => {
 						if (ref === null) {
 							return;
@@ -485,7 +486,7 @@ export function Overview() {
 					onClick={() => setEditTitle(true)}
 					className="text-[16px] text-black-30 p-[4px] text-left"
 				>
-					{agentName ?? "Unnamed Agent"}
+					{agentName ?? fallbackAgentName}
 				</button>
 			)}
 		</ContentPanel>

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -453,7 +453,7 @@ export function Overview() {
 				<input
 					type="text"
 					className="text-[16px] text-black-30 p-[4px] text-left outline-black-70 rounded-[8px]"
-					defaultValue={agentName ?? "Untitled Agent"}
+					defaultValue={agentName ?? "Unnamed Agent"}
 					ref={(ref) => {
 						if (ref === null) {
 							return;
@@ -485,7 +485,7 @@ export function Overview() {
 					onClick={() => setEditTitle(true)}
 					className="text-[16px] text-black-30 p-[4px] text-left"
 				>
-					{agentName}
+					{agentName ?? "Unnamed Agent"}
 				</button>
 			)}
 		</ContentPanel>

--- a/packages/contexts/agent-name.tsx
+++ b/packages/contexts/agent-name.tsx
@@ -12,7 +12,7 @@ import {
 
 const AgentNameContext = createContext<
 	| {
-			agentName: string;
+			agentName: string | null;
 			updateAgentName: (name: string) => Promise<void>;
 			isPending: boolean;
 	  }
@@ -33,11 +33,11 @@ export function AgentNameProvider({
 	updateAgentNameAction,
 }: {
 	children: ReactNode;
-	defaultValue: string;
-	updateAgentNameAction: (name: string) => Promise<string>;
+	defaultValue: string | null;
+	updateAgentNameAction: (name: string | null) => Promise<string | null>;
 }) {
 	const [serverAgentName, setServerAgentName] = useState(defaultValue);
-	const [agentName, setAgentName] = useOptimistic<string, string>(
+	const [agentName, setAgentName] = useOptimistic<string | null, string | null>(
 		serverAgentName,
 		(_, newAgentName) => newAgentName,
 	);
@@ -48,10 +48,12 @@ export function AgentNameProvider({
 			if (agentName === newAgentName) {
 				return;
 			}
+			const nullableAgentName =
+				newAgentName.trim() === "" ? null : newAgentName;
 			startTransition(async () => {
-				setAgentName(newAgentName);
-				await updateAgentNameAction(newAgentName);
-				setServerAgentName(newAgentName);
+				setAgentName(nullableAgentName);
+				const updatedAgentName = await updateAgentNameAction(nullableAgentName);
+				setServerAgentName(nullableAgentName);
 			});
 		},
 		[agentName, setAgentName, updateAgentNameAction],


### PR DESCRIPTION
## Changes
- Created `fallbackAgentName` constant to centralize default agent naming
- Updated all UI components to reference the new constant
- Modified `AgentNameProvider` to properly handle null values
- Changed default fallback text from "Unnamed Agent" to "Untitled Agent"
- Updated type signatures to accurately reflect nullable agent names

## Why
We needed to improve the consistency and maintainability of agent name handling across the application. The previous implementation had:
- Scattered fallback text definitions leading to inconsistencies
- Incomplete null-safety handling
- Misalignment with design requirements for default agent names

This refactor centralizes the fallback logic and makes the codebase more maintainable while properly handling null values in the database schema.

