### PR TITLE
Change the icon from braces to at_sign (Cursor, Cline flavor)

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -9,7 +9,7 @@ import {
 } from "@giselle-sdk/text-editor/react-internal";
 import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
-import { BracesIcon } from "lucide-react";
+import { AtSignIcon } from "lucide-react";
 import { DropdownMenu, Toolbar } from "radix-ui";
 import { type Source, useConnectedSources } from "./sources";
 
@@ -43,7 +43,7 @@ export function PromptPanel({
 						asChild
 					>
 						<DropdownMenu.Trigger>
-							<BracesIcon className="w-[18px]" />
+							<AtSignIcon className="w-[18px]" />
 						</DropdownMenu.Trigger>
 					</Toolbar.Button>
 					<DropdownMenu.Portal>


### PR DESCRIPTION
## Summary
Change the icon from braces to at_sign.

## Related Issue
None

## Changes
I change the icon from braces to at_sign.
Cursor and Cline use the `@` when referring to resources, so I used this as a reference.

## Testing
Please check it in playground page.

<img width=300 src="https://github.com/user-attachments/assets/4832c40b-cb8d-4ca3-aac6-c1fcbd5cf0a5" />


## Other Information
- https://lucide.dev/icons/at-sign