### PR TITLE
Enhance GitHub integration flows

### DIFF
--- a/app/(main)/settings/account/actions.ts
+++ b/app/(main)/settings/account/actions.ts
@@ -1,110 +1,38 @@
 "use server";
 
-import type { Provider } from "@/app/(auth)/lib";
-import { deleteOauthCredential, getAuthCallbackUrl } from "@/app/(auth)/lib";
 import { db, supabaseUserMappings, users } from "@/drizzle";
 import { logger } from "@/lib/logger";
-import { createClient, getUser } from "@/lib/supabase";
+import { getUser } from "@/lib/supabase";
+import {
+	connectIdentity,
+	disconnectIdentity,
+	reconnectIdentity,
+} from "@/services/accounts";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
-
-async function connectIdentity(provider: Provider) {
-	const supabase = await createClient();
-
-	// Manual linking allows the user to link multiple same-provider identities.
-	// But it introduces additional complexity, and not suitable for most use cases.
-	// We should check if the user already has the given provider identity here.
-	// https://supabase.com/docs/guides/auth/auth-identity-linking#manual-linking-beta
-	const supabaseUser = await getUser();
-	if (supabaseUser.identities) {
-		const existingIdentity = supabaseUser.identities.find(
-			(it) => it.provider === provider,
-		);
-		if (existingIdentity) {
-			throw new Error(`Already linked to ${provider}`);
-		}
-	}
-
-	const { data, error } = await supabase.auth.linkIdentity({
-		provider,
-		options: {
-			redirectTo: getAuthCallbackUrl({ next: "/settings/account", provider }),
-		},
-	});
-
-	if (error != null) {
-		const { code, message, name, status } = error;
-		throw new Error(`${name} occurred: ${code} (${status}): ${message}`);
-	}
-	if (data.url) {
-		redirect(data.url);
-	}
-}
-
-async function reconnectIdentity(provider: Provider) {
-	const supabase = await createClient();
-	const { data, error } = await supabase.auth.signInWithOAuth({
-		provider,
-		options: {
-			redirectTo: getAuthCallbackUrl({ next: "/settings/account", provider }),
-		},
-	});
-
-	if (error != null) {
-		const { code, message, name, status } = error;
-		throw new Error(`${name} occurred: ${code} (${status}): ${message}`);
-	}
-	if (data.url) {
-		redirect(data.url);
-	}
-}
-
-async function disconnectIdentity(provider: Provider) {
-	const supabaseUser = await getUser();
-	const supabase = await createClient();
-	if (!supabaseUser.identities) {
-		throw new Error("No identities");
-	}
-	if (supabaseUser.identities.length === 1) {
-		throw new Error("Cannot unlink last identity");
-	}
-	const identity = supabaseUser.identities.find(
-		(it) => it.provider === provider,
-	);
-	if (!identity) {
-		throw new Error(`No ${provider} identity`);
-	}
-	const { error } = await supabase.auth.unlinkIdentity(identity);
-	if (error) {
-		throw new Error("Failed to unlink identity", { cause: error });
-	}
-
-	await deleteOauthCredential(provider);
-}
 
 export async function connectGoogleIdentity() {
-	return connectIdentity("google");
+	return connectIdentity("google", "/settings/account");
 }
 
 export async function connectGitHubIdentity() {
-	return connectIdentity("github");
+	return connectIdentity("github", "/settings/account");
 }
 
 export async function reconnectGoogleIdentity() {
-	return reconnectIdentity("google");
+	return reconnectIdentity("google", "/settings/account");
 }
 
 export async function reconnectGitHubIdentity() {
-	return reconnectIdentity("github");
+	return reconnectIdentity("github", "/settings/account");
 }
 
 export async function disconnectGoogleIdentity() {
-	return disconnectIdentity("google");
+	return disconnectIdentity("google", "/settings/account");
 }
 
 export async function disconnectGitHubIdentity() {
-	return disconnectIdentity("github");
+	return disconnectIdentity("github", "/settings/account");
 }
 
 export async function getAccountInfo() {

--- a/app/(main)/settings/integration/github-integration.tsx
+++ b/app/(main)/settings/integration/github-integration.tsx
@@ -38,6 +38,7 @@ export async function GitHubIntegration() {
 					component: (
 						<GitHubAppInstallButton
 							installationUrl={await gitHubAppInstallURL()}
+							installed={installations.length > 0}
 						/>
 					),
 				}}

