### PR TITLE
Replace bunfig.toml with .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,0 @@
-[install]
-exact = true


### PR DESCRIPTION
## Summary
We've moved from bun to pnpm, bunfig.toml is not needed.
