### PR TITLE
Increase max server action duration to 800s with fluid compute

### DIFF
--- a/apps/studio.giselles.ai/app/(playground)/p/[agentId]/page.tsx
+++ b/apps/studio.giselles.ai/app/(playground)/p/[agentId]/page.tsx
@@ -62,9 +62,9 @@ import { ReactFlowProvider } from "@xyflow/react";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 
-// Extend the max duration of the server actions from this page to 5 minutes
+// The maximum duration of server actions on this page is extended to 800 seconds through enabled fluid compute.
 // https://vercel.com/docs/functions/runtimes#max-duration
-export const maxDuration = 300;
+export const maxDuration = 800;
 
 export default async function Page({
 	params,

--- a/apps/studio.giselles.ai/app/(playground)/p/[agentId]/prev/page.tsx
+++ b/apps/studio.giselles.ai/app/(playground)/p/[agentId]/prev/page.tsx
@@ -18,9 +18,9 @@ import {
 } from "./beta-proto/react-flow-adapter/types";
 import type { AgentId } from "./beta-proto/types";
 
-// Extend the max duration of the server actions from this page to 5 minutes
+// The maximum duration of server actions on this page is extended to 800 seconds through enabled fluid compute.
 // https://vercel.com/docs/functions/runtimes#max-duration
-export const maxDuration = 300;
+export const maxDuration = 800;
 
 function graphToReactFlow(grpah: Graph) {
 	const nodes: ReactFlowNode[] = grpah.nodes.map((node) => {

--- a/apps/studio.giselles.ai/app/webhooks/github/route.ts
+++ b/apps/studio.giselles.ai/app/webhooks/github/route.ts
@@ -8,9 +8,9 @@ import {
 	mockGitHubClientFactory,
 } from "./handle_event";
 
-// Extend the max duration of the server actions from this page to 5 minutes
+// The maximum duration of server actions on this page is extended to 800 seconds through enabled fluid compute.
 // https://vercel.com/docs/functions/runtimes#max-duration
-export const maxDuration = 300;
+export const maxDuration = 800;
 
 // debug mode
 // - skip verifying webhook signature


### PR DESCRIPTION
## Summary
Extended the maximum duration of server actions from 300s to 800s by enabling fluid compute.

## Related Issue
None

## Changes
Extended the maximum duration of server actions from 300s to 800s

## Testing
- The agent workflow can be executed on the Playground page.  
- The agent workflow can be executed via the GitHub App.

## Other Information
- [Fluid compute](https://vercel.com/fluid)
- [Vercel Functions Limits](https://vercel.com/docs/functions/limitations#max-duration)
