### PR TITLE
Change Unstructured partition strategy to Strategy.Auto

### DIFF
--- a/packages/actions.ts
+++ b/packages/actions.ts
@@ -39,7 +39,7 @@ export async function parse(id: FileId, name: string, blobUrl: string) {
 				fileName: name,
 				content,
 			},
-			strategy: Strategy.Fast,
+			strategy: Strategy.Auto,
 			splitPdfPage: false,
 			splitPdfConcurrencyLevel: 1,
 		},


### PR DESCRIPTION
## Summary
With some PDF files, the results of partition will be empty.

Strategy.Auto is:

- https://docs.unstructured.io/api-reference/api-services/partitioning

> auto (default strategy): The “auto” strategy will choose the partitioning strategy based on document characteristics and the function kwargs.

- https://docs.unstructured.io/api-reference/how-to/choose-partitioning-strategy#auto-partitioning-strategy-logic

> If the file is a PDF, the local processing logic or Unstructured tries to detect whether there are any embedded tables or images in that file.
> 
> If no embedded tables or images are detected, the fast strategy is used for that file. No high-resolution object detection model is used.
> If at least one embedded table or image is found, the hi_res strategy is used for that file. The layout_v1.0.0 high-resolution object detection model is used.

