### PR TITLE
Add permissions to the GitHub Actions workflow

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -23,6 +23,8 @@ jobs:
     timeout-minutes: 10
     env:
       LICENSE_REPORT: docs/packages-license.md
+    permissions:
+      contents: write
     steps:
       - name: Check if running in a fork
         id: fork-check


### PR DESCRIPTION
I have already changed the `GITHUB_TOKEN` permissions to read-only at the organizational level. This follows the [Principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).

In this pull request, I will make changes to workflows that should clearly be granted permissions.

Since all the tests in this pull request have passed, I think it is ok. If permissions-related problems occur in the future, we can deal with them on a case-by-case basis.
