### PR TITLE
fix: Add navigation link from Playground to home screen

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/component.tsx
@@ -3,6 +3,7 @@
 import clsx from "clsx";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { ChevronDownIcon, PlayIcon, View } from "lucide-react";
+import Link from "next/link";
 import { Dialog, DropdownMenu, VisuallyHidden } from "radix-ui";
 import { type ReactNode, useState } from "react";
 import { EditableText } from "../editor/properties-panel/ui";
@@ -19,7 +20,9 @@ export function Header({
 	return (
 		<div className="h-[54px] pl-[24px] pr-[16px] flex items-center justify-between shrink-0">
 			<div className="flex items-center gap-[8px] text-white-950">
-				<GiselleLogo className="fill-white-900 w-[70px] h-auto mt-[6px]" />
+				<Link href="/">
+					<GiselleLogo className="fill-white-900 w-[70px] h-auto mt-[6px]" />
+				</Link>
 				<Divider />
 				<div className="flex gap-[2px] group">
 					<EditableText


### PR DESCRIPTION
## Summary
Add navigation functionality to the Giselle logo in the Playground header, enabling users to return to the home screen by clicking the logo.

## Related Issue
Fixes #490

## Changes
- Import Next.js Link component
- Set navigation target to root path ('/')

## Testing
- Verified logo click navigation from Playground to home screen
- Confirmed proper styling and appearance of the clickable logo
- Tested across different screen sizes to ensure consistent behavior
- Verified that root path ('/') redirects based on auth state and user context

## Other Information
This change restores navigation functionality by adding a clickable logo in the header. While the issue suggested linking directly to '/agents', we chose to implement the link to root path ('/') instead. This approach allows the application to handle redirects based on authentication state and user context, making the navigation logic more flexible and maintainable.