### PR TITLE
Add duplicate agent functionality

### DIFF
--- a/app/(main)/agents/actions.ts
+++ b/app/(main)/agents/actions.ts
@@ -44,6 +44,12 @@ export async function copyAgent(
 		fetchCurrentTeam(),
 		fetch(agent.graphUrl).then((res) => res.json() as unknown as Graph),
 	]);
+	if (agent.teamDbId !== team.dbId) {
+		return {
+			result: "error",
+			message: "You are not allowed to duplicate this agent",
+		};
+	}
 	const newNodes = await Promise.all(
 		graph.nodes.map(async (node) => {
 			if (node.content.type !== "files") {

--- a/app/(main)/agents/actions.ts
+++ b/app/(main)/agents/actions.ts
@@ -27,7 +27,7 @@ type AgentDuplicationResult = AgentDuplicationSuccess | AgentDuplicationError;
 
 export async function copyAgent(
 	agentId: AgentId,
-	formData: FormData,
+	_formData: FormData,
 ): Promise<AgentDuplicationResult> {
 	if (typeof agentId !== "string" || agentId.length === 0) {
 		return { result: "error", message: "Please fill in the agent id" };
@@ -125,5 +125,9 @@ export async function copyAgent(
 			},
 		})
 		.returning({ id: agents.id });
-	return { result: "success", agentId: newAgentId };
+	if (insertResult.length === 0) {
+		return { result: "error", message: "Failed to save the duplicated agent" };
+	}
+	const newAgent = insertResult[0];
+	return { result: "success", agentId: newAgent.id };
 }

--- a/app/(main)/agents/actions.ts
+++ b/app/(main)/agents/actions.ts
@@ -1,0 +1,129 @@
+"use server";
+
+import { agents, db } from "@/drizzle";
+import { fetchCurrentUser } from "@/services/accounts";
+import { fetchCurrentTeam } from "@/services/teams";
+import { putGraph } from "@giselles-ai/actions";
+import {
+	buildFileFolderPath,
+	createFileId,
+	createGraphId,
+	pathJoin,
+	pathnameToFilename,
+} from "@giselles-ai/lib/utils";
+import type { AgentId, Graph, Node } from "@giselles-ai/types";
+import { createId } from "@paralleldrive/cuid2";
+import { copy, list } from "@vercel/blob";
+
+interface AgentDuplicationSuccess {
+	result: "success";
+	agentId: AgentId;
+}
+interface AgentDuplicationError {
+	result: "error";
+	message: string;
+}
+type AgentDuplicationResult = AgentDuplicationSuccess | AgentDuplicationError;
+
+export async function copyAgent(
+	agentId: AgentId,
+	formData: FormData,
+): Promise<AgentDuplicationResult> {
+	if (typeof agentId !== "string" || agentId.length === 0) {
+		return { result: "error", message: "Please fill in the agent id" };
+	}
+
+	const agent = await db.query.agents.findFirst({
+		where: (agents, { eq }) => eq(agents.id, agentId as AgentId),
+	});
+	if (agent === undefined || agent.graphUrl === null) {
+		return { result: "error", message: `${agentId} is not found.` };
+	}
+	const [user, team, graph] = await Promise.all([
+		fetchCurrentUser(),
+		fetchCurrentTeam(),
+		fetch(agent.graphUrl).then((res) => res.json() as unknown as Graph),
+	]);
+	const newNodes = await Promise.all(
+		graph.nodes.map(async (node) => {
+			if (node.content.type !== "files") {
+				return node;
+			}
+			const newData = await Promise.all(
+				node.content.data.map(async (fileData) => {
+					if (fileData.status !== "completed") {
+						return null;
+					}
+					const newFileId = createFileId();
+					const blobList = await list({
+						prefix: buildFileFolderPath(fileData.id),
+					});
+					let newFileBlobUrl = "";
+					let newTextDataUrl = "";
+					await Promise.all(
+						blobList.blobs.map(async (blob) => {
+							const copyResult = await copy(
+								blob.url,
+								pathJoin(
+									buildFileFolderPath(newFileId),
+									pathnameToFilename(blob.pathname),
+								),
+								{
+									addRandomSuffix: true,
+									access: "public",
+								},
+							);
+							if (blob.url === fileData.fileBlobUrl) {
+								newFileBlobUrl = copyResult.url;
+							}
+							if (blob.url === fileData.textDataUrl) {
+								newTextDataUrl = copyResult.url;
+							}
+						}),
+					);
+					return {
+						...fileData,
+						id: newFileId,
+						fileBlobUrl: newFileBlobUrl,
+						textDataUrl: newTextDataUrl,
+					};
+				}),
+			).then((data) => data.filter((d) => d !== null));
+			return {
+				...node,
+				content: {
+					...node.content,
+					data: newData,
+				},
+			} as Node;
+		}),
+	);
+	const newGraphId = createGraphId();
+	const { url } = await putGraph({ ...graph, id: newGraphId, nodes: newNodes });
+
+	const newAgentId = `agnt_${createId()}` as AgentId;
+	const insertResult = await db
+		.insert(agents)
+		.values({
+			id: newAgentId,
+			name: `Copy of ${agent.name ?? agentId}`,
+			teamDbId: team.dbId,
+			creatorDbId: user.dbId,
+			graphUrl: url,
+			graphv2: {
+				agentId: newAgentId,
+				nodes: [],
+				xyFlow: {
+					nodes: [],
+					edges: [],
+				},
+				connectors: [],
+				artifacts: [],
+				webSearches: [],
+				mode: "edit",
+				flowIndexes: [],
+			},
+		})
+		.returning({ id: agents.id });
+	return { result: "success", agentId: newAgentId };
+}

--- a/app/(main)/agents/components.tsx
+++ b/app/(main)/agents/components.tsx
@@ -1,12 +1,29 @@
 "use client";
 
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { AgentId } from "@/services/agents";
 import { Toast } from "@giselles-ai/components/toast";
 import { useToast } from "@giselles-ai/contexts/toast";
-import { CopyIcon, LoaderIcon } from "lucide-react";
+import { CopyIcon, LoaderCircleIcon } from "lucide-react";
 import { redirect } from "next/navigation";
-import { useTransition } from "react";
+import { useRef, useTransition } from "react";
 import { useFormStatus } from "react-dom";
 import { copyAgent } from "./actions";
 
@@ -30,10 +47,18 @@ export function Toasts() {
 	);
 }
 
-export function DuplicateAgentButton({ agentId }: { agentId: AgentId }) {
+export function DuplicateAgentButton({
+	agentId,
+	agentName,
+}: { agentId: AgentId; agentName: string | null }) {
 	const action = copyAgent.bind(null, agentId);
 	const { addToast } = useToast();
 	const [isPending, startTransition] = useTransition();
+	const formRef = useRef<HTMLFormElement>(null);
+
+	const handleConfirm = () => {
+		formRef.current?.requestSubmit();
+	};
 
 	const formAction = async (formData: FormData) => {
 		startTransition(async () => {
@@ -49,18 +74,52 @@ export function DuplicateAgentButton({ agentId }: { agentId: AgentId }) {
 	};
 
 	return (
-		<form action={formAction} className="absolute top-4 right-4">
-			<button
-				type="submit"
-				className="text-black-30 hover:text-black--30"
-				disabled={isPending}
+		<AlertDialog>
+			<form
+				ref={formRef}
+				action={formAction}
+				className="absolute top-4 right-4"
 			>
-				{isPending ? (
-					<LoaderIcon className="w-[16px] h-[16px] animate-spin" />
-				) : (
-					<CopyIcon className="w-[16px] h-[16px]" />
-				)}
-			</button>
-		</form>
+				<TooltipProvider delayDuration={0}>
+					<Tooltip>
+						<AlertDialogTrigger asChild>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									className="text-black-30 hover:text-black--30"
+									disabled={isPending}
+								>
+									{isPending ? (
+										<LoaderCircleIcon className="w-[16px] h-[16px] animate-spin" />
+									) : (
+										<CopyIcon className="w-[16px] h-[16px]" />
+									)}
+								</button>
+							</TooltipTrigger>
+						</AlertDialogTrigger>
+						<TooltipContent side="top">
+							<p>Duplicate Agent</p>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			</form>
+
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>
+						Are you sure to duplicate this agent?
+					</AlertDialogTitle>
+					{agentName && (
+						<AlertDialogDescription>{agentName}</AlertDialogDescription>
+					)}
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel className="border-2 bg-background hover:bg-accent hover:text-accent-foreground">
+						Cancel
+					</AlertDialogCancel>
+					<AlertDialogAction onClick={handleConfirm}>Copy</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
 	);
 }

--- a/app/(main)/agents/components.tsx
+++ b/app/(main)/agents/components.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import type { AgentId } from "@/services/agents";
+import { Toast } from "@giselles-ai/components/toast";
+import { useToast } from "@giselles-ai/contexts/toast";
+import { CopyIcon, LoaderIcon } from "lucide-react";
+import { redirect } from "next/navigation";
+import { useTransition } from "react";
 import { useFormStatus } from "react-dom";
+import { copyAgent } from "./actions";
 
 export function CreateAgentButton() {
 	const { pending } = useFormStatus();
@@ -9,5 +16,51 @@ export function CreateAgentButton() {
 		<Button type="submit" disabled={pending} data-loading={pending}>
 			New Agent +
 		</Button>
+	);
+}
+
+export function Toasts() {
+	const { toasts } = useToast();
+	return (
+		<>
+			{toasts.map(({ id, ...props }) => (
+				<Toast key={id} {...props} />
+			))}
+		</>
+	);
+}
+
+export function DuplicateAgentButton({ agentId }: { agentId: AgentId }) {
+	const action = copyAgent.bind(null, agentId);
+	const { addToast } = useToast();
+	const [isPending, startTransition] = useTransition();
+
+	const formAction = async (formData: FormData) => {
+		startTransition(async () => {
+			const res = await action(formData);
+			switch (res.result) {
+				case "success":
+					return redirect(`/p/${res.agentId}`);
+
+				case "error":
+					addToast({ message: res.message, type: "error" });
+			}
+		});
+	};
+
+	return (
+		<form action={formAction} className="absolute top-4 right-4">
+			<button
+				type="submit"
+				className="text-black-30 hover:text-black--30"
+				disabled={isPending}
+			>
+				{isPending ? (
+					<LoaderIcon className="w-[16px] h-[16px] animate-spin" />
+				) : (
+					<CopyIcon className="w-[16px] h-[16px]" />
+				)}
+			</button>
+		</form>
 	);
 }

--- a/app/(main)/agents/page.tsx
+++ b/app/(main)/agents/page.tsx
@@ -57,11 +57,10 @@ async function AgentList() {
 								<div className="absolute z-0 inset-0 border rounded-[8px] mask-fill bg-gradient-to-br bg-origin-border bg-clip-boarder border-transparent from-[hsla(192,73%,84%,0.5)] to-[hsla(192,60%,33%,0.4)]" />
 							</div>
 						</Link>
-						<DuplicateAgentButton agentId={agent.id} />
+						<DuplicateAgentButton agentId={agent.id} agentName={agent.name} />
 					</div>
 				))}
 			</div>
-			<Toasts />
 		</>
 	);
 }
@@ -72,6 +71,7 @@ export default function AgentListV2Page() {
 			<Suspense fallback={<p>loading...</p>}>
 				<AgentList />
 			</Suspense>
+			<Toasts />
 		</ToastProvider>
 	);
 }

--- a/app/(main)/agents/page.tsx
+++ b/app/(main)/agents/page.tsx
@@ -1,9 +1,11 @@
 import { agents, db } from "@/drizzle";
 import { fetchCurrentTeam } from "@/services/teams";
+import { ToastProvider } from "@giselles-ai/contexts/toast";
 import { formatTimestamp } from "@giselles-ai/lib/utils";
 import { and, eq, isNotNull } from "drizzle-orm";
 import Link from "next/link";
 import { type ReactNode, Suspense } from "react";
+import { DuplicateAgentButton, Toasts } from "./components";
 
 function DataList({ label, children }: { label: string; children: ReactNode }) {
 	return (
@@ -32,35 +34,44 @@ async function AgentList() {
 		);
 	}
 	return (
-		<div className="grid gap-[16px] grid-cols-3">
-			{dbAgents.map((agent) => (
-				<Link href={`/p/${agent.id}`} key={agent.id}>
-					<div className="bg-gradient-to-br from-[hsla(187,79%,54%,0.2)] to-[hsla(207,100%,9%,0.2)] p-[18px] relative rounded-[8px]">
-						<div className="divide-y divide-black-70">
-							<div className="h-[60px]">
-								<p className="font-rosart text-black-30 text-[18px]">
-									{agent.name ?? "Unname Agent"}
-								</p>
+		<>
+			<div className="grid gap-[16px] grid-cols-3">
+				{dbAgents.map((agent) => (
+					<div key={agent.id} className="relative">
+						<Link href={`/p/${agent.id}`}>
+							<div className="bg-gradient-to-br from-[hsla(187,79%,54%,0.2)] to-[hsla(207,100%,9%,0.2)] p-[18px] relative rounded-[8px]">
+								<div className="divide-y divide-black-70">
+									<div className="h-[60px]">
+										<p className="font-rosart text-black-30 text-[18px]">
+											{agent.name ?? "Unname Agent"}
+										</p>
+									</div>
+									<div className="pt-[8px] grid grid-col-3">
+										<DataList label="Last updated">
+											{formatTimestamp.toRelativeTime(
+												new Date(agent.updatedAt).getTime(),
+											)}
+										</DataList>
+									</div>
+								</div>
+								<div className="absolute z-0 inset-0 border rounded-[8px] mask-fill bg-gradient-to-br bg-origin-border bg-clip-boarder border-transparent from-[hsla(192,73%,84%,0.5)] to-[hsla(192,60%,33%,0.4)]" />
 							</div>
-							<div className="pt-[8px] grid grid-col-3">
-								<DataList label="Last updated">
-									{formatTimestamp.toRelativeTime(
-										new Date(agent.updatedAt).getTime(),
-									)}
-								</DataList>
-							</div>
-						</div>
-						<div className="absolute z-0 inset-0 border rounded-[8px] mask-fill bg-gradient-to-br bg-origin-border bg-clip-boarder border-transparent from-[hsla(192,73%,84%,0.5)] to-[hsla(192,60%,33%,0.4)]" />
+						</Link>
+						<DuplicateAgentButton agentId={agent.id} />
 					</div>
-				</Link>
-			))}
-		</div>
+				))}
+			</div>
+			<Toasts />
+		</>
 	);
 }
+
 export default function AgentListV2Page() {
 	return (
-		<Suspense fallback={<p>loading...</p>}>
-			<AgentList />
-		</Suspense>
+		<ToastProvider>
+			<Suspense fallback={<p>loading...</p>}>
+				<AgentList />
+			</Suspense>
+		</ToastProvider>
 	);
 }


### PR DESCRIPTION
## Summary
This pull request implements duplicating agents functionality.

## Related Issue
- https://github.com/giselles-ai/giselle/issues/303

## Changes
- Server Action for Agent Duplication: almost same logic with [app/dev/copy-agent](https://github.com/giselles-ai/giselle/tree/e46862ee5184fbf27c23573ee0936179d543b3e9/app/dev/copy-agent)
- UI for Duplication
  - Implemented on agent list page.
  - Uses AlertDialog to confirm duplication and useTransition to handle asynchronous state transitions.
  - On success, redirects the user to the newly duplicated agent’s page; on failure, shows an error toast.
