### PR TITLE
feat: Add Telemetry Metadata Support to Giselle React SDK

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -37,6 +37,12 @@ export default async function Layout({
 				github: gitHubIntegrationState,
 			}}
 			usageLimits={usageLimits}
+			// following settings is test. We'll replace for production.
+			telemetry={{
+				metadata: {
+					example: "metadata",
+				},
+			}}
 		>
 			{children}
 		</WorkspaceProvider>

--- a/packages/generation-runner/src/react/generation-runner.tsx
+++ b/packages/generation-runner/src/react/generation-runner.tsx
@@ -1,6 +1,7 @@
 import { useChat } from "@ai-sdk/react";
 import { type Generation, isQueuedGeneration } from "@giselle-sdk/data-type";
 import { useGiselleEngine } from "@giselle-sdk/giselle-engine/react";
+import { useTelemetry } from "@giselle-sdk/telemetry/react";
 import { useEffect, useRef } from "react";
 import { useGenerationRunnerSystem } from "./contexts/generation-runner-system";
 
@@ -84,6 +85,7 @@ function CompletionRunner({
 			await updateGenerationStatusToFailure(generation.id);
 		},
 	});
+	const telemetry = useTelemetry();
 	useEffect(() => {
 		if (generation.status !== "running") {
 			return;
@@ -100,6 +102,7 @@ function CompletionRunner({
 			{
 				body: {
 					generation,
+					telemetry,
 				},
 			},
 		);

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -20,6 +20,7 @@ import {
 import { AISDKError, appendResponseMessages, streamText } from "ai";
 import { filePath } from "../files/utils";
 import type { GiselleEngineContext } from "../types";
+import type { TelemetrySettings } from "./types";
 import {
 	buildMessageObject,
 	getGeneration,
@@ -34,7 +35,9 @@ import {
 export async function generateText(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
+	telemetry?: TelemetrySettings;
 }) {
+	console.log({ telemetry: args.telemetry });
 	const actionNode = args.generation.context.actionNode;
 	if (!isTextGenerationNode(actionNode)) {
 		throw new Error("Invalid generation type");
@@ -279,6 +282,7 @@ export async function generateText(args: {
 		},
 		experimental_telemetry: {
 			isEnabled: args.context.telemetry?.isEnabled,
+			metadata: args.telemetry?.metadata,
 		},
 	});
 	return streamTextResult;

--- a/packages/giselle-engine/src/core/generations/index.ts
+++ b/packages/giselle-engine/src/core/generations/index.ts
@@ -5,3 +5,4 @@ export * from "./get-node-generations";
 export * from "./generate-image";
 export * from "./get-generated-image";
 export * from "./set-generation";
+export * from "./types";

--- a/packages/giselle-engine/src/core/generations/types.ts
+++ b/packages/giselle-engine/src/core/generations/types.ts
@@ -1,0 +1,5 @@
+import type { TelemetrySettings as AI_TelemetrySettings } from "ai";
+
+export interface TelemetrySettings {
+	metadata?: AI_TelemetrySettings["metadata"];
+}

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -23,6 +23,7 @@ import {
 	getGeneration,
 	getNodeGenerations,
 	setGeneration,
+	type TelemetrySettings,
 } from "./generations";
 import {
 	type HandleGitHubWebhookOptions,
@@ -58,10 +59,14 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		getLanguageModelProviders: async () => {
 			return await getLanguageModelProviders({ context });
 		},
-		generateText: async (generation: QueuedGeneration) => {
+		generateText: async (
+			generation: QueuedGeneration,
+			telemetry?: TelemetrySettings,
+		) => {
 			return await generateText({
 				context,
 				generation,
+				telemetry,
 			});
 		},
 		getGeneration: async (generationId: GenerationId) => {

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -16,6 +16,7 @@ import type {
 import { getLanguageModelProviders } from "./configurations/get-language-model-providers";
 import { removeFile, uploadFile } from "./files";
 import {
+	type TelemetrySettings,
 	cancelGeneration,
 	generateImage,
 	generateText,
@@ -23,7 +24,6 @@ import {
 	getGeneration,
 	getNodeGenerations,
 	setGeneration,
-	type TelemetrySettings,
 } from "./generations";
 import {
 	type HandleGitHubWebhookOptions,

--- a/packages/giselle-engine/src/http/router.ts
+++ b/packages/giselle-engine/src/http/router.ts
@@ -15,6 +15,7 @@ import {
 } from "@giselle-sdk/data-type";
 import { z } from "zod";
 import type { GiselleEngine } from "../core";
+import type { TelemetrySettings } from "../core/generations";
 import { JsonResponse } from "../utils";
 import { createHandler } from "./create-handler";
 
@@ -54,9 +55,15 @@ export const createJsonRouters = {
 		}),
 	generateText: (giselleEngine: GiselleEngine) =>
 		createHandler({
-			input: z.object({ generation: QueuedGeneration }),
+			input: z.object({
+				generation: QueuedGeneration,
+				telemetry: z.custom<TelemetrySettings>().optional(),
+			}),
 			handler: async ({ input }) => {
-				const stream = await giselleEngine.generateText(input.generation);
+				const stream = await giselleEngine.generateText(
+					input.generation,
+					input.telemetry,
+				);
 				return stream.toDataStreamResponse();
 			},
 		}),

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@giselle-sdk/generation-runner",
+	"name": "@giselle-sdk/telemetry",
 	"version": "0.0.0",
 	"private": true,
 	"main": "./dist/index.js",
@@ -8,24 +8,20 @@
 	"scripts": {
 		"build": "tsup",
 		"check-types": "tsc --noEmit",
-		"clean": "rm -rf dist && rm -rf test/dist",
-		"format": "biome check --write ."
+		"format": "biome format --write ."
 	},
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
-			"require": "./dist/index.js",
-			"default": "./dist/index.js"
+			"require": "./dist/index.js"
 		},
 		"./react": {
 			"types": "./react/dist/index.d.ts",
 			"import": "./react/dist/index.mjs",
-			"require": "./react/dist/index.js",
-			"default": "./react/dist/index.js"
-		},
-		"./react-internal": "./src/react/index.ts"
+			"require": "./react/dist/index.js"
+		}
 	},
 	"devDependencies": {
 		"@giselle/giselle-sdk-tsconfig": "workspace:*",
@@ -33,12 +29,7 @@
 		"tsup": "catalog:"
 	},
 	"dependencies": {
-		"@ai-sdk/react": "catalog:",
-		"@giselle-sdk/data-type": "workspace:^",
-		"@giselle-sdk/giselle-engine": "workspace:^",
-		"@giselle-sdk/telemetry": "workspace:^",
 		"ai": "catalog:",
-		"react": "catalog:",
-		"zod": "catalog:"
+		"react": "catalog:"
 	}
 }

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/packages/telemetry/src/react/context.tsx
+++ b/packages/telemetry/src/react/context.tsx
@@ -1,0 +1,22 @@
+import { type ReactNode, createContext, useContext } from "react";
+import type { TelemetrySettings } from "../types";
+
+export const TelemetryContext = createContext<TelemetrySettings | undefined>(
+	undefined,
+);
+
+export function TelemetryProvider({
+	children,
+	settings,
+}: { children: ReactNode; settings?: TelemetrySettings }) {
+	return (
+		<TelemetryContext.Provider value={settings}>
+			{children}
+		</TelemetryContext.Provider>
+	);
+}
+
+export const useTelemetry = () => {
+	const settings = useContext(TelemetryContext);
+	return settings;
+};

--- a/packages/telemetry/src/react/index.ts
+++ b/packages/telemetry/src/react/index.ts
@@ -1,0 +1,1 @@
+export * from "./context";

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -1,0 +1,5 @@
+import type { TelemetrySettings as AI_TelemetrySettings } from "ai";
+
+export interface TelemetrySettings {
+	metadata?: AI_TelemetrySettings["metadata"];
+}

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": "@giselle/giselle-sdk-tsconfig/react-library.json",
+	"include": ["."],
+	"exclude": ["node_modules"]
+}

--- a/packages/telemetry/tsup.config.ts
+++ b/packages/telemetry/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+	{
+		entry: ["src/index.ts"],
+		format: ["cjs", "esm"],
+		dts: true,
+		sourcemap: true,
+	},
+	{
+		entry: ["src/react/index.ts"],
+		outDir: "react/dist",
+		format: ["cjs", "esm"],
+		dts: true,
+		sourcemap: true,
+	},
+]);

--- a/packages/telemetry/turbo.json
+++ b/packages/telemetry/turbo.json
@@ -1,0 +1,8 @@
+{
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["**/dist/**"]
+		}
+	}
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -37,8 +37,9 @@
 		"@giselle-sdk/giselle-engine": "workspace:^",
 		"@giselle-sdk/integration": "workspace:^",
 		"@giselle-sdk/run": "workspace:^",
-		"@giselle-sdk/workflow-designer": "workspace:^",
+		"@giselle-sdk/telemetry": "workspace:^",
 		"@giselle-sdk/usage-limits": "workspace:^",
+		"@giselle-sdk/workflow-designer": "workspace:^",
 		"react": "catalog:"
 	}
 }

--- a/packages/workspace/src/react/workspace.tsx
+++ b/packages/workspace/src/react/workspace.tsx
@@ -6,6 +6,8 @@ import { useGiselleEngine } from "@giselle-sdk/giselle-engine/react";
 import type { Integration } from "@giselle-sdk/integration";
 import { IntegrationProvider } from "@giselle-sdk/integration/react";
 import { RunSystemContextProvider } from "@giselle-sdk/run/react";
+import type { TelemetrySettings } from "@giselle-sdk/telemetry";
+import { TelemetryProvider } from "@giselle-sdk/telemetry/react";
 import type { UsageLimits } from "@giselle-sdk/usage-limits";
 import { UsageLimitsProvider } from "@giselle-sdk/usage-limits/react";
 import { WorkflowDesignerProvider } from "@giselle-sdk/workflow-designer/react";
@@ -16,11 +18,13 @@ export function WorkspaceProvider({
 	workspaceId,
 	integration,
 	usageLimits,
+	telemetry,
 }: {
 	children: ReactNode;
 	workspaceId: WorkspaceId;
 	integration?: Integration;
 	usageLimits?: UsageLimits;
+	telemetry?: TelemetrySettings;
 }) {
 	const client = useGiselleEngine();
 
@@ -38,16 +42,18 @@ export function WorkspaceProvider({
 		return null;
 	}
 	return (
-		<UsageLimitsProvider limits={usageLimits}>
-			<IntegrationProvider integration={integration}>
-				<WorkflowDesignerProvider data={workspace}>
-					<GenerationRunnerSystemProvider>
-						<RunSystemContextProvider workspaceId={workspaceId}>
-							{children}
-						</RunSystemContextProvider>
-					</GenerationRunnerSystemProvider>
-				</WorkflowDesignerProvider>
-			</IntegrationProvider>
-		</UsageLimitsProvider>
+		<TelemetryProvider settings={telemetry}>
+			<UsageLimitsProvider limits={usageLimits}>
+				<IntegrationProvider integration={integration}>
+					<WorkflowDesignerProvider data={workspace}>
+						<GenerationRunnerSystemProvider>
+							<RunSystemContextProvider workspaceId={workspaceId}>
+								{children}
+							</RunSystemContextProvider>
+						</GenerationRunnerSystemProvider>
+					</WorkflowDesignerProvider>
+				</IntegrationProvider>
+			</UsageLimitsProvider>
+		</TelemetryProvider>
 	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -768,6 +768,9 @@ importers:
       '@giselle-sdk/giselle-engine':
         specifier: workspace:^
         version: link:../giselle-engine
+      '@giselle-sdk/telemetry':
+        specifier: workspace:^
+        version: link:../telemetry
       ai:
         specifier: 'catalog:'
         version: 4.1.62(react@19.0.0)(zod@3.24.1)
@@ -966,6 +969,25 @@ importers:
       '@giselle-sdk/giselle-engine':
         specifier: workspace:^
         version: link:../giselle-engine
+      react:
+        specifier: 'catalog:'
+        version: 19.0.0
+    devDependencies:
+      '@giselle/giselle-sdk-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.4
+      tsup:
+        specifier: 'catalog:'
+        version: 8.3.5(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
+
+  packages/telemetry:
+    dependencies:
+      ai:
+        specifier: 'catalog:'
+        version: 4.1.62(react@19.0.0)(zod@3.24.1)
       react:
         specifier: 'catalog:'
         version: 19.0.0
@@ -1186,6 +1208,9 @@ importers:
       '@giselle-sdk/run':
         specifier: workspace:^
         version: link:../run
+      '@giselle-sdk/telemetry':
+        specifier: workspace:^
+        version: link:../telemetry
       '@giselle-sdk/usage-limits':
         specifier: workspace:^
         version: link:../usage-limits

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -8,7 +8,7 @@
 	"scripts": {
 		"build": "tsup",
 		"check-types": "tsc --noEmit",
-		"format": "biome format --write .",
+		"format": "biome format --write ."
 	},
 	"exports": {
 		"./package.json": "./package.json",


### PR DESCRIPTION
This pull request introduces telemetry metadata support to the Giselle React SDK. By configuring the `telemetry.metadata` property within the `WorkspaceProvider`, developers can now send custom metadata along with `generateText` requests. This metadata will be available as part of the AI SDK's telemetry options, enabling more granular tracking and analysis of AI interactions.

**Key changes:**

*   **New `@giselle-sdk/telemetry` package:**  This package provides the `TelemetryProvider` and `useTelemetry` hook for managing telemetry settings within the Giselle React SDK.
*   **`TelemetryProvider` in `WorkspaceProvider`:**  The `WorkspaceProvider` now accepts an optional `telemetry` prop, allowing developers to configure telemetry settings for the entire workspace.
*   **`useTelemetry` hook:**  This hook allows components within the `WorkspaceProvider` to access the configured telemetry settings.
*   **Metadata propagation to `generateText`:** The `generateText` function in `@giselle-engine` now accepts a `telemetry` parameter, which includes the metadata configured in the `WorkspaceProvider`. This metadata is then passed to the AI SDK's telemetry options.

**Example Usage:**

```tsx
<WorkspaceProvider
  workspaceId={workspaceId}
  telemetry={{
    metadata: {
      example: "metadata",
    },
  }}
>
  {children}
</WorkspaceProvider>
```

**Note:**

*   The current implementation includes a test metadata example. This will be replaced with production-ready settings in a future update.

**Benefits:**

*   Enhanced telemetry data for AI interactions.
*   Improved ability to track and analyze AI usage patterns.
*   Greater flexibility in customizing telemetry data.

**Additional Notes and Considerations:**

*   **Testing:**  It would be beneficial to add unit tests or integration tests to verify that the telemetry metadata is being correctly propagated and included in the AI SDK's telemetry data.
*   **Documentation:**  Update the Giselle React SDK documentation to reflect the new telemetry metadata support and provide clear instructions on how to configure and use it.
*   **Privacy:**  Ensure that any metadata being collected adheres to privacy regulations and best practices.  Consider adding options for users to control the collection of telemetry data.
*   **Configuration:**  Think about how the `telemetry` settings will be configured in a production environment.  Will they be hardcoded, read from environment variables, or managed through a configuration service?
*   **Error Handling:**  Consider adding error handling to gracefully handle cases where telemetry data cannot be sent or processed.

I hope this is helpful! Let me know if you have any other questions.
