### PR TITLE
Remove flag & activate GitHub integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ CRON_SECRET=
 ## Enable @vercel/flags at all times in the development environment
 DEBUG_FLAG="true"
 VIEW_FLAG="true"
-GITHUB_INTEGRATION_FLAG="true"
 PLAYGROUND_V2_FLAG="true"
 DEVELOPER_FLAG="true"
 

--- a/app/(main)/settings/integration/page.tsx
+++ b/app/(main)/settings/integration/page.tsx
@@ -1,11 +1,6 @@
-import { githubIntegrationFlag } from "@/flags";
 import { GitHubIntegration } from "./github-integration";
 
 export default async function IntegrationPage() {
-	const displayGitHubIntegration = await githubIntegrationFlag();
-	if (!displayGitHubIntegration) {
-		return null;
-	}
 	return (
 		<div className="grid gap-[16px]">
 			<h3

--- a/app/(main)/settings/layout.tsx
+++ b/app/(main)/settings/layout.tsx
@@ -1,4 +1,3 @@
-import { githubIntegrationFlag } from "@/flags";
 import { UserIcon, UsersIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { IntegrationIcon } from "./components/integration-icon";
@@ -7,29 +6,22 @@ import { MenuLink } from "./components/menu-link";
 export default async function SettingLayout({
 	children,
 }: { children: ReactNode }) {
-	const displayGitHubIntegration = await githubIntegrationFlag();
-
 	return (
 		<div className="flex divide-x divide-black-80 h-full">
 			<div className="w-[200px] p-[24px]">
 				<div className="grid gap-[16px]">
-					{/**<h3 className="px-[16px] text-[14px] font-rosart text-black-30">
-						Account
-					</h3>**/}
 					<MenuLink
 						href="/settings/account"
 						icon={<UserIcon className="w-4 h-4" />}
 					>
 						Account
 					</MenuLink>
-					{displayGitHubIntegration && (
-						<MenuLink
-							href="/settings/integration"
-							icon={<IntegrationIcon className="w-4 h-4" />}
-						>
-							Integration
-						</MenuLink>
-					)}
+					<MenuLink
+						href="/settings/integration"
+						icon={<IntegrationIcon className="w-4 h-4" />}
+					>
+						Integration
+					</MenuLink>
 					<MenuLink
 						href="/settings/team"
 						icon={<UsersIcon className="w-4 h-4" />}

--- a/app/(playground)/p/[agentId]/prev/beta-proto/feature-flags/types.ts
+++ b/app/(playground)/p/[agentId]/prev/beta-proto/feature-flags/types.ts
@@ -1,6 +1,5 @@
 export interface FeatureFlags {
 	debugFlag: boolean;
 	viewFlag: boolean;
-	gitHubIntegrationFlag: boolean;
 	playgroundV2Flag: boolean;
 }

--- a/app/(playground)/p/[agentId]/prev/beta-proto/left-menu/left-menu.tsx
+++ b/app/(playground)/p/[agentId]/prev/beta-proto/left-menu/left-menu.tsx
@@ -1,14 +1,12 @@
 import { GithubIcon } from "lucide-react";
 import { useState } from "react";
 import { LayersIcon } from "../components/icons/layers";
-import { useFeatureFlags } from "../feature-flags/context";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/tabs";
 import { GitHubIntegration } from "./github-integration/github-integration";
 import { Overview } from "./overview/overview";
 
 export function LeftMenu() {
 	const [tabValue, setTabValue] = useState("");
-	const { gitHubIntegrationFlag } = useFeatureFlags();
 	return (
 		<Tabs
 			orientation="vertical"
@@ -19,11 +17,9 @@ export function LeftMenu() {
 				<TabsTrigger value="overview">
 					<LayersIcon className="w-[18px] h-[18px] fill-black-30" />
 				</TabsTrigger>
-				{gitHubIntegrationFlag && (
-					<TabsTrigger value="github">
-						<GithubIcon className="w-[18px] h-[18px] stroke-black-30" />
-					</TabsTrigger>
-				)}
+				<TabsTrigger value="github">
+					<GithubIcon className="w-[18px] h-[18px] stroke-black-30" />
+				</TabsTrigger>
 			</TabsList>
 			<TabsContent value="overview">
 				<Overview setTabValue={setTabValue} />

--- a/app/(playground)/p/[agentId]/prev/page.tsx
+++ b/app/(playground)/p/[agentId]/prev/page.tsx
@@ -1,10 +1,7 @@
 import { getOauthCredential } from "@/app/(auth)/lib";
 import { getTeamMembershipByAgentId } from "@/app/(auth)/lib/get-team-membership-by-agent-id";
 import { agents, db } from "@/drizzle";
-import {
-	debugFlag as getDebugFlag,
-	githubIntegrationFlag as getGitHubIntegrationFlag,
-} from "@/flags";
+import { debugFlag as getDebugFlag } from "@/flags";
 import { getUser } from "@/lib/supabase";
 import {
 	type GitHubUserClient,
@@ -13,7 +10,7 @@ import {
 } from "@/services/external/github";
 import "@xyflow/react/dist/style.css";
 import { eq } from "drizzle-orm";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { Playground } from "./beta-proto/component";
 import type { Repository } from "./beta-proto/github-integration/context";
 import type { Graph } from "./beta-proto/graph/types";
@@ -128,8 +125,6 @@ export default async function AgentPlaygroundPage({
 	}
 
 	const debugFlag = await getDebugFlag();
-	const gitHubIntegrationFlag = await getGitHubIntegrationFlag();
-
 	const agent = await getAgent(agentId);
 	const gitHubIntegrationSetting = await getGitHubIntegrationSetting(
 		agent.dbId,
@@ -144,7 +139,6 @@ export default async function AgentPlaygroundPage({
 			featureFlags={{
 				debugFlag,
 				viewFlag: true,
-				gitHubIntegrationFlag,
 				playgroundV2Flag: false,
 			}}
 			gitHubIntegration={{

--- a/flags.ts
+++ b/flags.ts
@@ -39,19 +39,6 @@ export const viewFlag = flag<boolean>({
 	],
 });
 
-export const githubIntegrationFlag = flag<boolean>({
-	key: "github-integration",
-	async decide() {
-		return takeLocalEnv("GITHUB_INTEGRATION_FLAG");
-	},
-	description: "Enable GitHub Integration",
-	defaultValue: false,
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const playgroundV2Flag = flag<boolean>({
 	key: "playground-v2",
 	async decide() {


### PR DESCRIPTION
closes https://github.com/giselles-ai/giselle/issues/322

## Summary
Remove flag & activate GitHub integration.
You can now access `/settings/integration` to install or manage Giselle GitHub App.

