### PR TITLE
feat: add providerOptions key for params on generateImage

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-image.ts
+++ b/packages/giselle-engine/src/core/generations/generate-image.ts
@@ -32,9 +32,14 @@ import {
 	setNodeGenerationIndex,
 } from "./utils";
 
+type ProviderOptions = Parameters<
+	typeof generateImageAiSdk
+>[0]["providerOptions"];
+
 export async function generateImage(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
+	providerOptions?: ProviderOptions;
 }) {
 	const actionNode = args.generation.context.actionNode;
 	if (!isImageGenerationNode(actionNode)) {
@@ -211,6 +216,7 @@ export async function generateImage(args: {
 		prompt,
 		size: actionNode.content.llm.configurations.size,
 		n: actionNode.content.llm.configurations.n,
+		providerOptions: args.providerOptions,
 	});
 
 	const generationOutputs: GenerationOutput[] = [];


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

**example code**

```ts
await generateImage({
	context,
	generation,
	providerOptions: {
		fal: {
            		num_images: 2 // for creation 2 images
          	}
        },
});
```

![image](https://github.com/user-attachments/assets/3b5fa1ce-2c62-41c1-8e1a-fce64108ebc8)

Just wondering — If `generateImage` is specifically tied to `fal`, then the providerOptions interface could be simplified like this:

```ts
await generateImage({
	context,
	generation,
	providerOptions: {
		num_images: 2 // NO fal section
        },
});
```

## Related Issue
<!-- Mention the related issue number if applicable. -->

closed https://github.com/giselles-ai/giselle/issues/486

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

`generateImage` function's argument to add `providerOptions` property at `packages/giselle-engine/src/core/index.ts:147`.

## Other Information
<!-- Add any other relevant information for the reviewer. -->

For example, The parameter information for fal-ai/flux/schnell can be found at [that link](https://fal.ai/models/fal-ai/flux/schnell/api#schema-input),
but verifying how the other options actually behave seems a bit challenging(num_images is easy to checking).

