### PR TITLE
Improve OAuth authentication error handling with user-friendly feedback

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/account/account-toasts.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/account-toasts.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { useToast } from "@/packages/contexts/toast";
+import { Toast } from "@/packages/components/toast";
+
+export function AccountToasts() {
+	const searchParams = useSearchParams();
+	const { toasts, addToast } = useToast();
+	// Reference to track already processed errors to prevent duplicate handling
+	const processedErrorRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		// Get the authentication error from URL parameters
+		const authError = searchParams?.get("authError");
+
+		// Only process if there's an error and it's not already processed
+		if (authError && processedErrorRef.current !== authError) {
+			// Update reference to mark this error as processed
+			processedErrorRef.current = authError;
+
+			// Display toast notification with the error message
+			addToast({
+				title: "Authentication Failed",
+				message: authError,
+				type: "error",
+				duration: 8000, // Display for 8 seconds
+			});
+
+			// Clean up URL parameters to avoid showing the same error on page refresh
+			const newUrl = window.location.pathname;
+			window.history.replaceState({}, "", newUrl);
+		}
+	}, [searchParams, addToast]); // Include addToast in dependencies to ensure effect runs when it changes
+
+	// Render all active toast notifications
+	return toasts.map((toast) => <Toast key={toast.id} {...toast} />);
+}

--- a/apps/studio.giselles.ai/app/(main)/settings/account/account-toasts.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/account-toasts.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { Toast } from "@/packages/components/toast";
+import { useToast } from "@/packages/contexts/toast";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
-import { useToast } from "@/packages/contexts/toast";
-import { Toast } from "@/packages/components/toast";
 
 export function AccountToasts() {
 	const searchParams = useSearchParams();

--- a/apps/studio.giselles.ai/app/(main)/settings/account/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/page.tsx
@@ -1,3 +1,4 @@
+import { ToastProvider } from "@/packages/contexts/toast";
 import { ClickableText } from "@/components/ui/clicable-text";
 import { Field } from "@/components/ui/field";
 import { Label } from "@/components/ui/label";
@@ -9,69 +10,73 @@ import { AccountDisplayNameForm } from "./account-display-name-form";
 import { getAccountInfo } from "./actions";
 import { GitHubAuthentication } from "./github-authentication";
 import { GoogleAuthentication } from "./google-authentication";
+import { AccountToasts } from "./account-toasts";
 
 export default async function AccountSettingPage() {
 	const { displayName, email } = await getAccountInfo();
 
 	return (
-		<div className="grid gap-[16px]">
-			<h3
-				className="text-[32px] text-black--30 font-rosart"
-				style={{ textShadow: "0px 0px 20px hsla(207, 100%, 48%, 1)" }}
-			>
-				Account
-			</h3>
-			<Card title="Account Information">
-				<div className="max-w-[600px] grid gap-[16px]">
-					<div className="grid gap-[4px]">
-						<Label>Display name</Label>
-						<AccountDisplayNameForm displayName={displayName} />
-					</div>
+		<ToastProvider>
+			<div className="grid gap-[16px]">
+				<h3
+					className="text-[32px] text-black--30 font-rosart"
+					style={{ textShadow: "0px 0px 20px hsla(207, 100%, 48%, 1)" }}
+				>
+					Account
+				</h3>
+				<Card title="Account Information">
+					<div className="max-w-[600px] grid gap-[16px]">
+						<div className="grid gap-[4px]">
+							<Label>Display name</Label>
+							<AccountDisplayNameForm displayName={displayName} />
+						</div>
 
-					<Field
-						label="Email"
-						name="email"
-						type="email"
-						value={email ?? "No email"}
-						disabled
-					/>
-				</div>
-			</Card>
-			<Card
-				title="Authentication"
-				description="Connect your Giselle account to third-party services."
-			>
-				<Suspense
-					fallback={
-						<Skeleton className="rounded-md border border-black-70 w-full h-16" />
-					}
+						<Field
+							label="Email"
+							name="email"
+							type="email"
+							value={email ?? "No email"}
+							disabled
+						/>
+					</div>
+				</Card>
+				<Card
+					title="Authentication"
+					description="Connect your Giselle account to third-party services."
 				>
-					<GitHubAuthentication />
-				</Suspense>
-				<Suspense
-					fallback={
-						<Skeleton className="rounded-md border border-black-70 w-full h-16" />
-					}
-				>
-					<GoogleAuthentication />
-				</Suspense>
-			</Card>
-			<Card
-				title="Reset Password"
-				action={{
-					content: "Reset Password",
-					href: "/password_reset/new_password",
-				}}
-			/>
-			<Card title="Delete Account">
-				<div className="w-[220px]">
-					<ClickableText asChild>
-						<Link href="mailto:support@giselles.ai?Subject=Please%20delete%20my%20giselle%20account">
-							Contact Support
-						</Link>
-					</ClickableText>
-				</div>
-			</Card>
-		</div>
+					<Suspense
+						fallback={
+							<Skeleton className="rounded-md border border-black-70 w-full h-16" />
+						}
+					>
+						<GitHubAuthentication />
+					</Suspense>
+					<Suspense
+						fallback={
+							<Skeleton className="rounded-md border border-black-70 w-full h-16" />
+						}
+					>
+						<GoogleAuthentication />
+					</Suspense>
+				</Card>
+				<Card
+					title="Reset Password"
+					action={{
+						content: "Reset Password",
+						href: "/password_reset/new_password",
+					}}
+				/>
+				<Card title="Delete Account">
+					<div className="w-[220px]">
+						<ClickableText asChild>
+							<Link href="mailto:support@giselles.ai?Subject=Please%20delete%20my%20giselle%20account">
+								Contact Support
+							</Link>
+						</ClickableText>
+					</div>
+				</Card>
+			</div>
+			<AccountToasts />
+		</ToastProvider>
 	);
 }

--- a/apps/studio.giselles.ai/app/(main)/settings/account/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/page.tsx
@@ -1,16 +1,16 @@
-import { ToastProvider } from "@/packages/contexts/toast";
 import { ClickableText } from "@/components/ui/clicable-text";
 import { Field } from "@/components/ui/field";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ToastProvider } from "@/packages/contexts/toast";
 import Link from "next/link";
 import { Suspense } from "react";
 import { Card } from "../components/card";
 import { AccountDisplayNameForm } from "./account-display-name-form";
+import { AccountToasts } from "./account-toasts";
 import { getAccountInfo } from "./actions";
 import { GitHubAuthentication } from "./github-authentication";
 import { GoogleAuthentication } from "./google-authentication";
-import { AccountToasts } from "./account-toasts";
 
 export default async function AccountSettingPage() {
 	const { displayName, email } = await getAccountInfo();


### PR DESCRIPTION
## Summary
This PR enhances the OAuth authentication flow by adding user-friendly error handling when GitHub authorization is cancelled or fails. Previously, users would see a raw error page when cancelling GitHub authentication; now they are redirected back to the account settings page with a clear toast notification.

## Related Issue
close: #272

## Changes
- Redirect users back to their original page when authentication errors occur
- Create a new `AccountToasts` component to handle and display authentication errors
- Add proper error message extraction from URL parameters
- Clean up URL parameters after displaying errors for better UX

## Testing
- Tested OAuth connection flow with GitHub
- Verified proper error handling when cancelling GitHub authorization
- Confirmed toast notifications display correctly with appropriate error messages
- Tested with both successful and failed authentication scenarios

## Other Information
This implementation uses React's useRef to prevent duplicate error processing and handles cleanup of URL parameters to avoid re-displaying errors on page refresh. 