### PR TITLE
[PoC]GitHub node

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DEBUG_FLAG="true"
 VIEW_FLAG="true"
 PLAYGROUND_V2_FLAG="true"
 DEVELOPER_FLAG="true"
+GITHUB_NODE_FLAG="true"
 
 # @vercel/blob https://vercel.com/docs/storage/vercel-blob/using-blob-sdk
 # @see https://vercel.com/docs/storage/vercel-blob/client-upload#prepare-your-local-project

--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -1,6 +1,6 @@
 import { getTeamMembershipByAgentId } from "@/app/(auth)/lib/get-team-membership-by-agent-id";
 import { agents, db, githubIntegrationSettings } from "@/drizzle";
-import { developerFlag } from "@/flags";
+import { developerFlag, gitHubNodeFlag } from "@/flags";
 import {
 	ExternalServiceName,
 	VercelBlobOperation,
@@ -23,6 +23,7 @@ import { AgentNameProvider } from "@giselles-ai/contexts/agent-name";
 import { DeveloperModeProvider } from "@giselles-ai/contexts/developer-mode";
 import { ExecutionProvider } from "@giselles-ai/contexts/execution";
 import { GitHubIntegrationProvider } from "@giselles-ai/contexts/github-integration";
+import { GitHubNodeModeProvider } from "@giselles-ai/contexts/github-node-mode";
 import { GraphContextProvider } from "@giselles-ai/contexts/graph";
 import { MousePositionProvider } from "@giselles-ai/contexts/mouse-position";
 import { PlaygroundModeProvider } from "@giselles-ai/contexts/playground-mode";
@@ -70,8 +71,9 @@ export default async function Page({
 }: {
 	params: Promise<{ agentId: AgentId }>;
 }) {
-	const [developerMode, { agentId }, user] = await Promise.all([
+	const [developerMode, gitHubNodeMode, { agentId }, user] = await Promise.all([
 		developerFlag(),
+		gitHubNodeFlag(),
 		params,
 		getUser(),
 	]);
@@ -360,50 +362,52 @@ export default async function Page({
 
 	return (
 		<DeveloperModeProvider developerMode={developerMode}>
-			<GraphContextProvider
-				defaultGraph={graph}
-				onPersistAction={persistGraph}
-				defaultGraphUrl={graphUrl}
-			>
-				<GitHubIntegrationProvider
-					{...gitHubIntegrationState}
-					installUrl={await gitHubAppInstallURL()}
-					upsertGitHubIntegrationSettingAction={
-						upsertGitHubIntegrationSettingAction
-					}
-					connectGitHubIdentityAction={connectGitHubIdentityAction}
-					reconnectGitHubIdentityAction={reconnectGitHubIdentityAction}
+			<GitHubNodeModeProvider gitHubNodeMode={gitHubNodeMode}>
+				<GraphContextProvider
+					defaultGraph={graph}
+					onPersistAction={persistGraph}
+					defaultGraphUrl={graphUrl}
 				>
-					<PropertiesPanelProvider>
-						<ReactFlowProvider>
-							<ToolbarContextProvider>
-								<MousePositionProvider>
-									<ToastProvider>
-										<AgentNameProvider
-											defaultValue={agent.name}
-											updateAgentNameAction={updateAgentName}
-										>
-											<PlaygroundModeProvider>
-												<ExecutionProvider
-													executeStepAction={executeStepAction}
-													putExecutionAction={putExecutionAction}
-													retryStepAction={retryStepAction}
-													executeNodeAction={executeNodeAction}
-													onFinishPerformExecutionAction={
-														onFinishPerformExecutionAction
-													}
-												>
-													<Playground />
-												</ExecutionProvider>
-											</PlaygroundModeProvider>
-										</AgentNameProvider>
-									</ToastProvider>
-								</MousePositionProvider>
-							</ToolbarContextProvider>
-						</ReactFlowProvider>
-					</PropertiesPanelProvider>
-				</GitHubIntegrationProvider>
-			</GraphContextProvider>
+					<GitHubIntegrationProvider
+						{...gitHubIntegrationState}
+						installUrl={await gitHubAppInstallURL()}
+						upsertGitHubIntegrationSettingAction={
+							upsertGitHubIntegrationSettingAction
+						}
+						connectGitHubIdentityAction={connectGitHubIdentityAction}
+						reconnectGitHubIdentityAction={reconnectGitHubIdentityAction}
+					>
+						<PropertiesPanelProvider>
+							<ReactFlowProvider>
+								<ToolbarContextProvider>
+									<MousePositionProvider>
+										<ToastProvider>
+											<AgentNameProvider
+												defaultValue={agent.name}
+												updateAgentNameAction={updateAgentName}
+											>
+												<PlaygroundModeProvider>
+													<ExecutionProvider
+														executeStepAction={executeStepAction}
+														putExecutionAction={putExecutionAction}
+														retryStepAction={retryStepAction}
+														executeNodeAction={executeNodeAction}
+														onFinishPerformExecutionAction={
+															onFinishPerformExecutionAction
+														}
+													>
+														<Playground />
+													</ExecutionProvider>
+												</PlaygroundModeProvider>
+											</AgentNameProvider>
+										</ToastProvider>
+									</MousePositionProvider>
+								</ToolbarContextProvider>
+							</ReactFlowProvider>
+						</PropertiesPanelProvider>
+					</GitHubIntegrationProvider>
+				</GraphContextProvider>
+			</GitHubNodeModeProvider>
 		</DeveloperModeProvider>
 	);
 }

--- a/flags.ts
+++ b/flags.ts
@@ -77,3 +77,16 @@ export const developerFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const gitHubNodeFlag = flag<boolean>({
+	key: "github-node",
+	async decide() {
+		return takeLocalEnv("GITHUB_NODE_FLAG");
+	},
+	description: "Enable GitHub Node",
+	defaultValue: false,
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});

--- a/packages/components/content-type-icon.tsx
+++ b/packages/components/content-type-icon.tsx
@@ -2,6 +2,7 @@ import { DocumentIcon } from "@giselles-ai/icons/document";
 import { GlobeIcon } from "@giselles-ai/icons/globe";
 import { PromptIcon } from "@giselles-ai/icons/prompt";
 import { TextGenerationIcon } from "@giselles-ai/icons/text-generation";
+import { SiGithub } from "@icons-pack/react-simple-icons";
 import type { SVGProps } from "react";
 import type { Node } from "../types";
 
@@ -23,5 +24,9 @@ export function ContentTypeIcon({
 			return <DocumentIcon {...props} />;
 		case "files":
 			return <DocumentIcon {...props} />;
+		case "github":
+			return <SiGithub {...props} />;
+		default:
+			throw new Error(contentType satisfies never);
 	}
 }

--- a/packages/components/editor.tsx
+++ b/packages/components/editor.tsx
@@ -9,9 +9,8 @@ import {
 	useReactFlow,
 	useUpdateNodeInternals,
 } from "@xyflow/react";
-import bg from "./bg.png";
 import "@xyflow/react/dist/style.css";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useGraph } from "../contexts/graph";
 import { useMousePosition } from "../contexts/mouse-position";
 import { usePropertiesPanel } from "../contexts/properties-panel";
@@ -19,6 +18,7 @@ import { useToast } from "../contexts/toast";
 import { useToolbar } from "../contexts/toolbar";
 import { createNodeId, isTextGeneration } from "../lib/utils";
 import type { NodeId, Tool } from "../types";
+import bg from "./bg.png";
 import { Edge } from "./edge";
 import { Header } from "./header";
 import { KeyboardShortcut } from "./keyboard-shortcut";
@@ -129,6 +129,9 @@ export function Editor() {
 											break;
 										case "file":
 											setTab("File");
+											break;
+										case "github":
+											setTab("GitHub");
 											break;
 										default:
 											break;
@@ -277,6 +280,25 @@ export function Editor() {
 											temperature: 0.7,
 											topP: 1,
 											instruction: "Write a short story about a cat",
+											sources: [],
+										},
+									},
+								},
+							});
+							break;
+						case "addGitHubNode":
+							dispatch({
+								type: "addNode",
+								input: {
+									node: {
+										id: createNodeId(),
+										name: `GitHub node - ${graph.nodes.length + 1}`,
+										position,
+										selected: false,
+										type: "action",
+										content: {
+											type: "github",
+											instruction: "Execute GitHub operation",
 											sources: [],
 										},
 									},

--- a/packages/components/node.tsx
+++ b/packages/components/node.tsx
@@ -1,4 +1,3 @@
-import { TextGenerationIcon } from "@giselles-ai/icons/text-generation";
 import {
 	Handle,
 	type NodeProps,
@@ -6,17 +5,12 @@ import {
 	type Node as XYFlowNode,
 } from "@xyflow/react";
 import clsx from "clsx/lite";
-import React, {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useGraph } from "../contexts/graph";
 import type {
 	File,
 	Files,
+	GitHub,
 	Node as NodeType,
 	Text,
 	TextGeneration,
@@ -30,12 +24,14 @@ type FileNode = XYFlowNode<{ node: File }>;
 type FilesNode = XYFlowNode<{ node: Files }>;
 type TextGenerationNode = XYFlowNode<{ node: TextGeneration }>;
 type WebSearchNode = XYFlowNode<{ node: WebSearch }>;
+type GitHubNode = XYFlowNode<{ node: GitHub }>;
 export type Node =
 	| TextNode
 	| FileNode
 	| TextGenerationNode
 	| WebSearchNode
-	| FilesNode;
+	| FilesNode
+	| GitHubNode;
 
 export function PreviewNode({ tool }: { tool: Tool }) {
 	switch (tool.action) {
@@ -111,6 +107,32 @@ export function PreviewNode({ tool }: { tool: Tool }) {
 								temperature: 0.7,
 								topP: 1,
 								instruction: "",
+								sources: [],
+							},
+						},
+					}}
+				/>
+			);
+		case "addGitHubNode":
+			return (
+				<Node
+					type="preview"
+					dragging={true}
+					zIndex={1}
+					isConnectable
+					positionAbsoluteX={0}
+					positionAbsoluteY={0}
+					id="nd_preview"
+					data={{
+						node: {
+							id: "nd_preview",
+							name: "GitHub Node",
+							position: { x: 0, y: 0 },
+							selected: false,
+							type: "action",
+							content: {
+								type: "github",
+								instruction: "Execute GitHub operation",
 								sources: [],
 							},
 						},
@@ -218,6 +240,11 @@ export function Node({
 				...data.node.content.sources,
 			].filter((item) => item !== undefined);
 		}
+		if (data.node.content.type === "github") {
+			return [...data.node.content.sources].filter(
+				(item) => item !== undefined,
+			);
+		}
 		return [];
 	}, [data.node]);
 	const { graph, dispatch } = useGraph();
@@ -275,6 +302,9 @@ export function Node({
 			>
 				{data.node.content.type === "textGeneration" && (
 					<NodeHeader name="Text Generator" contentType={"textGeneration"} />
+				)}
+				{data.node.content.type === "github" && (
+					<NodeHeader name="GitHub" contentType={"github"} />
 				)}
 				{data.node.content.type === "webSearch" && (
 					<NodeHeader name="Web Search" contentType="webSearch" />

--- a/packages/components/properties-panel.tsx
+++ b/packages/components/properties-panel.tsx
@@ -299,7 +299,10 @@ export function PropertiesPanel() {
 								<TabsTrigger value="File">File</TabsTrigger>
 							)}
 							{selectedNode?.content?.type === "github" && (
-								<TabsTrigger value="GitHub">GitHub</TabsTrigger>
+								<>
+									<TabsTrigger value="GitHub">GitHub</TabsTrigger>
+									<TabsTrigger value="Result">Result</TabsTrigger>
+								</>
 							)}
 						</TabsList>
 					</div>
@@ -332,6 +335,17 @@ export function PropertiesPanel() {
 										onClick={() => executeNode(selectedNode.id)}
 									>
 										Generate
+									</button>
+								</div>
+							)}
+							{selectedNode.content.type === "github" && (
+								<div className="">
+									<button
+										type="button"
+										className="relative z-10 rounded-[8px] shadow-[0px_0px_3px_0px_#FFFFFF40_inset] py-[3px] px-[8px] bg-black-80 text-black-30 font-rosart text-[14px] disabled:bg-black-40"
+										onClick={() => executeNode(selectedNode.id)}
+									>
+										Execute
 									</button>
 								</div>
 							)}

--- a/packages/components/properties-panel.tsx
+++ b/packages/components/properties-panel.tsx
@@ -68,7 +68,6 @@ import type {
 	Text,
 	TextContent,
 	TextGenerateActionContent,
-	TextGeneration,
 } from "../types";
 import { Block } from "./block";
 import ClipboardButton from "./clipboard-button";
@@ -759,12 +758,17 @@ function NodeDropdown({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end" sideOffset={6}>
 				<DropdownMenuRadioGroup onValueChange={handleValueChange}>
-					<DropdownMenuLabel>Text Generator</DropdownMenuLabel>
-					{textGenerationNodes.map((node) => (
-						<DropdownMenuRadioItem value={node.id} key={node.id}>
-							{node.name}
-						</DropdownMenuRadioItem>
-					))}
+					{textGenerationNodes.length > 0 && (
+						<>
+							<DropdownMenuLabel>Text Generator</DropdownMenuLabel>
+							{textGenerationNodes.map((node) => (
+								<DropdownMenuRadioItem value={node.id} key={node.id}>
+									{node.name}
+								</DropdownMenuRadioItem>
+							))}
+						</>
+					)}
+
 					{textNodes.length > 0 && (
 						<>
 							<DropdownMenuSeparator />
@@ -2218,12 +2222,15 @@ function TabContentGitHub({
 	const {
 		graph: { nodes, connections },
 	} = useGraph();
-	const connectableTextNodes: Text[] = nodes
-		.filter((node) => node.content.type === "text")
-		.map((node) => node as Text);
-	const connectableTextGenerationNodes: TextGeneration[] = nodes
-		.filter((node) => node.content.type === "textGeneration")
-		.map((node) => node as TextGeneration);
+	const connectableTextNodes = nodes.filter(
+		(node) => node.content.type === "text",
+	);
+	const connectableTextGenerationNodes = nodes.filter(
+		(node) => node.content.type === "textGeneration",
+	);
+	const connectableGitHubNodes = nodes.filter(
+		(node) => node.content.type === "github",
+	);
 	const sourceNodes = useMemo(
 		() =>
 			content.sources
@@ -2257,6 +2264,7 @@ function TabContentGitHub({
 							nodes={[
 								...connectableTextNodes,
 								...connectableTextGenerationNodes,
+								...connectableGitHubNodes,
 							]}
 							onValueChange={(node) => {
 								onSourceConnect?.(node);
@@ -2304,6 +2312,7 @@ function TabContentGitHub({
 								nodes={[
 									...connectableTextNodes,
 									...connectableTextGenerationNodes,
+									...connectableGitHubNodes,
 								]}
 								onValueChange={(node) => {
 									onSourceConnect?.(node);

--- a/packages/components/toolbar.tsx
+++ b/packages/components/toolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useGitHubNodeMode } from "@giselles-ai/contexts/github-node-mode";
 import { TextGenerationIcon } from "@giselles-ai/icons/text-generation";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import * as ToggleGroup from "@radix-ui/react-toggle-group";
@@ -42,6 +43,8 @@ function ToggleGroupItem({
 
 export function Toolbar() {
 	const { selectTool, selectedTool } = useToolbar();
+	const gitHubNodeMode = useGitHubNodeMode();
+
 	return (
 		<div className="relative rounded-[46px] overflow-hidden bg-black-100">
 			<div className="absolute z-0 rounded-[46px] inset-0 border mask-fill bg-gradient-to-br from-[hsla(232,37%,72%,0.2)] to-[hsla(218,58%,21%,0.9)] bg-origin-border bg-clip-boarder border-transparent" />
@@ -75,13 +78,15 @@ export function Toolbar() {
 								className={"w-[24px] h-[24px] text-black-30 fill-current"}
 							/>
 						</ToggleGroupItem>
-						<ToggleGroupItem
-							value="addGitHubNode"
-							tooltip="GitHub"
-							shortcut="h"
-						>
-							<SiGithub className={"w-[24px] h-[24px] text-black-30"} />
-						</ToggleGroupItem>
+						{gitHubNodeMode && (
+							<ToggleGroupItem
+								value="addGitHubNode"
+								tooltip="GitHub"
+								shortcut="h"
+							>
+								<SiGithub className={"w-[24px] h-[24px] text-black-30"} />
+							</ToggleGroupItem>
+						)}
 					</div>
 				</ToggleGroup.Root>
 			</div>

--- a/packages/components/toolbar.tsx
+++ b/packages/components/toolbar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { TextGenerationIcon } from "@giselles-ai/icons/text-generation";
+import { SiGithub } from "@icons-pack/react-simple-icons";
 import * as ToggleGroup from "@radix-ui/react-toggle-group";
 import { FileUpIcon, LetterTextIcon, MousePointer2Icon } from "lucide-react";
-import { type ComponentProps, forwardRef } from "react";
+import type { ComponentProps } from "react";
 import { useToolbar } from "../contexts/toolbar";
 import type { Tool } from "../types";
 import { Tooltip } from "./tooltip";
@@ -73,6 +74,13 @@ export function Toolbar() {
 							<TextGenerationIcon
 								className={"w-[24px] h-[24px] text-black-30 fill-current"}
 							/>
+						</ToggleGroupItem>
+						<ToggleGroupItem
+							value="addGitHubNode"
+							tooltip="GitHub"
+							shortcut="h"
+						>
+							<SiGithub className={"w-[24px] h-[24px] text-black-30"} />
 						</ToggleGroupItem>
 					</div>
 				</ToggleGroup.Root>

--- a/packages/contexts/github-node-mode.tsx
+++ b/packages/contexts/github-node-mode.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { type ReactNode, createContext, useContext } from "react";
+
+const GitHubNodeModeContext = createContext<boolean | undefined>(undefined);
+
+export function GitHubNodeModeProvider({
+	children,
+	gitHubNodeMode,
+}: { children: ReactNode; gitHubNodeMode: boolean }) {
+	return (
+		<GitHubNodeModeContext.Provider value={gitHubNodeMode}>
+			{children}
+		</GitHubNodeModeContext.Provider>
+	);
+}
+
+export const useGitHubNodeMode = () => {
+	const context = useContext(GitHubNodeModeContext);
+	if (context === undefined) {
+		throw new Error(
+			"useGitHubNodeMode must be used within a GitHubNodeModeProvider",
+		);
+	}
+	return context;
+};

--- a/packages/contexts/toolbar.tsx
+++ b/packages/contexts/toolbar.tsx
@@ -54,11 +54,18 @@ export function ToolbarContextProvider({
 					action: "move",
 					category: "move",
 				});
-			default:
+			case "addGitHubNode":
+				return setSelectedTool({
+					action: "addGitHubNode",
+					category: "edit",
+				});
+			case undefined:
 				return setSelectedTool({
 					action: "move",
 					category: "move",
 				});
+			default:
+				throw new Error(tool satisfies never);
 		}
 	};
 

--- a/packages/lib/execution.ts
+++ b/packages/lib/execution.ts
@@ -245,12 +245,17 @@ async function resolveSources(
 					} satisfies ExecutionSource;
 				}
 				case "github": {
-					// FIXME: returning sample data
-					// returns github resouce (issue, pull request, comment, etc.) is ideal
+					const generatedArtifact = artifactResolver(node.id, context);
+					if (
+						generatedArtifact === null ||
+						generatedArtifact.type !== "generatedArtifact"
+					) {
+						return null;
+					}
 					return {
 						type: "github",
-						title: "sample title",
-						content: "sample content",
+						title: generatedArtifact.object.title,
+						content: generatedArtifact.object.content,
 						nodeId: node.id,
 					} satisfies ExecutionSource;
 				}
@@ -437,11 +442,11 @@ async function performFlowExecution(
 
 			return {
 				type: "text",
-				title: "GitHub API Response",
-				content: result,
+				title: result.title,
+				content: result.content,
 				messages: {
-					plan: "This is a sample plan",
-					description: "This is a sample description",
+					plan: result.plan,
+					description: result.description,
 				},
 			} satisfies TextArtifactObject;
 		}

--- a/packages/lib/execution.ts
+++ b/packages/lib/execution.ts
@@ -148,8 +148,17 @@ interface TextGenerationSource extends ExecutionSourceBase {
 	title: string;
 	content: string;
 }
+interface GitHubSource extends ExecutionSourceBase {
+	type: "github";
+	title: string;
+	content: string;
+}
 
-type ExecutionSource = TextSource | TextGenerationSource | FileSource;
+type ExecutionSource =
+	| TextSource
+	| TextGenerationSource
+	| FileSource
+	| GitHubSource;
 async function resolveSources(
 	sources: NodeHandle[],
 	context: ExecutionContext,
@@ -231,6 +240,16 @@ async function resolveSources(
 						type: "textGeneration",
 						title: generatedArtifact.object.title,
 						content: generatedArtifact.object.content,
+						nodeId: node.id,
+					} satisfies ExecutionSource;
+				}
+				case "github": {
+					// FIXME: returning sample data
+					// returns github resouce (issue, pull request, comment, etc.) is ideal
+					return {
+						type: "github",
+						title: "sample title",
+						content: "sample content",
 						nodeId: node.id,
 					} satisfies ExecutionSource;
 				}
@@ -405,6 +424,21 @@ async function performFlowExecution(
 				messages: {
 					plan: object.plan,
 					description: object.description,
+				},
+			} satisfies TextArtifactObject;
+		}
+		case "github": {
+			// FIXME: scaffold
+			console.log("========== GITHUB NODE ==========");
+			console.log({ context });
+			console.log("========== /GITHUB NODE/ ==========");
+			return {
+				type: "text",
+				title: "GitHub Issue Comment",
+				content: "This is a sample comment",
+				messages: {
+					plan: "This is a sample plan",
+					description: "This is a sample description",
 				},
 			} satisfies TextArtifactObject;
 		}

--- a/packages/lib/execution.ts
+++ b/packages/lib/execution.ts
@@ -43,6 +43,7 @@ import type {
 	TextGenerateActionContent,
 } from "../types";
 import { AgentTimeNotAvailableError } from "./errors";
+import { GitHubAgent } from "./github-agent";
 import { textGenerationPrompt } from "./prompts";
 import { langfuseModel, toErrorWithMessage } from "./utils";
 
@@ -428,14 +429,16 @@ async function performFlowExecution(
 			} satisfies TextArtifactObject;
 		}
 		case "github": {
-			// FIXME: scaffold
-			console.log("========== GITHUB NODE ==========");
-			console.log({ context });
-			console.log("========== /GITHUB NODE/ ==========");
+			const installationId = 60443388;
+			const agent = await GitHubAgent.build(installationId);
+
+			const instruction = node.content.instruction;
+			const result = await agent.execute(instruction);
+
 			return {
 				type: "text",
-				title: "GitHub Issue Comment",
-				content: "This is a sample comment",
+				title: "GitHub API Response",
+				content: result,
 				messages: {
 					plan: "This is a sample plan",
 					description: "This is a sample description",

--- a/packages/lib/github-agent.ts
+++ b/packages/lib/github-agent.ts
@@ -69,6 +69,7 @@ export type GitHubArtifact = z.infer<typeof githubArtifactSchema>;
 
 export class GitHubAgent {
 	readonly MAX_STEPS = 5;
+	readonly MODEL = openai("gpt-4o-mini");
 
 	private client: Octokit;
 	private constructor(client: Octokit) {
@@ -83,7 +84,7 @@ export class GitHubAgent {
 	public async execute(prompt: string) {
 		try {
 			const res = await generateText({
-				model: openai("gpt-4o-mini"),
+				model: this.MODEL,
 				tools: this.tools(),
 				maxSteps: this.MAX_STEPS,
 				experimental_output: Output.object({
@@ -111,7 +112,7 @@ Always prioritize:
 				prompt,
 			});
 
-			return res.experimental_output;
+			return { result: res.experimental_output, usage: res.usage };
 		} catch (error: unknown) {
 			if (NoSuchToolError.isInstance(error)) {
 				throw new Error(

--- a/packages/lib/github-agent.ts
+++ b/packages/lib/github-agent.ts
@@ -1,0 +1,143 @@
+import { buildAppInstallationClient } from "@/services/external/github";
+import { openai } from "@ai-sdk/openai";
+import type { Octokit } from "@octokit/core";
+import { generateText, tool } from "ai";
+import { z } from "zod";
+
+export class GitHubAgent {
+	private client: Octokit;
+	private constructor(client: Octokit) {
+		this.client = client;
+	}
+
+	public static async build(installationId: number) {
+		const client = await buildAppInstallationClient(installationId);
+		return new GitHubAgent(client);
+	}
+
+	public async execute(instruction: string) {
+		const res = await generateText({
+			// model: anthropic("claude-3-5-sonnet-latest"),
+			model: openai("gpt-4o-mini"),
+			tools: this.tools,
+			maxSteps: 5,
+			system:
+				"You are an expert of GitHub API." +
+				"Follow the instruction carefully and accurately." +
+				"Don't execute mutation, only query.",
+			prompt: instruction,
+		});
+
+		return res.text;
+	}
+
+	public tools = {
+		introspectSchema: tool({
+			description:
+				"Executes a GraphQL introspection query to fetch all types defined in the schema.",
+			parameters: z.object({}),
+			execute: async () => {
+				console.log("========= introspectSchema =========");
+				const res = await this.client.request("GET /graphql/schema", {
+					query: `query {
+            __schema {
+              types {
+                name
+                kind
+                description
+                fields {
+                  name
+                }
+              }
+            }
+          }`,
+				});
+				return JSON.stringify(res.data, null, 2);
+			},
+		}),
+		introspectType: tool({
+			description:
+				"Executes a GraphQL introspection query to retrieve information about a specific type.",
+			parameters: z.object({ type: z.string() }),
+			execute: async ({ type }) => {
+				console.log("========= introspectType =========");
+				const res = await this.client.request("GET /graphql/schema", {
+					query: `query {
+            __type(name: ${type}) {
+              name
+              kind
+              description
+              fields {
+                name
+              }
+            }
+          }`,
+				});
+				return JSON.stringify(res.data, null, 2);
+			},
+		}),
+		query: tool({
+			description: "Executes a GitHub GraphQL query with optional variables.",
+			parameters: z.object({
+				query: z.string(),
+				variables: z.record(z.any()).optional(),
+			}),
+			execute: async ({ query, variables }) => {
+				console.log("Executing GraphQL query...");
+				console.log({ query, variables });
+				const res = await this.client.request("POST /graphql", {
+					query,
+					variables,
+				});
+				return JSON.stringify(res.data, null, 2);
+			},
+		}),
+		// getRepository: tool({
+		// 	description: "Get a repository",
+		// 	parameters: z.object({ owner: z.string(), repo: z.string() }),
+		// 	execute: async ({ owner, repo }) => {
+		// 		const res = await this.client.request("GET /repos/{owner}/{repo}", {
+		// 			owner,
+		// 			repo,
+		// 		});
+		// 		return JSON.stringify(res.data, null, 2);
+		// 	},
+		// }),
+		// getIssues: tool({
+		// 	description: "List issues from a repository",
+		// 	parameters: z.object({
+		// 		owner: z.string(),
+		// 		repo: z.string(),
+		// 	}),
+		// 	execute: async ({ owner, repo }) => {
+		// 		const res = await this.client.request(
+		// 			"GET /repos/{owner}/{repo}/issues",
+		// 			{
+		// 				owner,
+		// 				repo,
+		// 			},
+		// 		);
+		// 		return JSON.stringify(res.data, null, 2);
+		// 	},
+		// }),
+		// getIssue: tool({
+		// 	description: "Get issue from a repository",
+		// 	parameters: z.object({
+		// 		owner: z.string(),
+		// 		repo: z.string(),
+		// 		issueNumber: z.number(),
+		// 	}),
+		// 	execute: async ({ owner, repo, issueNumber }) => {
+		// 		const res = await this.client.request(
+		// 			"GET /repos/{owner}/{repo}/issues/{issue_number}",
+		// 			{
+		// 				owner,
+		// 				repo,
+		// 				issue_number: issueNumber,
+		// 			},
+		// 		);
+		// 		return JSON.stringify(res.data, null, 2);
+		// 	},
+		// }),
+	};
+}

--- a/packages/lib/github-agent.ts
+++ b/packages/lib/github-agent.ts
@@ -16,10 +16,9 @@ import {
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import type { AgentId } from "../types";
+import type { GitHubIntegrationSetting } from "./github";
 
-// Fetch installation id from repository name
-// FIXME: add githubIntegrationSetting.installationId column is preferred
-export async function fetchInstallationId(agentId: AgentId) {
+export async function fetchGitHubIntegrationSetting(agentId: AgentId) {
 	const res = await db
 		.select()
 		.from(githubIntegrationSettings)
@@ -27,13 +26,18 @@ export async function fetchInstallationId(agentId: AgentId) {
 		.where(eq(agents.id, agentId))
 		.limit(1);
 	if (res.length === 0) {
-		throw new Error("Installation ID not found");
+		throw new Error("GitHub integration setting not found");
 	}
-	const setting = res[0];
+	return res[0].github_integration_settings;
+}
 
+// Fetch installation id from repository name
+// FIXME: add githubIntegrationSetting.installationId column is preferred
+export async function fetchInstallationId(
+	integrationSetting: GitHubIntegrationSetting,
+) {
 	const appClient = await buildAppClient();
-	const [owner, repo] =
-		setting.github_integration_settings.repositoryFullName.split("/");
+	const [owner, repo] = integrationSetting.repositoryFullName.split("/");
 	const { data: installation } = await appClient.request(
 		"GET /repos/{owner}/{repo}/installation",
 		{

--- a/packages/lib/prompts.ts
+++ b/packages/lib/prompts.ts
@@ -83,10 +83,11 @@ export const gitHubAgentPrompt = `You are a GitHub API expert tasked with analyz
 {{instruction}}
 </instruction>
 
-{{#if requirement}}
-<requirement>
-{{requirement}}
-</requirement>
+{{#if integrationSetting}}
+<integration_setting>
+Repository: {{integrationSetting.repositoryFullName}}
+Event: {{integrationSetting.event}}
+</integration_setting>
 {{/if}}
 
 ${sources}

--- a/packages/lib/prompts.ts
+++ b/packages/lib/prompts.ts
@@ -1,21 +1,7 @@
 import HandleBars from "handlebars";
 HandleBars.registerHelper("eq", (arg1, arg2) => arg1 === arg2);
 
-export const textGenerationPrompt = `You are tasked with generating text based on specific instructions, requirements, and sources provided by the user. Follow these steps carefully:
-
-1. Read and analyze the following inputs:
-
-<instruction>
-{{instruction}}
-</instruction>
-
-{{#if requirement}}
-<requirement>
-{{requirement}}
-</requirement>
-{{/if}}
-
-{{#if sources}}
+const sources = `{{#if sources}}
 <sources>
 {{#each sources}}
 {{#if (eq this.type "text")}}
@@ -30,10 +16,31 @@ export const textGenerationPrompt = `You are tasked with generating text based o
 <file id="{{this.nodeId}}" title="{{this.title}}">
 {{this.content}}
 </file>
+{{else if (eq this.type "github")}}
+<github id="{{this.nodeId}}" title="{{this.title}}">
+{{this.content}}
+</github>
 {{/if}}
 {{/each}}
 </sources>
 {{/if}}
+`;
+
+export const textGenerationPrompt = `You are tasked with generating text based on specific instructions, requirements, and sources provided by the user. Follow these steps carefully:
+
+1. Read and analyze the following inputs:
+
+<instruction>
+{{instruction}}
+</instruction>
+
+{{#if requirement}}
+<requirement>
+{{requirement}}
+</requirement>
+{{/if}}
+
+${sources}
 
 2. Process the instruction:
     - Carefully read and understand the instruction provided.
@@ -66,4 +73,51 @@ export const textGenerationPrompt = `You are tasked with generating text based o
     - If the instruction asks for specific sections or formatting, include appropriate subtags within your response.
 
 Remember to adhere strictly to the given instruction, fulfill all requirements, and make proper use of the provided sources. Your goal is to produce a well-crafted, accurate, and relevant piece of text that fully satisfies the user's request.
+`;
+
+export const gitHubAgentPrompt = `You are a GitHub API expert tasked with analyzing GitHub repositories and data through the GitHub GraphQL API. Your role is to provide accurate insights and information based on the provided instructions and sources.
+
+1. Read and analyze the following inputs:
+
+<instruction>
+{{instruction}}
+</instruction>
+
+{{#if requirement}}
+<requirement>
+{{requirement}}
+</requirement>
+{{/if}}
+
+${sources}
+
+2. GitHub API Guidelines:
+    - You can ONLY perform READ operations through GraphQL queries
+    - You MUST reject any requests for mutations or data modifications
+    - Always respect GitHub API rate limits
+    - Structure queries efficiently to minimize API calls
+
+3. Query Planning and Execution:
+    - Break down complex requests into manageable GraphQL queries
+    - Handle pagination appropriately for large datasets
+    - Use aliases and fragments to optimize queries
+    - Validate all query parameters before execution
+
+4. Data Analysis and Response:
+    - Process retrieved data accurately and thoroughly
+    - Provide context and explanations for technical findings
+    - Include relevant metrics and statistics
+    - Format complex data in clear, readable structures
+
+5. Generate your artifact:
+    plan: Detailed explanation of how you'll retrieve the data
+    title: Clear, concise title for the artifact
+    content: Well-formatted markdown content with findings
+    description: Comprehensive explanation of the artifact and suggestions
+
+Remember:
+- Security: Never expose sensitive repository data
+- Accuracy: Double-check all query results
+- Clarity: Present technical information in an understandable way
+- Compliance: Follow GitHub API best practices
 `;

--- a/packages/lib/utils.ts
+++ b/packages/lib/utils.ts
@@ -11,6 +11,7 @@ import type {
 	Files,
 	Flow,
 	FlowId,
+	GitHub,
 	GitHubIntegrationSettingId,
 	Graph,
 	GraphId,
@@ -95,6 +96,10 @@ export function isFile(node: Node): node is File {
 }
 export function isFiles(node: Node): node is Files {
 	return node.content.type === "files";
+}
+
+export function isGitHub(node: Node): node is GitHub {
+	return node.content.type === "github";
 }
 
 interface Element {

--- a/packages/types.ts
+++ b/packages/types.ts
@@ -40,7 +40,19 @@ interface WebSearchActionContent extends ActionContentBase {
 export interface WebSearch extends Action {
 	content: WebSearchActionContent;
 }
-type ActionContent = TextGenerateActionContent | WebSearchActionContent;
+export interface GitHubActionContent extends ActionContentBase {
+	type: "github";
+	instruction: string;
+	sources: NodeHandle[];
+}
+export interface GitHub extends Action {
+	content: GitHubActionContent;
+}
+
+type ActionContent =
+	| TextGenerateActionContent
+	| WebSearchActionContent
+	| GitHubActionContent;
 
 interface Variable extends NodeBase {
 	type: "variable";
@@ -208,10 +220,16 @@ interface MoveTool extends ToolBase {
 	category: "move";
 	action: "move";
 }
+export interface AddGitHubNodeTool extends ToolBase {
+	category: "edit";
+	action: "addGitHubNode";
+}
+
 export type Tool =
 	| AddTextNodeTool
 	| AddFileNodeTool
 	| AddTextGenerationNodeTool
+	| AddGitHubNodeTool
 	| MoveTool;
 
 export type FlowId = `flw_${string}`;

--- a/services/external/github/app.ts
+++ b/services/external/github/app.ts
@@ -12,14 +12,25 @@ import { RequestError } from "@octokit/request-error";
  * @throws {Error} If the request to get app information fails.
  */
 export async function gitHubAppInstallURL(): Promise<string> {
-	const auth = appAuth();
-	const app = await auth({ type: "app" });
-	const octokit = new Octokit({ auth: app.token });
+	const octokit = await buildAppClient();
 	const res = await octokit.request("GET /app");
 	if (res.status !== 200 || !res.data) {
 		throw new Error("Failed to get app information");
 	}
 	return `https://github.com/apps/${res.data.slug}/installations/new`;
+}
+
+/**
+ * Builds an authenticated GitHub App client.
+ *
+ * Authenticating as a GitHub App: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app
+ *
+ * @returns {Promise<Octokit>} A promise that resolves to an authenticated Octokit instance.
+ */
+export async function buildAppClient() {
+	const auth = appAuth();
+	const app = await auth({ type: "app" });
+	return new Octokit({ auth: app.token });
 }
 
 /**

--- a/services/external/github/index.ts
+++ b/services/external/github/index.ts
@@ -1,4 +1,5 @@
 export {
+	buildAppClient,
 	buildAppInstallationClient,
 	gitHubAppInstallURL,
 	needsAdditionalPermissions,


### PR DESCRIPTION
## Summary

This Pull Request adds a proof-of-concept “GitHub Node” feature controlled by the `GITHUB_NODE_FLAG`. When enabled, users can place a GitHub Node in the playground. Additionally, we introduce a `GitHubAgent` that allows read-only GraphQL operations via the LLM.

## Key Changes

1. **`.env.example`**  
   - Added `GITHUB_NODE_FLAG` to enable GitHub Node functionality

2. **`flags.ts`**  
   - Defined `gitHubNodeFlag` to toggle GitHub Node mode

3. **`page.tsx`**  
   - Injects `GitHubNodeModeProvider` so that the playground can render GitHub Node UI if the flag is on

4. **`github-node-mode.tsx`**  
   - Provides a React context hook `useGitHubNodeMode` for enabling/disabling GitHub Node

5. **UI updates** (`editor.tsx`, `node.tsx`, `properties-panel.tsx`, `toolbar.tsx`)  
   - Adds a GitHub Node option in the toolbar  
   - Properties panel displays an `instruction` field for agent-based GitHub operations

6. **`execution.ts` and `github-agent.ts`**  
   - Introduces `GitHubAgent` to handle read-only GitHub GraphQL requests via the LLM  
   - Returns structured output (`plan`, `title`, `content`, `description`) for the agent

7. **Non-intrusive for existing flows**  
   - When the flag is disabled, nothing changes and the GitHub Node remains hidden

---

### Why not split the tool into getIssue / createIssue, etc.?

- **Simplified PoC**  
  We opted to have a single “query” tool that the LLM uses to build GraphQL queries on the fly. If we introduced separate tools like getIssue, createIssue, and so on, the overhead for the LLM to choose among them and for us to maintain them would be higher in this early prototype.

- **Future expansion**  
  In a production setting, more granular actions might make sense. For now, read-only GraphQL queries are enough for demonstration, so a single tool approach is more straightforward to implement.

---

### Why an LLM-based Agent instead of a rule-based GitHub Node?

- **Flexibility**  
  A rule-based node would require new action logic for each scenario. By delegating decision-making to the LLM, we can handle a variety of read operations with minimal changes, providing a more adaptive and “hands-free” user experience.

- **PoC Impact**  
  Demonstrating “AI decides how to fetch GitHub data” makes for a strong proof-of-concept. This approach highlights the power of AI to compose the appropriate queries and deliver results without manual step-by-step configuration.

### Risks / Notes

- **Read-only GraphQL**  
  We restrict queries to read-only. No mutations are performed, so the repository remains safe during experimentation.
- **Production considerations**  
  For real-world usage, we would need more granular permissions, approval flows, and robust error handling to avoid unintended operations.

## Testing
There are two methods to debug the GitHub Node locally.

### Debug in the Playground

- GitHub integration setup is required, as the GitHub Node uses this information to interact with GitHub
- Place the GitHub Node
- Add an instruction such as: "List all files in this repository"
- Click "Execute"

### Debug with a Dummy Webhook Event
- Follow the same steps as "Debug in the Playground"
- Add `GITHUB_WEBHOOK_DEBUG=1` to your `.env.local` file
- Send a curl request as shown below:

```sh
curl -X POST http://localhost:3000/webhooks/github \
  -H "Content-Type: application/json" \
  -H "X-GitHub-Event: issue_comment" \
  -d '{
   "action": "created",
   "issue": {
     "number": 1,
     "title": "Hello, world!",
     "body": "Hello, world! Hello, world!"
   },
   "repository": {
     "owner": {
       "login": "sample-user"
     },
     "full_name": "r06-sandbox-edge/github-app-sandbox",
     "name": "sample-repo"
   },
   "comment": {
     "body": "/giselle ebisawa-20250206\nCould you list up all open issues?"
   },
   "installation": {
     "id": 12345
   }
 }'
```

You can then view the debug logs in your local server.


