### PR TITLE
 Adjust panel paddings for better layout

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/index.tsx
@@ -257,8 +257,9 @@ export function Editor() {
 
 								<PanelResizeHandle
 									className={clsx(
-										"w-[1px] bg-black-400/50 transition-colors",
-										"data-[resize-handle-state=hover]:bg-black-400 data-[resize-handle-state=drag]:bg-black-400",
+										"w-[12px] flex items-center justify-center cursor-col-resize",
+										"after:content-[''] after:w-[3px] after:h-[32px] after:bg-[#3a3f44] after:rounded-full",
+										"hover:after:bg-[#4a90e2]",
 									)}
 								/>
 								<Panel

--- a/internal-packages/workflow-designer-ui/src/editor/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/index.tsx
@@ -248,7 +248,10 @@ export function Editor() {
 								direction="horizontal"
 								className="bg-black-900 h-full flex"
 							>
-								<Panel className="flex-1 px-[16px] pb-[16px] pr-0" defaultSize={100}>
+								<Panel
+									className="flex-1 px-[16px] pb-[16px] pr-0"
+									defaultSize={100}
+								>
 									<div className="h-full flex">
 										{/* <Debug /> */}
 										<NodeCanvas />

--- a/internal-packages/workflow-designer-ui/src/editor/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/index.tsx
@@ -248,8 +248,8 @@ export function Editor() {
 								direction="horizontal"
 								className="bg-black-900 h-full flex"
 							>
-								<Panel className="flex-1 px-[16px] pb-[16px]" defaultSize={100}>
-									<div className="flex h-full rounded-[16px] overflow-hidden">
+								<Panel className="flex-1 px-[16px] pb-[16px] pr-0" defaultSize={100}>
+									<div className="h-full flex">
 										{/* <Debug /> */}
 										<NodeCanvas />
 									</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -136,7 +136,7 @@ export function TextGenerationNodePropertiesPanel({
 
 			<PanelGroup
 				direction="vertical"
-				className="flex-1 flex flex-col gap-[16px]"
+				className="flex-1 flex flex-col"
 			>
 				<Panel>
 					<PropertiesPanelContent>
@@ -309,8 +309,9 @@ export function TextGenerationNodePropertiesPanel({
 				</Panel>
 				<PanelResizeHandle
 					className={clsx(
-						"h-[1px] bg-black-400/50 transition-colors",
-						"data-[resize-handle-state=hover]:bg-black-400 data-[resize-handle-state=drag]:bg-black-400",
+						"h-[12px] flex items-center justify-center cursor-row-resize",
+						"after:content-[''] after:h-[3px] after:w-[32px] after:bg-[#3a3f44] after:rounded-full",
+						"hover:after:bg-[#4a90e2]",
 					)}
 				/>
 				<Panel>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -134,10 +134,7 @@ export function TextGenerationNodePropertiesPanel({
 				}
 			/>
 
-			<PanelGroup
-				direction="vertical"
-				className="flex-1 flex flex-col"
-			>
+			<PanelGroup direction="vertical" className="flex-1 flex flex-col">
 				<Panel>
 					<PropertiesPanelContent>
 						<Tabs.Root

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/properties-panel.tsx
@@ -63,7 +63,7 @@ export function PropertiesPanelHeader({
 		inputRef.current.value = currentValue ?? fallbackName;
 	}, [onChangeName, fallbackName]);
 	return (
-		<div className="h-[48px] flex justify-between items-center px-[16px] shrink-0">
+		<div className="h-[48px] flex justify-between items-center pl-0 pr-[16px] shrink-0">
 			<div className="flex gap-[8px] items-center">
 				<div className="w-[28px] h-[28px] bg-white-900 rounded-[4px] flex items-center justify-center">
 					{icon}
@@ -92,7 +92,7 @@ export function PropertiesPanelContent({
 	children: ReactNode;
 }) {
 	return (
-		<div className="px-[16px] flex-1 h-full flex flex-col overflow-hidden">
+		<div className="pl-0 pr-[16px] flex-1 h-full flex flex-col overflow-hidden">
 			{children}
 		</div>
 	);


### PR DESCRIPTION
## Summary
This PR removes unnecessary padding from property panel headers and main editor panel, while improving spacing consistency between panels and adding resize handles for better UI appearance and usability.

## Changes
- Removed left padding from property panel headers
- Removed right padding from main editor panel
- Improved spacing consistency between panels
- Added resize handles between panels for adjustable sizing

## Testing
Verified that the UI displays correctly with the modified padding settings, consistent panel spacing, and that the resize handles function properly when dragging.

## Screen shot
<img width="320" alt="スクリーンショット 2025-03-24 21 57 33" src="https://github.com/user-attachments/assets/b12de20f-a6cd-4ea3-96d5-512200fcbf69" />→<img width="320" alt="スクリーンショット 2025-03-24 21 57 57" src="https://github.com/user-attachments/assets/ba1b8e51-8ec0-48aa-bf6e-b4b3b7969be5" />

