### PR TITLE
Improve workflow inference timing

### DIFF
--- a/packages/workflow-designer/src/workflow-designer.ts
+++ b/packages/workflow-designer/src/workflow-designer.ts
@@ -88,6 +88,7 @@ export function WorkflowDesigner({
 				inputId,
 			},
 		];
+		updateWorkflowMap();
 	}
 	function setUiNodeState(
 		unsafeNodeId: string | NodeId,

--- a/packages/workflow-utils/package.json
+++ b/packages/workflow-utils/package.json
@@ -9,7 +9,8 @@
 		"build": "tsup",
 		"typecheck": "tsc --noEmit",
 		"clean": "rm -rf .turbo dist node_modules",
-		"format": "biome check --write ."
+		"format": "biome check --write .",
+		"test": "vitest run"
 	},
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/workflow-utils/src/build-workflow.test.ts
+++ b/packages/workflow-utils/src/build-workflow.test.ts
@@ -1,26 +1,161 @@
-// import { testWorkspace } from "@giselle-sdk/test-utils";
-// import { describe, expect, test } from "vitest";
-// import { buildWorkflowMap } from "./build-workflow";
+import type {
+	Connection,
+	ConnectionId,
+	Node,
+	NodeId,
+	WorkflowId,
+} from "@giselle-sdk/data-type";
+import { describe, expect, test } from "vitest";
+import { buildWorkflowMap } from "./build-workflow";
 
