### PR TITLE
fix: improve password reset error handling

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/password_reset/new_password/actions.ts
+++ b/apps/studio.giselles.ai/app/(auth)/password_reset/new_password/actions.ts
@@ -1,54 +1,52 @@
 "use server";
 
 import { createClient } from "@/lib/supabase";
+import type { AuthError } from "@supabase/supabase-js";
 import { redirect } from "next/navigation";
 
 interface SerializableError {
-	name: string;
-	message: string;
-	status: number;
-	code?: string;
+	name: AuthError["name"];
+	message: AuthError["message"];
+	status?: AuthError["status"];
+	code?: AuthError["code"];
 }
 
-const createError = (
-	message: string,
-	status: number,
-	code?: string,
-): SerializableError => ({
-	name: "PasswordResetError",
-	message,
-	status,
-	code,
-});
+const serializeError = (error: AuthError): SerializableError => {
+	const serialized: SerializableError = {
+		name: error.name,
+		message: error.message,
+	};
+	if (error.status) {
+		serialized.status = error.status;
+	}
+	if (error.code) {
+		serialized.code = error.code;
+	}
+	return serialized;
+};
 
 export const resetPassword = async (
 	_prevState: SerializableError | null,
 	formData: FormData,
 ): Promise<SerializableError | null> => {
 	const newPassword = formData.get("new_password");
-	if (newPassword == null || typeof newPassword !== "string") {
-		return createError(
-			"Please enter a valid password",
-			422,
-			"validation_failed",
-		);
+	if (
+		newPassword == null ||
+		typeof newPassword !== "string" ||
+		newPassword.trim() === ""
+	) {
+		return {
+			name: "PasswordResetError",
+			message: "Please enter a valid password",
+			status: 422,
+			code: "validation_failed",
+		};
 	}
 	const supabase = await createClient();
 	const { error } = await supabase.auth.updateUser({ password: newPassword });
-	if (error?.code === "same_password") {
-		return createError(
-			"The new password must be different from your current password",
-			422,
-			error.code,
-		);
-	}
 	if (error) {
 		console.error("Password reset error:", error);
-		return createError(
-			"Failed to reset password. Please try again later.",
-			400,
-			error.code,
-		);
+		return serializeError(error);
 	}
 	redirect("/password_reset/complete");
 	return null;


### PR DESCRIPTION
## Summary
Improve error handling in the password reset functionality by implementing type-safe error serialization and utilizing Supabase's native error messages. This change resolves the Server Components render error and provides better error feedback to users.

## Related Issue
Fixes #301

![image](https://github.com/user-attachments/assets/6eaeadba-7d00-4698-a42b-bbe2db0de0b7)

## Changes
- Add type-safe SerializableError interface utilizing AuthError types
- Replace custom error creation with serializeError utility
- Add proper empty string validation for password input
- Use Supabase's native error messages instead of custom ones
- Handle undefined error properties safely during serialization
- Add error logging for debugging purposes

## Testing
1. Test empty password submission - should show validation error
2. Test whitespace-only password - should show validation error
3. Test same password submission - should show Supabase's native error message
4. Verify no Server Components render errors occur
5. Confirm error messages are properly displayed in the UI

## Other Information
This refactor simplifies our error handling by leveraging Supabase's error system while maintaining type safety. The implementation now properly handles serialization of server-side errors for client-side display, resolving the original Server Components render error.