### PR TITLE
Add functionality to notify user with specified error on server side

### DIFF
--- a/app/(playground)/p/[agentId]/page.tsx
+++ b/app/(playground)/p/[agentId]/page.tsx
@@ -33,6 +33,7 @@ import {
 	executeNode,
 	executeStep,
 	retryStep,
+	wrapAgentExecutionServerAction,
 } from "@giselles-ai/lib/execution";
 import {
 	type CreateGitHubIntegrationSettingResult,
@@ -174,14 +175,16 @@ export default async function Page({
 		artifacts: Artifact[],
 	) {
 		"use server";
-		return await executeStep({
-			agentId,
-			flowId,
-			executionId,
-			stepId,
-			artifacts,
-			stream: true,
-		});
+		return await wrapAgentExecutionServerAction(async () =>
+			executeStep({
+				agentId,
+				flowId,
+				executionId,
+				stepId,
+				artifacts,
+				stream: true,
+			}),
+		);
 	}
 	async function putExecutionAction(executionSnapshot: ExecutionSnapshot) {
 		"use server";
@@ -217,19 +220,23 @@ export default async function Page({
 		artifacts: Artifact[],
 	) {
 		"use server";
-		return await retryStep({
-			agentId,
-			retryExecutionSnapshotUrl,
-			executionId,
-			stepId,
-			artifacts,
-			stream: true,
-		});
+		return await wrapAgentExecutionServerAction(async () =>
+			retryStep({
+				agentId,
+				retryExecutionSnapshotUrl,
+				executionId,
+				stepId,
+				artifacts,
+				stream: true,
+			}),
+		);
 	}
 
 	async function executeNodeAction(executionId: ExecutionId, nodeId: NodeId) {
 		"use server";
-		return await executeNode({ agentId, executionId, nodeId, stream: true });
+		return await wrapAgentExecutionServerAction(async () =>
+			executeNode({ agentId, executionId, nodeId, stream: true }),
+		);
 	}
 
 	async function onFinishPerformExecutionAction(

--- a/packages/lib/errors.ts
+++ b/packages/lib/errors.ts
@@ -1,4 +1,11 @@
-export class AgentTimeNotAvailableError extends Error {
+export class UserDisplayableServerActionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = this.constructor.name;
+	}
+}
+
+export class AgentTimeNotAvailableError extends UserDisplayableServerActionError {
 	constructor(
 		message = "Your agent time has been depleted. Please upgrade your plan to continue using this feature.",
 	) {
@@ -9,6 +16,13 @@ export class AgentTimeNotAvailableError extends Error {
 		if (Error.captureStackTrace) {
 			Error.captureStackTrace(this, AgentTimeNotAvailableError);
 		}
+	}
+}
+
+export class FileNotReadyError extends UserDisplayableServerActionError {
+	constructor(message: string) {
+		super(message);
+		this.name = this.constructor.name;
 	}
 }
 


### PR DESCRIPTION
## Summary
closes #364 

Improve error handling to properly display server-side exceptions on the client side even in production builds.

## Changes
- Add `UserDisplayableServerActionError` as a base class for errors that can be safely displayed to clients
- Add `wrapAgentExecutionServerAction` function to wrap server action execution results
  - Preserve error messages that should be shown to users
  - Convert other errors to generic messages
- Unify error handling across execution-related components

<img width="944" alt="スクリーンショット 2025-02-13 15 55 08" src="https://github.com/user-attachments/assets/f25ec35c-3973-4dd5-b414-f91c5ce78549" />