-// describe("buildWorkflowMap", () => {
-// 	const workflowMap = buildWorkflowMap(
-// 		testWorkspace.nodeMap,
-// 		testWorkspace.connectionMap,
-// 		testWorkspace.id,
-// 	);
-// 	test("testWorkspace can build 3 workflows", () => {
-// 		expect(workflowMap.size).toBe(3);
-// 	});
-// 	test("first workflow has 3 jobs", () => {
-// 		const workflowIterator = workflowMap.values();
-// 		const firstWorkflow = workflowIterator.next().value;
-// 		expect(firstWorkflow?.jobMap.size).toBe(3);
-// 	});
-// 	test("first workflow`s first job has 2 steps", () => {
-// 		const workflowIterator = workflowMap.values();
-// 		const firstWorkflow = workflowIterator.next().value;
-// 		const jobIterator = firstWorkflow?.jobMap.values();
-// 		const firstJob = jobIterator?.next().value;
-// 		expect(firstJob?.stepMap.size).toBe(2);
-// 	});
-// });
+// Sample data for tests based on provided workflow JSON
+const sampleNodes: Node[] = [
+	{
+		id: "nd-KzXeXSIffRIMwZtX",
+		type: "action",
+		inputs: [],
+		outputs: [
+			{
+				id: "otp-93MKjM7HdSu3hOdw",
+				label: "Output",
+				accessor: "generated-text",
+			},
+		],
+		content: {
+			type: "textGeneration",
+			llm: {
+				provider: "openai",
+				id: "gpt-4o-mini",
+				configurations: {
+					temperature: 0.7,
+					topP: 1,
+					presencePenalty: 0,
+					frequencyPenalty: 0,
+				},
+			},
+			prompt:
+				'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Hello"}]}]}',
+		},
+	},
+	{
+		id: "nd-P2EllMigi6Tm6gij",
+		type: "action",
+		inputs: [{ id: "inp-id3Grof8Hyy3DJbN", label: "Input" }],
+		outputs: [
+			{
+				id: "otp-Fdzlled7cDxSIa7G",
+				label: "Output",
+				accessor: "generated-text",
+			},
+		],
+		content: {
+			type: "textGeneration",
+			llm: {
+				provider: "openai",
+				id: "gpt-4o-mini",
+				configurations: {
+					temperature: 0.7,
+					topP: 1,
+					presencePenalty: 0,
+					frequencyPenalty: 0,
+				},
+			},
+		},
+	},
+] as Node[];
+
+const sampleConnections: Connection[] = [
+	{
+		id: "cnnc-7SZdtE1iSWtoghGD",
+		outputNode: {
+			id: "nd-KzXeXSIffRIMwZtX",
+			type: "action",
+			content: { type: "textGeneration" },
+		},
+		outputId: "otp-93MKjM7HdSu3hOdw",
+		inputNode: {
+			id: "nd-P2EllMigi6Tm6gij",
+			type: "action",
+			content: { type: "textGeneration" },
+		},
+		inputId: "inp-id3Grof8Hyy3DJbN",
+	},
+] as Connection[];
+
+// Setup helper variables
+const nodeMap = new Map<NodeId, Node>(
+	sampleNodes.map((node) => [node.id, node]),
+);
+const connectionMap = new Map<ConnectionId, Connection>(
+	sampleConnections.map((connection) => [connection.id, connection]),
+);
+
+describe("buildWorkflowMap", () => {
+	test("should create a workflow map from sample nodes and connections", () => {
+		const result = buildWorkflowMap(nodeMap, connectionMap);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(1); // One workflow in our sample
+
+		// Get the workflow from the map
+		const workflow = Array.from(result.values())[0];
+
+		// Check workflow structure
+		expect(workflow.nodes.length).toBe(2); // Two nodes in our workflow
+		expect(workflow.jobs.length).toBe(2); // Two jobs because of the dependency structure
+
+		// Check if nodes are included in the workflow
+		const nodeIds = workflow.nodes.map((node) => node.id);
+		expect(nodeIds).toContain("nd-KzXeXSIffRIMwZtX");
+		expect(nodeIds).toContain("nd-P2EllMigi6Tm6gij");
+
+		// Check job structure
+		const jobsWithFirstNode = workflow.jobs.filter((job) =>
+			job.actions.some((action) => action.node.id === "nd-KzXeXSIffRIMwZtX"),
+		);
+		const jobsWithSecondNode = workflow.jobs.filter((job) =>
+			job.actions.some((action) => action.node.id === "nd-P2EllMigi6Tm6gij"),
+		);
+
+		expect(jobsWithFirstNode.length).toBe(1);
+		expect(jobsWithSecondNode.length).toBe(1);
+
+		// Check dependency relationship in generation templates
+		const secondNodeJob = jobsWithSecondNode[0];
+		expect(secondNodeJob.actions[0].generationTemplate.sourceNodes.length).toBe(
+			1,
+		);
+		expect(secondNodeJob.actions[0].generationTemplate.sourceNodes[0].id).toBe(
+			"nd-KzXeXSIffRIMwZtX",
+		);
+	});
+
+	test("should handle empty maps", () => {
+		const emptyNodeMap = new Map<NodeId, Node>();
+		const emptyConnectionMap = new Map<ConnectionId, Connection>();
+
+		const result = buildWorkflowMap(emptyNodeMap, emptyConnectionMap);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(0);
+	});
+
+	test("should handle maps with only non-action nodes", () => {
+		const nonActionNode: Node = {
+			id: "nd-NonAction",
+			type: "data",
+			inputs: [],
+			outputs: [],
+			content: { type: "data" },
+		} as unknown as Node;
+
+		const nonActionNodeMap = new Map<NodeId, Node>([
+			["nd-NonAction", nonActionNode],
+		]);
+
+		const result = buildWorkflowMap(nonActionNodeMap, connectionMap);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(0);
+	});
+});

--- a/packages/workflow-utils/src/helper.test.ts
+++ b/packages/workflow-utils/src/helper.test.ts
@@ -1,222 +1,240 @@
-// import { type NodeData, type NodeId, WorkflowId } from "@giselle-sdk/data-type";
-// import {
-// 	connection1,
-// 	connection2,
-// 	connection3,
-// 	connection4,
-// 	connection5,
-// 	testWorkspace,
-// 	textGenerationNode1,
-// 	textGenerationNode2,
-// 	textGenerationNode3,
-// 	textGenerationNode4,
-// 	textGenerationNode5,
-// 	textGenerationNode6,
-// 	textGenerationNode7,
-// 	textNode1,
-// } from "@giselle-sdk/test-utils";
-// import { describe, expect, test } from "vitest";
-// import {
-// 	createConnectedNodeIdMap,
-// 	createJobMap,
-// 	findConnectedConnectionMap,
-// 	findConnectedNodeMap,
-// } from "./helper";
+import {
+	type ActionNode,
+	type Connection,
+	type ConnectionId,
+	type Node,
+	type NodeId,
+	type WorkflowId,
+	isActionNode,
+} from "@giselle-sdk/data-type";
+import { describe, expect, test } from "vitest";
+import {
+	createConnectedNodeIdMap,
+	createJobMap,
+	findConnectedConnectionMap,
+	findConnectedNodeMap,
+} from "./helper";
 
