### PR TITLE
fix: return cancelled generation from cancelGeneration

### DIFF
--- a/packages/giselle-engine/src/core/generations/cancel-generation.ts
+++ b/packages/giselle-engine/src/core/generations/cancel-generation.ts
@@ -13,14 +13,15 @@ export async function cancelGeneration(args: {
 	if (generation === undefined) {
 		throw new Error(`Generation ${args.generationId} not found`);
 	}
+	const cancelledGeneration: CancelledGeneration = {
+		...generation,
+		status: "cancelled",
+		cancelledAt: Date.now(),
+	};
 	await Promise.all([
 		setGeneration({
 			storage: args.context.storage,
-			generation: {
-				...generation,
-				status: "cancelled",
-				cancelledAt: Date.now(),
-			} as CancelledGeneration,
+			generation: cancelledGeneration,
 		}),
 		setNodeGenerationIndex({
 			storage: args.context.storage,
@@ -36,4 +37,5 @@ export async function cancelGeneration(args: {
 			},
 		}),
 	]);
+	return cancelledGeneration;
 }


### PR DESCRIPTION
## Summary
This PR fixes the issue where stopping a generator node results in an empty response, causing a JSON parse error. The change ensures that the `cancelGeneration` function returns a proper cancelled generation object, maintaining consistency with other API endpoints.

## Related Issue
Fixes #493

## Changes
- Modified `cancelGeneration` function to return the cancelled generation object
- Extracted cancelled generation to a variable for better code organization
- Made API response consistent with other generation-related endpoints
- Fixed JSON parse error when stopping generator nodes

## Testing
- Tested stopping a running generator node
- Verified that the response contains the proper cancelled generation object
- Confirmed that frontend handles the response correctly without JSON parse errors

## Other Information
This change improves API consistency and error handling while maintaining the existing functionality. The fix addresses the backend error reported in Sentry while ensuring a better user experience.