### PR TITLE
feat(text-generation): enable long text generation with ai-sdk

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -201,6 +201,8 @@ export async function generateText(args: {
 	const streamTextResult = streamText({
 		model: generationModel(actionNode.content.llm),
 		messages,
+		maxSteps: 5, // enable multi-step calls
+		experimental_continueSteps: true,
 		onError: async ({ error }) => {
 			if (AISDKError.isInstance(error)) {
 				const failedGeneration = {


### PR DESCRIPTION
## Summary
- Added maxSteps and experimental_continueSteps options to streamText to enable generating longer text that exceeds model token limits
- These options allow the AI SDK to make multiple continuation calls to generate extended content

## Feature plan
- Current implementation always enables longText generation options which increases API costs
- Will add a configurable option to control this feature in a future update

Reference: https://sdk.vercel.ai/docs/ai-sdk-core/generating-text#generating-long-text

🤖 Generated with [Claude Code](https://claude.ai/code)