### PR TITLE
Added robust input validation using valibot for email and password fields, with errors

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/components/form.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/components/form.tsx
@@ -7,20 +7,22 @@ import { Label } from "@/components/ui/label";
 import type { AuthError } from "@/lib/supabase";
 import { TriangleAlertIcon } from "lucide-react";
 import Link from "next/link";
-import type { FC } from "react";
 
-type FormProps = {
+type FormProps<T extends Record<string, string | undefined>> = {
 	authError: AuthError | null;
 	linkToResetPassword?: boolean;
 	submitText?: string;
 	isPending: boolean;
+	validationError?: T | null;
 };
-export const Form: FC<FormProps> = ({
+
+export const Form = <T extends Record<string, string | undefined>>({
 	linkToResetPassword = false,
 	submitText = "Submit",
 	authError,
 	isPending,
-}) => {
+	validationError,
+}: FormProps<T>) => {
 	return (
 		<div className="grid gap-6">
 			{authError && (
@@ -35,7 +37,20 @@ export const Form: FC<FormProps> = ({
 			<div className="grid gap-[16px]">
 				<div className="grid gap-[4px]">
 					<Label htmlFor="email">Email</Label>
-					<Input id="email" type="email" name="email" required />
+					<Input
+						id="email"
+						type="email"
+						name="email"
+						required
+						className={
+							validationError && "email" in validationError
+								? "border-red-500"
+								: ""
+						}
+					/>
+					{validationError && "email" in validationError && (
+						<p className="text-red-500 text-sm mt-1">{validationError.email}</p>
+					)}
 				</div>
 				<div className="grid gap-[4px]">
 					<div className="flex items-center">
@@ -49,7 +64,22 @@ export const Form: FC<FormProps> = ({
 							</Link>
 						)}
 					</div>
-					<Input id="password" type="password" name="password" required />
+					<Input
+						id="password"
+						type="password"
+						name="password"
+						required
+						className={
+							validationError && "password" in validationError
+								? "border-red-500"
+								: ""
+						}
+					/>
+					{validationError && "password" in validationError && (
+						<p className="text-red-500 text-sm mt-1">
+							{validationError.password}
+						</p>
+					)}
 				</div>
 				<Button
 					className="w-full"

--- a/apps/studio.giselles.ai/app/(auth)/signup/email/signup-form.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/signup/email/signup-form.tsx
@@ -1,20 +1,40 @@
 "use client";
 
 import type { AuthError } from "@/lib/supabase";
-import { type FC, useActionState } from "react";
+import { type FC, useActionState, useState } from "react";
+import { safeParse } from "valibot";
 import { Form } from "../../components";
 import { useSignupContext } from "../context";
 import { signup } from "./signup";
+import { type ValidationErrors, signupSchema } from "./validations";
 
 export const SignupForm: FC = () => {
 	const { dispatch } = useSignupContext();
+	const [validationError, setValidationError] =
+		useState<ValidationErrors | null>(null);
+
 	const [authError, action, isPending] = useActionState(
 		(prevState: AuthError | null, formData: FormData) => {
-			// type-casting here for convenience
-			// in practice, you should validate your inputs
 			const email = formData.get("email") as string;
 			const password = formData.get("password") as string;
 
+			const result = safeParse(signupSchema, { email, password });
+
+			if (!result.success) {
+				const errors: ValidationErrors = {};
+
+				for (const issue of result.issues) {
+					const path = issue.path?.[0]?.key;
+					if (path === "email" || path === "password") {
+						errors[path] = issue.message;
+					}
+				}
+
+				setValidationError(errors);
+				return prevState;
+			}
+
+			setValidationError(null);
 			dispatch({ type: "SET_EMAIL", email });
 
 			return signup(email, password);
@@ -22,8 +42,13 @@ export const SignupForm: FC = () => {
 		null,
 	);
 	return (
-		<form action={action}>
-			<Form submitText="Sign up" authError={authError} isPending={isPending} />
+		<form action={action} noValidate>
+			<Form<ValidationErrors>
+				submitText="Sign up"
+				authError={authError}
+				isPending={isPending}
+				validationError={validationError}
+			/>
 		</form>
 	);
 };

--- a/apps/studio.giselles.ai/app/(auth)/signup/email/validations.ts
+++ b/apps/studio.giselles.ai/app/(auth)/signup/email/validations.ts
@@ -1,0 +1,20 @@
+import * as v from "valibot";
+
+export const signupSchema = v.object({
+	email: v.pipe(
+		v.string("Email is required"),
+		v.minLength(1, "Email is required"),
+		v.maxLength(254, "Email address is too long"),
+		v.email("Email address is not valid"),
+	),
+	password: v.pipe(
+		v.string("Password is required"),
+		v.minLength(6, "Password must be at least 6 characters"),
+	),
+});
+
+export type SignupForm = v.InferOutput<typeof signupSchema>;
+
+export type ValidationErrors = {
+	[K in keyof SignupForm]?: string;
+};


### PR DESCRIPTION
## Summary
Added client-side validation for email and password fields using valibot with visual feedback for invalid inputs to improve user experience during signup.

## Related Issue
close: #347

## Changes
- Updated Form component to use generics for flexible error handling
- Implemented client-side validation with valibot
- Added visual error feedback (red border and error messages)
- Created new validation schema file with email and password rules
- Made form component more reusable with TypeScript generics

## Testing
- Tested form with various valid and invalid email formats
- Verified error messages appear correctly for invalid inputs
- Confirmed password validation works for too short passwords
- Checked that validation feedback clears after corrections

## Other Information
This PR enhances the UX by providing immediate feedback to users without requiring server roundtrips for basic validation.

I checked Supabase Auth documentation but couldn't find clear rules for email validation, so I utilized valibot's email validation. This approach effectively handles common email validation cases:

- Emails without `@` symbol are rejected
- Consecutive dots `.` in the address are rejected

These validations provide sufficient coverage for our use case.
