### PR TITLE
Fix dev warnings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+public-hoist-pattern[] = require-in-the-middle

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"prebuild": "node prepare-font.js",
 		"build": "next build",
 		"start": "next start",
-		"check": "pnpm dlx @biomejs/biome check --write .",
+		"check": "biome check --write .",
 		"lint": "next lint",
 		"test": "vitest"
 	},

--- a/prepare-font.js
+++ b/prepare-font.js
@@ -1,4 +1,7 @@
+const { loadEnvConfig } = require('@next/env')
 const fs = require("node:fs").promises;
+
+loadEnvConfig(process.cwd())
 
 const fileNames = [
 	"Rosart-Regular",

--- a/prepare-font.js
+++ b/prepare-font.js
@@ -1,7 +1,7 @@
-const { loadEnvConfig } = require('@next/env')
+const { loadEnvConfig } = require("@next/env");
 const fs = require("node:fs").promises;
 
-loadEnvConfig(process.cwd())
+loadEnvConfig(process.cwd());
 
 const fileNames = [
 	"Rosart-Regular",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,7 +12,7 @@ const config = {
 		"./src/**/*.{ts,tsx}",
 		"./services/**/*.{ts,tsx}",
 		"./packages/**/*.{ts,tsx}",
-		"!./node_modules"
+		"!./node_modules",
 	],
 	prefix: "",
 	theme: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,7 @@ const config = {
 		"./src/**/*.{ts,tsx}",
 		"./services/**/*.{ts,tsx}",
 		"./packages/**/*.{ts,tsx}",
+		"!./node_modules"
 	],
 	prefix: "",
 	theme: {


### PR DESCRIPTION
## Summary

This pull request fixes these problems in development.


### tailwind warning

```
warn - Your `content` configuration includes a pattern which looks like it's accidentally matching all of `node_modules` and can cause serious performance issues.
warn - Pattern: `./packages/**/*.ts`
warn - See our documentation for recommendations:
warn - https://tailwindcss.com/docs/content-configuration#pattern-recommendations
```

### require-in-the-middle can't be external

```
⚠ ./node_modules/.pnpm/https://github.com/opentelemetry+instrumentation@0.53.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/esm/platform/node
Package require-in-the-middle can't be external
The request require-in-the-middle matches serverExternalPackages (or the default list).
The request could not be resolved by Node.js from the project directory.
Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.
Try to install it into the project directory by running npm install require-in-the-middle from the project directory.
```

This error occurs because Next.js (Turbopack) fails to resolve `require-in-the-middle`, a dependency of `@opentelemetry/instrumentation`, due to pnpm's strict `node_modules` structure.

`public-hoist-pattern` is a temporary workaround to hoist `require-in-the-middle` to the root `node_modules`, making it accessible to Turbopack.

This is a temporary fix for [https://github.com/vercel/next.js/issues/68805](https://github.com/vercel/next.js/issues/68805).  We should monitor the issue for a permanent Turbopack fix and remove this workaround when resolved.

### prepare-font.js is not download fonts even if `FORCE_DOWNLOAD_FONTS=1`

Previously, Bun automatically loads `.env` and `.env.local`, but Node.js (and thus pnpm scripts) requires explicit configuration.
