### PR TITLE
UI Improvements: Add Generate Button on Empty Generation Panels

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
@@ -5,12 +5,12 @@ import type {
 } from "@giselle-sdk/data-type";
 import clsx from "clsx/lite";
 import { useNodeGenerations, useWorkflowDesigner } from "giselle-sdk/react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { StackBlicksIcon, WilliIcon } from "../../../icons";
 import { EmptyState } from "../../../ui/empty-state";
 import { GenerationView } from "../../../ui/generation-view";
 
-function Empty() {
+function Empty({ onGenerate }: { onGenerate?: () => void }) {
 	return (
 		<div className="bg-white-900/10 h-full rounded-[8px] flex justify-center items-center text-black-400">
 			<EmptyState
@@ -18,12 +18,39 @@ function Empty() {
 				title="Nothing is generated."
 				description="Generate with the current Prompt or adjust the Prompt and the results will be displayed."
 				className="text-black-400"
-			/>
+			>
+				{onGenerate && (
+					<button
+						type="button"
+						onClick={onGenerate}
+						className="flex items-center justify-center px-[24px] py-[12px] mt-[16px] bg-[#141519] text-white rounded-[9999px] border border-white-900/15 transition-all hover:bg-[#1e1f26] hover:border-white-900/25 hover:translate-y-[-1px] cursor-pointer font-hubot font-[500] text-[14px]"
+					>
+						<span className="mr-[8px] generate-star">✦</span>
+						Generate with the current prompt
+					</button>
+				)}
+				<style jsx>{`
+					.generate-star {
+						display: inline-block;
+					}
+					button:hover .generate-star {
+						animation: rotateStar 0.7s ease-in-out;
+					}
+					@keyframes rotateStar {
+						0% { transform: rotate(0deg) scale(1); }
+						50% { transform: rotate(180deg) scale(1.5); }
+						100% { transform: rotate(360deg) scale(1); }
+					}
+				`}</style>
+			</EmptyState>
 		</div>
 	);
 }
 
-export function GenerationPanel({ node }: { node: ImageGenerationNode }) {
+export function GenerationPanel({
+	node,
+	onClickGenerateButton,
+}: { node: ImageGenerationNode; onClickGenerateButton?: () => void }) {
 	const { data } = useWorkflowDesigner();
 	const { generations } = useNodeGenerations({
 		nodeId: node.id,
@@ -41,8 +68,15 @@ export function GenerationPanel({ node }: { node: ImageGenerationNode }) {
 			setCurrentGeneration(latestGeneration);
 		}
 	}, [generations]);
+
+	const handleGenerate = useCallback(() => {
+		if (onClickGenerateButton) {
+			onClickGenerateButton();
+		}
+	}, [onClickGenerateButton]);
+
 	if (currentGeneration === undefined) {
-		return <Empty />;
+		return <Empty onGenerate={handleGenerate} />;
 	}
 	return (
 		<div className="bg-white-900/10 h-full rounded-[8px] flex flex-col">

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -109,10 +109,7 @@ export function ImageGenerationNodePropertiesPanel({
 				}
 			/>
 
-			<PanelGroup
-				direction="vertical"
-				className="flex-1 flex flex-col gap-[16px]"
-			>
+			<PanelGroup direction="vertical" className="flex-1 flex flex-col">
 				<Panel>
 					<PropertiesPanelContent>
 						<Tabs.Root
@@ -165,8 +162,9 @@ export function ImageGenerationNodePropertiesPanel({
 				</Panel>
 				<PanelResizeHandle
 					className={clsx(
-						"h-[1px] bg-black-400/50 transition-colors",
-						"data-[resize-handle-state=hover]:bg-black-400 data-[resize-handle-state=drag]:bg-black-400",
+						"h-[12px] flex items-center justify-center cursor-row-resize",
+						"after:content-[''] after:h-[3px] after:w-[32px] after:bg-[#3a3f44] after:rounded-full",
+						"hover:after:bg-[#4a90e2]",
 					)}
 				/>
 				<Panel>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -169,7 +169,7 @@ export function ImageGenerationNodePropertiesPanel({
 				/>
 				<Panel>
 					<PropertiesPanelContent>
-						<GenerationPanel node={node} />
+						<GenerationPanel node={node} onClickGenerateButton={generateText} />
 					</PropertiesPanelContent>
 				</Panel>
 			</PanelGroup>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
@@ -6,12 +6,12 @@ import type {
 import clsx from "clsx/lite";
 import { useNodeGenerations, useWorkflowDesigner } from "giselle-sdk/react";
 import { useCallback, useEffect, useState } from "react";
-import { StackBlicksIcon, WilliIcon } from "../../../icons";
+import { StackBlicksIcon } from "../../../icons";
 import ClipboardButton from "../../../ui/clipboard-button";
 import { EmptyState } from "../../../ui/empty-state";
 import { GenerationView } from "../../../ui/generation-view";
 
-function Empty() {
+function Empty({ onGenerate }: { onGenerate?: () => void }) {
 	return (
 		<div className="bg-white-900/10 h-full rounded-[8px] flex justify-center items-center text-black-400">
 			<EmptyState
@@ -19,7 +19,31 @@ function Empty() {
 				title="Nothing is generated."
 				description="Generate with the current Prompt or adjust the Prompt and the results will be displayed."
 				className="text-black-400"
-			/>
+			>
+				{onGenerate && (
+					<button
+						type="button"
+						onClick={onGenerate}
+						className="flex items-center justify-center px-[24px] py-[12px] mt-[16px] bg-[#141519] text-white rounded-[9999px] border border-white-900/15 transition-all hover:bg-[#1e1f26] hover:border-white-900/25 hover:translate-y-[-1px] cursor-pointer font-hubot font-[500] text-[14px]"
+					>
+						<span className="mr-[8px] generate-star">✦</span>
+						Generate with the current prompt
+					</button>
+				)}
+				<style jsx>{`
+					.generate-star {
+						display: inline-block;
+					}
+					button:hover .generate-star {
+						animation: rotateStar 0.7s ease-in-out;
+					}
+					@keyframes rotateStar {
+						0% { transform: rotate(0deg) scale(1); }
+						50% { transform: rotate(180deg) scale(1.5); }
+						100% { transform: rotate(360deg) scale(1); }
+					}
+				`}</style>
+			</EmptyState>
 		</div>
 	);
 }
@@ -54,7 +78,10 @@ function getGenerationTextContent(generation: Generation): string {
 		.join("\n");
 }
 
-export function GenerationPanel({ node }: { node: TextGenerationNode }) {
+export function GenerationPanel({
+	node,
+	onClickGenerateButton,
+}: { node: TextGenerationNode; onClickGenerateButton?: () => void }) {
 	const { data } = useWorkflowDesigner();
 	const { generations } = useNodeGenerations({
 		nodeId: node.id,
@@ -72,8 +99,15 @@ export function GenerationPanel({ node }: { node: TextGenerationNode }) {
 			setCurrentGeneration(latestGeneration);
 		}
 	}, [generations]);
+
+	const handleGenerate = useCallback(() => {
+		if (onClickGenerateButton) {
+			onClickGenerateButton();
+		}
+	}, [onClickGenerateButton]);
+
 	if (currentGeneration === undefined) {
-		return <Empty />;
+		return <Empty onGenerate={handleGenerate} />;
 	}
 	return (
 		<div className="bg-white-900/10 h-full rounded-[8px] py-[8px]">

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -313,7 +313,7 @@ export function TextGenerationNodePropertiesPanel({
 				/>
 				<Panel>
 					<PropertiesPanelContent>
-						<GenerationPanel node={node} />
+						<GenerationPanel node={node} onClickGenerateButton={generateText} />
 					</PropertiesPanelContent>
 				</Panel>
 			</PanelGroup>

--- a/internal-packages/workflow-designer-ui/src/ui/slider.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/slider.tsx
@@ -14,10 +14,17 @@ function SliderInner({
 			)}
 			{...props}
 		>
-			<SliderPrimitive.Track className="relative h-[4px] w-full grow overflow-hidden bg-black-400">
-				<SliderPrimitive.Range className="absolute h-full bg-white-900" />
+			<SliderPrimitive.Track
+				className="relative h-[2px] w-full grow overflow-hidden bg-transparent 
+				before:content-[''] before:absolute before:inset-0 
+				before:bg-[repeating-linear-gradient(90deg,#F7F9FD_0px,#F7F9FD_2px,transparent_2px,transparent_4px)]"
+			>
+				<SliderPrimitive.Range className="absolute h-full bg-white-900 rounded-[9999px]" />
 			</SliderPrimitive.Track>
-			<SliderPrimitive.Thumb className="block h-[12px] w-[12px] rounded-full bg-white-900" />
+			<SliderPrimitive.Thumb
+				className="block h-[10px] w-[10px] rounded-full bg-white-900 
+				transition-transform hover:scale-110 focus:outline-none focus:ring-0 active:outline-none active:ring-0"
+			/>
 		</SliderPrimitive.Root>
 	);
 }


### PR DESCRIPTION
## Summary
- Add Generate button to empty generation panels for better UX
- Update ImageGenerationPanel resize handle style to match TextGenerationPanel
- Improve code organization with onClickGenerateButton props for cleaner separation of concerns

## Background
This PR extracts and refines UI improvements from PR #529, which contained several valuable UI enhancements along with other changes. I've isolated the most useful UI changes and refactored them to be more maintainable:

- Extracted the Generate button functionality for empty generation panels
- Standardized the resize handle styling across components
- Improved the code structure by properly separating presentation from logic

## Test plan
- Verify the Generate button appears on empty generation panels and works correctly
- Check that clicking the button triggers the generation process
- Ensure resize handles have consistent styling across panels

🤖 Generated with [Claude Code](https://claude.ai/code)