### PR TITLE
feat(text-editor): add undo/redo functionality with TipTap History extension

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2,7 +2,7 @@
 
 
 ## Summary
-* 1018 MIT
+* 1019 MIT
 * 104 Apache 2.0
 * 57 ISC
 * 34 New BSD
@@ -3739,6 +3739,17 @@ LGPL-3.0-or-later permitted
 
 <a name="@tiptap/extension-floating-menu"></a>
 ### @tiptap/extension-floating-menu v2.11.5
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
+<a name="@tiptap/extension-history"></a>
+### @tiptap/extension-history v2.11.5
 #### 
 
 ##### Paths

--- a/packages/text-editor/package.json
+++ b/packages/text-editor/package.json
@@ -40,6 +40,7 @@
 		"@tiptap/extension-code": "catalog:",
 		"@tiptap/extension-code-block-lowlight": "catalog:",
 		"@tiptap/extension-document": "catalog:",
+		"@tiptap/extension-history": "catalog:",
 		"@tiptap/extension-italic": "catalog:",
 		"@tiptap/extension-list-item": "catalog:",
 		"@tiptap/extension-ordered-list": "catalog:",

--- a/packages/text-editor/src/extensions/index.ts
+++ b/packages/text-editor/src/extensions/index.ts
@@ -3,6 +3,7 @@ import BulletList from "@tiptap/extension-bullet-list";
 import Code from "@tiptap/extension-code";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import Document from "@tiptap/extension-document";
+import History from "@tiptap/extension-history";
 import Italic from "@tiptap/extension-italic";
 import ListItem from "@tiptap/extension-list-item";
 import OrderedList from "@tiptap/extension-ordered-list";
@@ -34,4 +35,5 @@ export const extensions = [
 	OrderedList,
 	Strike,
 	Text,
+	History,
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     '@tiptap/extension-document':
       specifier: 2.11.5
       version: 2.11.5
+    '@tiptap/extension-history':
+      specifier: 2.11.5
+      version: 2.11.5
     '@tiptap/extension-italic':
       specifier: 2.11.5
       version: 2.11.5
@@ -1001,6 +1004,9 @@ importers:
       '@tiptap/extension-document':
         specifier: 'catalog:'
         version: 2.11.5(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))
+      '@tiptap/extension-history':
+        specifier: 'catalog:'
+        version: 2.11.5(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5)
       '@tiptap/extension-italic':
         specifier: 'catalog:'
         version: 2.11.5(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))
@@ -4611,6 +4617,12 @@ packages:
 
   '@tiptap/extension-floating-menu@2.11.5':
     resolution: {integrity: sha512-HsMI0hV5Lwzm530Z5tBeyNCBNG38eJ3qjfdV2OHlfSf3+KOEfn6a5AUdoNaZO02LF79/8+7BaYU2drafag9cxQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-history@2.11.5':
+    resolution: {integrity: sha512-b+wOS33Dz1azw6F1i9LFTEIJ/gUui0Jwz5ZvmVDpL2ZHBhq1Ui0/spTT+tuZOXq7Y/uCbKL8Liu4WoedIvhboQ==}
     peerDependencies:
       '@tiptap/core': ^2.7.0
       '@tiptap/pm': ^2.7.0
@@ -13179,6 +13191,11 @@ snapshots:
       '@tiptap/core': 2.11.5(@tiptap/pm@2.11.5)
       '@tiptap/pm': 2.11.5
       tippy.js: 6.3.7
+
+  '@tiptap/extension-history@2.11.5(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))(@tiptap/pm@2.11.5)':
+    dependencies:
+      '@tiptap/core': 2.11.5(@tiptap/pm@2.11.5)
+      '@tiptap/pm': 2.11.5
 
   '@tiptap/extension-italic@2.11.5(@tiptap/core@2.11.5(@tiptap/pm@2.11.5))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,7 @@ catalog:
   "@tiptap/extension-italic": 2.11.5
   "@tiptap/extension-ordered-list": 2.11.5
   "@tiptap/extension-strike": 2.11.5
+  "@tiptap/extension-history": 2.11.5
   "@tiptap/html": 2.11.5
   highlight.js: 11.11.1
   lowlight: 3.3.0


### PR DESCRIPTION
- Added @tiptap/extension-history dependency
- Integrated History extension into the TextEditor component
- Enables standard keyboard shortcuts (cmd+z, cmd+shift+z) for undo/redo operations

Fixes #468
