### PR TITLE
Modify GitHub webhook event handling to gracefully handle null commands

### DIFF
--- a/app/webhooks/github/handle_event.ts
+++ b/app/webhooks/github/handle_event.ts
@@ -88,9 +88,8 @@ async function handleIssueComment(
 	const payload = event.payload;
 	const command = parseCommand(payload.comment.body);
 	if (command === null) {
-		throw new WebhookPayloadError(
-			`Command not found. payload: ${JSON.stringify(payload)}`,
-		);
+		// nothing to do
+		return;
 	}
 	if (payload.installation === undefined) {
 		throw new WebhookPayloadError(


### PR DESCRIPTION
## Summary
If the comment body does not include call sign, there is nothing to do.
In this case, handler returns 400 error now, but handling as success is better.
