### PR TITLE
Fix GitHub command parsing with robust line ending

### DIFF
--- a/app/webhooks/github/command.test.ts
+++ b/app/webhooks/github/command.test.ts
@@ -63,27 +63,21 @@ test("invalid command format returns null", () => {
 });
 
 test("command with multiple spaces", () => {
-	expect(
-		parseCommand("/giselle    hello   \nsome content"),
-	).toStrictEqual({
+	expect(parseCommand("/giselle    hello   \nsome content")).toStrictEqual({
 		callSign: "hello",
 		content: "some content",
 	});
 });
 
 test("command with empty content", () => {
-	expect(
-		parseCommand("/giselle hello\n"),
-	).toStrictEqual({
+	expect(parseCommand("/giselle hello\n")).toStrictEqual({
 		callSign: "hello",
 		content: "",
 	});
 });
 
 test("command with no empty line after command", () => {
-	expect(
-		parseCommand("/giselle hello content"),
-	).toStrictEqual({
+	expect(parseCommand("/giselle hello content")).toStrictEqual({
 		callSign: "hello",
 		content: "content",
 	});

--- a/app/webhooks/github/command.test.ts
+++ b/app/webhooks/github/command.test.ts
@@ -33,3 +33,58 @@ test("parseCommand3", () => {
 		content: "Please write a blog.\nTheme is free.\n\nText mood is ....",
 	});
 });
+
+test("parseCommand4 - with \\n line endings", () => {
+	expect(
+		parseCommand(`
+/giselle hello\n\nPlease write a blog.\nTheme is free.
+`),
+	).toStrictEqual({
+		callSign: "hello",
+		content: "Please write a blog.\nTheme is free.",
+	});
+});
+
+test("parseCommand5 - mixed line endings", () => {
+	expect(
+		parseCommand(`
+/giselle hello\r\n\nPlease write a blog.\r\nTheme is free.
+`),
+	).toStrictEqual({
+		callSign: "hello",
+		content: "Please write a blog.\nTheme is free.",
+	});
+});
+
+test("invalid command format returns null", () => {
+	expect(parseCommand("invalid command")).toBe(null);
+	expect(parseCommand("/invalid hello")).toBe(null);
+	expect(parseCommand("giselle hello")).toBe(null);
+});
+
+test("command with multiple spaces", () => {
+	expect(
+		parseCommand("/giselle    hello   \nsome content"),
+	).toStrictEqual({
+		callSign: "hello",
+		content: "some content",
+	});
+});
+
+test("command with empty content", () => {
+	expect(
+		parseCommand("/giselle hello\n"),
+	).toStrictEqual({
+		callSign: "hello",
+		content: "",
+	});
+});
+
+test("command with no empty line after command", () => {
+	expect(
+		parseCommand("/giselle hello content"),
+	).toStrictEqual({
+		callSign: "hello",
+		content: "content",
+	});
+});

--- a/app/webhooks/github/command.ts
+++ b/app/webhooks/github/command.ts
@@ -1,19 +1,29 @@
 export interface Command {
 	callSign: string;
-	instruction: string;
+	content: string;
 }
 
-export function parseCommand(text: string) {
-	const lines = text.trim().split("\r\n");
+export function parseCommand(text: string): Command | null {
+	// Normalize line breaks and split into lines
+	const normalizedText = text.replace(/\r\n|\r|\n/g, "\n");
+	const lines = normalizedText.trim().split("\n");
 
 	const commandLine = lines[0];
-	const commandMatch = commandLine.match(/^\/giselle\s+([^\]]+)/);
+	const commandMatch = commandLine.match(/^\/giselle\s+([^\n]+)/);
 	if (!commandMatch) {
 		return null;
 	}
 
+	// Extract callSign (first word) and remaining content
+	const parts = commandMatch[1].trim().split(/\s+/);
+	const callSign = parts[0];
+	const firstLineContent = parts.slice(1).join(" ");
+
+	// Combine remaining content
+	const content = [firstLineContent, ...lines.slice(1)].join("\n").trim();
+
 	return {
-		callSign: commandMatch[1],
-		content: lines.slice(1).join("\n").trim(),
+		callSign,
+		content,
 	};
 }


### PR DESCRIPTION
## Summary
The `comment.body` text in GitHub Webhook Event payload is like this:

```
    "body": "/giselle ebisawa-20250124\n\nHello, world!!",
```

Since our `parseCommand` is only support `\r\n` as line breaks, this comment is not handled properly.

## Related Issue
- https://github.com/giselles-ai/giselle/issues/308

## Changes
- Fix `parseCommand` and add tests

