### PR TITLE
Add unified validation and enhance connection styling for node connections

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/connector/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/connector/component.tsx
@@ -46,6 +46,9 @@ export function Connector({
 					"group-data-[output-node-content-type=textGeneration]:group-data-[input-node-content-type=textGeneration]:!stroke-[url(#textGenerationToTextGeneration)]",
 					"group-data-[output-node-content-type=file]:group-data-[input-node-content-type=textGeneration]:!stroke-[url(#fileToTextGeneration)]",
 					"group-data-[output-node-content-type=text]:group-data-[input-node-content-type=textGeneration]:!stroke-[url(#textToTextGeneration)]",
+					"group-data-[output-node-content-type=textGeneration]:group-data-[input-node-content-type=imageGeneration]:!stroke-[url(#textGenerationToImageGeneration)]",
+					"group-data-[output-node-content-type=file]:group-data-[input-node-content-type=imageGeneration]:!stroke-[url(#fileToImageGeneration)]",
+					"group-data-[output-node-content-type=text]:group-data-[input-node-content-type=imageGeneration]:!stroke-[url(#textToImageGeneration)]",
 				)}
 			/>
 		</g>
@@ -78,6 +81,36 @@ export function GradientDef() {
 				</linearGradient>
 				<linearGradient
 					id="textToTextGeneration"
+					x1="0%"
+					y1="0%"
+					x2="100%"
+					y2="0%"
+				>
+					<stop offset="0%" stopColor="var(--color-node-plaintext-900)" />
+					<stop offset="100%" stopColor="var(--color-primary-900)" />
+				</linearGradient>
+				<linearGradient
+					id="textGenerationToImageGeneration"
+					x1="0%"
+					y1="0%"
+					x2="100%"
+					y2="0%"
+				>
+					<stop offset="0%" stopColor="var(--color-primary-900)" />
+					<stop offset="100%" stopColor="var(--color-primary-900)" />
+				</linearGradient>
+				<linearGradient
+					id="fileToImageGeneration"
+					x1="0%"
+					y1="0%"
+					x2="100%"
+					y2="0%"
+				>
+					<stop offset="0%" stopColor="var(--color-node-data-900)" />
+					<stop offset="100%" stopColor="var(--color-primary-900)" />
+				</linearGradient>
+				<linearGradient
+					id="textToImageGeneration"
 					x1="0%"
 					y1="0%"
 					x2="100%"

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -177,6 +177,7 @@ export function NodeComponent({
 							>
 								<Handle
 									type="target"
+									isConnectable={false}
 									position={Position.Left}
 									id={input.id}
 									className={clsx(

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
@@ -87,6 +87,15 @@ function SourceSelect({
 	const [selectedOutputIds, setSelectedOutputIds] = useState<OutputId[]>([]);
 	const { generatedSources, textSources, fileSources, githubSources } =
 		useSourceCategories(sources);
+	const { canConnectNodes } = useWorkflowDesigner();
+	const canConnect = useCallback(
+		(source: Source) => {
+			const { canConnect } = canConnectNodes(source.node, node);
+			return canConnect;
+		},
+		[canConnectNodes, node],
+	);
+
 	return (
 		<Popover.Root
 			onOpenChange={(open) => {
@@ -158,6 +167,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={generatedSource.output.id}
 											source={generatedSource}
+											disabled={!canConnect(generatedSource)}
 										/>
 									))}
 								</div>
@@ -171,6 +181,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={textSource.output.id}
 											source={textSource}
+											disabled={!canConnect(textSource)}
 										/>
 									))}
 								</div>
@@ -185,7 +196,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={fileSource.output.id}
 											source={fileSource}
-											disabled={true}
+											disabled={!canConnect(fileSource)}
 										/>
 									))}
 								</div>
@@ -199,7 +210,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={githubSource.output.id}
 											source={githubSource}
-											disabled={true}
+											disabled={!canConnect(githubSource)}
 										/>
 									))}
 								</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
