### PR TITLE
fix(giselle-engine): remove console.log from generate-text function

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -40,7 +40,6 @@ export async function generateText(args: {
 	generation: QueuedGeneration;
 	telemetry?: TelemetrySettings;
 }) {
-	console.log({ telemetry: args.telemetry });
 	const actionNode = args.generation.context.actionNode;
 	if (!isTextGenerationNode(actionNode)) {
 		throw new Error("Invalid generation type");


### PR DESCRIPTION
## Summary
- Remove unnecessary console.log statement from the generate-text function in giselle-engine

## Test plan
- Verify that the text generation functionality continues to work as expected without the debug logging

🤖 Generated with [Claude Code](https://claude.ai/code)