### PR TITLE
Add fetch diff functionality to issue_comment handler

### DIFF
--- a/apps/studio.giselles.ai/app/webhooks/github/handle_event.ts
+++ b/apps/studio.giselles.ai/app/webhooks/github/handle_event.ts
@@ -265,15 +265,23 @@ async function executeIntegrationFlow(
 	});
 
 	if (finalExecution.status === "completed") {
-		await octokit.request(
-			"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-			{
-				owner: payload.repository.owner.login,
-				repo: payload.repository.name,
-				issue_number: payload.issue.number,
-				body: finalExecution.artifacts[finalExecution.artifacts.length - 1]
-					.object.content,
-			},
-		);
+		switch (integrationSetting.nextAction) {
+			case "github.issue_comment.reply":
+				await octokit.request(
+					"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+					{
+						owner: payload.repository.owner.login,
+						repo: payload.repository.name,
+						issue_number: payload.issue.number,
+						body: finalExecution.artifacts[finalExecution.artifacts.length - 1]
+							.object.content,
+					},
+				);
+				break;
+			default: {
+				const _exhaustiveCheck: never = integrationSetting.nextAction;
+				throw new Error(`Unhandled next action: ${_exhaustiveCheck}`);
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Add functionality to fetch pull request diff to our GitHub integration.

We currently receive `issue_comment` webhook events.
Pull requests also fire these `issue_comment` events.

:memo: I did not add Node mapping.