@@ -87,13 +87,13 @@ function SourceSelect({
 	const [selectedOutputIds, setSelectedOutputIds] = useState<OutputId[]>([]);
 	const { generatedSources, textSources, fileSources, githubSources } =
 		useSourceCategories(sources);
-	const { canConnectNodes } = useWorkflowDesigner();
-	const canConnect = useCallback(
+	const { isSupportedConnection } = useWorkflowDesigner();
+	const isSupported = useCallback(
 		(source: Source) => {
-			const { canConnect } = canConnectNodes(source.node, node);
+			const { canConnect } = isSupportedConnection(source.node, node);
 			return canConnect;
 		},
-		[canConnectNodes, node],
+		[isSupportedConnection, node],
 	);
 
 	return (
@@ -167,7 +167,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={generatedSource.output.id}
 											source={generatedSource}
-											disabled={!canConnect(generatedSource)}
+											disabled={!isSupported(generatedSource)}
 										/>
 									))}
 								</div>
@@ -181,7 +181,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={textSource.output.id}
 											source={textSource}
-											disabled={!canConnect(textSource)}
+											disabled={!isSupported(textSource)}
 										/>
 									))}
 								</div>
@@ -196,7 +196,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={fileSource.output.id}
 											source={fileSource}
-											disabled={!canConnect(fileSource)}
+											disabled={!isSupported(fileSource)}
 										/>
 									))}
 								</div>
@@ -210,7 +210,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={githubSource.output.id}
 											source={githubSource}
-											disabled={!canConnect(githubSource)}
+											disabled={!isSupported(githubSource)}
 										/>
 									))}
 								</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
@@ -87,6 +87,15 @@ function SourceSelect({
 	const [selectedOutputIds, setSelectedOutputIds] = useState<OutputId[]>([]);
 	const { generatedSources, textSources, fileSources, githubSources } =
 		useSourceCategories(sources);
+	const { canConnectNodes } = useWorkflowDesigner();
+	const canConnect = useCallback(
+		(source: Source) => {
+			const { canConnect } = canConnectNodes(source.node, node);
+			return canConnect;
+		},
+		[canConnectNodes, node],
+	);
+
 	return (
 		<Popover.Root
 			onOpenChange={(open) => {
@@ -158,6 +167,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={generatedSource.output.id}
 											source={generatedSource}
+											disabled={!canConnect(generatedSource)}
 										/>
 									))}
 								</div>
@@ -171,6 +181,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={textSource.output.id}
 											source={textSource}
+											disabled={!canConnect(textSource)}
 										/>
 									))}
 								</div>
@@ -185,7 +196,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={fileSource.output.id}
 											source={fileSource}
-											disabled={node.content.llm.provider === "openai"}
+											disabled={!canConnect(fileSource)}
 										/>
 									))}
 								</div>
@@ -199,7 +210,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={githubSource.output.id}
 											source={githubSource}
-											disabled={node.content.llm.provider === "openai"}
+											disabled={!canConnect(githubSource)}
 										/>
 									))}
 								</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
@@ -87,13 +87,13 @@ function SourceSelect({
 	const [selectedOutputIds, setSelectedOutputIds] = useState<OutputId[]>([]);
 	const { generatedSources, textSources, fileSources, githubSources } =
 		useSourceCategories(sources);
-	const { canConnectNodes } = useWorkflowDesigner();
-	const canConnect = useCallback(
+	const { isSupportedConnection } = useWorkflowDesigner();
+	const isSupported = useCallback(
 		(source: Source) => {
-			const { canConnect } = canConnectNodes(source.node, node);
+			const { canConnect } = isSupportedConnection(source.node, node);
 			return canConnect;
 		},
-		[canConnectNodes, node],
+		[isSupportedConnection, node],
 	);
 
 	return (
@@ -167,7 +167,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={generatedSource.output.id}
 											source={generatedSource}
-											disabled={!canConnect(generatedSource)}
+											disabled={!isSupported(generatedSource)}
 										/>
 									))}
 								</div>
@@ -181,7 +181,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={textSource.output.id}
 											source={textSource}
-											disabled={!canConnect(textSource)}
+											disabled={!isSupported(textSource)}
 										/>
 									))}
 								</div>
