### PR TITLE
Improve tab order in auth form

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/components/form.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/components/form.tsx
@@ -53,32 +53,32 @@ export const Form = <T extends Record<string, string | undefined>>({
 					)}
 				</div>
 				<div className="grid gap-[4px]">
-					<Label htmlFor="password">Password</Label>
-					<Input
-						id="password"
-						type="password"
-						name="password"
-						required
-						className={
-							validationError && "password" in validationError
-								? "border-red-500"
-								: ""
-						}
-					/>
+					<div className="grid gap-[4px] relative">
+						<Label htmlFor="password">Password</Label>
+						<Input
+							id="password"
+							type="password"
+							name="password"
+							required
+							className={
+								validationError && "password" in validationError
+									? "border-red-500"
+									: ""
+							}
+						/>
+						{linkToResetPassword && (
+							<Link
+								href="/password_reset"
+								className="text-[12px] text-black-70 absolute top-0 right-0"
+							>
+								Forgot your password?
+							</Link>
+						)}
+					</div>
 					{validationError && "password" in validationError && (
 						<p className="text-red-500 text-sm mt-1">
 							{validationError.password}
 						</p>
-					)}
-					{linkToResetPassword && (
-						<div className="text-right">
-							<Link
-								href="/password_reset"
-								className="ml-auto text-[12px] text-black-70"
-							>
-								Forgot your password?
-							</Link>
-						</div>
 					)}
 				</div>
 				<Button

--- a/apps/studio.giselles.ai/app/(auth)/components/form.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/components/form.tsx
@@ -53,17 +53,7 @@ export const Form = <T extends Record<string, string | undefined>>({
 					)}
 				</div>
 				<div className="grid gap-[4px]">
-					<div className="flex items-center">
-						<Label htmlFor="password">Password</Label>
-						{linkToResetPassword && (
-							<Link
-								href="/password_reset"
-								className="ml-auto text-[12px] text-black-70"
-							>
-								Forgot your password?
-							</Link>
-						)}
-					</div>
+					<Label htmlFor="password">Password</Label>
 					<Input
 						id="password"
 						type="password"
@@ -79,6 +69,16 @@ export const Form = <T extends Record<string, string | undefined>>({
 						<p className="text-red-500 text-sm mt-1">
 							{validationError.password}
 						</p>
+					)}
+					{linkToResetPassword && (
+						<div className="text-right">
+							<Link
+								href="/password_reset"
+								className="ml-auto text-[12px] text-black-70"
+							>
+								Forgot your password?
+							</Link>
+						</div>
 					)}
 				</div>
 				<Button


### PR DESCRIPTION
## Summary
This PR updates the layout of the password reset link and improves tab navigation in the authentication form for better accessibility and user experience.

## Related Issue
close: #348

## Changes
- Changed the positioning of the "Forgot your password?" link from `ml-auto` to absolute positioning
- Updated the CSS class for better alignment of the password reset link
- Fixed the password reset layout for improved usability

## Testing
Verified that the tab order works correctly when navigating through the authentication form and the password reset link is properly positioned.

## Other Information
This change improves accessibility by providing a more logical tab navigation flow in the authentication form.
