### PR TITLE
feat(middleware): Add production access restriction

### DIFF
--- a/apps/playground/middleware.ts
+++ b/apps/playground/middleware.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+	if (process.env.VERCEL_ENV === "production") {
+		return new NextResponse(null, { status: 404 });
+	}
+	return NextResponse.next();
+}


### PR DESCRIPTION
Block access to playground app in production environment by returning 404 responses, while allowing normal access in development and staging(required Vercel login to Edge team).

This change improves security by preventing unauthorized access to the playground environment when deployed to production.
