### PR TITLE
Align property names with corresponding table column names

### DIFF
--- a/app/api/cron/daily-sales-summary/process-daily-sales-summary.ts
+++ b/app/api/cron/daily-sales-summary/process-daily-sales-summary.ts
@@ -201,8 +201,8 @@ async function fetchUserSeats(
 		.where(
 			and(
 				eq(userSeatUsageReports.teamDbId, teamDbId),
-				gte(userSeatUsageReports.timestamp, periodStartDate),
-				lt(userSeatUsageReports.timestamp, periodEndDate),
+				gte(userSeatUsageReports.createdAt, periodStartDate),
+				lt(userSeatUsageReports.createdAt, periodEndDate),
 			),
 		);
 	if (res.length === 0) {

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -527,11 +527,11 @@ export const agentTimeUsageReports = pgTable(
 		accumulatedDurationMs: numeric("accumulated_duration_ms").notNull(),
 		minutesIncrement: integer("minutes_increment").notNull(),
 		stripeMeterEventId: text("stripe_meter_event_id").notNull(),
-		timestamp: timestamp("created_at").defaultNow().notNull(),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
 	},
 	(table) => ({
 		teamDbIdIdx: index().on(table.teamDbId),
-		timestampIdx: index().on(table.timestamp),
+		createdAtIdx: index().on(table.createdAt),
 		stripeMeterEventIdIdx: index().on(table.stripeMeterEventId),
 	}),
 );
@@ -546,11 +546,11 @@ export const userSeatUsageReports = pgTable(
 		// Keep snapshot for audit purposes
 		userDbIdList: integer("user_db_id_list").array().notNull(),
 		stripeMeterEventId: text("stripe_meter_event_id").notNull(),
-		timestamp: timestamp("created_at").defaultNow().notNull(),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
 	},
 	(table) => ({
 		teamDbIdIdx: index().on(table.teamDbId),
-		timestampIdx: index().on(table.timestamp),
+		createdAtIdx: index().on(table.createdAt),
 		stripeMeterEventIdIdx: index().on(table.stripeMeterEventId),
 	}),
 );

--- a/services/usage-based-billing/agent-time-usage-dao.ts
+++ b/services/usage-based-billing/agent-time-usage-dao.ts
@@ -98,11 +98,11 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 			.where(
 				and(
 					eq(agentTimeUsageReports.teamDbId, teamDbId),
-					gt(agentTimeUsageReports.timestamp, periodStart),
-					lte(agentTimeUsageReports.timestamp, periodEnd),
+					gt(agentTimeUsageReports.createdAt, periodStart),
+					lte(agentTimeUsageReports.createdAt, periodEnd),
 				),
 			)
-			.orderBy(desc(agentTimeUsageReports.timestamp))
+			.orderBy(desc(agentTimeUsageReports.createdAt))
 			.limit(1);
 		if (reports.length === 0) {
 			return null;
@@ -115,7 +115,7 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 			),
 			minutesIncrement: reports[0].minutesIncrement,
 			stripeMeterEventId: reports[0].stripeMeterEventId,
-			timestamp: reports[0].timestamp,
+			createdAt: reports[0].createdAt,
 		};
 	}
 
@@ -133,7 +133,7 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 				accumulatedDurationMs: params.accumulatedDurationMs.toString(),
 				minutesIncrement: params.minutesIncrement,
 				stripeMeterEventId: params.stripeMeterEventId,
-				timestamp: params.timestamp,
+				createdAt: params.timestamp,
 			})
 			.returning();
 		if (report == null) {
@@ -145,7 +145,7 @@ export class AgentTimeUsageDAO implements AgentTimeUsageDataAccess {
 			accumulatedDurationMs: safeStringToNumber(report.accumulatedDurationMs),
 			minutesIncrement: report.minutesIncrement,
 			stripeMeterEventId: report.stripeMeterEventId,
-			timestamp: report.timestamp,
+			createdAt: report.createdAt,
 		};
 	}
 

--- a/services/usage-based-billing/agent-time-usage.test.ts
+++ b/services/usage-based-billing/agent-time-usage.test.ts
@@ -134,7 +134,7 @@ describe("processUnreportedActivities", () => {
 				accumulatedDurationMs: 60000,
 				minutesIncrement: 1,
 				stripeMeterEventId: "meter_123",
-				timestamp: new Date(),
+				createdAt: new Date(),
 			})),
 			markActivitiesAsProcessed: mock(async () => {}),
 		};
@@ -174,7 +174,7 @@ describe("processUnreportedActivities", () => {
 				accumulatedDurationMs: 60000,
 				minutesIncrement: 1,
 				stripeMeterEventId: "meter_123",
-				timestamp: new Date(),
+				createdAt: new Date(),
 			})),
 			markActivitiesAsProcessed: mock(async () => {}),
 		};
@@ -219,7 +219,7 @@ describe("processUnreportedActivities", () => {
 				accumulatedDurationMs: 60000,
 				minutesIncrement: 1,
 				stripeMeterEventId: "meter_123",
-				timestamp: new Date(),
+				createdAt: new Date(),
 			})),
 			markActivitiesAsProcessed: mock(async () => {}),
 		};
@@ -277,7 +277,7 @@ describe("processUnreportedActivities", () => {
 				accumulatedDurationMs: 60000,
 				minutesIncrement: 1,
 				stripeMeterEventId: "meter_123",
-				timestamp: new Date(),
+				createdAt: new Date(),
 			})),
 			markActivitiesAsProcessed: mock(async () => {}),
 		};

--- a/services/usage-based-billing/types.ts
+++ b/services/usage-based-billing/types.ts
@@ -11,7 +11,7 @@ export type AgentTimeUsageReport = {
 	accumulatedDurationMs: number;
 	minutesIncrement: number;
 	stripeMeterEventId: string;
-	timestamp: Date;
+	createdAt: Date;
 };
 
 export type Subscription = {

--- a/services/usage-based-billing/user-seat.ts
+++ b/services/usage-based-billing/user-seat.ts
@@ -45,13 +45,13 @@ export async function reportUserSeatUsage(
 async function saveUserSeatUsage(
 	stripeMeterEventId: string,
 	teamDbId: number,
-	timestamp: Date,
+	createdAt: Date,
 	teamMembers: number[],
 ) {
 	await db.insert(userSeatUsageReports).values({
 		stripeMeterEventId,
 		teamDbId,
-		timestamp,
+		createdAt,
 		userDbIdList: teamMembers,
 	});
 }


### PR DESCRIPTION
## Summary
The `agentTimeUsageReports` and `userSeatUsageReports` tables have a `created_at` column, but the corresponding property name in TypeScript is `timestamp`.
Because this inconsistency increases cognitive load, this pull request will align the property names.

This change does not require database migrations.