### PR TITLE
fix: Update cancel URL in Stripe Checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-# Giselle app
-NEXT_PUBLIC_SERVICE_SITE_URL="https://example.com/"
-
 # for signed cookie
 COOKIE_SECRET=
 

--- a/services/teams/actions/create-team.ts
+++ b/services/teams/actions/create-team.ts
@@ -60,12 +60,10 @@ async function prepareProTeamCreation(supabaseUser: User, teamName: string) {
 
 async function createCheckout(userDbId: number, teamName: string) {
 	const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
-	const serviceSiteUrl = process.env.NEXT_PUBLIC_SERVICE_SITE_URL;
 	invariant(siteUrl, "NEXT_PUBLIC_SITE_URL is not set");
-	invariant(serviceSiteUrl, "NEXT_PUBLIC_SERVICE_SITE_URL is not set");
 
 	const successUrl = `${siteUrl}/subscriptions/success`;
-	const cancelUrl = `${serviceSiteUrl}/pricing`;
+	const cancelUrl = `${siteUrl}/settings/team`;
 
 	const subscriptionMetadata: Record<string, string> = {
 		[DRAFT_TEAM_USER_DB_ID_METADATA_KEY]: userDbId.toString(),

--- a/services/teams/actions/upgrade-team.ts
+++ b/services/teams/actions/upgrade-team.ts
@@ -8,12 +8,10 @@ import { createCheckoutSession } from "./create-checkout-session";
 
 export async function upgradeTeam(team: CurrentTeam) {
 	const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
-	const serviceSiteUrl = process.env.NEXT_PUBLIC_SERVICE_SITE_URL;
 	invariant(siteUrl, "NEXT_PUBLIC_SITE_URL is not set");
-	invariant(serviceSiteUrl, "NEXT_PUBLIC_SERVICE_SITE_URL is not set");
 
 	const successUrl = `${siteUrl}/settings/team`;
-	const cancelUrl = `${serviceSiteUrl}/pricing`;
+	const cancelUrl = successUrl;
 
 	const subscriptionMetadata: Record<string, string> = {
 		[UPGRADING_TEAM_DB_ID_KEY]: team.dbId.toString(),


### PR DESCRIPTION
## Summary
Update cancel URL in Stripe Checkout to navigate back to `/settings/team` instead of `/pricing`.

## Related Issue
Fixes #310

## Changes
- Update cancel URL in `create-team.ts` to use NEXT_PUBLIC_SITE_URL and `/settings/team`
- Update cancel URL in `upgrade-team.ts` to use success URL
- Remove unused environment variables in `.env.example`

## Testing
- Tested navigation flow in preview environment for both entry points:
  1. Navigate to payment page from:
     - Pro plan signup modal
     - Team settings upgrade button
  2. Click back button
  3. Verified redirection to `/settings/team`

## Other Information
- This change ensures consistent navigation behavior when users cancel or go back from the payment page
- The environment variable `NEXT_PUBLIC_SERVICE_SITE_URL` will be removed from Vercel after merging to main