### PR TITLE
Correct model name `o3mini` -> `o3-mini`

### DIFF
--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -58,7 +58,7 @@ const o1Mini: OpenAILanguageModel = {
 
 const o3Mini: OpenAILanguageModel = {
 	provider: "openai",
-	id: "o3mini",
+	id: "o3-mini",
 	capabilities: Capability.TextGeneration,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

this PR enables o3-mini node to work without error

## Related Issue

- https://github.com/giselles-ai/giselle/issues/505

## Changes

Fix typo in model name: `o3mini` -> `o3-mini`

## Testing

Confirmed that o3-mini node works on develop env ✅ 
![image](https://github.com/user-attachments/assets/37f47e1b-17c1-47f0-81be-9a3d8a3e4335)




## Other Information
<!-- Add any other relevant information for the reviewer. -->
