### PR TITLE
Enable Google OAuth when non-falsy `GOOGLE_OAUTH_FLAG` is provided

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -55,7 +55,13 @@ export const playgroundV2Flag = flag<boolean>({
 export const googleOauthFlag = flag<boolean>({
 	key: "google-oauth",
 	async decide() {
-		return takeLocalEnv("GOOGLE_OAUTH_FLAG");
+		if (
+			process.env.GOOGLE_OAUTH_FLAG === undefined ||
+			process.env.GOOGLE_OAUTH_FLAG === "false"
+		) {
+			return false;
+		}
+		return true;
 	},
 	description: "Enable Google OAuth",
 	defaultValue: false,


### PR DESCRIPTION
## Summary

This PR publishes Google OAuth  signup/login function on our  staging environment
- we need this to submit our OAuth client for verification by Google

## Related Issue

- https://github.com/giselles-ai/giselle/issues/92

This PR is the revised version of #370 

## Changes

- Enable toggling Google OAuth functionality via environmental variable on non-development environments
  - not by removing feature flag itself (ref: https://github.com/giselles-ai/giselle/pull/370#discussion_r1962944463)

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
