### PR TITLE
Fix 'accesor' typo in textGenerationNode outputs

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/state.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/state.tsx
@@ -184,7 +184,7 @@ export function textGenerationNode(llm: TextGenerationLanguageModelData) {
 		{
 			id: OutputId.generate(),
 			label: "Output",
-			accesor: "generated-text",
+			accessor: "generated-text",
 		},
 	];
 	const languageModel = languageModels.find(
@@ -198,7 +198,7 @@ export function textGenerationNode(llm: TextGenerationLanguageModelData) {
 		outputs.push({
 			id: OutputId.generate(),
 			label: "Source",
-			accesor: "source",
+			accessor: "source",
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Fixed a typo in textGenerationNode outputs by changing 'accesor' to 'accessor' in the state.tsx file
- Note: This was developed in parallel with PR #570 which addresses the same issue

## Test plan
- Verify that text generation node outputs work correctly with the fixed field name

🤖 Generated with [Claude Code](https://claude.ai/code)