### PR TITLE
Increase function duration to 800 seconds

### DIFF
--- a/apps/studio.giselles.ai/app/api/giselle/[...next-giselle]/route.ts
+++ b/apps/studio.giselles.ai/app/api/giselle/[...next-giselle]/route.ts
@@ -1,3 +1,7 @@
 import { giselleEngine } from "@/app/giselle-engine";
 
+// The maximum duration of server actions on this page is extended to 800 seconds through enabled fluid compute.
+// https://vercel.com/docs/functions/runtimes#max-duration
+export const maxDuration = 800;
+
 export const { GET, POST } = giselleEngine.handlers;

--- a/packages/generation-runner/src/react/contexts/generation-runner-system.tsx
+++ b/packages/generation-runner/src/react/contexts/generation-runner-system.tsx
@@ -130,7 +130,7 @@ export function GenerationRunnerSystemProvider({
 		) => {
 			let status = generationListener.current[generationId].status;
 			const messages = generationListener.current[generationId].messages;
-			const timeoutDuration = options?.timeout || 1000 * 60 * 5;
+			const timeoutDuration = options?.timeout || 1000 * 800; // The maximum duration of through enabled fluid compute. https://vercel.com/docs/functions/runtimes#max-duration
 			const startTime = Date.now();
 
 			while (true) {


### PR DESCRIPTION
## Summary
- Extend maxDuration to 800 seconds for Vercel serverless functions to support longer-running operations
- Update timeout in generation-runner from 300 to 800 seconds to match the new limit

## Test plan
- Verify that long-running API operations complete successfully without timeout errors
- Test generation workflow with complex operations requiring extended processing time

🤖 Generated with [Claude Code](https://claude.ai/code)