### PR TITLE
Enable form submission on Enter key press

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
@@ -77,7 +77,12 @@ export function AccountDisplayNameForm({
 		<div className="flex flex-col gap-2">
 			<div className="flex items-center gap-2">
 				{isEditingName ? (
-					<>
+					<form
+						onSubmit={(e) => {
+							e.preventDefault();
+							handleSaveDisplayName();
+						}}
+					>
 						<Input
 							value={tempDisplayName}
 							onChange={handleChange}
@@ -85,6 +90,7 @@ export function AccountDisplayNameForm({
 							disabled={isLoading}
 						/>
 						<Button
+							type="submit"
 							className="shrink-0 h-8 w-8 rounded-full p-0"
 							onClick={handleSaveDisplayName}
 							disabled={isLoading || !!error}
@@ -92,13 +98,14 @@ export function AccountDisplayNameForm({
 							<Check className="h-4 w-4" />
 						</Button>
 						<Button
+							type="button"
 							className="shrink-0 h-8 w-8 rounded-full p-0"
 							onClick={handleCancelDislayName}
 							disabled={isLoading}
 						>
 							<X className="h-4 w-4" />
 						</Button>
-					</>
+					</form>
 				) : (
 					<>
 						<span className="text-lg">{displayName}</span>

--- a/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
@@ -75,13 +75,14 @@ export function AccountDisplayNameForm({
 
 	return (
 		<div className="flex flex-col gap-2">
-			<div className="flex items-center gap-2">
+			<div>
 				{isEditingName ? (
 					<form
 						onSubmit={(e) => {
 							e.preventDefault();
 							handleSaveDisplayName();
 						}}
+						className="flex items-center gap-2"
 					>
 						<Input
 							value={tempDisplayName}
@@ -107,7 +108,7 @@ export function AccountDisplayNameForm({
 						</Button>
 					</form>
 				) : (
-					<>
+					<div className="flex items-center gap-2">
 						<span className="text-lg">{displayName}</span>
 						<Button
 							className="shrink-0 h-8 w-8 rounded-full p-0"
@@ -115,7 +116,7 @@ export function AccountDisplayNameForm({
 						>
 							<Pencil className="h-4 w-4" />
 						</Button>
-					</>
+					</div>
 				)}
 			</div>
 

--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-name-form.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-name-form.tsx
@@ -75,13 +75,14 @@ export function TeamNameForm({ id: teamId, name }: Team) {
 	return (
 		<Card title="Team name">
 			<div className="flex flex-col gap-2">
-				<div className="flex items-center gap-2">
+				<div>
 					{isEditingName ? (
 						<form
 							onSubmit={(e) => {
 								e.preventDefault();
 								handleSaveTeamName();
 							}}
+							className="flex items-center gap-2"
 						>
 							<Input
 								value={tempTeamName}
@@ -107,7 +108,7 @@ export function TeamNameForm({ id: teamId, name }: Team) {
 							</Button>
 						</form>
 					) : (
-						<>
+						<div className="flex items-center gap-2">
 							<span className="text-lg">{teamName}</span>
 							<Button
 								className="shrink-0 h-8 w-8 rounded-full p-0"
@@ -115,7 +116,7 @@ export function TeamNameForm({ id: teamId, name }: Team) {
 							>
 								<Pencil className="h-4 w-4" />
 							</Button>
-						</>
+						</div>
 					)}
 				</div>
 

--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-name-form.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-name-form.tsx
@@ -77,7 +77,12 @@ export function TeamNameForm({ id: teamId, name }: Team) {
 			<div className="flex flex-col gap-2">
 				<div className="flex items-center gap-2">
 					{isEditingName ? (
-						<>
+						<form
+							onSubmit={(e) => {
+								e.preventDefault();
+								handleSaveTeamName();
+							}}
+						>
 							<Input
 								value={tempTeamName}
 								onChange={handleChange}
@@ -85,6 +90,7 @@ export function TeamNameForm({ id: teamId, name }: Team) {
 								disabled={isLoading}
 							/>
 							<Button
+								type="submit"
 								className="shrink-0 h-8 w-8 rounded-full p-0"
 								onClick={handleSaveTeamName}
 								disabled={isLoading || !!error}
@@ -92,13 +98,14 @@ export function TeamNameForm({ id: teamId, name }: Team) {
 								<Check className="h-4 w-4" />
 							</Button>
 							<Button
+								type="button"
 								className="shrink-0 h-8 w-8 rounded-full p-0"
 								onClick={handleCancelTeamName}
 								disabled={isLoading}
 							>
 								<X className="h-4 w-4" />
 							</Button>
-						</>
+						</form>
 					) : (
 						<>
 							<span className="text-lg">{teamName}</span>


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Enabled form submission by pressing the Enter key.

This is now supported for the following forms:

- Account Display Name
- Team Name


https://github.com/user-attachments/assets/edc89090-fcfc-40bd-ada2-d02e937ed608


https://github.com/user-attachments/assets/1b5203d1-c728-4929-bdd2-04c819585685



## Related Issue
<!-- Mention the related issue number if applicable. -->
https://github.com/giselles-ai/giselle/issues/132

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
The v2 settings page was already configured to allow form submission using the Enter key, so no additional changes were necessary.