-// test("createConnectionMap", () => {
-// 	expect(
-// 		createConnectedNodeIdMap(
-// 			new Set(testWorkspace.connectionMap.values()),
-// 			new Set(testWorkspace.nodeMap.keys()),
-// 		),
-// 	).toStrictEqual(
-// 		new Map([
-// 			[textNode1.id, new Set([textGenerationNode1.id])],
-// 			[textGenerationNode1.id, new Set([textNode1.id, textGenerationNode2.id])],
-// 			[
-// 				textGenerationNode2.id,
-// 				new Set([
-// 					textGenerationNode1.id,
-// 					textGenerationNode3.id,
-// 					textGenerationNode4.id,
-// 				]),
-// 			],
-// 			[textGenerationNode3.id, new Set([textGenerationNode2.id])],
-// 			[textGenerationNode4.id, new Set([textGenerationNode2.id])],
-// 			[textGenerationNode5.id, new Set([textGenerationNode6.id])],
-// 			[textGenerationNode6.id, new Set([textGenerationNode5.id])],
-// 		]),
-// 	);
-// });
+// Sample data for tests based on provided workflow JSON
+const sampleNodes: Node[] = [
+	{
+		id: "nd-KzXeXSIffRIMwZtX",
+		type: "action",
+		inputs: [],
+		outputs: [
+			{
+				id: "otp-93MKjM7HdSu3hOdw",
+				label: "Output",
+				accessor: "generated-text",
+			},
+		],
+		content: {
+			type: "textGeneration",
+			llm: {
+				provider: "openai",
+				id: "gpt-4o-mini",
+				configurations: {
+					temperature: 0.7,
+					topP: 1,
+					presencePenalty: 0,
+					frequencyPenalty: 0,
+				},
+			},
+			prompt:
+				'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Hello"}]}]}',
+		},
+	},
+	{
+		id: "nd-P2EllMigi6Tm6gij",
+		type: "action",
+		inputs: [{ id: "inp-id3Grof8Hyy3DJbN", label: "Input" }],
+		outputs: [
+			{
+				id: "otp-Fdzlled7cDxSIa7G",
+				label: "Output",
+				accessor: "generated-text",
+			},
+		],
+		content: {
+			type: "textGeneration",
+			llm: {
+				provider: "openai",
+				id: "gpt-4o-mini",
+				configurations: {
+					temperature: 0.7,
+					topP: 1,
+					presencePenalty: 0,
+					frequencyPenalty: 0,
+				},
+			},
+		},
+	},
+] as Node[];
 
