### PR TITLE
Integrate Langfuse Telemetry for Giselle Engine

### DIFF
--- a/apps/studio.giselles.ai/app/giselle-engine.ts
+++ b/apps/studio.giselles.ai/app/giselle-engine.ts
@@ -1,3 +1,4 @@
+import { waitForLangfuseFlush } from "@/instrumentation.node";
 import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next-internal";
 
 import { createStorage } from "unstorage";
@@ -21,4 +22,8 @@ export const giselleEngine = NextGiselleEngine({
 	basePath: "/api/giselle",
 	storage,
 	llmProviders: ["openai", "anthropic", "google", "perplexity"],
+	telemetry: {
+		isEnabled: true,
+		waitForFlushFn: waitForLangfuseFlush,
+	},
 });

--- a/apps/studio.giselles.ai/instrumentation.node.ts
+++ b/apps/studio.giselles.ai/instrumentation.node.ts
@@ -4,10 +4,27 @@ import {
 	noopSpanProcessor,
 } from "@/lib/opentelemetry";
 import { registerOTel } from "@vercel/otel";
+import { LangfuseExporter } from "langfuse-vercel";
+
+/**
+ * @link https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor
+ */
+const otelBspScheduleDelayDefault = 5000;
+const OTEL_BSP_SCHEDULE_DELAY =
+	Number(process.env.OTEL_BSP_SCHEDULE_DELAY) || otelBspScheduleDelayDefault;
+const LANGFUSE_FLUSH_INTERVAL = 1000;
+
+export const waitForLangfuseFlush = () =>
+	new Promise((resolve) =>
+		setTimeout(resolve, OTEL_BSP_SCHEDULE_DELAY + LANGFUSE_FLUSH_INTERVAL),
+	);
 
 registerOTel({
 	serviceName: "giselle",
 	spanProcessors: [noopSpanProcessor],
 	metricReader,
 	logRecordProcessor,
+	traceExporter: new LangfuseExporter({
+		flushInterval: LANGFUSE_FLUSH_INTERVAL,
+	}),
 });

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -88,6 +88,7 @@
 		"import-in-the-middle": "1.11.0",
 		"input-otp": "1.4.2",
 		"langfuse": "3.26.0",
+		"langfuse-vercel": "3.37.0",
 		"lucide-react": "0.417.0",
 		"next": "15.1.4",
 		"next-auth": "5.0.0-beta.25",
@@ -133,7 +134,9 @@
 		"vite-tsconfig-paths": "5.1.4",
 		"vitest": "3.0.5"
 	},
-	"trustedDependencies": ["@sentry/cli"],
+	"trustedDependencies": [
+		"@sentry/cli"
+	],
 	"overrides": {
 		"cookie": "^0.7.2"
 	}

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -265,6 +265,9 @@ export async function generateText(args: {
 				}),
 			]);
 		},
+		experimental_telemetry: {
+			isEnabled: args.context.telemetry?.isEnabled,
+		},
 	});
 	return streamTextResult;
 }

