### PR TITLE
Fix MIME Type Detection for Markdown Files

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -103,8 +103,17 @@ export function FilePanel({ node, config }: FilePanelProps) {
 					isValid = false;
 					break;
 				}
+				// Get file extension if possible
+				let itemType = dataTransferItem.type;
+				const file = dataTransferItem.getAsFile();
+				if (!itemType && file) {
+					const extension = file.name.split('.').pop()?.toLowerCase();
+					if (extension === 'md' || extension === 'markdown') {
+						itemType = 'text/markdown';
+					}
+				}
 				isValid = config.accept.some((accept) =>
-					new RegExp(accept).test(dataTransferItem.type),
+					new RegExp(accept).test(itemType),
 				);
 			}
 			return isValid;
@@ -119,11 +128,20 @@ export function FilePanel({ node, config }: FilePanelProps) {
 					throw new FileSizeExceededError();
 				}
 
+				// Determine MIME type from file extension if needed
+				let mimeType = file.type;
+				if (!mimeType) {
+					const extension = file.name.split('.').pop()?.toLowerCase();
+					if (extension === 'md' || extension === 'markdown') {
+						mimeType = 'text/markdown';
+					}
+				}
+
 				const isValid = config.accept.some((accept) =>
-					new RegExp(accept).test(file.type),
+					new RegExp(accept).test(mimeType),
 				);
 				if (!isValid) {
-					throw new InvalidFileTypeError(config.accept, file.type);
+					throw new InvalidFileTypeError(config.accept, mimeType);
 				}
 			}
 		},

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -107,9 +107,9 @@ export function FilePanel({ node, config }: FilePanelProps) {
 				let itemType = dataTransferItem.type;
 				const file = dataTransferItem.getAsFile();
 				if (!itemType && file) {
-					const extension = file.name.split('.').pop()?.toLowerCase();
-					if (extension === 'md' || extension === 'markdown') {
-						itemType = 'text/markdown';
+					const extension = file.name.split(".").pop()?.toLowerCase();
+					if (extension === "md" || extension === "markdown") {
+						itemType = "text/markdown";
 					}
 				}
 				isValid = config.accept.some((accept) =>
@@ -131,9 +131,9 @@ export function FilePanel({ node, config }: FilePanelProps) {
 				// Determine MIME type from file extension if needed
 				let mimeType = file.type;
 				if (!mimeType) {
-					const extension = file.name.split('.').pop()?.toLowerCase();
-					if (extension === 'md' || extension === 'markdown') {
-						mimeType = 'text/markdown';
+					const extension = file.name.split(".").pop()?.toLowerCase();
+					if (extension === "md" || extension === "markdown") {
+						mimeType = "text/markdown";
 					}
 				}
 


### PR DESCRIPTION
ref: https://github.com/giselles-ai/giselle/issues/428

### Problem
When uploading Markdown (.md) files, the browser sometimes returns an empty string for the MIME type instead of `text/markdown`. This causes validation to fail and prevents users from uploading Markdown files to Text nodes.

### Solution
Enhanced the file validation process to detect Markdown files by their extension when the browser doesn't provide a proper MIME type:

1. Added logic to check file extensions when MIME type is empty
2. For files with `.md` or `.markdown` extensions, explicitly set the MIME type to `text/markdown`
3. Updated both drag-and-drop validation and file selection validation

### Changes
- Modified `validateItems` function to check file extensions during drag-and-drop operations
- Updated `assertFiles` function to determine MIME type from file extension when browser returns empty type
- Improved error handling for cases where file type cannot be determined

### Testing
- Verified that Markdown files can now be uploaded successfully to Text nodes
- Confirmed that validation still works correctly for other file types
- Tested with various browsers to ensure consistent behavior

This fix ensures a better user experience when working with Markdown files in the workflow designer.
