### PR TITLE
set vercel blob to storage engine for Playground

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -31,7 +31,8 @@
 
 ## Tasks
 
-- [ ] Set viewport
+- [ ] Set viewport to storage
+- [ ] Auto detect storage backend
 - [ ] Workflow View
 - [ ] Update text node icon
 - [ ] Add generate text short cut

--- a/apps/playground/giselle-engine.ts
+++ b/apps/playground/giselle-engine.ts
@@ -1,18 +1,17 @@
-import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next-internal";
-// import { NextGiselleEngine } from "giselle-sdk/next";
+import { NextGiselleEngine } from "giselle-sdk/next";
 
 import { createStorage } from "unstorage";
-import fsDriver from "unstorage/drivers/fs";
-// import vercelBlobDriver from "unstorage/drivers/vercel-blob";
+// import fsDriver from "unstorage/drivers/fs";
+import vercelBlobDriver from "unstorage/drivers/vercel-blob";
 
 const storage = createStorage({
-	driver: fsDriver({
-		base: "./.storage",
-	}),
-	// driver: vercelBlobDriver({
-	// 	access: "public",
-	// 	base: "dev-jan-2025",
+	// driver: fsDriver({
+	// 	base: "./.storage",
 	// }),
+	driver: vercelBlobDriver({
+		access: "public",
+		base: "private-beta",
+	}),
 });
 
 export const giselleEngine = NextGiselleEngine({


### PR DESCRIPTION
> [!NOTE]
> After this pull request, developers will need a BLOB_READ_WRITE_TOKEN to use Vercel Blob. In the future, giselle-engine will automatically detect which storage backend to use (local storage, Vercel Blob, or other options)