### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting assignment

### DIFF
--- a/packages/data-mod/src/utils.ts
+++ b/packages/data-mod/src/utils.ts
@@ -23,12 +23,18 @@ export function setValueAtPath(
 
 	let parent = obj;
 	for (const key of parentPath) {
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+			return;
+		}
 		if (parent[key] === undefined) {
 			parent[key] = typeof key === "number" ? [] : {};
 		}
 		parent = parent[key];
 	}
 
+	if (lastKey === '__proto__' || lastKey === 'constructor' || lastKey === 'prototype') {
+		return;
+	}
 	parent[lastKey] = value;
 }
 

--- a/packages/data-mod/src/utils.ts
+++ b/packages/data-mod/src/utils.ts
@@ -23,7 +23,7 @@ export function setValueAtPath(
 
 	let parent = obj;
 	for (const key of parentPath) {
-		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+		if (key === "__proto__" || key === "constructor" || key === "prototype") {
 			return;
 		}
 		if (parent[key] === undefined) {
@@ -32,7 +32,11 @@ export function setValueAtPath(
 		parent = parent[key];
 	}
 
-	if (lastKey === '__proto__' || lastKey === 'constructor' || lastKey === 'prototype') {
+	if (
+		lastKey === "__proto__" ||
+		lastKey === "constructor" ||
+		lastKey === "prototype"
+	) {
 		return;
 	}
 	parent[lastKey] = value;


### PR DESCRIPTION
Potential fix for [https://github.com/giselles-ai/giselle/security/code-scanning/4](https://github.com/giselles-ai/giselle/security/code-scanning/4)

To fix the prototype pollution issue, we need to ensure that the property names used in the `setValueAtPath` function do not include dangerous property names like `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a check to filter out these property names before assigning values to the object.

The best way to fix the problem without changing existing functionality is to add a validation step in the `setValueAtPath` function to reject dangerous property names. This can be done by adding a condition to check if the property name is one of the dangerous names and, if so, returning early without making any changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
