### PR TITLE
Temporarily hide the GitHubResourceLoader node in toolbar

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -202,10 +202,10 @@ export function Toolbar() {
 													<TextFileIcon className="w-[20px] h-[20px]" />
 													<p className="text-[14px]">Text</p>
 												</ToggleGroup.Item>
-												<ToggleGroup.Item value="addGitHubNode" data-tool>
+												{/* <ToggleGroup.Item value="addGitHubNode" data-tool>
 													<GitHubIcon className="w-[20px] h-[20px]" />
 													<p className="text-[14px]">GitHub</p>
-												</ToggleGroup.Item>
+												</ToggleGroup.Item> */}
 											</ToggleGroup.Root>
 										</div>
 									</Popover.Content>


### PR DESCRIPTION
## Summary
Temporarily hide the GitHubResourceLoader node in the toolbar as it is not functioning properly.

## Related Issue
None.

## Changes
Just hide the GitHubResourceLoader node in toolbar.

## Testing
Please check it in playground page.

## Other Information
<!-- Add any other relevant information for the reviewer. -->