@@ -196,7 +196,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={fileSource.output.id}
 											source={fileSource}
-											disabled={!canConnect(fileSource)}
+											disabled={!isSupported(fileSource)}
 										/>
 									))}
 								</div>
@@ -210,7 +210,7 @@ function SourceSelect({
 										<SourceToggleItem
 											key={githubSource.output.id}
 											source={githubSource}
-											disabled={!canConnect(githubSource)}
+											disabled={!isSupported(githubSource)}
 										/>
 									))}
 								</div>

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -122,7 +122,7 @@ async function buildGenerationMessageForTextGeneration(
 				}
 				break;
 			}
-			case "file": {
+			case "file":
 				switch (contextNode.content.category) {
 					case "text":
 					case "image":
@@ -144,6 +144,15 @@ async function buildGenerationMessageForTextGeneration(
 						throw new Error(`Unhandled category: ${_exhaustiveCheck}`);
 					}
 				}
+				break;
+
+			case "github":
+			case "imageGeneration":
+				throw new Error("Not implemented");
+
+			default: {
+				const _exhaustiveCheck: never = contextNode.content;
+				throw new Error(`Unhandled type: ${_exhaustiveCheck}`);
 			}
 		}
 	}
@@ -499,7 +508,7 @@ async function buildGenerationMessageForImageGeneration(
 				}
 				break;
 			}
-			case "file": {
+			case "file":
 				switch (contextNode.content.category) {
 					case "text":
 					case "image":
@@ -521,6 +530,15 @@ async function buildGenerationMessageForImageGeneration(
 						throw new Error(`Unhandled category: ${_exhaustiveCheck}`);
 					}
 				}
+				break;
+
+			case "github":
+			case "imageGeneration":
+				throw new Error("Not implemented");
+
+			default: {
+				const _exhaustiveCheck: never = contextNode.content;
+				throw new Error(`Unhandled type: ${_exhaustiveCheck}`);
 			}
 		}
 	}

--- a/packages/workflow-designer/package.json
+++ b/packages/workflow-designer/package.json
@@ -9,9 +9,13 @@
 		"build": "tsup",
 		"check-types": "tsc --noEmit",
 		"clean": "rm -rf .turbo dist node_modules react",
-		"format": "biome check --write ."
+		"format": "biome check --write .",
+		"test": "vitest run"
 	},
-	"files": ["dist/**/*", "react/dist/**/*"],
+	"files": [
+		"dist/**/*",
+		"react/dist/**/*"
+	],
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
@@ -31,7 +35,8 @@
 	"devDependencies": {
 		"@giselle/giselle-sdk-tsconfig": "workspace:*",
 		"@types/react": "catalog:",
-		"tsup": "catalog:"
+		"tsup": "catalog:",
+		"vitest": "catalog:"
 	},
 	"dependencies": {
 		"@giselle-sdk/data-type": "workspace:*",

--- a/packages/workflow-designer/package.json
+++ b/packages/workflow-designer/package.json
@@ -12,10 +12,7 @@
 		"format": "biome check --write .",
 		"test": "vitest run"
 	},