-// describe("findConnectedNodeMap", () => {
-// 	const connectionMap = createConnectedNodeIdMap(
-// 		new Set(testWorkspace.connectionMap.values()),
-// 		new Set(testWorkspace.nodeMap.keys()),
-// 	);
-// 	test("start by textGenerationNode1", () => {
-// 		expect(
-// 			findConnectedNodeMap(
-// 				textGenerationNode1.id,
-// 				testWorkspace.nodeMap,
-// 				connectionMap,
-// 			),
-// 		).toStrictEqual(
-// 			new Map<NodeId, NodeData>([
-// 				[textGenerationNode1.id, textGenerationNode1],
-// 				[textNode1.id, textNode1],
-// 				[textGenerationNode2.id, textGenerationNode2],
-// 				[textGenerationNode3.id, textGenerationNode3],
-// 				[textGenerationNode4.id, textGenerationNode4],
-// 			]),
-// 		);
-// 	});
-// 	test("start by textGenerationNode2", () => {
-// 		expect(
-// 			findConnectedNodeMap(
-// 				textGenerationNode2.id,
-// 				testWorkspace.nodeMap,
-// 				connectionMap,
-// 			),
-// 		).toStrictEqual(
-// 			new Map<NodeId, NodeData>([
-// 				[textGenerationNode1.id, textGenerationNode1],
-// 				[textNode1.id, textNode1],
-// 				[textGenerationNode2.id, textGenerationNode2],
-// 				[textGenerationNode3.id, textGenerationNode3],
-// 				[textGenerationNode4.id, textGenerationNode4],
-// 			]),
-// 		);
-// 	});
-// 	test("start by textGenerationNode4", () => {
-// 		expect(
-// 			findConnectedNodeMap(
-// 				textGenerationNode5.id,
-// 				testWorkspace.nodeMap,
-// 				connectionMap,
-// 			),
-// 		).toStrictEqual(
-// 			new Map<NodeId, NodeData>([
-// 				[textGenerationNode5.id, textGenerationNode5],
-// 				[textGenerationNode6.id, textGenerationNode6],
-// 			]),
-// 		);
-// 	});
-// 	test("start by textGenerationNode6", () => {
-// 		expect(
-// 			findConnectedNodeMap(
-// 				textGenerationNode7.id,
-// 				testWorkspace.nodeMap,
-// 				connectionMap,
-// 			),
-// 		).toStrictEqual(
-// 			new Map<NodeId, NodeData>([
-// 				[textGenerationNode7.id, textGenerationNode7],
-// 			]),
-// 		);
-// 	});
-// });
+const sampleConnections: Connection[] = [
+	{
+		id: "cnnc-7SZdtE1iSWtoghGD",
+		outputNode: {
+			id: "nd-KzXeXSIffRIMwZtX",
+			type: "action",
+			content: { type: "textGeneration" },
+		},
+		outputId: "otp-93MKjM7HdSu3hOdw",
+		inputNode: {
+			id: "nd-P2EllMigi6Tm6gij",
+			type: "action",
+			content: { type: "textGeneration" },
+		},
+		inputId: "inp-id3Grof8Hyy3DJbN",
+	},
+] as Connection[];
 
