### PR TITLE
Modified the GitHub Integration to display not only organizations but also repositories

### DIFF
--- a/app/(main)/settings/integration/github-integration.tsx
+++ b/app/(main)/settings/integration/github-integration.tsx
@@ -6,7 +6,7 @@ import {
 	needsAuthorization,
 } from "@/services/external/github";
 import { SiGithub } from "@icons-pack/react-simple-icons";
-import { Building2 } from "lucide-react";
+import { Building2, Lock, Unlock } from "lucide-react";
 import { Card } from "../components/card";
 import { GitHubAppConfigureButton } from "../components/github-app-configure-button";
 
@@ -29,6 +29,15 @@ export async function GitHubIntegration() {
 	try {
 		const gitHubUser = await gitHubClient.getUser();
 		const { installations } = await gitHubClient.getInstallations();
+		const installationsWithRepos = await Promise.all(
+			installations.map(async (installation) => {
+				const repos = await gitHubClient.getRepositories(installation.id);
+				return {
+					...installation,
+					repositories: repos.repositories,
+				};
+			}),
+		);
 
 		return (
 			<Card
@@ -42,7 +51,7 @@ export async function GitHubIntegration() {
 					),
 				}}
 			>
-				{installations.map((installation) => (
+				{installationsWithRepos.map((installation) => (
 					<Installation key={installation.id} installation={installation} />
 				))}
 			</Card>
@@ -67,7 +76,11 @@ export async function GitHubIntegration() {
 type InstallationProps = {
 	installation: Awaited<
 		ReturnType<GitHubUserClient["getInstallations"]>
-	>["installations"][number];
+	>["installations"][number] & {
+		repositories: Awaited<
+			ReturnType<GitHubUserClient["getRepositories"]>
+		>["repositories"];
+	};
 };
 
 function Installation({ installation }: InstallationProps) {
@@ -77,18 +90,39 @@ function Installation({ installation }: InstallationProps) {
 	}
 
 	return (
-		<div className="flex items-center space-x-4">
-			{"login" in account ? (
-				<>
-					<SiGithub className="w-6 h-6 text-primary" size={24} />
-					<span className="font-medium">{account.login}</span>
-				</>
-			) : (
-				<>
-					<Building2 className="w-6 h-6 text-primary" size={24} />
-					<span className="font-medium">{account.name}</span>
-				</>
-			)}
+		<div className="space-y-4">
+			<div className="flex items-center space-x-4">
+				{"login" in account ? (
+					<>
+						<SiGithub className="w-6 h-6 text-primary" size={24} />
+						<span className="font-medium">{account.login}</span>
+					</>
+				) : (
+					<>
+						<Building2 className="w-6 h-6 text-primary" size={24} />
+						<span className="font-medium">{account.name}</span>
+					</>
+				)}
+			</div>
+			<div className="space-y-2 pl-10">
+				{installation.repositories.map((repo) => (
+					<div key={repo.id} className="flex items-center space-x-2">
+						{repo.private ? (
+							<Lock className="w-4 h-4 text-muted-foreground" />
+						) : (
+							<Unlock className="w-4 h-4 text-muted-foreground" />
+						)}
+						<a
+							href={repo.html_url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-sm hover:underline"
+						>
+							{repo.name}
+						</a>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
I modified the GitHub Integration to display not only organizations but also repositories.

## Related Issue
None

## Changes
I have improved the `/settings/integration` page by displaying not only the linked GitHub organizations but also the GitHub repositories and their links.

![localhost_3000_settings_integration](https://github.com/user-attachments/assets/280e9a46-b991-44e3-b78a-5c1f70344aba)

## Testing
Please visit the `/settings/integration` page.

## Other Information
I found it inconvenient that only GitHub organizations were displayed, as I couldn't keep track of the linked repositories, so I improved it.

