### PR TITLE
Improve how to contribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-<!-- Complete [TODO] -->
-
 # Contributing
 
 Thank you for your interest in this project! Please contribute according to the following guidelines:
@@ -8,33 +6,12 @@ Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in
 
 ## Development environment setup
 
-To set up a development environment, please follow these steps:
+Giselle has both a Cloud version and a Self-hosting version, which can be found in the following directories:
 
-### 1. Fork this repository and clone it
+- Cloud: [apps/studio.giselles.ai/](apps/studio.giselles.ai/)
+- Self-hosting: [apps/playground/](apps/playground/)
 
-1. [Fork this repository](https://github.com/giselles-ai/giselle/fork) to your own GitHub account
-2. [Clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
-
-### 2. Prerequisites
-
-- pnpm (Version: 10.0.0)
-
-### 3. Set up your .env file
-
-1. Duplicate .env.example to .env.
-2. Please set the environment variables in the .env file.
-
-### 4. Install dependencies
-
-```sh
-pnpm install
-```
-
-### 5. Start developing and watch for code changes
-
-```sh
-pnpm dev
-```
+External contributors should contribute to the Self-hosting version. Please follow the [Getting Started](apps/playground#getting-started) guide.
 
 ## Issues and feature requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Giselle has both a Cloud version and a Self-hosting version, which can be found 
 - Cloud: [apps/studio.giselles.ai/](apps/studio.giselles.ai/)
 - Self-hosting: [apps/playground/](apps/playground/)
 
-External contributors should contribute to the Self-hosting version. Please follow the [Getting Started](apps/playground#getting-started) guide.
+External contributors may find it easier to contribute to the Self-hosting version. Please follow the [Getting Started](apps/playground#getting-started) guide.
 
 ## Issues and feature requests
 

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -23,6 +23,8 @@
 3. Install dependencies
 
     ```sh
+    corepack enable
+    corepack prepare
     pnpm install
     ```
 

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -23,8 +23,6 @@
 3. Install dependencies
 
     ```sh
-    corepack enable
-    corepack prepare
     pnpm install
     ```
 

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -4,6 +4,7 @@
 	"engines": {
 		"node": "22.x"
 	},
+	"packageManager": "pnpm@10.6.5",
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack --port 6180",

--- a/apps/studio.giselles.ai/README.md
+++ b/apps/studio.giselles.ai/README.md
@@ -1,45 +1,7 @@
-<div align="center">
-  <a href="https://giselles.ai">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./docs/assets/giselle-circular-logo.png">
-      <img alt="Giselle logo" src="./docs/assets/giselle-circular-logo.png" height="128">
-    </picture>
-  </a>
-  <h1>Giselle</h1>
-</div>
+# Giselle Cloud
 
-## Introduction
+https://studio.giselles.ai/
 
-Giselle is an open source AI for agentic workflows, enabling seamless human-AI collaboration.
+## Getting Started
 
-## Using Giselle
-
-### Cloud
-
-We host [Giselle](https://giselles.ai/) as a cloud service for anyone to use instantly. It has all the same features as the self-hosted version, and includes 30 minutes of free Agent time per month in the free plan.
-
-### Self-hosting
-
-Follow this [starter guide](CONTRIBUTING.md#development-environment-setup) to get Giselle running in your environment.
-
-## Roadmap
-
-Giselle is currently still in active development. The roadmap for the public repository is currently being created, and once it's finalized, we will update this README accordingly.
-
-## Contributing
-
-We welcome your contributions to help improve Giselle!
-
-Here are some ways you can contribute:
-
-- [Report a bug](https://github.com/giselles-ai/giselle/issues/new?template=1_bug_report.yml) you found while using Giselle
-- [Request a feature](https://github.com/giselles-ai/giselle/discussions/categories/ideas) that you believe would be helpful
-- [Submit a pull request](CONTRIBUTING.md#how-to-submit-a-pull-request) if you'd like to add new features or fix bugs
-
-For more details, please see the [contributing guide](CONTRIBUTING.md).
-
-## License
-
-Giselle is licensed under the [Apache License Version 2.0](LICENSE).
-
-Licenses for third-party packages can be found in [docs/packages-license.md](docs/packages-license.md).
+WIP

--- a/apps/studio.giselles.ai/README.md
+++ b/apps/studio.giselles.ai/README.md
@@ -13,8 +13,6 @@ https://studio.giselles.ai/
 2. Install dependencies
 
     ```sh
-    corepack enable
-    corepack prepare
     pnpm install
     ```
 

--- a/apps/studio.giselles.ai/README.md
+++ b/apps/studio.giselles.ai/README.md
@@ -4,4 +4,22 @@ https://studio.giselles.ai/
 
 ## Getting Started
 
-WIP
+> [!WARNING]
+> It is difficult to start because there are many environment variables that need to be set.
+
+1. Set up your `.env` file
+    1. Duplicate `.env.example` to `.env`.
+    2. Please set the environment variables in the `.env` file.
+2. Install dependencies
+
+    ```sh
+    corepack enable
+    corepack prepare
+    pnpm install
+    ```
+
+3. Start developing and watch for code changes
+
+    ```sh
+    pnpm turbo dev
+    ```


### PR DESCRIPTION
Added a clear path to guide external contributors:

* README.md -> CONTRIBUTING.md -> apps/playground#getting-started
