### PR TITLE
fix: Add background color to empty node name section for better visibility

### DIFF
--- a/packages/components/node.tsx
+++ b/packages/components/node.tsx
@@ -187,7 +187,10 @@ function NodeNameEditable({
 			) : (
 				<button
 					type="button"
-					className="flex items-center gap-[12px] cursor-auto"
+					className={clsx(
+						"flex items-center gap-[12px] cursor-auto min-w-[120px]",
+						name.length === 0 && "min-h-[18px] bg-black-80/80",
+					)}
 					onClick={(event) => {
 						event.stopPropagation();
 					}}


### PR DESCRIPTION
## Summary
Add a background color to the node name section when it's empty to improve visibility and make it clear that the area is still interactive and editable.

## Related Issue
Fixes #267 - Unable to re-edit node name after deleting it

## Changes
- Add min-width to node name section for consistent sizing
- Add background color (bg-black-80/80) when name length is 0
- Add min-height to empty name section for better visibility
- Use clsx for conditional className application

## Testing
- Verified that empty node name section is visible with background color
- Confirmed that double-click functionality works on empty name section
- Tested name editing functionality after complete deletion

## Other Information
The background color addition makes it clear to users that there is still an interactive area even when the node name is empty, preventing confusion about the editability of empty names.