### PR TITLE
Update integration page style

### DIFF
--- a/app/(main)/settings/integration/github-integration.tsx
+++ b/app/(main)/settings/integration/github-integration.tsx
@@ -6,7 +6,6 @@ import {
 	needsAuthorization,
 } from "@/services/external/github";
 import { SiGithub } from "@icons-pack/react-simple-icons";
-import { Building2, Lock, Unlock } from "lucide-react";
 import { GitHubAppInstallButton } from "../../../../packages/components/github-app-install-button";
 import { Card } from "../components/card";
 
@@ -40,22 +39,32 @@ export async function GitHubIntegration() {
 		);
 
 		return (
-			<Card
-				title="GitHub Integration"
-				description={`Logged in as @${gitHubUser.login}.`}
-				action={{
-					component: (
+			<div className="space-y-8 text-black-30">
+				<div className="flex items-center justify-between">
+					<div className="flex items-center space-x-3">
+						<SiGithub className="w-8 h-8" />
+						<div>
+							<h2 className="text-lg">GitHub</h2>
+							<div className="text-sm text-muted-foreground">
+								Logged in as (
+								<span className="text-blue-500">@{gitHubUser.login}</span>)
+							</div>
+						</div>
+					</div>
+					<div>
 						<GitHubAppInstallButton
 							installationUrl={await gitHubAppInstallURL()}
 							installed={installations.length > 0}
 						/>
-					),
-				}}
-			>
-				{installationsWithRepos.map((installation) => (
-					<Installation key={installation.id} installation={installation} />
-				))}
-			</Card>
+					</div>
+				</div>
+
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					{installationsWithRepos.map((installation) => (
+						<Installation key={installation.id} installation={installation} />
+					))}
+				</div>
+			</div>
 		);
 	} catch (error) {
 		if (needsAuthorization(error)) {
@@ -87,32 +96,27 @@ type InstallationProps = {
 function Installation({ installation }: InstallationProps) {
 	const account = installation.account;
 	if (!account) {
-		return;
+		return null;
 	}
 
+	const displayName = "login" in account ? account.login : account.name || "";
+	const avatarUrl = "avatar_url" in account ? account.avatar_url : undefined;
+
 	return (
-		<div className="space-y-4">
-			<div className="flex items-center space-x-4">
-				{"login" in account ? (
-					<>
-						<SiGithub className="w-6 h-6 text-primary" size={24} />
-						<span className="font-medium">{account.login}</span>
-					</>
-				) : (
-					<>
-						<Building2 className="w-6 h-6 text-primary" size={24} />
-						<span className="font-medium">{account.name}</span>
-					</>
+		<div className="overflow-hidden rounded-lg border border-black-70">
+			<div className="flex items-center space-x-3 border-b border-black-70 p-3 bg-black-70">
+				{avatarUrl && (
+					<img
+						src={avatarUrl}
+						alt={displayName}
+						className="w-6 h-6 rounded-full"
+					/>
 				)}
+				<span>{displayName}</span>
 			</div>
-			<div className="space-y-2 pl-10">
+			<div className="p-4 space-y-3">
 				{installation.repositories.map((repo) => (
-					<div key={repo.id} className="flex items-center space-x-2">
-						{repo.private ? (
-							<Lock className="w-4 h-4 text-muted-foreground" />
-						) : (
-							<Unlock className="w-4 h-4 text-muted-foreground" />
-						)}
+					<div key={repo.id} className="flex items-center">
 						<a
 							href={repo.html_url}
 							target="_blank"
@@ -121,6 +125,9 @@ function Installation({ installation }: InstallationProps) {
 						>
 							{repo.name}
 						</a>
+						<span className="ml-2 rounded-full px-2 py-0.5 text-xs border border-black-30">
+							{repo.private ? "Private" : "Public"}
+						</span>
 					</div>
 				))}
 			</div>


### PR DESCRIPTION
## Summary
Enhanced the integration page UI and functionality.

### GitHub is not connected.
<img width="824" alt="スクリーンショット 2025-01-31 14 57 32" src="https://github.com/user-attachments/assets/ad86d177-b266-43ba-b9e1-d5112c36fc34" />

The "Connect" button redirects users to `/settings/account`.


### GitHub is connected.
<img width="816" alt="スクリーンショット 2025-01-31 14 57 54" src="https://github.com/user-attachments/assets/26cddead-2d0d-4249-9ca0-24dd8ae2bfb2" />

## Related Issue
- https://github.com/giselles-ai/giselle/pull/340

## Other Information

The GitHub connection-related code has become somewhat complex and needs refactoring in the near future.