### PR TITLE
Publish Google OAuth signup/login on staging environment

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/components/oauth-providers.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/components/oauth-providers.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-import { googleOauthFlag } from "@/flags";
 import { SiGithub, SiGoogle } from "@icons-pack/react-simple-icons";
 import type { FC } from "react";
 import { authorizeGitHub, authorizeGoogle } from "../actions";
@@ -8,31 +7,30 @@ type OauthProvidersProps = {
 	labelPrefix: string;
 };
 
-export const OAuthProviders: FC<OauthProvidersProps> = async ({
-	labelPrefix,
-}) => {
-	const displayGoogleOauth = await googleOauthFlag();
+export const OAuthProviders: FC<OauthProvidersProps> = ({ labelPrefix }) => (
+	<div className="space-y-2">
+		<Button asChild variant="link">
+			<form>
+				<SiGoogle className="h-[20px] w-[20px]" />
+				<button type="submit" formAction={authorizeGoogle}>
+					{labelPrefix} with Google
+				</button>
+			</form>
+		</Button>
+		{/**<button
+							className="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500"
+							type="button"
+						>
+							<Microsoft className="h-5 w-5 mr-2" /> Sign up with Microsoft
+						</button>**/}
 
-	return (
-		<div className="space-y-2">
-			{displayGoogleOauth && (
-				<Button asChild variant="link">
-					<form>
-						<SiGoogle className="h-[20px] w-[20px]" />
-						<button type="submit" formAction={authorizeGoogle}>
-							{labelPrefix} with Google
-						</button>
-					</form>
-				</Button>
-			)}
-			<Button asChild variant="link">
-				<form>
-					<SiGithub className="h-[20px] w-[20px]" />
-					<button type="submit" formAction={authorizeGitHub}>
-						{labelPrefix} with GitHub
-					</button>
-				</form>
-			</Button>
-		</div>
-	);
-};
+		<Button asChild variant="link">
+			<form>
+				<SiGithub className="h-[20px] w-[20px]" />
+				<button type="submit" formAction={authorizeGitHub}>
+					{labelPrefix} with GitHub
+				</button>
+			</form>
+		</Button>
+	</div>
+);

--- a/apps/studio.giselles.ai/app/(auth)/components/oauth-providers.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/components/oauth-providers.tsx
@@ -17,12 +17,6 @@ export const OAuthProviders: FC<OauthProvidersProps> = ({ labelPrefix }) => (
 				</button>
 			</form>
 		</Button>
-		{/**<button
-							className="w-full flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500"
-							type="button"
-						>
-							<Microsoft className="h-5 w-5 mr-2" /> Sign up with Microsoft
-						</button>**/}
 
 		<Button asChild variant="link">
 			<form>

--- a/apps/studio.giselles.ai/app/(main)/settings/account/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/page.tsx
@@ -2,7 +2,6 @@ import { ClickableText } from "@/components/ui/clicable-text";
 import { Field } from "@/components/ui/field";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { googleOauthFlag } from "@/flags";
 import Link from "next/link";
 import { Suspense } from "react";
 import { Card } from "../components/card";
@@ -13,7 +12,6 @@ import { GoogleAuthentication } from "./google-authentication";
 
 export default async function AccountSettingPage() {
 	const { displayName, email } = await getAccountInfo();
-	const displayGoogleOauth = await googleOauthFlag();
 
 	return (
 		<div className="grid gap-[16px]">
@@ -50,15 +48,13 @@ export default async function AccountSettingPage() {
 				>
 					<GitHubAuthentication />
 				</Suspense>
-				{displayGoogleOauth && (
-					<Suspense
-						fallback={
-							<Skeleton className="rounded-md border border-black-70 w-full h-16" />
-						}
-					>
-						<GoogleAuthentication />
-					</Suspense>
-				)}
+				<Suspense
+					fallback={
+						<Skeleton className="rounded-md border border-black-70 w-full h-16" />
+					}
+				>
+					<GoogleAuthentication />
+				</Suspense>
 			</Card>
 			<Card
 				title="Reset Password"

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -52,19 +52,6 @@ export const playgroundV2Flag = flag<boolean>({
 	],
 });
 
-export const googleOauthFlag = flag<boolean>({
-	key: "google-oauth",
-	async decide() {
-		return takeLocalEnv("GOOGLE_OAUTH_FLAG");
-	},
-	description: "Enable Google OAuth",
-	defaultValue: false,
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const developerFlag = flag<boolean>({
 	key: "developer",
 	async decide() {


### PR DESCRIPTION
## Summary

This PR publishes Google OAuth  signup/login function on our  staging environment
- we need this to submit our OAuth client for verification by Google

## Related Issue

- https://github.com/giselles-ai/giselle/issues/92

## Changes

Removed feature flags related to
- Google OAuth signup/login functionality
- Google OAuth connect button on setting page

## Testing

Tested on corresponding Preview environment ✅ 
(not tested on staging env  yet)

can signup & login ✅ 


can view connection status on setting page ✅ 
![image](https://github.com/user-attachments/assets/ef592a48-f37c-4322-b69a-f95cea3ff49d)

can connect to Google account ✅ 
![image](https://github.com/user-attachments/assets/0e052c3d-107f-4ff3-b30f-edec3306ee0b)

## Other Information
<!-- Add any other relevant information for the reviewer. -->
