### PR TITLE
Add override nodes support to run data

### DIFF
--- a/packages/data-mod/src/index.ts
+++ b/packages/data-mod/src/index.ts
@@ -1,8 +1,10 @@
 import type { ZodIssue } from "zod";
+import { addOverrideNodes } from "./mods/add-override-nodes";
 import { fixTypoAccesorToAccessor } from "./mods/fix-typo-accesor-to-accessor";
 
 export function dataMod(data: unknown, issue: ZodIssue) {
 	let modData = data;
 	modData = fixTypoAccesorToAccessor(modData, issue);
+	modData = addOverrideNodes(modData, issue);
 	return modData;
 }

--- a/packages/data-mod/src/mods/add-override-nodes.ts
+++ b/packages/data-mod/src/mods/add-override-nodes.ts
@@ -1,0 +1,15 @@
+import type { ZodIssue } from "zod";
+import { isObject, setValueAtPath } from "../utils";
+
+export function addOverrideNodes(data: unknown, issue: ZodIssue) {
+	const lastPath = issue.path[issue.path.length - 1];
+	if (lastPath !== "overrideNodes") {
+		return data;
+	}
+	if (!isObject(data)) {
+		return data;
+	}
+	const newData = { ...data };
+	setValueAtPath(newData, issue.path, []);
+	return newData;
+}

--- a/packages/data-type/src/run/index.ts
+++ b/packages/data-type/src/run/index.ts
@@ -1,5 +1,6 @@
 import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod";
+import { OverrideNode } from "../node";
 import { Workflow } from "../workflow";
 import { WorkspaceId } from "../workspace";
 
@@ -22,6 +23,7 @@ export const QueuedRun = RunBase.extend({
 	createdAt: z.number(),
 	workspaceId: WorkspaceId.schema,
 	workflow: Workflow,
+	overrideNodes: z.array(OverrideNode),
 	queuedAt: z.number(),
 });
 export type QueuedRun = z.infer<typeof QueuedRun>;
@@ -31,6 +33,7 @@ export const RunningRun = RunBase.extend({
 	createdAt: z.number(),
 	workspaceId: WorkspaceId.schema,
 	workflow: Workflow,
+	overrideNodes: z.array(OverrideNode),
 	queuedAt: z.number(),
 	startedAt: z.number(),
 });
