### PR TITLE
Add Node.js 22.x engine requirement to package.json

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "playground",
 	"version": "0.1.0",
+	"engines": {
+		"node": "22.x"
+	},
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack --port 6180",

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "web",
 	"version": "0.1.0",
+	"engines": {
+		"node": "22.x"
+	},
 	"private": true,
 	"scripts": {
 		"predev": "node prepare-font.js",


### PR DESCRIPTION
## Summary
I added Node.js 22.x engine requirement to package.json.

With this PR change, we will be able to verify the operation in the Vercel preview environment when changing the major Node.js version.

## Related Issue
None

## Changes
This ensures the project uses Node.js 22.x during deployment by adding the engine specification to the package.json files for vercel deployment.

## Testing
Please test in preview enviroment.

## Other Information
- doc: [Version overrides in package\.json](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions)