-	"files": [
-		"dist/**/*",
-		"react/dist/**/*"
-	],
+	"files": ["dist/**/*", "react/dist/**/*"],
 	"exports": {
 		"./package.json": "./package.json",
 		".": {

--- a/packages/workflow-designer/src/is-supported-connection.test.ts
+++ b/packages/workflow-designer/src/is-supported-connection.test.ts
@@ -1,0 +1,228 @@
+import type {
+	FileNode,
+	GitHubNode,
+	ImageGenerationLanguageModelData,
+	ImageGenerationNode,
+	NodeId,
+	TextGenerationLanguageModelData,
+	TextGenerationNode,
+	VariableNode,
+} from "@giselle-sdk/data-type";
+import {
+	anthropicLanguageModels,
+	falLanguageModels,
+	openaiLanguageModels,
+	perplexityLanguageModels,
+} from "@giselle-sdk/language-model";
+import { describe, expect, test } from "vitest";
+
+import { isSupportedConnection } from "./is-supported-connection";
+
+describe("isSupportedConnection", () => {
+	const createTextGenerationNode = (
+		id: NodeId,
+		llm: TextGenerationLanguageModelData = anthropicLanguageModels[0],
+	): TextGenerationNode => ({
+		id,
+		type: "action",
+		inputs: [],
+		outputs: [],
+		content: {
+			type: "textGeneration",
+			llm,
+		},
+	});
+
+	const createImageGenerationNode = (
+		id: NodeId,
+		llm: ImageGenerationLanguageModelData = falLanguageModels[0],
+	): ImageGenerationNode => ({
+		id,
+		type: "action",
+		inputs: [],
+		outputs: [],
+		content: {
+			type: "imageGeneration",
+			llm,
+		},
+	});
+
+	const createFileNode = (
+		id: NodeId,
+		category: "text" | "pdf" | "image" = "text",
+	): FileNode => ({
+		id,
+		type: "variable",
+		inputs: [],
+		outputs: [],
+		content: {
+			type: "file",
+			category,
+			files: [],
+		},
+	});
+
+	const createGitHubNode = (id: NodeId): GitHubNode => ({
+		id,
+		type: "variable",
+		inputs: [],
+		outputs: [],
+		content: {
+			type: "github",
+			objectReferences: [],
+		},
+	});
+
+	const createTextNode = (id: NodeId): VariableNode => ({
+		id,
+		type: "variable",
+		inputs: [],
+		outputs: [],
+		content: {
+			type: "text",
+			text: "",
+		},
+	});
+
+	describe("Basic validation", () => {
+		test("should reject connection between the same node", () => {
+			const node = createTextGenerationNode("nd-test1");
+			const result = isSupportedConnection(node, node);
+
+			expect(result.canConnect).toBe(false);
+			expect(result).toHaveProperty(
+				"message",
+				"Connecting to the same node is not allowed",
+			);
+		});
+
+		test("should reject non-action node as input", () => {
+			const outputNode = createTextGenerationNode("nd-test2");
+			const inputNode = createTextNode("nd-test3");
+
+			const result = isSupportedConnection(outputNode, inputNode);
+
+			expect(result.canConnect).toBe(false);
+			expect(result).toHaveProperty(
+				"message",
+				"This node does not receive inputs",
+			);
+		});
+	});
+
+	describe("Output node restrictions", () => {
+		test("should reject image generation node as output", () => {
+			const outputNode = createImageGenerationNode("nd-test4");
+			const inputNode = createTextGenerationNode("nd-test5");
+
+			const result = isSupportedConnection(outputNode, inputNode);
+
+			expect(result.canConnect).toBe(false);
+			expect(result).toHaveProperty(
+				"message",
+				"Image generation node is not supported as an output",
+			);
+		});
+
+		test("should reject GitHub node as output", () => {
+			const outputNode = createGitHubNode("nd-test6");
+			const inputNode = createTextGenerationNode("nd-test7");
+
+			const result = isSupportedConnection(outputNode, inputNode);
+
+			expect(result.canConnect).toBe(false);
+			expect(result).toHaveProperty(
+				"message",
+				"GitHub node is not supported as an output",
+			);
+		});
+	});
+
+	describe("File node restrictions", () => {
+		test("should reject file node as input for image generation", () => {
+			const fileNode = createFileNode("nd-test8");
+			const inputNode = createImageGenerationNode("nd-test9");
+
+			const result = isSupportedConnection(fileNode, inputNode);
+
+			expect(result.canConnect).toBe(false);
+			expect(result).toHaveProperty(
+				"message",
+				"File node is not supported as an input for Image Generation",
+			);
+		});
+
+		test("should reject file node as input for OpenAI", () => {
+			const fileNode = createFileNode("nd-test10");
+			const inputNode = createTextGenerationNode(
+				"nd-test11",
+				openaiLanguageModels[0],
+			);
+
+			const result = isSupportedConnection(fileNode, inputNode);
+
+			expect(result.canConnect).toBe(false);
+			expect(result).toHaveProperty(
+				"message",
+				"File node is not supported as an input for OpenAI",
+			);
+		});
+
+		test("should reject file node as input for Perplexity", () => {
+			const fileNode = createFileNode("nd-test12");
+			const inputNode = createTextGenerationNode(
+				"nd-test13",
+				perplexityLanguageModels[0],
+			);
+
+			const result = isSupportedConnection(fileNode, inputNode);
+
+			expect(result.canConnect).toBe(false);
+			expect(result).toHaveProperty(
+				"message",
+				"File node is not supported as an input for Perplexity",
+			);
+		});
+
+		test("should allow file node as input for Anthropic", () => {
+			const fileNode = createFileNode("nd-test14");
+			const inputNode = createTextGenerationNode(
+				"nd-test15",
+				anthropicLanguageModels[0],
+			);
+
+			const result = isSupportedConnection(fileNode, inputNode);
+			expect(result.canConnect).toBe(true);
+		});
+
+		test.each([
+			["text", true],
+			["pdf", true],
+			["image", true],
+		])("should handle %s file category correctly", (category, expected) => {
+			const fileNode = createFileNode(
+				"nd-test16",
+				category as "text" | "pdf" | "image",
+			);
+			const inputNode = createTextGenerationNode(
+				"nd-test17",
+				anthropicLanguageModels[0],
+			);
+
+			const result = isSupportedConnection(fileNode, inputNode);
+			expect(result.canConnect).toBe(expected);
+		});
+	});
+
+	describe("Valid connections", () => {
+		test("should allow valid connection between compatible nodes", () => {
+			const outputNode = createTextGenerationNode("nd-test18");
+			const inputNode = createTextGenerationNode("nd-test19");
+
+			const result = isSupportedConnection(outputNode, inputNode);
+
+			expect(result.canConnect).toBe(true);
+			expect(result).not.toHaveProperty("message");
+		});
+	});
+});

--- a/packages/workflow-designer/src/is-supported-connection.ts
+++ b/packages/workflow-designer/src/is-supported-connection.ts
@@ -1,0 +1,62 @@
+import type { Node } from "@giselle-sdk/data-type";
+
+export type ConnectionValidationResult =
+	| { canConnect: true }
+	| { canConnect: false; message: string };
+
+export function isSupportedConnection(
+	outputNode: Node,
+	inputNode: Node,
+): ConnectionValidationResult {
+	if (outputNode.id === inputNode.id) {
+		return {
+			canConnect: false,
+			message: "Connecting to the same node is not allowed",
+		};
+	}
+	if (inputNode.type !== "action") {
+		return {
+			canConnect: false,
+			message: "This node does not receive inputs",
+		};
+	}
+
+	if (outputNode.content.type === "imageGeneration") {
+		return {
+			canConnect: false,
+			message: "Image generation node is not supported as an output",
+		};
+	}
+	if (outputNode.content.type === "github") {
+		return {
+			canConnect: false,
+			message: "GitHub node is not supported as an output",
+		};
+	}
+
+	if (outputNode.content.type === "file") {
+		if (inputNode.content.type === "imageGeneration") {
+			return {
+				canConnect: false,
+				message: "File node is not supported as an input for Image Generation",
+			};
+		}
+
+		if (inputNode.content.llm.provider === "openai") {
+			return {
+				canConnect: false,
+				message: "File node is not supported as an input for OpenAI",
+			};
+		}
+		if (inputNode.content.llm.provider === "perplexity") {
+			return {
+				canConnect: false,
+				message: "File node is not supported as an input for Perplexity",
+			};
+		}
+	}
+
+	return {
+		canConnect: true,
+	};
+}

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -29,7 +29,7 @@ export interface WorkflowDesignerContextValue
 			| "deleteConnection"
 			| "setUiViewport"
 			| "updateName"
-			| "canConnectNodes"
+			| "isSupportedConnection"
 		>,
 		ReturnType<typeof usePropertiesPanel>,
 		ReturnType<typeof useView> {
@@ -157,15 +157,14 @@ export function WorkflowDesignerProvider({
 		[setAndSaveWorkspace],
 	);
 
-	const canConnectNodes = useCallback<WorkflowDesigner["canConnectNodes"]>(
-		(outputNode, inputNode) => {
-			return workflowDesignerRef.current?.canConnectNodes(
-				outputNode,
-				inputNode,
-			);
-		},
-		[],
-	);
+	const isSupportedConnection = useCallback<
+		WorkflowDesigner["isSupportedConnection"]
+	>((outputNode, inputNode) => {
+		return workflowDesignerRef.current?.isSupportedConnection(
+			outputNode,
+			inputNode,
+		);
+	}, []);
 
 	const setUiNodeState = useCallback(
 		(
@@ -287,7 +286,7 @@ export function WorkflowDesignerProvider({
 				isLoading,
 				setUiViewport,
 				updateName,
-				canConnectNodes,
+				isSupportedConnection,
 				...usePropertiesPanelHelper,
 				...useViewHelper,
 			}}

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -29,6 +29,7 @@ export interface WorkflowDesignerContextValue
 			| "deleteConnection"
 			| "setUiViewport"
 			| "updateName"
+			| "canConnectNodes"
 		>,
 		ReturnType<typeof usePropertiesPanel>,
 		ReturnType<typeof useView> {
@@ -156,6 +157,16 @@ export function WorkflowDesignerProvider({
 		[setAndSaveWorkspace],
 	);
 
+	const canConnectNodes = useCallback<WorkflowDesigner["canConnectNodes"]>(
+		(outputNode, inputNode) => {
+			return workflowDesignerRef.current?.canConnectNodes(
+				outputNode,
+				inputNode,
+			);
+		},
+		[],
+	);
+
 	const setUiNodeState = useCallback(
 		(
 			nodeId: string | NodeId,
@@ -276,6 +287,7 @@ export function WorkflowDesignerProvider({
 				isLoading,
 				setUiViewport,
 				updateName,
+				canConnectNodes,
 				...usePropertiesPanelHelper,
 				...useViewHelper,
 			}}

--- a/packages/workflow-designer/src/workflow-designer.ts
+++ b/packages/workflow-designer/src/workflow-designer.ts
@@ -118,7 +118,7 @@ export function WorkflowDesigner({
 	function updateName(newName: string | undefined) {
 		name = newName;
 	}
-	function canConnectNodes(
+	function isSupportedConnection(
 		outputNode: Node,
 		inputNode: Node,
 	): { canConnect: true } | { canConnect: false; message: string } {
@@ -189,6 +189,6 @@ export function WorkflowDesigner({
 		deleteNode,
 		deleteConnection,
 		updateName,
-		canConnectNodes,
+		isSupportedConnection,
 	};
 }

--- a/packages/workflow-designer/src/workflow-designer.ts
+++ b/packages/workflow-designer/src/workflow-designer.ts
@@ -11,6 +11,7 @@ import {
 	generateInitialWorkspace,
 } from "@giselle-sdk/data-type";
 import { buildWorkflowMap } from "@giselle-sdk/workflow-utils";
+import { isSupportedConnection } from "./is-supported-connection";
 
 interface AddNodeOptions {
 	ui?: NodeUIState;
@@ -117,66 +118,6 @@ export function WorkflowDesigner({
 	}
 	function updateName(newName: string | undefined) {
 		name = newName;
-	}
-	function isSupportedConnection(
-		outputNode: Node,
-		inputNode: Node,
-	): { canConnect: true } | { canConnect: false; message: string } {
-		// FIXME: Use language model to check if the nodes can be connected
-		// For now, giselle's connecting capability is not tied with language model's capability
-		// So we need to check if the nodes can be connected by ourselves
-		if (outputNode.id === inputNode.id) {
-			return {
-				canConnect: false,
-				message: "Connecting to the same node is not allowed",
-			};
-		}
-		if (inputNode.type !== "action") {
-			return {
-				canConnect: false,
-				message: "This node does not receive inputs",
-			};
-		}
-
-		if (outputNode.content.type === "imageGeneration") {
-			return {
-				canConnect: false,
-				message: "Image generation node is not supported as an output",
-			};
-		}
-		if (outputNode.content.type === "github") {
-			return {
-				canConnect: false,
-				message: "GitHub node is not supported as an output",
-			};
-		}
-
-		if (outputNode.content.type === "file") {
-			if (inputNode.content.type === "imageGeneration") {
-				return {
-					canConnect: false,
-					message:
-						"File node is not supported as an input for Image Generation",
-				};
-			}
-
-			if (inputNode.content.llm.provider === "openai") {
-				return {
-					canConnect: false,
-					message: "File node is not supported as an input for OpenAI",
-				};
-			}
-			if (inputNode.content.llm.provider === "perplexity") {
-				return {
-					canConnect: false,
-					message: "File node is not supported as an input for Perplexity",
-				};
-			}
-		}
-
-		return {
-			canConnect: true,
-		};
 	}
 
 	return {

--- a/packages/workflow-designer/turbo.json
+++ b/packages/workflow-designer/turbo.json
@@ -1,8 +1,13 @@
 {
-	"extends": ["//"],
+	"extends": [
+		"//"
+	],
 	"tasks": {
 		"build": {
-			"outputs": ["**/dist/**"]
-		}
+			"outputs": [
+				"**/dist/**"
+			]
+		},
+		"test": {}
 	}
 }

--- a/packages/workflow-designer/turbo.json
+++ b/packages/workflow-designer/turbo.json
@@ -1,12 +1,8 @@
 {
-	"extends": [
-		"//"
-	],
+	"extends": ["//"],
 	"tasks": {
 		"build": {
-			"outputs": [
-				"**/dist/**"
-			]
+			"outputs": ["**/dist/**"]
 		},
 		"test": {}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1177,6 +1177,9 @@ importers:
       tsup:
         specifier: 'catalog:'
         version: 8.3.5(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(terser@5.38.0)(yaml@2.7.0)
 
   packages/workflow-utils:
     dependencies:


### PR DESCRIPTION
## Overview
Added validation functionality for node connections in the workflow designer. This enhancement prevents invalid connections and provides clear feedback to users.

## Key Changes

1. Connection Validation Implementation
   - Implemented `isSupportedConnection` function to validate node connections
   - Added error message display for invalid connections
   - Integrated validation with the existing connection handling system

2. Validation Rules
   - Prevent connections to the same node
   - Restrict inputs to action nodes only
   - Prevent output from image generation nodes
   - Prevent output from GitHub nodes
   - Add file node connection restrictions (block connections to OpenAI, Perplexity, and image generation)

3. Connection Styling Enhancements
   - Added new gradient definitions for image generation connections
   - Implemented visual styling for connections between different node types
   - Added CSS classes for connections between text/file/textGeneration and imageGeneration nodes

The styling work complements the validation functionality by providing visual cues about the different types of connections, making the overall feature more cohesive and user-friendly.

4. UI/UX Improvements
   - Disable invalid source options in the UI
   - Add toast notifications for connection errors
   - Update connector styles (add gradients for image generation nodes)

## Testing Checklist

### Local
- [x] Verify that connections to the same node are prevented
- [x] Confirm that connections to non-action nodes are blocked
- [x] Test that image generation nodes cannot be used as outputs
- [x] Validate file node connection restrictions
- [x] Check that error toast notifications appear correctly
- [x] Verify that invalid sources are properly disabled in the Input Panel UI

### Preview
- [x] Verify that connections to the same node are prevented
- [x] Confirm that connections to non-action nodes are blocked
- [x] Test that image generation nodes cannot be used as outputs
- [x] Validate file node connection restrictions
- [x] Check that error toast notifications appear correctly
- [x] Verify that invalid sources are properly disabled in the Input Panel UI