### PR TITLE
Fix: Correct size selection in image generation model panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/model-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/model-panel.tsx
@@ -63,7 +63,7 @@ export function ImageGenerationModelPanel({
 							...languageModel,
 							configurations: {
 								...languageModel.configurations,
-								n: value,
+								size: value,
 							},
 						}),
 					);


### PR DESCRIPTION
## Summary
I fixed the correct size selection in image generation model panel.

## Related Issue
None.

## Changes
Fix the error:

```
ZodError: [
  {
    "code": "invalid_type",
    "expected": "number",
    "received": "string",
    "path": [
      "configurations",
      "n"
    ],
    "message": "Expected number, received string"
  }
]
  at <object>.children.onValueChange (../../internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/model-panel.tsx:35:54)
  at k (../src/Select.tsx:1233:17)
  at <object>.{children#2}.onPointerUp (../src/Select.tsx:1282:55)
...
(10 additional frame(s) were not displayed)
```

## Testing
1. Go to the playground.
2. Place the image generator node `fal-ai/model-name`
3. Change the image size in Model tab.

## Other Information
<!-- Add any other relevant information for the reviewer. -->
