### PR TITLE
fix the link to /settings/account/authentication

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/integration/v2/github-integration.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/integration/v2/github-integration.tsx
@@ -108,7 +108,7 @@ function Header({ account, installed, installationUrl }: HeaderProps) {
 					/>
 				) : (
 					<Button asChild>
-						<Link href="/settings/account/authentcation">
+						<Link href="/settings/account/authentication">
 							Configure GitHub App
 						</Link>
 					</Button>


### PR DESCRIPTION
## Summary
I fixed the link to /settings/account/authentication.

## Related Issue
None.

## Changes
Just fix the link to /settings/account/authentication.

## Testing
1. Vist `/settings/team/integrations`
2. Click the `Configure GitHub App` button 

## Other Information
<!-- Add any other relevant information for the reviewer. -->
