### PR TITLE
Add a "Using Giselle" section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 
 Giselle is an open source AI for agentic workflows, enabling seamless human-AI collaboration.
 
+## Using Giselle
+
+### Cloud
+
+We host a [Giselle](https://giselles.ai/) as a cloud service for anyone to use instantly. It has all the same features as the self-hosted version, and includes 30 minutes of free Agent time per month in the free plan.
+
+### Self-hosting
+
+Follow this [starter guide](CONTRIBUTING.md#development-environment-setup) to get Giselle running in your environment.
+
 ## Roadmap
 
 Giselle is currently still in active development. The roadmap for the public repository is currently being created, and once it's finalized, we will update this README accordingly.


### PR DESCRIPTION
## Summary
I have specified that both the Cloud version and the Self-hosted version are available for use.


## Related Issue
None.

## Changes
I added a "Using Giselle" section in README.

## Testing
Please read the [README.md](https://github.com/giselles-ai/giselle/blob/0f537d3b7be286c9284fdc935302b1a05d000469/README.md#using-giselle).

## Other Information
