### PR TITLE
Pin third-party GitHub Actions versions with Full Changeset Hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "10:00"
+      timezone: "Asia/Tokyo"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Biome
-        uses: biomejs/setup-biome@v2.2.1
+        uses: biomejs/setup-biome@1cbe33ead22c7a2fded3b52fa2893611c815c9b5 # v2.2.1
         with:
           version: 1.9.4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - run: pnpm install
       - name: Run Biome
         run: biome ci .

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -66,11 +66,11 @@ jobs:
           else
             echo "files_changed=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         if: steps.determine.outputs.files_changed == 'true'
       - run: pnpm install
         if: steps.determine.outputs.files_changed == 'true'
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
         if: steps.determine.outputs.files_changed == 'true'
         with:
           ruby-version: '3.3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Install Dependencies
         run: pnpm install
 
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           version: pnpm version
           title: 'package release'


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
To mitigate the risk of third-party GitHub Actions being compromised with malware, I are now pinning their versions using Full Changeset Hashes.

Previously, some GitHub Actions were pinned to major versions like v2, allowing for loose version upgrades. With this change, such automatic upgrades will no longer occur. Instead, I will use Dependabot version updates to update them once a month.

## What would you like reviewers to focus on?

* We will not pin the versions of official GitHub Actions using Full Changeset Hashes
* This PR does not upgrade any GitHub Actions
    * Using https://github.com/suzuki-shunsuke/pinact
* We will introduce Dependabot version updates to update GitHub Actions once a month

## Other Information
<!-- Add any other relevant information for the reviewer. -->
> * Using https://github.com/suzuki-shunsuke/pinact

1. Create .pinact.yaml

    ```console
    pinact init
    ```

2. Edit .pinact.yaml

    ```diff
    --- .pinact.yaml.bak	2025-03-17 16:14:13
    +++ .pinact.yaml	2025-03-17 16:16:20
    @@ -5,5 +5,10 @@
       - pattern: "^(.*/)?action\\.ya?ml$"
     
     ignore_actions:
    -# - name: actions/checkout
    -# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
    +  - name: actions/cache
    +  - name: actions/checkout
    +  - name: actions/create-github-app-token
    +  - name: actions/setup-node
    +  - name: route06/actions/.github/workflows/codeql.yml
    +  - name: route06/actions/.github/workflows/create_gh_issue.yml
    +  - name: route06/actions/.github/workflows/dependency_review.yml
    ```

3. Update .github/workflows/*.yml

    ```console
    pinact run
    ```

4. Verify version annotations

    ```console
    pinact run --verify
    ```
