### PR TITLE
feat(workflow-designer-ui): Improve node input UI

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -190,6 +190,23 @@ export function NodeComponent({
 								</div>
 							</div>
 						))}
+						{node.type === "action" && node.inputs.length === 0 && (
+							<div className="relative flex items-center h-[28px]" key="blank">
+								<Handle
+									type="target"
+									position={Position.Left}
+									id="blank-handle"
+									className={clsx(
+										"!absolute !w-[11px] !h-[11px] !rounded-full !-left-[5px] !translate-x-[50%] !border-[1.5px] !bg-black-900",
+										"group-data-[content-type=textGeneration]:!border-generation-node-1",
+										"group-data-[content-type=imageGeneration]:!border-generation-node-1",
+									)}
+								/>
+								<div className="text-[14px] px-[12px] text-white-900">
+									Input
+								</div>
+							</div>
+						)}
 					</div>
 
 					<div className="grid">

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -177,6 +177,7 @@ export function NodeComponent({
 							>
 								<Handle
 									type="target"
+									isConnectable={false}
 									position={Position.Left}
 									id={input.id}
 									className={clsx(
@@ -194,6 +195,7 @@ export function NodeComponent({
 							<div className="relative flex items-center h-[28px]" key="blank">
 								<Handle
 									type="target"
+									isConnectable={false}
 									position={Position.Left}
 									id="blank-handle"
 									className={clsx(
@@ -218,6 +220,7 @@ export function NodeComponent({
 								<Handle
 									id={output.id}
 									type="source"
+									isConnectable={false}
 									position={Position.Right}
 									data-state={
 										connectedOutputIds?.some(

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -185,7 +185,7 @@ export function NodeComponent({
 										"group-data-[content-type=imageGeneration]:!bg-generation-node-1 group-data-[content-type=imageGeneration]:!border-generation-node-1",
 									)}
 								/>
-								<div className="text-[14px] text-black--30 px-[12px] text-white-900">
+								<div className="text-[14px] px-[12px] text-white-900">
 									{input.label}
 								</div>
 							</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -16,11 +16,11 @@ import {
 	PropertiesPanelRoot,
 } from "../ui";
 import { GenerationPanel } from "./generation-panel";
+import { InputPanel } from "./input-panel";
 import { KeyboardShortcuts } from "./keyboard-shortcuts";
 import { ImageGenerationModelPanel } from "./model-panel";
 import { PromptPanel } from "./prompt-panel";
 import { useConnectedSources } from "./sources";
-import { SourcesPanel } from "./sources-panel";
 
 export function ImageGenerationNodePropertiesPanel({
 	node,
@@ -132,7 +132,7 @@ export function ImageGenerationNodePropertiesPanel({
 							>
 								<Tabs.Trigger value="prompt">Prompt</Tabs.Trigger>
 								<Tabs.Trigger value="model">Model</Tabs.Trigger>
-								<Tabs.Trigger value="sources">Sources</Tabs.Trigger>
+								<Tabs.Trigger value="input">Input</Tabs.Trigger>
 							</Tabs.List>
 							<Tabs.Content
 								value="prompt"
@@ -155,10 +155,10 @@ export function ImageGenerationNodePropertiesPanel({
 								/>
 							</Tabs.Content>
 							<Tabs.Content
-								value="sources"
+								value="input"
 								className="flex-1 flex flex-col overflow-y-auto"
 							>
-								<SourcesPanel node={node} />
+								<InputPanel node={node} />
 							</Tabs.Content>
 						</Tabs.Root>
 					</PropertiesPanelContent>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
@@ -1,9 +1,9 @@
 import {
 	type Connection,
+	type ImageGenerationNode,
 	type Input,
 	InputId,
 	OutputId,
-	type TextGenerationNode,
 } from "@giselle-sdk/data-type";
 import { isJsonContent, jsonContentToText } from "@giselle-sdk/text-editor";
 import clsx from "clsx/lite";
@@ -76,7 +76,7 @@ function SourceSelect({
 	onValueChange,
 	contentProps,
 }: {
-	node: TextGenerationNode;
+	node: ImageGenerationNode;
 	sources: Source[];
 	onValueChange?: (value: OutputId[]) => void;
 	contentProps?: Omit<
@@ -185,7 +185,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={fileSource.output.id}
 											source={fileSource}
-											disabled={node.content.llm.provider === "openai"}
+											disabled={true}
 										/>
 									))}
 								</div>
@@ -199,7 +199,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={githubSource.output.id}
 											source={githubSource}
-											disabled={node.content.llm.provider === "openai"}
+											disabled={true}
 										/>
 									))}
 								</div>
@@ -282,20 +282,20 @@ function SourceListItem({
 	);
 }
 
-export function SourcesPanel({
-	node: textGenerationNode,
+export function InputPanel({
+	node: imageGenerationNode,
 }: {
-	node: TextGenerationNode;
+	node: ImageGenerationNode;
 }) {
 	const { data, addConnection, deleteConnection, updateNodeData } =
 		useWorkflowDesigner();
 	const sources = useMemo<Source[]>(() => {
 		const tmpSources: Source[] = [];
 		const connections = data.connections.filter(
-			(connection) => connection.inputNode.id === textGenerationNode.id,
+			(connection) => connection.inputNode.id === imageGenerationNode.id,
 		);
 		for (const node of data.nodes) {
-			if (node.id === textGenerationNode.id) {
+			if (node.id === imageGenerationNode.id) {
 				continue;
 			}
 			for (const output of node.outputs) {
@@ -310,14 +310,14 @@ export function SourcesPanel({
 			}
 		}
 		return tmpSources;
-	}, [data.nodes, data.connections, textGenerationNode.id]);
-	const connectedSources = useConnectedSources(textGenerationNode);
+	}, [data.nodes, data.connections, imageGenerationNode.id]);
+	const connectedSources = useConnectedSources(imageGenerationNode);
 
 	const handleConnectionChange = useCallback(
 		(connectOutputIds: OutputId[]) => {
 			const currentConnectedOutputIds = data.connections
 				.filter(
-					(connection) => connection.inputNode.id === textGenerationNode.id,
+					(connection) => connection.inputNode.id === imageGenerationNode.id,
 				)
 				.map((connection) => connection.outputId);
 			const newConnectOutputIdSet = new Set(connectOutputIds);
@@ -326,7 +326,7 @@ export function SourcesPanel({
 				currentConnectedOutputIdSet,
 			);
 
-			let mutableInputs = textGenerationNode.inputs;
+			let mutableInputs = imageGenerationNode.inputs;
 			for (const outputId of addedOutputIdSet) {
 				const outputNode = data.nodes.find((node) =>
 					node.outputs.some((output) => output.id === outputId),
@@ -336,15 +336,15 @@ export function SourcesPanel({
 				}
 				const newInput: Input = {
 					id: InputId.generate(),
-					label: "Source",
+					label: "Input",
 				};
 
 				mutableInputs = [...mutableInputs, newInput];
-				updateNodeData(textGenerationNode, {
+				updateNodeData(imageGenerationNode, {
 					inputs: mutableInputs,
 				});
 				addConnection({
-					inputNode: textGenerationNode,
+					inputNode: imageGenerationNode,
 					inputId: newInput.id,
 					outputId,
 					outputNode: outputNode,
@@ -358,7 +358,7 @@ export function SourcesPanel({
 			for (const outputId of removedOutputIdSet) {
 				const connection = data.connections.find(
 					(connection) =>
-						connection.inputNode.id === textGenerationNode.id &&
+						connection.inputNode.id === imageGenerationNode.id &&
 						connection.outputId === outputId,
 				);
 				if (connection === undefined) {
@@ -369,13 +369,13 @@ export function SourcesPanel({
 				mutableInputs = mutableInputs.filter(
 					(input) => input.id !== connection.inputId,
 				);
-				updateNodeData(textGenerationNode, {
+				updateNodeData(imageGenerationNode, {
 					inputs: mutableInputs,
 				});
 			}
 		},
 		[
-			textGenerationNode,
+			imageGenerationNode,
 			data.nodes,
 			data.connections,
 			addConnection,
@@ -387,16 +387,16 @@ export function SourcesPanel({
 	const handleRemove = useCallback(
 		(connection: Connection) => {
 			deleteConnection(connection.id);
-			updateNodeData(textGenerationNode, {
-				inputs: textGenerationNode.inputs.filter(
+			updateNodeData(imageGenerationNode, {
+				inputs: imageGenerationNode.inputs.filter(
 					(input) => input.id !== connection.inputId,
 				),
 			});
 		},
-		[textGenerationNode, deleteConnection, updateNodeData],
+		[imageGenerationNode, deleteConnection, updateNodeData],
 	);
 
-	if (textGenerationNode.inputs.length === 0) {
+	if (imageGenerationNode.inputs.length === 0) {
 		return (
 			<div className="mt-[60px]">
 				<EmptyState
@@ -404,7 +404,7 @@ export function SourcesPanel({
 					description="Select the data you want to refer to from the output and the information and knowledge you have."
 				>
 					<SourceSelect
-						node={textGenerationNode}
+						node={imageGenerationNode}
 						sources={sources}
 						onValueChange={handleConnectionChange}
 					/>
@@ -416,7 +416,7 @@ export function SourcesPanel({
 		<div>
 			<div className="flex justify-end">
 				<SourceSelect
-					node={textGenerationNode}
+					node={imageGenerationNode}
 					sources={sources}
 					onValueChange={handleConnectionChange}
 					contentProps={{

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -21,6 +21,7 @@ import {
 	PropertiesPanelRoot,
 } from "../ui";
 import { GenerationPanel } from "./generation-panel";
+import { InputPanel } from "./input-panel";
 import { KeyboardShortcuts } from "./keyboard-shortcuts";
 import {
 	AnthropicModelPanel,
@@ -30,7 +31,6 @@ import {
 } from "./model";
 import { PromptPanel } from "./prompt-panel";
 import { useConnectedSources } from "./sources";
-import { SourcesPanel } from "./sources-panel";
 
 export function TextGenerationNodePropertiesPanel({
 	node,
@@ -154,7 +154,7 @@ export function TextGenerationNodePropertiesPanel({
 							>
 								<Tabs.Trigger value="prompt">Prompt</Tabs.Trigger>
 								<Tabs.Trigger value="model">Model</Tabs.Trigger>
-								<Tabs.Trigger value="sources">Sources</Tabs.Trigger>
+								<Tabs.Trigger value="input">Input</Tabs.Trigger>
 							</Tabs.List>
 							<Tabs.Content
 								value="prompt"
@@ -296,10 +296,10 @@ export function TextGenerationNodePropertiesPanel({
 								)}
 							</Tabs.Content>
 							<Tabs.Content
-								value="sources"
+								value="input"
 								className="flex-1 flex flex-col overflow-y-auto"
 							>
-								<SourcesPanel node={node} />
+								<InputPanel node={node} />
 							</Tabs.Content>
 						</Tabs.Root>
 					</PropertiesPanelContent>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
@@ -1,9 +1,9 @@
 import {
 	type Connection,
-	type ImageGenerationNode,
 	type Input,
 	InputId,
 	OutputId,
+	type TextGenerationNode,
 } from "@giselle-sdk/data-type";
 import { isJsonContent, jsonContentToText } from "@giselle-sdk/text-editor";
 import clsx from "clsx/lite";
@@ -76,7 +76,7 @@ function SourceSelect({
 	onValueChange,
 	contentProps,
 }: {
-	node: ImageGenerationNode;
+	node: TextGenerationNode;
 	sources: Source[];
 	onValueChange?: (value: OutputId[]) => void;
 	contentProps?: Omit<
@@ -185,7 +185,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={fileSource.output.id}
 											source={fileSource}
-											disabled={true}
+											disabled={node.content.llm.provider === "openai"}
 										/>
 									))}
 								</div>
@@ -199,7 +199,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={githubSource.output.id}
 											source={githubSource}
-											disabled={true}
+											disabled={node.content.llm.provider === "openai"}
 										/>
 									))}
 								</div>
@@ -282,20 +282,20 @@ function SourceListItem({
 	);
 }
 
-export function SourcesPanel({
-	node: imageGenerationNode,
+export function InputPanel({
+	node: textGenerationNode,
 }: {
-	node: ImageGenerationNode;
+	node: TextGenerationNode;
 }) {
 	const { data, addConnection, deleteConnection, updateNodeData } =
 		useWorkflowDesigner();
 	const sources = useMemo<Source[]>(() => {
 		const tmpSources: Source[] = [];
 		const connections = data.connections.filter(
-			(connection) => connection.inputNode.id === imageGenerationNode.id,
+			(connection) => connection.inputNode.id === textGenerationNode.id,
 		);
 		for (const node of data.nodes) {
-			if (node.id === imageGenerationNode.id) {
+			if (node.id === textGenerationNode.id) {
 				continue;
 			}
 			for (const output of node.outputs) {
@@ -310,14 +310,14 @@ export function SourcesPanel({
 			}
 		}
 		return tmpSources;
-	}, [data.nodes, data.connections, imageGenerationNode.id]);
-	const connectedSources = useConnectedSources(imageGenerationNode);
+	}, [data.nodes, data.connections, textGenerationNode.id]);
+	const connectedSources = useConnectedSources(textGenerationNode);
 
 	const handleConnectionChange = useCallback(
 		(connectOutputIds: OutputId[]) => {
 			const currentConnectedOutputIds = data.connections
 				.filter(
-					(connection) => connection.inputNode.id === imageGenerationNode.id,
+					(connection) => connection.inputNode.id === textGenerationNode.id,
 				)
 				.map((connection) => connection.outputId);
 			const newConnectOutputIdSet = new Set(connectOutputIds);
@@ -326,7 +326,7 @@ export function SourcesPanel({
 				currentConnectedOutputIdSet,
 			);
 
-			let mutableInputs = imageGenerationNode.inputs;
+			let mutableInputs = textGenerationNode.inputs;
 			for (const outputId of addedOutputIdSet) {
 				const outputNode = data.nodes.find((node) =>
 					node.outputs.some((output) => output.id === outputId),
@@ -336,15 +336,15 @@ export function SourcesPanel({
 				}
 				const newInput: Input = {
 					id: InputId.generate(),
-					label: "Source",
+					label: "Input",
 				};
 
 				mutableInputs = [...mutableInputs, newInput];
-				updateNodeData(imageGenerationNode, {
+				updateNodeData(textGenerationNode, {
 					inputs: mutableInputs,
 				});
 				addConnection({
-					inputNode: imageGenerationNode,
+					inputNode: textGenerationNode,
 					inputId: newInput.id,
 					outputId,
 					outputNode: outputNode,
@@ -358,7 +358,7 @@ export function SourcesPanel({
 			for (const outputId of removedOutputIdSet) {
 				const connection = data.connections.find(
 					(connection) =>
-						connection.inputNode.id === imageGenerationNode.id &&
+						connection.inputNode.id === textGenerationNode.id &&
 						connection.outputId === outputId,
 				);
 				if (connection === undefined) {
@@ -369,13 +369,13 @@ export function SourcesPanel({
 				mutableInputs = mutableInputs.filter(
 					(input) => input.id !== connection.inputId,
 				);
-				updateNodeData(imageGenerationNode, {
+				updateNodeData(textGenerationNode, {
 					inputs: mutableInputs,
 				});
 			}
 		},
 		[
-			imageGenerationNode,
+			textGenerationNode,
 			data.nodes,
 			data.connections,
 			addConnection,
@@ -387,16 +387,16 @@ export function SourcesPanel({
 	const handleRemove = useCallback(
 		(connection: Connection) => {
 			deleteConnection(connection.id);
-			updateNodeData(imageGenerationNode, {
-				inputs: imageGenerationNode.inputs.filter(
+			updateNodeData(textGenerationNode, {
+				inputs: textGenerationNode.inputs.filter(
 					(input) => input.id !== connection.inputId,
 				),
 			});
 		},
-		[imageGenerationNode, deleteConnection, updateNodeData],
+		[textGenerationNode, deleteConnection, updateNodeData],
 	);
 
-	if (imageGenerationNode.inputs.length === 0) {
+	if (textGenerationNode.inputs.length === 0) {
 		return (
 			<div className="mt-[60px]">
 				<EmptyState
@@ -404,7 +404,7 @@ export function SourcesPanel({
 					description="Select the data you want to refer to from the output and the information and knowledge you have."
 				>
 					<SourceSelect
-						node={imageGenerationNode}
+						node={textGenerationNode}
 						sources={sources}
 						onValueChange={handleConnectionChange}
 					/>
@@ -416,7 +416,7 @@ export function SourcesPanel({
 		<div>
 			<div className="flex justify-end">
 				<SourceSelect
-					node={imageGenerationNode}
+					node={textGenerationNode}
 					sources={sources}
 					onValueChange={handleConnectionChange}
 					contentProps={{


### PR DESCRIPTION
## Changes
- Display blank `Input` on the left of generation node when no input is connected.
  - To highlight the `input` feature to users.
- Rename "Source" to "Input" in Properties panel.
  - Since the Output has a `Source` feature for search grounding, we want to prevent user confusion.
- Disable connection via dragging feature of React Flow.
  - This feature is currently not implemented in our application.