### PR TITLE
Enable diff retrieval as payload when executing Agent via GitHub webhook

### DIFF
--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -77,7 +77,7 @@ function Installed({
 					<div className="flex flex-col gap-[16px]">
 						<fieldset className="flex flex-col gap-[4px]">
 							<Label>Event</Label>
-							<Select name="event" value={data?.event}>
+							<Select name="event" defaultValue={data?.event}>
 								<SelectTrigger>
 									<SelectValue placeholder="Select a trigger" />
 								</SelectTrigger>

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/payload-map-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/payload-map-form.tsx
@@ -97,7 +97,9 @@ export function PayloadMapForm({
 						key={`${payloadMap.payload}-${payloadMap.nodeId}`}
 						className="group col-span-3 grid grid-cols-[200px_20px_200px] gap-[8px] items-center h-[28px] bg-black-750 rounded-[8px] text-[14px] border-[1px] border-white-950/10"
 					>
-						<p className="w-[200px] px-[12px] "> {payloadMap.payload} </p>
+						<p className="w-[200px] px-[12px]">
+							{payloadMap.payload.split(".").splice(2).join(".")}
+						</p>
 						<div className="w-[20px] flex justify-center text-primary-800">
 							→
 						</div>


### PR DESCRIPTION
Added functionality to retrieve the diff as part of the payload when executing the Agent via GitHub Webhook.