### PR TITLE
Add error handling for usage limit in text and image generation for giselle-engine

### DIFF
--- a/packages/giselle-engine/src/http/router.ts
+++ b/packages/giselle-engine/src/http/router.ts
@@ -194,8 +194,15 @@ export const createJsonRouters = {
 				overrideNodes: z.array(OverrideNode).optional(),
 			}),
 			handler: async ({ input }) => {
-				const result = await giselleEngine.runApi(input);
-				return new Response(result);
+				try {
+					const result = await giselleEngine.runApi(input);
+					return new Response(result);
+				} catch (error) {
+					if (error instanceof UsageLimitError) {
+						return new Response(error.message, { status: 429 });
+					}
+					throw error;
+				}
 			},
 		}),
 	generateImage: (giselleEngine: GiselleEngine) =>


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Add error handling for usage limit in text and image generation for giselle-engine

## Related Issue
<!-- Mention the related issue number if applicable. -->
https://github.com/giselles-ai/giselle/issues/509

## Changes
<!-- List the main changes made in this PR. -->
I changed the giselle-engine text and image generation service to return HTTP Status 429 to clients when usage limit errors occur.


## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
Issue #509 indicates that HTTP status codes 402 or 406 should be returned when a Usage Limit Error occurs. 

However, after I have checked again about proper HTTP status codes, it seems that returning 429 is the standard practice for rate limiting.  I would appreciate your feedback on this.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429
https://sdk.vercel.ai/docs/advanced/rate-limiting
