### PR TITLE
Gemini 2.0 Search Grounding Support

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -1,4 +1,4 @@
-import type { TextGenerationNode } from "@giselle-sdk/data-type";
+import { OutputId, type TextGenerationNode } from "@giselle-sdk/data-type";
 import clsx from "clsx/lite";
 import { useNodeGenerations, useWorkflowDesigner } from "giselle-sdk/react";
 import { CommandIcon, CornerDownLeft } from "lucide-react";
@@ -150,6 +150,48 @@ export function TextGenerationNodePropertiesPanel({
 								{node.content.llm.provider === "google" && (
 									<GoogleModelPanel
 										googleLanguageModel={node.content.llm}
+										onSearchGroundingConfigurationChange={(enable) => {
+											if (enable) {
+												updateNodeData(node, {
+													...node,
+													content: {
+														...node.content,
+														llm: {
+															...node.content.llm,
+															configurations: {
+																...node.content.llm.configurations,
+																searchGrounding: enable,
+															},
+														},
+													},
+													outputs: [
+														...node.outputs,
+														{
+															id: OutputId.generate(),
+															label: "Source",
+															accesor: "source",
+														},
+													],
+												});
+											} else {
+												updateNodeData(node, {
+													...node,
+													content: {
+														...node.content,
+														llm: {
+															...node.content.llm,
+															configurations: {
+																...node.content.llm.configurations,
+																searchGrounding: false,
+															},
+														},
+													},
+													outputs: node.outputs.filter(
+														(output) => output.accesor !== "source",
+													),
+												});
+											}
+										}}
 										onModelChange={(value) =>
 											updateNodeDataContent(node, {
 												...node.content,

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -151,6 +151,9 @@ export function TextGenerationNodePropertiesPanel({
 									<GoogleModelPanel
 										googleLanguageModel={node.content.llm}
 										onSearchGroundingConfigurationChange={(enable) => {
+											if (node.content.llm.provider !== "google") {
+												return;
+											}
 											if (enable) {
 												updateNodeData(node, {
 													...node,

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/google.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/google.tsx
@@ -16,9 +16,11 @@ import { languageModelAvailable } from "./utils";
 export function GoogleModelPanel({
 	googleLanguageModel,
 	onModelChange,
+	onSearchGroundingConfigurationChange,
 }: {
 	googleLanguageModel: GoogleLanguageModelData;
 	onModelChange: (changedValue: GoogleLanguageModelData) => void;
+	onSearchGroundingConfigurationChange: (enabled: boolean) => void;
 }) {
 	const limits = useUsageLimits();
 
@@ -95,15 +97,7 @@ export function GoogleModelPanel({
 						name="searchGrounding"
 						checked={googleLanguageModel.configurations.searchGrounding}
 						onCheckedChange={(checked) => {
-							onModelChange(
-								GoogleLanguageModelData.parse({
-									...googleLanguageModel,
-									configurations: {
-										...googleLanguageModel.configurations,
-										searchGrounding: checked,
-									},
-								}),
-							);
+							onSearchGroundingConfigurationChange(checked);
 						}}
 					/>
 				</div>

--- a/packages/data-type/src/generation/output.ts
+++ b/packages/data-type/src/generation/output.ts
@@ -32,12 +32,14 @@ export interface UrlSource {
 	sourceType: "url";
 	id: string;
 	url: string;
+	title: string;
 	providerMetadata?: ProviderMetadata;
 }
 export const UrlSource = z.object({
 	sourceType: z.literal("url"),
 	id: z.string(),
 	url: z.string().url(),
+	title: z.string(),
 	providerMetadata: z.custom<ProviderMetadata>().optional(),
 }) as z.ZodType<UrlSource>;
 

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -388,3 +388,26 @@ function getFilesDescription(
 	}
 	return `${getOrdinal(currentCount + 1)} attached file`;
 }
+
+export async function getRedirectedUrlAndTitle(url: string) {
+	// Make the request with fetch and set redirect to 'follow'
+	const response = await fetch(url, {
+		redirect: "follow", // This automatically follows redirects
+	});
+
+	// Get the final URL after redirects
+	const finalUrl = response.url;
+
+	// Get the HTML content
+	const html = await response.text();
+
+	// Extract title using a simple regex pattern
+	const titleMatch = html.match(/<title[^>]*>(.*?)<\/title>/i);
+	const title = titleMatch ? titleMatch[1].trim() : "No title found";
+
+	return {
+		originalUrl: url,
+		redirectedUrl: finalUrl,
+		title: title,
+	};
+}


### PR DESCRIPTION
This pull request introduces support for Search Grounding in Gemini 2.0. When Search Grounding is enabled, a "Source" output is created on the Text Generation node.

![image](https://github.com/user-attachments/assets/89ac18e9-c7d3-4806-a4e0-e6ba844bc54d)


The "Source" output contains a JSON representation of the URLs and titles referenced during the Search Grounding process. This allows users to leverage these sources in subsequent Text Generation nodes, enabling a wider range of possibilities.

### Future Improvements
Currently, the content of the "Source" output cannot be directly viewed on the canvas. Future work will focus on providing a way to inspect the contents of the "Source" output within the canvas environment.