@@ -41,6 +44,7 @@ export const CompletedRun = RunBase.extend({
 	createdAt: z.number(),
 	workspaceId: WorkspaceId.schema,
 	workflow: Workflow,
+	overrideNodes: z.array(OverrideNode),
 	queuedAt: z.number(),
 	startedAt: z.number(),
 	completedAt: z.number(),
@@ -52,6 +56,7 @@ export const CancelledRun = RunBase.extend({
 	createdAt: z.number(),
 	workspaceId: WorkspaceId.schema,
 	workflow: Workflow,
+	overrideNodes: z.array(OverrideNode),
 	queuedAt: z.number().optional(),
 	startedAt: z.number().optional(),
 	cancelledAt: z.number(),

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -83,8 +83,15 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 			workspaceId: WorkspaceId,
 			workflowId: WorkflowId,
 			run: CreatedRun,
+			overrideNodes?: OverrideNode[],
 		) => {
-			return await addRun({ context, workspaceId, workflowId, run });
+			return await addRun({
+				context,
+				workspaceId,
+				workflowId,
+				run,
+				overrideNodes: overrideNodes || [],
+			});
 		},
 		startRun: async (runId: RunId) => {
 			return await startRun({ context, runId });

--- a/packages/giselle-engine/src/core/runs/add-run.ts
+++ b/packages/giselle-engine/src/core/runs/add-run.ts
@@ -1,19 +1,192 @@
-import type {
-	CreatedRun,
-	QueuedRun,
-	RunId,
-	WorkflowId,
-	WorkspaceId,
+import {
+	type CreatedRun,
+	type FileNode,
+	type GenerationTemplate,
+	type GitHubNode,
+	type ImageGenerationNode,
+	type OverrideNode,
+	type QueuedRun,
+	type RunId,
+	type TextGenerationNode,
+	type TextNode,
+	type WorkflowId,
+	type WorkspaceId,
+	isOverrideFileContent,
+	isOverrideGitHubContent,
+	isOverrideImageGenerationContent,
+	isOverrideTextContent,
+	isOverrideTextGenerationContent,
 } from "@giselle-sdk/data-type";
 import type { Storage } from "unstorage";
 import type { GiselleEngineContext } from "../types";
 import { getWorkspace } from "../workspaces/utils";
 import { setRun } from "./utils";
 
+export function overrideGenerationTemplate(
+	template: GenerationTemplate,
+	overrideNodes: OverrideNode[],
+): GenerationTemplate {
+	let overridedTemplate = template;
+	for (const overrideNode of overrideNodes) {
+		if (overrideNode.id === template.actionNode.id) {
+			switch (template.actionNode.content.type) {
+				case "textGeneration": {
+					if (isOverrideTextGenerationContent(overrideNode.content)) {
+						overridedTemplate = {
+							...overridedTemplate,
+							actionNode: {
+								...overridedTemplate.actionNode,
+								content: {
+									...overridedTemplate.actionNode.content,
+									prompt: overrideNode.content.prompt,
+								},
+							},
+						};
+					}
+					break;
+				}
+				case "imageGeneration": {
+					if (isOverrideImageGenerationContent(overrideNode.content)) {
+						overridedTemplate = {
+							...overridedTemplate,
+							actionNode: {
+								...overridedTemplate.actionNode,
+								content: {
+									...overridedTemplate.actionNode.content,
+									prompt: overrideNode.content.prompt,
+								},
+							},
+						};
+					}
+					break;
+				}
+				default: {
+					const _exhaustiveCheck: never = template.actionNode.content;
+					throw new Error(`Unhandled action node type: ${_exhaustiveCheck}`);
+				}
+			}
+		}
+		for (const sourceNode of template.sourceNodes) {
+			if (overrideNode.id !== sourceNode.id) {
+				continue;
+			}
+			switch (sourceNode.content.type) {
+				case "textGeneration": {
+					overridedTemplate = {
+						...overridedTemplate,
+						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
+							if (
+								node.id === sourceNode.id &&
+								isOverrideTextGenerationContent(overrideNode.content)
+							) {
+								return {
+									...node,
+									content: {
+										...node.content,
+										prompt: overrideNode.content.prompt,
+									},
+								} as TextGenerationNode;
+							}
+							return node;
+						}),
+					};
+					break;
+				}
+				case "imageGeneration":
+					overridedTemplate = {
+						...overridedTemplate,
+						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
+							if (
+								node.id === sourceNode.id &&
+								isOverrideImageGenerationContent(overrideNode.content)
+							) {
+								return {
+									...node,
+									content: {
+										...node.content,
+										prompt: overrideNode.content.prompt,
+									},
+								} as ImageGenerationNode;
+							}
+							return node;
+						}),
+					};
+					break;
+				case "file":
+					overridedTemplate = {
+						...overridedTemplate,
+						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
+							if (
+								node.id === sourceNode.id &&
+								isOverrideFileContent(overrideNode.content)
+							) {
+								return {
+									...node,
+									content: {
+										...node.content,
+										files: overrideNode.content.files,
+									},
+								} as FileNode;
+							}
+							return node;
+						}),
+					};
+					break;
+				case "text":
+					overridedTemplate = {
+						...overridedTemplate,
+						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
+							if (
+								node.id === sourceNode.id &&
+								isOverrideTextContent(overrideNode.content)
+							) {
+								return {
+									...node,
+									content: {
+										...node.content,
+										text: overrideNode.content.text,
+									},
+								} as TextNode;
+							}
+							return node;
+						}),
+					};
+					break;
+				case "github":
+					overridedTemplate = {
+						...overridedTemplate,
+						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
+							if (
+								node.id === sourceNode.id &&
+								isOverrideGitHubContent(overrideNode.content)
+							) {
+								return {
+									...node,
+									content: {
+										...node.content,
+										objectReferences: overrideNode.content.objectReferences,
+									},
+								} as GitHubNode;
+							}
+							return node;
+						}),
+					};
+					break;
+				default: {
+					const _exhaustiveCheck: never = sourceNode.content;
+					throw new Error(`Unhandled source node type: ${_exhaustiveCheck}`);
+				}
+			}
+		}
+	}
+	return overridedTemplate;
+}
+
 export async function addRun(args: {
 	workspaceId: WorkspaceId;
 	workflowId: WorkflowId;
 	run: CreatedRun;
+	overrideNodes: OverrideNode[];
 	context: GiselleEngineContext;
 }) {
 	const workspace = await getWorkspace({
@@ -31,12 +204,27 @@ export async function addRun(args: {
 		throw new Error("Workflow not found");
 	}
 
+	const overrideWorkflow = {
+		...workflow,
+		jobs: workflow.jobs.map((job) => ({
+			...job,
+			actions: job.actions.map((action) => ({
+				...action,
+				generationTemplate: overrideGenerationTemplate(
+					action.generationTemplate,
+					args.overrideNodes ?? [],
+				),
+			})),
+		})),
+	};
+
 	/** @todo upload openai file to vector store */
 	const queuedRun = {
 		...args.run,
 		status: "queued",
 		workspaceId: args.workspaceId,
-		workflow,
+		workflow: overrideWorkflow,
+		overrideNodes: args.overrideNodes,
 		queuedAt: Date.now(),
 	} satisfies QueuedRun;
 	await Promise.all([

--- a/packages/giselle-engine/src/core/runs/run-api.ts
+++ b/packages/giselle-engine/src/core/runs/run-api.ts
@@ -1,188 +1,17 @@
 import {
 	type CreatedRun,
-	type FileNode,
 	GenerationId,
-	type GenerationTemplate,
-	type GitHubNode,
-	type ImageGenerationNode,
 	type JobId,
 	type OverrideNode,
 	type QueuedGeneration,
 	RunId,
-	type TextGenerationNode,
-	type TextNode,
 	type WorkflowId,
 	type WorkspaceId,
-	isOverrideFileContent,
-	isOverrideGitHubContent,
-	isOverrideImageGenerationContent,
-	isOverrideTextContent,
-	isOverrideTextGenerationContent,
 } from "@giselle-sdk/data-type";
 import { generateText } from "../generations";
 import type { GiselleEngineContext } from "../types";
 import { addRun } from "./add-run";
 import { startRun } from "./start-run";
-
-function overrideGenerationTemplate(
-	template: GenerationTemplate,
-	overrideNodes: OverrideNode[],
-) {
-	let overridedTemplate = template;
-	for (const overrideNode of overrideNodes) {
-		if (overrideNode.id === template.actionNode.id) {
-			switch (template.actionNode.content.type) {
-				case "textGeneration": {
-					if (isOverrideTextGenerationContent(overrideNode.content)) {
-						overridedTemplate = {
-							...overridedTemplate,
-							actionNode: {
-								...overridedTemplate.actionNode,
-								content: {
-									...overridedTemplate.actionNode.content,
-									prompt: overrideNode.content.prompt,
-								},
-							},
-						};
-					}
-					break;
-				}
-				case "imageGeneration": {
-					if (isOverrideImageGenerationContent(overrideNode.content)) {
-						overridedTemplate = {
-							...overridedTemplate,
-							actionNode: {
-								...overridedTemplate.actionNode,
-								content: {
-									...overridedTemplate.actionNode.content,
-									prompt: overrideNode.content.prompt,
-								},
-							},
-						};
-					}
-					break;
-				}
-				default: {
-					const _exhaustiveCheck: never = template.actionNode.content;
-					throw new Error(`Unhandled action node type: ${_exhaustiveCheck}`);
-				}
-			}
-		}
-		for (const sourceNode of template.sourceNodes) {
-			if (overrideNode.id !== sourceNode.id) {
-				continue;
-			}
-			switch (sourceNode.content.type) {
-				case "textGeneration": {
-					overridedTemplate = {
-						...overridedTemplate,
-						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
-							if (
-								node.id === sourceNode.id &&
-								isOverrideTextGenerationContent(overrideNode.content)
-							) {
-								return {
-									...node,
-									content: {
-										...node.content,
-										prompt: overrideNode.content.prompt,
-									},
-								} as TextGenerationNode;
-							}
-							return node;
-						}),
-					};
-					break;
-				}
-				case "imageGeneration":
-					overridedTemplate = {
-						...overridedTemplate,
-						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
-							if (
-								node.id === sourceNode.id &&
-								isOverrideImageGenerationContent(overrideNode.content)
-							) {
-								return {
-									...node,
-									content: {
-										...node.content,
-										prompt: overrideNode.content.prompt,
-									},
-								} as ImageGenerationNode;
-							}
-							return node;
-						}),
-					};
-					break;
-				case "file":
-					overridedTemplate = {
-						...overridedTemplate,
-						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
-							if (
-								node.id === sourceNode.id &&
-								isOverrideFileContent(overrideNode.content)
-							) {
-								return {
-									...node,
-									content: {
-										...node.content,
-										files: overrideNode.content.files,
-									},
-								} as FileNode;
-							}
-							return node;
-						}),
-					};
-					break;
-				case "text":
-					overridedTemplate = {
-						...overridedTemplate,
-						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
-							if (
-								node.id === sourceNode.id &&
-								isOverrideTextContent(overrideNode.content)
-							) {
-								return {
-									...node,
-									content: {
-										...node.content,
-										text: overrideNode.content.text,
-									},
-								} as TextNode;
-							}
-							return node;
-						}),
-					};
-					break;
-				case "github":
-					overridedTemplate = {
-						...overridedTemplate,
-						sourceNodes: overridedTemplate.sourceNodes.map((node) => {
-							if (
-								node.id === sourceNode.id &&
-								isOverrideGitHubContent(overrideNode.content)
-							) {
-								return {
-									...node,
-									content: {
-										...node.content,
-										objectReferences: overrideNode.content.objectReferences,
-									},
-								} as GitHubNode;
-							}
-							return node;
-						}),
-					};
-					break;
-				default: {
-					const _exhaustiveCheck: never = sourceNode.content;
-					throw new Error(`Unhandled source node type: ${_exhaustiveCheck}`);
-				}
-			}
-		}
-	}
-	return overridedTemplate;
-}
 
 export async function runApi(args: {
 	workspaceId: WorkspaceId;
@@ -196,7 +25,11 @@ export async function runApi(args: {
 		status: "created",
 		createdAt: Date.now(),
 	} satisfies CreatedRun;
-	const run = await addRun({ ...args, run: createdRun });
+	const run = await addRun({
+		...args,
+		run: createdRun,
+		overrideNodes: args.overrideNodes ?? [],
+	});
 	await startRun({
 		runId,
 		context: args.context,
@@ -209,10 +42,7 @@ export async function runApi(args: {
 				const generation = {
 					id: generationId,
 					context: {
-						...overrideGenerationTemplate(
-							action.generationTemplate,
-							args.overrideNodes ?? [],
-						),
+						...action.generationTemplate,
 						origin: { type: "run", id: runId },
 					},
 					status: "queued",

--- a/packages/giselle-engine/src/core/runs/utils.ts
+++ b/packages/giselle-engine/src/core/runs/utils.ts
@@ -1,3 +1,4 @@
+import { dataMod } from "@giselle-sdk/data-mod";
 import { Run, type RunId } from "@giselle-sdk/data-type";
 import type { Storage } from "unstorage";
 
@@ -21,6 +22,22 @@ export async function setRun({
 	}
 }
 
+function parseAndMod(runLike: unknown, mod = false) {
+	const parseResult = Run.safeParse(runLike);
+	if (parseResult.success) {
+		return parseResult.data;
+	}
+	if (mod) {
+		throw parseResult.error;
+	}
+
+	let modData = runLike;
+	for (const issue of parseResult.error.issues) {
+		modData = dataMod(modData, issue);
+	}
+	return parseAndMod(modData, true);
+}
+
 export async function getRun({
 	storage,
 	runId,
@@ -32,5 +49,5 @@ export async function getRun({
 	if (run == null) {
 		return undefined;
 	}
-	return Run.parse(run);
+	return parseAndMod(run);
 }


### PR DESCRIPTION
## Summary
- Adds overrideNodes array to run data schemas to store node content overrides
- Implements data modification utility to handle missing overrideNodes
- Moves override functionality from run-api to add-run for better separation of concerns
- Updates workflow data structure to apply overrides during run creation

This modification is part of implementing the "run with override parameters" feature. It provides the underlying data structures and logic needed to support a run button with override parameters in the UI.

## Test plan
- Verify runs created with overrideNodes properly store the overrides
- Ensure backward compatibility with existing runs by testing with and without overrideNodes
- Confirm node content overrides are properly applied to generation templates

🤖 Generated with [Claude Code](https://claude.ai/code)