--- a/app/(main)/settings/integration/github-integration.tsx
+++ b/app/(main)/settings/integration/github-integration.tsx
@@ -7,8 +7,8 @@ import {
 } from "@/services/external/github";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import { Building2 } from "lucide-react";
+import { GitHubAppConfigureButton } from "../../../../packages/components/github-app-configure-button";
 import { Card } from "../components/card";
-import { GitHubAppConfigureButton } from "../components/github-app-configure-button";
 
 export async function GitHubIntegration() {
 	const credential = await getOauthCredential("github");

--- a/app/(main)/settings/integration/github-integration.tsx
+++ b/app/(main)/settings/integration/github-integration.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/services/external/github";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import { Building2 } from "lucide-react";
-import { GitHubAppConfigureButton } from "../../../../packages/components/github-app-configure-button";
+import { GitHubAppInstallButton } from "../../../../packages/components/github-app-install-button";
 import { Card } from "../components/card";
 
 export async function GitHubIntegration() {
@@ -36,7 +36,7 @@ export async function GitHubIntegration() {
 				description={`Logged in as @${gitHubUser.login}.`}
 				action={{
 					component: (
-						<GitHubAppConfigureButton
+						<GitHubAppInstallButton
 							installationUrl={await gitHubAppInstallURL()}
 						/>
 					),

--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/opentelemetry";
 import { getUser } from "@/lib/supabase";
 import { saveAgentActivity } from "@/services/agents/activities";
+import { gitHubAppInstallURL } from "@/services/external/github";
 import type {
 	GitHubNextAction,
 	GitHubTriggerEvent,
@@ -355,6 +356,7 @@ export default async function Page({
 			>
 				<GitHubIntegrationProvider
 					{...gitHubIntegrationState}
+					installUrl={await gitHubAppInstallURL()}
 					upsertGitHubIntegrationSettingAction={
 						upsertGitHubIntegrationSettingAction
 					}

--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -9,6 +9,7 @@ import {
 	withCountMeasurement,
 } from "@/lib/opentelemetry";
 import { getUser } from "@/lib/supabase";
+import { connectIdentity } from "@/services/accounts";
 import { saveAgentActivity } from "@/services/agents/activities";
 import { gitHubAppInstallURL } from "@/services/external/github";
 import type {
@@ -249,6 +250,11 @@ export default async function Page({
 		await reportAgentTimeUsage(agentId, endedAtDate);
 	}
 
+	async function connectGitHubIdentityAction() {
+		"use server";
+		return connectIdentity("github", `/p/${agentId}`);
+	}
+
 	async function upsertGitHubIntegrationSettingAction(
 		_: unknown,
 		formData: FormData,
@@ -360,6 +366,7 @@ export default async function Page({
 					upsertGitHubIntegrationSettingAction={
 						upsertGitHubIntegrationSettingAction
 					}
+					connectGitHubIdentityAction={connectGitHubIdentityAction}
 				>
 					<PropertiesPanelProvider>
 						<ReactFlowProvider>

--- a/packages/components/github-app-configure-button.tsx
+++ b/packages/components/github-app-configure-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { ExternalLink } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 
@@ -63,5 +64,14 @@ export function GitHubAppConfigureButton({ installationUrl }: Props) {
 		};
 	}, [router]);
 
-	return <Button onClick={handleInstall}>Configure GitHub App</Button>;
+	return (
+		<Button
+			variant="link"
+			onClick={handleInstall}
+			className="flex items-center gap-2 w-full justify-center px-6 py-3 text-sm font-medium flex-shrink text-black-30"
+		>
+			Add Giselle's GitHub App
+			<ExternalLink className="w-5 h-5" />
+		</Button>
+	);
 }

--- a/packages/components/github-app-install-button.tsx
+++ b/packages/components/github-app-install-button.tsx
@@ -7,9 +7,10 @@ import { useEffect, useRef } from "react";
 
 type Props = {
 	installationUrl: string;
+	installed: boolean;
 };
 
-export function GitHubAppInstallButton({ installationUrl }: Props) {
+export function GitHubAppInstallButton({ installationUrl, installed }: Props) {
 	const popupRef = useRef<Window | null>(null);
 	const intervalRef = useRef<number | null>(null);
 	const router = useRouter();
@@ -70,7 +71,9 @@ export function GitHubAppInstallButton({ installationUrl }: Props) {
 			onClick={handleInstall}
 			className="flex items-center gap-2 w-full justify-center px-6 py-3 text-sm font-medium flex-shrink text-black-30"
 		>
-			Add Giselle's GitHub App
+			{installed
+				? "Configure Giselle's GitHub App"
+				: "Add Giselle's GitHub App"}
 			<ExternalLink className="w-5 h-5" />
 		</Button>
 	);

--- a/packages/components/github-app-install-button.tsx
+++ b/packages/components/github-app-install-button.tsx
@@ -9,7 +9,7 @@ type Props = {
 	installationUrl: string;
 };
 
-export function GitHubAppConfigureButton({ installationUrl }: Props) {
+export function GitHubAppInstallButton({ installationUrl }: Props) {
 	const popupRef = useRef<Window | null>(null);
 	const intervalRef = useRef<number | null>(null);
 	const router = useRouter();

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -25,7 +25,6 @@ import {
 	TrashIcon,
 	XIcon,
 } from "lucide-react";
-import Link from "next/link";
 import {
 	type ComponentProps,
 	type ReactNode,
@@ -579,7 +578,10 @@ function GitHubIntegration() {
 		</ContentPanel>
 	);
 }
+
 function GoToAccountSettings() {
+	const { connectGitHubIdentityAction } = useGitHubIntegration();
+
 	return (
 		<div className="grid gap-[16px] text-center">
 			<WilliIcon className="w-8 h-8 fill-slate-600 mx-auto" />
@@ -587,19 +589,31 @@ function GoToAccountSettings() {
 				You are not signed in. Please log in with GitHub using the button below
 				to get started and explore the world of Giselle.
 			</div>
-			<Button
-				asChild
-				variant="link"
-				className="flex items-center gap-2 w-full justify-center text-blue-200 border-blue-200"
-			>
-				<Link href="/settings/account">
-					<SiGithub className="h-[20px] w-[20px] text-white" />
-					Continue with GitHub
-				</Link>
-			</Button>
+			<GitHubConnectionButton action={connectGitHubIdentityAction} />
 		</div>
 	);
 }
+
+function GitHubConnectionButton({ action }: { action: () => Promise<void> }) {
+	const [_, formAction, isPending] = useActionState(async () => {
+		await action();
+	}, null);
+
+	return (
+		<form action={formAction}>
+			<Button
+				variant="link"
+				className="flex items-center gap-2 w-full justify-center text-blue-200 border-blue-200"
+				type="submit"
+				disabled={isPending}
+			>
+				<SiGithub className="h-[20px] w-[20px] text-white" />
+				Continue with GitHub
+			</Button>
+		</form>
+	);
+}
+
 const integrationEventList = [
 	{
 		type: "github.issue_comment.created" satisfies GitHubTriggerEvent,

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -5,6 +5,7 @@ import type {
 } from "@/services/external/github/types";
 import { LayersIcon } from "@giselles-ai/icons/layers";
 import { WilliIcon } from "@giselles-ai/icons/willi";
+import { SiGithub } from "@icons-pack/react-simple-icons";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import * as Tabs from "@radix-ui/react-tabs";
@@ -580,12 +581,21 @@ function GitHubIntegration() {
 }
 function GoToAccountSettings() {
 	return (
-		<div className="grid gap-[16px]">
+		<div className="grid gap-[16px] text-center">
+			<WilliIcon className="w-8 h-8 fill-slate-600 mx-auto" />
 			<div className="text-sm text-gray-600">
-				Please connect your GitHub account to get started
+				You are not signed in. Please log in with GitHub using the button below
+				to get started and explore the world of Giselle.
 			</div>
-			<Button asChild>
-				<Link href="/settings/account">Connect GitHub</Link>
+			<Button
+				asChild
+				variant="link"
+				className="flex items-center gap-2 w-full justify-center text-blue-200 border-blue-200"
+			>
+				<Link href="/settings/account">
+					<SiGithub className="h-[20px] w-[20px] text-white" />
+					Continue with GitHub
+				</Link>
 			</Button>
 		</div>
 	);

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { GitHubAppConfigureButton } from "@/packages/components/github-app-configure-button";
+import { GitHubAppInstallButton } from "@/packages/components/github-app-install-button";
 import type {
 	GitHubNextAction,
 	GitHubTriggerEvent,
@@ -656,7 +656,7 @@ function GitHubIntegrationForm() {
 				<p>{upsertGitHubIntegrationSettingActionResult.message}</p>
 			)}
 			<ContentPanelSection>
-				<GitHubAppConfigureButton installationUrl={installUrl} />
+				<GitHubAppInstallButton installationUrl={installUrl} />
 				<ContentPanelSectionHeader title="Repository" />
 				<Select
 					name="repositoryFullName"

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -19,7 +19,6 @@ import {
 	ChevronUp,
 	DownloadIcon,
 	FrameIcon,
-	GithubIcon,
 	HammerIcon,
 	ListTreeIcon,
 	PlusIcon,
@@ -364,7 +363,7 @@ export function NavigationPanel() {
 						<LayersIcon className="w-[18px] h-[18px] fill-black-30" />
 					</TabsTrigger>
 					<TabsTrigger value="github">
-						<GithubIcon className="w-[18px] h-[18px] stroke-black-30" />
+						<SiGithub className="w-[18px] h-[18px] stroke-black-30" />
 					</TabsTrigger>
 					<TabsTrigger value="structure">
 						<ListTreeIcon className="w-[18px] h-[18px] stroke-black-30" />

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { GitHubAppConfigureButton } from "@/packages/components/github-app-configure-button";
 import type {
 	GitHubNextAction,
 	GitHubTriggerEvent,
@@ -613,8 +614,12 @@ const nextActionList = [
 	},
 ] as const;
 function GitHubIntegrationForm() {
-	const { setting, repositories, upsertGitHubIntegrationSettingAction } =
-		useGitHubIntegration();
+	const {
+		installUrl,
+		setting,
+		repositories,
+		upsertGitHubIntegrationSettingAction,
+	} = useGitHubIntegration();
 	const { popoverOpen, setPopoverOpen } = useTabValue();
 	const { graph } = useGraph();
 	const [callSign, setCallSign] = useState(setting?.callSign ?? "");
@@ -651,6 +656,7 @@ function GitHubIntegrationForm() {
 				<p>{upsertGitHubIntegrationSettingActionResult.message}</p>
 			)}
 			<ContentPanelSection>
+				<GitHubAppConfigureButton installationUrl={installUrl} />
 				<ContentPanelSectionHeader title="Repository" />
 				<Select
 					name="repositoryFullName"
@@ -662,7 +668,6 @@ function GitHubIntegrationForm() {
 					defaultValue={setting?.repositoryFullName}
 				/>
 			</ContentPanelSection>
-
 			<ContentPanelSection>
 				<ContentPanelSectionHeader title="Trigger" />
 				<ContentPanelSectionFormField>
@@ -698,7 +703,6 @@ function GitHubIntegrationForm() {
 					</ContentPanelSectionFormField>
 				</ContentPanelSectionFormField>
 			</ContentPanelSection>
-
 			<ContentPanelSection>
 				<ContentPanelSectionHeader title="Action" />
 				<ContentPanelSectionFormField>

--- a/packages/contexts/github-integration.tsx
+++ b/packages/contexts/github-integration.tsx
@@ -1,14 +1,7 @@
 "use client";
 
-import type { gitHubIntegrations, githubIntegrationSettings } from "@/drizzle";
 import type { components } from "@octokit/openapi-types";
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useOptimistic,
-	useState,
-} from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import type {
 	CreateGitHubIntegrationSettingResult,
 	GitHubIntegrationSetting,
@@ -17,6 +10,7 @@ import type {
 type Repository = components["schemas"]["repository"];
 
 export interface GitHubIntegrationState {
+	installUrl: string;
 	repositories: Repository[];
 	needsAuthorization: boolean;
 	setting: GitHubIntegrationSetting | undefined;

--- a/packages/contexts/github-integration.tsx
+++ b/packages/contexts/github-integration.tsx
@@ -8,6 +8,7 @@ import type {
 
 export type GitHubIntegrationContextType = GitHubIntegrationState & {
 	installUrl: string;
+	connectGitHubIdentityAction: () => Promise<void>;
 	upsertGitHubIntegrationSettingAction: (
 		_: unknown,
 		formData: FormData,

--- a/packages/contexts/github-integration.tsx
+++ b/packages/contexts/github-integration.tsx
@@ -1,34 +1,28 @@
 "use client";
 
-import type { components } from "@octokit/openapi-types";
 import { createContext, useCallback, useContext, useState } from "react";
 import type {
 	CreateGitHubIntegrationSettingResult,
-	GitHubIntegrationSetting,
+	GitHubIntegrationState,
 } from "../lib/github";
 
-type Repository = components["schemas"]["repository"];
-
-export interface GitHubIntegrationState {
+export type GitHubIntegrationContextType = GitHubIntegrationState & {
 	installUrl: string;
-	repositories: Repository[];
-	needsAuthorization: boolean;
-	setting: GitHubIntegrationSetting | undefined;
 	upsertGitHubIntegrationSettingAction: (
 		_: unknown,
 		formData: FormData,
 	) => Promise<CreateGitHubIntegrationSettingResult>;
-}
+};
 
 export const GitHubIntegrationContext =
-	createContext<GitHubIntegrationState | null>(null);
+	createContext<GitHubIntegrationContextType | null>(null);
 
 export function GitHubIntegrationProvider({
 	children,
 	setting: defaultSetting,
 	upsertGitHubIntegrationSettingAction,
 	...value
-}: GitHubIntegrationState & {
+}: GitHubIntegrationContextType & {
 	children: React.ReactNode;
 }) {
 	const [serverSetting, setServerSetting] = useState(defaultSetting);

--- a/packages/lib/github.ts
+++ b/packages/lib/github.ts
@@ -4,7 +4,6 @@ import { getOauthCredential } from "@/app/(auth)/lib";
 import { db, type githubIntegrationSettings } from "@/drizzle";
 import {
 	buildGitHubUserClient,
-	gitHubAppInstallURL,
 	needsAuthorization,
 } from "@/services/external/github";
 import type { GitHubIntegrationState } from "../contexts/github-integration";
@@ -12,13 +11,14 @@ import type { GitHubIntegrationState } from "../contexts/github-integration";
 export async function getGitHubIntegrationState(
 	agentDbId: number,
 ): Promise<
-	Omit<GitHubIntegrationState, "upsertGitHubIntegrationSettingAction">
+	Omit<
+		GitHubIntegrationState,
+		"upsertGitHubIntegrationSettingAction" | "installUrl"
+	>
 > {
-	const installUrl = await gitHubAppInstallURL();
 	const credential = await getOauthCredential("github");
 	if (!credential) {
 		return {
-			installUrl,
 			needsAuthorization: true,
 			repositories: [],
 			setting: undefined,
@@ -45,7 +45,6 @@ export async function getGitHubIntegrationState(
 			}),
 		]);
 		return {
-			installUrl,
 			needsAuthorization: false,
 			repositories,
 			setting: githubIntegrationSetting,
@@ -53,7 +52,6 @@ export async function getGitHubIntegrationState(
 	} catch (error) {
 		if (needsAuthorization(error)) {
 			return {
-				installUrl,
 				needsAuthorization: true,
 				repositories: [],
 				setting: undefined,

--- a/packages/lib/github.ts
+++ b/packages/lib/github.ts
@@ -14,15 +14,19 @@ export async function getGitHubIntegrationState(
 	const credential = await getOauthCredential("github");
 	if (!credential) {
 		return {
-			needsAuthorization: true,
-			repositories: [],
-			setting: undefined,
+			status: "unauthorized",
 		};
 	}
 
 	try {
 		const gitHubClient = buildGitHubUserClient(credential);
 		const { installations } = await gitHubClient.getInstallations();
+		if (installations.length === 0) {
+			return {
+				status: "not-installed",
+			};
+		}
+
 		const [repositories, githubIntegrationSetting] = await Promise.all([
 			Promise.all(
 				installations.map(async (installation) => {
@@ -40,16 +44,14 @@ export async function getGitHubIntegrationState(
 			}),
 		]);
 		return {
-			needsAuthorization: false,
+			status: "installed",
 			repositories,
 			setting: githubIntegrationSetting,
 		};
 	} catch (error) {
 		if (needsAuthorization(error)) {
 			return {
-				needsAuthorization: true,
-				repositories: [],
-				setting: undefined,
+				status: "unauthorized",
 			};
 		}
 		throw error;
@@ -57,12 +59,29 @@ export async function getGitHubIntegrationState(
 }
 
 type Repository = components["schemas"]["repository"];
+export type GitHubIntegrationState = (
+	| GitHubIntegrationStateUnauthorized
+	| GitHubIntegrationStateNotInstalled
+	| GitHubIntegrationStateInstalled
+) &
+	GitHubIntegrationSettingState;
 
-export interface GitHubIntegrationState {
-	needsAuthorization: boolean;
+export type GitHubIntegrationStateUnauthorized = {
+	status: "unauthorized";
+};
+
+export type GitHubIntegrationStateNotInstalled = {
+	status: "not-installed";
+};
+
+export type GitHubIntegrationStateInstalled = {
+	status: "installed";
 	repositories: Repository[];
-	setting: GitHubIntegrationSetting | undefined;
-}
+};
+
+export type GitHubIntegrationSettingState = {
+	setting?: GitHubIntegrationSetting;
+};
 
 export type GitHubIntegrationSetting = Omit<
 	typeof githubIntegrationSettings.$inferSelect,

--- a/packages/lib/github.ts
+++ b/packages/lib/github.ts
@@ -6,16 +6,11 @@ import {
 	buildGitHubUserClient,
 	needsAuthorization,
 } from "@/services/external/github";
-import type { GitHubIntegrationState } from "../contexts/github-integration";
+import type { components } from "@octokit/openapi-types";
 
 export async function getGitHubIntegrationState(
 	agentDbId: number,
-): Promise<
-	Omit<
-		GitHubIntegrationState,
-		"upsertGitHubIntegrationSettingAction" | "installUrl"
-	>
-> {
+): Promise<GitHubIntegrationState> {
 	const credential = await getOauthCredential("github");
 	if (!credential) {
 		return {
@@ -59,6 +54,14 @@ export async function getGitHubIntegrationState(
 		}
 		throw error;
 	}
+}
+
+type Repository = components["schemas"]["repository"];
+
+export interface GitHubIntegrationState {
+	needsAuthorization: boolean;
+	repositories: Repository[];
+	setting: GitHubIntegrationSetting | undefined;
 }
 
 export type GitHubIntegrationSetting = Omit<

--- a/packages/lib/github.ts
+++ b/packages/lib/github.ts
@@ -4,6 +4,7 @@ import { getOauthCredential } from "@/app/(auth)/lib";
 import { db, type githubIntegrationSettings } from "@/drizzle";
 import {
 	buildGitHubUserClient,
+	gitHubAppInstallURL,
 	needsAuthorization,
 } from "@/services/external/github";
 import type { GitHubIntegrationState } from "../contexts/github-integration";
@@ -13,9 +14,11 @@ export async function getGitHubIntegrationState(
 ): Promise<
 	Omit<GitHubIntegrationState, "upsertGitHubIntegrationSettingAction">
 > {
+	const installUrl = await gitHubAppInstallURL();
 	const credential = await getOauthCredential("github");
 	if (!credential) {
 		return {
+			installUrl,
 			needsAuthorization: true,
 			repositories: [],
 			setting: undefined,
@@ -42,6 +45,7 @@ export async function getGitHubIntegrationState(
 			}),
 		]);
 		return {
+			installUrl,
 			needsAuthorization: false,
 			repositories,
 			setting: githubIntegrationSetting,
@@ -49,6 +53,7 @@ export async function getGitHubIntegrationState(
 	} catch (error) {
 		if (needsAuthorization(error)) {
 			return {
+				installUrl,
 				needsAuthorization: true,
 				repositories: [],
 				setting: undefined,

--- a/services/accounts/identity.ts
+++ b/services/accounts/identity.ts
@@ -1,0 +1,80 @@
+import type { Provider } from "@/app/(auth)/lib";
+import { deleteOauthCredential, getAuthCallbackUrl } from "@/app/(auth)/lib";
+import { createClient, getUser } from "@/lib/supabase";
+import { redirect } from "next/navigation";
+
+export async function connectIdentity(provider: Provider, next: string) {
+	const supabase = await createClient();
+
+	// Manual linking allows the user to link multiple same-provider identities.
+	// But it introduces additional complexity, and not suitable for most use cases.
+	// We should check if the user already has the given provider identity here.
+	// https://supabase.com/docs/guides/auth/auth-identity-linking#manual-linking-beta
+	const supabaseUser = await getUser();
+	if (supabaseUser.identities) {
+		const existingIdentity = supabaseUser.identities.find(
+			(it) => it.provider === provider,
+		);
+		if (existingIdentity) {
+			throw new Error(`Already linked to ${provider}`);
+		}
+	}
+
+	const { data, error } = await supabase.auth.linkIdentity({
+		provider,
+		options: {
+			redirectTo: getAuthCallbackUrl({ next, provider }),
+		},
+	});
+
+	if (error != null) {
+		const { code, message, name, status } = error;
+		throw new Error(`${name} occurred: ${code} (${status}): ${message}`);
+	}
+
+	if (data.url) {
+		redirect(data.url);
+	}
+}
+
+export async function reconnectIdentity(provider: Provider, next: string) {
+	const supabase = await createClient();
+	const { data, error } = await supabase.auth.signInWithOAuth({
+		provider,
+		options: {
+			redirectTo: getAuthCallbackUrl({ next, provider }),
+		},
+	});
+
+	if (error != null) {
+		const { code, message, name, status } = error;
+		throw new Error(`${name} occurred: ${code} (${status}): ${message}`);
+	}
+	if (data.url) {
+		redirect(data.url);
+	}
+}
+
+export async function disconnectIdentity(provider: Provider, next: string) {
+	const supabaseUser = await getUser();
+	const supabase = await createClient();
+	if (!supabaseUser.identities) {
+		throw new Error("No identities");
+	}
+	if (supabaseUser.identities.length === 1) {
+		throw new Error("Cannot unlink last identity");
+	}
+	const identity = supabaseUser.identities.find(
+		(it) => it.provider === provider,
+	);
+	if (!identity) {
+		throw new Error(`No ${provider} identity`);
+	}
+	const { error } = await supabase.auth.unlinkIdentity(identity);
+	if (error) {
+		throw new Error("Failed to unlink identity", { cause: error });
+	}
+
+	await deleteOauthCredential(provider);
+	redirect(next);
+}

--- a/services/accounts/index.ts
+++ b/services/accounts/index.ts
@@ -1,2 +1,7 @@
 export { initializeAccount } from "./actions/initialize-account";
 export { fetchCurrentUser } from "./fetch-current-user";
+export {
+	connectIdentity,
+	disconnectIdentity,
+	reconnectIdentity,
+} from "./identity";


### PR DESCRIPTION
## Summary
This pull request improves the GitHub integration flow on the agent edit screen.

### The user does not authorized with GitHub:
<img width="475" alt="スクリーンショット 2025-01-30 10 15 55" src="https://github.com/user-attachments/assets/1bff62da-a3f2-492f-999e-c84703288f24" />

Before this change:
Clicking the button would navigate the user to the /settings/account page.

After this change:
The button now initiates the GitHub authorization flow directly on the agent edit screen, streamlining the process.

### The user authorized but does not install Giselle GitHub App:
<img width="444" alt="スクリーンショット 2025-01-30 10 17 22" src="https://github.com/user-attachments/assets/30235f63-828f-4562-a934-9330e4fdc9e8" />

The user is now prompted to install the Giselle GitHub App directly from this screen.


### The user authorized and installed Giselle GitHub App:
<img width="454" alt="スクリーンショット 2025-01-30 10 17 43" src="https://github.com/user-attachments/assets/1b7478d4-80df-4f55-8a25-281ad51f8a18" />

The user can now configure the Giselle GitHub App from this screen.
Configuration options include:

- Adding repositories
- Removing repositories
- etc.
