### PR TITLE
Remove hardcoded dev server port

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -32,6 +32,12 @@
     pnpm turbo dev
     ```
 
+    By default, the development server runs on port 3000 (this is the standard Next.js default). If you need to use a different port, you can set the `PORT` environment variable:
+
+    ```sh
+    PORT=6180 pnpm turbo dev
+    ```
+
 ## Tasks
 
 - [ ] Rework biome config(create tools/biome and each package import it)

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -7,7 +7,7 @@
 	"packageManager": "pnpm@10.6.5",
 	"private": true,
 	"scripts": {
-		"dev": "next dev --turbopack --port 6180",
+		"dev": "next dev --turbopack",
 		"clean": "rm -rf .next .turbo node_modules",
 		"build": "next build",
 		"start": "next start",

--- a/docs/vibe/01-introduction.md
+++ b/docs/vibe/01-introduction.md
@@ -58,10 +58,10 @@ To start using Giselle's playground:
 
    # Google AI API Key
    GOOGLE_AI_API_KEY=your_google_ai_api_key
-   
+
    # Perplexity API Key
    PERPLEXITY_API_KEY=your_perplexity_api_key
-   
+
    # FAL AI API Key
    FAL_API_KEY=your_fal_api_key
    ```
@@ -73,6 +73,12 @@ To start using Giselle's playground:
    pnpm dev
    ```
 
-4. Open your browser and visit `http://localhost:6180` to access the playground interface.
+   By default, the development server runs on port 3000 (this is the standard Next.js default). If you need to use a different port, you can set the `PORT` environment variable:
+
+   ```bash
+   PORT=6180 pnpm dev
+   ```
+
+4. Open your browser and visit `http://localhost:3000` to access the playground interface.
 
 The playground allows you to experiment with Giselle's core features in a standalone environment without needing to set up authentication or other production features.


### PR DESCRIPTION
## Summary
- Remove hardcoded port 6180 from playground package.json to use Next.js default (3000)
- Update documentation to explain how to change port using PORT environment variable
- Update localhost URLs in documentation to reflect the default port

## Background
Originally, hardcoded dev server port (6180) was used to prevent port conflicts between different dev servers. However, this approach creates problems with collaborative tools and vibe coding environments (as noted in PR #529 where port conflicts occurred).

Following next.js conventions by using the default port (3000) and allowing override through the PORT environment variable is a better approach for:

1. Developers using vibe coding tools like Cursor, Cline, etc.
2. Following standard conventions that most developers would expect
3. Maintaining consistency with framework defaults while still allowing customization

## Test plan
- Run the dev server without specifying a port and confirm it runs on port 3000
- Test setting PORT environment variable to override the default port

🤖 Generated with [Claude Code](https://claude.ai/code)