-// describe("findConnectedConnections", () => {
-// 	const connectionMap = createConnectedNodeIdMap(
-// 		new Set(testWorkspace.connectionMap.values()),
-// 		new Set(testWorkspace.nodeMap.keys()),
-// 	);
-// 	test("start by textGenerationNode1", () => {
-// 		const connectedNodeMap = findConnectedNodeMap(
-// 			textGenerationNode1.id,
-// 			testWorkspace.nodeMap,
-// 			connectionMap,
-// 		);
-// 		expect(
-// 			findConnectedConnectionMap(
-// 				new Set(connectedNodeMap.keys()),
-// 				new Set(testWorkspace.connectionMap.values()),
-// 			),
-// 		).toStrictEqual(
-// 			new Map([
-// 				[connection1.id, connection1],
-// 				[connection2.id, connection2],
-// 				[connection3.id, connection3],
-// 				[connection4.id, connection4],
-// 			]),
-// 		);
-// 	});
-// 	test("start by textGenerationNode4", () => {
-// 		const connectedNodeMap = findConnectedNodeMap(
-// 			textGenerationNode5.id,
-// 			testWorkspace.nodeMap,
-// 			connectionMap,
-// 		);
-// 		expect(
-// 			findConnectedConnectionMap(
-// 				new Set(connectedNodeMap.keys()),
-// 				new Set(testWorkspace.connectionMap.values()),
-// 			),
-// 		).toStrictEqual(new Map([[connection5.id, connection5]]));
-// 	});
-// });
-// describe("createJobsFromGraph", () => {
-// 	const connectionMap = createConnectedNodeIdMap(
-// 		new Set(testWorkspace.connectionMap.values()),
-// 		new Set(testWorkspace.nodeMap.keys()),
-// 	);
-// 	test("start by textGenerationNode1", () => {
-// 		const connectedNodeMap = findConnectedNodeMap(
-// 			textGenerationNode1.id,
-// 			testWorkspace.nodeMap,
-// 			connectionMap,
-// 		);
-// 		const connectedConnectionMap = findConnectedConnectionMap(
-// 			new Set(connectedNodeMap.keys()),
-// 			new Set(testWorkspace.connectionMap.values()),
-// 		);
-// 		const workflowId = WorkflowId.generate();
-// 		const jobSet = createJobMap(
-// 			new Set(connectedNodeMap.values()),
-// 			new Set(connectedConnectionMap.values()),
-// 			workflowId,
-// 		);
-// 		expect(jobSet.size).toBe(3);
-// 		const jobSetIterator = jobSet.values();
-// 		const firstJob = jobSetIterator.next().value;
-// 		expect(firstJob?.stepMap.size).toBe(2);
-// 		const firstJobFirstStep = firstJob?.stepMap.values().next().value;
-// 		expect(firstJobFirstStep?.nodeId).toBe(textGenerationNode1.id);
-// 		expect(firstJobFirstStep?.variableNodeIds).toStrictEqual(
-// 			new Set([textNode1.id]),
-// 		);
-// 		const secondJob = jobSetIterator.next().value;
-// 		expect(secondJob?.stepMap.size).toBe(1);
-// 		const secondJobFirstStep = secondJob?.stepMap.values().next().value;
-// 		expect(secondJobFirstStep?.nodeId).toBe(textGenerationNode2.id);
-// 		expect(secondJobFirstStep?.variableNodeIds).toStrictEqual(new Set());
-// 		const thirdJob = jobSetIterator.next().value;
-// 		expect(thirdJob?.stepMap.size).toBe(1);
-// 		const thirdJobFirstStep = thirdJob?.stepMap.values().next().value;
-// 		expect(thirdJobFirstStep?.nodeId).toBe(textGenerationNode3.id);
-// 		expect(thirdJobFirstStep?.variableNodeIds).toStrictEqual(new Set());
-// 	});
-// 	test("start by textGenerationNode4", () => {
-// 		const connectedNodeMap = findConnectedNodeMap(
-// 			textGenerationNode5.id,
-// 			testWorkspace.nodeMap,
-// 			connectionMap,
-// 		);
-// 		const connectedConnectionMap = findConnectedConnectionMap(
-// 			new Set(connectedNodeMap.keys()),
-// 			new Set(testWorkspace.connectionMap.values()),
-// 		);
-// 		const workflowId = WorkflowId.generate();
-// 		const jobSet = createJobMap(
-// 			new Set(connectedNodeMap.values()),
-// 			new Set(connectedConnectionMap.values()),
-// 			workflowId,
-// 		);
-// 		expect(jobSet.size).toBe(2);
-// 		const firstJob = jobSet.values().next().value;
-// 		expect(firstJob?.stepMap.size).toBe(1);
-// 		const firstJobFirstStep = firstJob?.stepMap.values().next().value;
-// 		expect(firstJobFirstStep?.nodeId).toBe(textGenerationNode5.id);
-// 	});
-// });
+// Setup helper variables
+const nodeSet = new Set<Node>(sampleNodes);
+const connectionSet = new Set<Connection>(sampleConnections);
+const nodeIdSet = new Set<NodeId>(sampleNodes.map((node) => node.id));
+const nodeMap = new Map<NodeId, Node>(
+	sampleNodes.map((node) => [node.id, node]),
+);
+const connectionMap = new Map<ConnectionId, Connection>(
+	sampleConnections.map((connection) => [connection.id, connection]),
+);
+const workflowId = "wf-N5RH1s46zdx3XjQj" as WorkflowId;
+
+describe("createConnectedNodeIdMap", () => {
+	test("should create a correct connection map for sample nodes", () => {
+		const result = createConnectedNodeIdMap(connectionSet, nodeIdSet);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(2); // Two nodes in our sample
+
+		// Check node1 connections
+		const node1Connections = result.get("nd-KzXeXSIffRIMwZtX");
+		expect(node1Connections).toBeInstanceOf(Set);
+		expect(node1Connections?.size).toBe(1);
+		expect(node1Connections?.has("nd-P2EllMigi6Tm6gij")).toBe(true);
+
+		// Check node2 connections
+		const node2Connections = result.get("nd-P2EllMigi6Tm6gij");
+		expect(node2Connections).toBeInstanceOf(Set);
+		expect(node2Connections?.size).toBe(1);
+		expect(node2Connections?.has("nd-KzXeXSIffRIMwZtX")).toBe(true);
+	});
+
+	test("should handle empty connections", () => {
+		const result = createConnectedNodeIdMap(new Set<Connection>(), nodeIdSet);
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(0);
+	});
+});
+
+describe("findConnectedNodeMap", () => {
+	const connectedNodeIdMap = createConnectedNodeIdMap(connectionSet, nodeIdSet);
+
+	test("should find all connected nodes starting from first node", () => {
+		const result = findConnectedNodeMap(
+			"nd-KzXeXSIffRIMwZtX",
+			nodeMap,
+			connectedNodeIdMap,
+		);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(2); // Both nodes are connected
+		expect(result.has("nd-KzXeXSIffRIMwZtX")).toBe(true);
+		expect(result.has("nd-P2EllMigi6Tm6gij")).toBe(true);
+	});
+
+	test("should find all connected nodes starting from second node", () => {
+		const result = findConnectedNodeMap(
+			"nd-P2EllMigi6Tm6gij",
+			nodeMap,
+			connectedNodeIdMap,
+		);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(2); // Both nodes are connected
+		expect(result.has("nd-KzXeXSIffRIMwZtX")).toBe(true);
+		expect(result.has("nd-P2EllMigi6Tm6gij")).toBe(true);
+	});
+
+	test("should handle non-existent starting node", () => {
+		const result = findConnectedNodeMap(
+			"non-existent-node-id" as NodeId,
+			nodeMap,
+			connectedNodeIdMap,
+		);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(0);
+	});
+});
+
+describe("findConnectedConnectionMap", () => {
+	test("should find connections between connected nodes", () => {
+		const connectedNodeIdMap = createConnectedNodeIdMap(
+			connectionSet,
+			nodeIdSet,
+		);
+		const connectedNodeMap = findConnectedNodeMap(
+			"nd-KzXeXSIffRIMwZtX",
+			nodeMap,
+			connectedNodeIdMap,
+		);
+
+		const result = findConnectedConnectionMap(
+			new Set(connectedNodeMap.keys()),
+			connectionSet,
+		);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(1); // One connection in our sample
+		expect(result.has("cnnc-7SZdtE1iSWtoghGD")).toBe(true);
+	});
+
+	test("should handle empty node set", () => {
+		const result = findConnectedConnectionMap(new Set<NodeId>(), connectionSet);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(0);
+	});
+});
+
+describe("createJobMap", () => {
+	test("should create jobs for the sample workflow", () => {
+		const result = createJobMap(nodeSet, connectionSet, workflowId);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(2); // Two jobs because of the dependency structure
+
+		// Convert to array to analyze in order
+		const jobsArray = Array.from(result.values());
+
+		// First job should contain the first node (which has no inputs)
+		expect(jobsArray[0].workflowId).toBe(workflowId);
+		expect(jobsArray[0].actions.length).toBe(1);
+		expect(jobsArray[0].actions[0].node.id).toBe("nd-KzXeXSIffRIMwZtX");
+
+		// Second job should contain the second node (which depends on the first)
+		expect(jobsArray[1].workflowId).toBe(workflowId);
+		expect(jobsArray[1].actions.length).toBe(1);
+		expect(jobsArray[1].actions[0].node.id).toBe("nd-P2EllMigi6Tm6gij");
+
+		// Check generation templates
+		expect(jobsArray[0].actions[0].generationTemplate.sourceNodes.length).toBe(
+			0,
+		);
+		expect(jobsArray[1].actions[0].generationTemplate.sourceNodes.length).toBe(
+			1,
+		);
+		expect(jobsArray[1].actions[0].generationTemplate.sourceNodes[0].id).toBe(
+			"nd-KzXeXSIffRIMwZtX",
+		);
+	});
+
+	test("should handle empty node set", () => {
+		const result = createJobMap(new Set<Node>(), connectionSet, workflowId);
+
+		expect(result).toBeInstanceOf(Map);
+		expect(result.size).toBe(0);
+	});
+});

--- a/packages/workflow-utils/turbo.json
+++ b/packages/workflow-utils/turbo.json
@@ -3,6 +3,7 @@
 	"tasks": {
 		"build": {
 			"outputs": ["**/dist/**"]
-		}
+		},
+		"test": {}
 	}
 }


### PR DESCRIPTION
## Summary
- Improve workflow inference by triggering workflow map refresh when creating nodes
- Add comprehensive tests for workflow building utilities

## Test plan
- Run unit tests with `cd packages/workflow-utils && vitest`
- Verify that workflows update immediately when adding nodes

🤖 Generated with [Claude Code](https://claude.ai/code)