### PR TITLE
Update GitHub integration form with call sign guidance

### DIFF
--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -661,6 +661,9 @@ function GitHubIntegrationForm() {
 		integration.status === "installed" ? integration.repositories : [];
 	const { popoverOpen, setPopoverOpen } = useTabValue();
 	const { graph } = useGraph();
+	const [repositoryFullName, setRepositoryFullName] = useState(
+		setting?.repositoryFullName ?? "",
+	);
 	const [callSign, setCallSign] = useState(setting?.callSign ?? "");
 	const [eventNodeMappings, setEventNodeMappings] = useState<
 		GitHubEventNodeMapping[]
@@ -709,6 +712,9 @@ function GitHubIntegrationForm() {
 						label: repository.full_name,
 					}))}
 					defaultValue={setting?.repositoryFullName}
+					onValueChange={(value) => {
+						setRepositoryFullName(value);
+					}}
 				/>
 			</ContentPanelSection>
 			<ContentPanelSection>
@@ -736,13 +742,13 @@ function GitHubIntegrationForm() {
 							value={callSign}
 							onChange={(e) => setCallSign(e.target.value)}
 						/>
-						{/* <span className="text-black-70 text-[12px]">
+						<span className="text-black-70 text-[12px]">
 							You can call this agent by commenting{" "}
 							<span className="py-[0px] px-[4px] text-black--30 bg-black-70 rounded-[2px]">
 								/giselle {callSign === "" ? "[call sign]" : callSign}
 							</span>{" "}
-							in the issue route06inc/giselle.
-						</span> */}
+							in the issue in {repositoryFullName}.
+						</span>
 					</ContentPanelSectionFormField>
 				</ContentPanelSectionFormField>
 			</ContentPanelSection>

--- a/packages/components/navigation-panel.tsx
+++ b/packages/components/navigation-panel.tsx
@@ -747,7 +747,9 @@ function GitHubIntegrationForm() {
 							<span className="py-[0px] px-[4px] text-black--30 bg-black-70 rounded-[2px]">
 								/giselle {callSign === "" ? "[call sign]" : callSign}
 							</span>{" "}
-							in the issue in {repositoryFullName}.
+							{repositoryFullName === ""
+								? "in the issue"
+								: `in the issue in ${repositoryFullName}`}
 						</span>
 					</ContentPanelSectionFormField>
 				</ContentPanelSectionFormField>


### PR DESCRIPTION
## Summary
Added guidance about call sign.

<img width="364" alt="スクリーンショット 2025-02-06 14 03 18" src="https://github.com/user-attachments/assets/2c1591d3-62e8-4d5f-8e9c-971b05edb0c4" />