--- a/packages/giselle-engine/src/core/types.ts
+++ b/packages/giselle-engine/src/core/types.ts
@@ -10,6 +10,10 @@ export interface GiselleEngineContext {
 	storage: Storage;
 	llmProviders: LanguageModelProvider[];
 	integrationConfigs?: GiselleIntegrationConfig[];
+	telemetry?: {
+		isEnabled?: boolean;
+		waitForFlushFn?: () => Promise<unknown>;
+	};
 }
 
 export interface GitHubIntegrationConfig {
@@ -26,4 +30,8 @@ export interface GiselleEngineConfig {
 	storage: Storage;
 	llmProviders?: LanguageModelProvider[];
 	integrationConfigs?: GiselleIntegrationConfig[];
+	telemetry?: {
+		isEnabled?: boolean;
+		waitForFlushFn?: () => Promise<unknown>;
+	};
 }

--- a/packages/giselle-engine/src/next/next-giselle-engine.ts
+++ b/packages/giselle-engine/src/next/next-giselle-engine.ts
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { GiselleEngine, type GiselleEngineConfig } from "../core";
 import {
 	type FormDataRouterHandlers,
@@ -97,6 +98,9 @@ export function NextGiselleEngine(config: NextGiselleEngineConfig) {
 		giselleEngine,
 		basePath: config.basePath,
 	});
+	if (config?.telemetry?.isEnabled && config?.telemetry?.waitForFlushFn) {
+		after(config.telemetry.waitForFlushFn);
+	}
 	return {
 		...giselleEngine,
 		handlers: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,9 @@ importers:
       langfuse:
         specifier: 3.26.0
         version: 3.26.0
+      langfuse-vercel:
+        specifier: 3.37.0
+        version: 3.37.0(ai@4.0.16(react@19.0.0)(zod@3.24.1))
       lucide-react:
         specifier: 0.417.0
         version: 0.417.0(react@19.0.0)
@@ -6773,8 +6776,22 @@ packages:
     resolution: {integrity: sha512-8wWnPtmhMBBgVicLR9SjQ1O29fgvTJyRDE5kaF8b908TvE0PXZmxs068GGhLCCdTMUGpU6WXqKRHTZfXAuIzXA==}
     engines: {node: '>=18'}
 
+  langfuse-core@3.37.0:
+    resolution: {integrity: sha512-7ZOFJ51u4dOeCpsQ8otNuNYeMb7xsExVQcOIBOByPFKjjd1mjf/03xF907F44dRzgf7n1U8ZYa0XgMSRgxKNoA==}
+    engines: {node: '>=18'}
+
+  langfuse-vercel@3.37.0:
+    resolution: {integrity: sha512-whRqHtKPK0icQ24cQCkmOSwaGjA0glSFJWvoQkAYnDpjV+BlVVZysvk9zcqsU7cOM62Z5tx9WJOGzYM4p1/gyw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ai: '>=3.2.44'
+
   langfuse@3.26.0:
     resolution: {integrity: sha512-zG5BxI0NOtqxG71/fDFr6AXJ1Uggnv6768v/aZF40VH+epAysom2f9uX0ppvA4U6xFY0WyBUk9P+uF6xIFZyqw==}
+    engines: {node: '>=18'}
+
+  langfuse@3.37.0:
+    resolution: {integrity: sha512-NpemB+5i6VT9CXmBwQTE4q1DPOY/DH7OMxBJn8Rcirw+z2HYJpTRH8j48cBjzwqmYtqLdqyJMzAALa2ReQ50hQ==}
     engines: {node: '>=18'}
 
   lie@3.1.1:
@@ -15535,9 +15552,23 @@ snapshots:
     dependencies:
       mustache: 4.2.0
 
+  langfuse-core@3.37.0:
+    dependencies:
+      mustache: 4.2.0
+
+  langfuse-vercel@3.37.0(ai@4.0.16(react@19.0.0)(zod@3.24.1)):
+    dependencies:
+      ai: 4.0.16(react@19.0.0)(zod@3.24.1)
+      langfuse: 3.37.0
+      langfuse-core: 3.37.0
+
   langfuse@3.26.0:
     dependencies:
       langfuse-core: 3.32.0
+
+  langfuse@3.37.0:
+    dependencies:
+      langfuse-core: 3.37.0
 
   lie@3.1.1:
     dependencies:


### PR DESCRIPTION
This pull request integrates Langfuse telemetry into the Giselle Engine to enable enhanced monitoring and insights into its performance.

### Key changes:

- **Adds langfuse-vercel dependency**: Installs the langfuse-vercel package for seamless integration with Vercel environments.
- **Configures Langfuse Exporter**: Sets up a LangfuseExporter in instrumentation.node.ts to send telemetry data to Langfuse. A flushInterval is configured to control the frequency of data transmission.
- **Introduces waitForLangfuseFlush**: Creates a function waitForLangfuseFlush in instrumentation.node.ts that returns a promise that resolves after a delay, ensuring that telemetry data is flushed before the serverless function terminates. This addresses potential data loss in serverless environments.
- **Enables Telemetry in Giselle Engine**: Adds a telemetry configuration option to GiselleEngineConfig and GiselleEngineContext to enable/disable telemetry and provide a waitForFlushFn.
- **Calls waitForFlushFn after request**: In NextGiselleEngine, the waitForFlushFn is called using after from next/server to ensure telemetry data is flushed after each request.
- **Passes telemetry config to generateText**: The telemetry config is passed to the generateText function to enable telemetry within the text generation process.

### Benefits:

- **Improved Observability**: Gain deeper insights into the performance and usage of the Giselle Engine.
- **Enhanced Debugging**: Facilitate easier identification and resolution of issues.
- **Data-Driven Optimization**: Enable data-driven decisions to improve the engine's efficiency and effectiveness.
Considerations:

Telemetry is enabled by default for `studio.giselles.ai`. It can be disabled by setting telemetry.isEnabled to false in the Giselle Engine configuration.