### PR TITLE
Implement HTTP Server for Workflow Execution

### DIFF
--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -24,7 +24,7 @@ import {
 	upsertGithubIntegrationSetting,
 	urlToObjectID,
 } from "./github";
-import { addRun, startRun } from "./runs";
+import { addRun, runApi, startRun } from "./runs";
 import type { GiselleEngineConfig, GiselleEngineContext } from "./types";
 import { createWorkspace, getWorkspace, updateWorkspace } from "./workspaces";
 export * from "./types";
@@ -108,6 +108,12 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 				context,
 				workspaceId,
 			});
+		},
+		runApi: async (args: {
+			workspaceId: WorkspaceId;
+			workflowId: WorkflowId;
+		}) => {
+			return await runApi({ ...args, context });
 		},
 	};
 }

--- a/packages/giselle-engine/src/core/runs/index.ts
+++ b/packages/giselle-engine/src/core/runs/index.ts
@@ -1,2 +1,3 @@
 export * from "./add-run";
 export * from "./start-run";
+export * from "./run-api";

--- a/packages/giselle-engine/src/core/runs/run-api.ts
+++ b/packages/giselle-engine/src/core/runs/run-api.ts
@@ -1,0 +1,59 @@
+import {
+	type CreatedRun,
+	GenerationId,
+	type JobId,
+	type QueuedGeneration,
+	RunId,
+	type WorkflowId,
+	type WorkspaceId,
+} from "@giselle-sdk/data-type";
+import { generateText } from "../generations";
+import type { GiselleEngineContext } from "../types";
+import { addRun } from "./add-run";
+import { startRun } from "./start-run";
+
+export async function runApi(args: {
+	workspaceId: WorkspaceId;
+	workflowId: WorkflowId;
+	context: GiselleEngineContext;
+}) {
+	const runId = RunId.generate();
+	const createdRun = {
+		id: runId,
+		status: "created",
+		createdAt: Date.now(),
+	} satisfies CreatedRun;
+	const run = await addRun({ ...args, run: createdRun });
+	await startRun({
+		runId,
+		context: args.context,
+	});
+	const jobResults: Record<JobId, string[]> = {};
+	for (const job of run.workflow.jobs) {
+		const jobResult = await Promise.all(
+			job.actions.map(async (action) => {
+				const generationId = GenerationId.generate();
+				const generation = {
+					id: generationId,
+					context: {
+						...action.generationTemplate,
+						origin: { type: "run", id: runId },
+					},
+					status: "queued",
+					createdAt: Date.now(),
+					ququedAt: Date.now(),
+				} satisfies QueuedGeneration;
+				const streamTextResult = await generateText({
+					context: args.context,
+					generation,
+				});
+				await streamTextResult.consumeStream();
+				return await streamTextResult.text;
+			}),
+		);
+		jobResults[job.id] = jobResult;
+	}
+	return jobResults[run.workflow.jobs[run.workflow.jobs.length - 1].id].join(
+		"/n",
+	);
+}

--- a/packages/giselle-engine/src/http/router.ts
+++ b/packages/giselle-engine/src/http/router.ts
@@ -170,6 +170,17 @@ export const createJsonRouters = {
 				});
 			},
 		}),
+	runApi: (giselleEngine: GiselleEngine) =>
+		createHandler({
+			input: z.object({
+				workspaceId: WorkspaceId.schema,
+				workflowId: WorkflowId.schema,
+			}),
+			handler: async ({ input }) => {
+				const result = await giselleEngine.runApi(input);
+				return new Response(result);
+			},
+		}),
 } as const;
 
 export const jsonRouterPaths = Object.keys(


### PR DESCRIPTION
I've added an HTTP server to the workflow runtime. I'm not entirely happy with the name 'run-api', so I'll probably reconsider it at some point.

The browser runtime has some code duplication, and I'd like to unify it in the future, but I think this is fine for now.