### PR TITLE
Improve generation timeout handling

### DIFF
--- a/packages/generation-runner/src/react/contexts/generation-runner-system.tsx
+++ b/packages/generation-runner/src/react/contexts/generation-runner-system.tsx
@@ -95,9 +95,7 @@ export function GenerationRunnerSystemProvider({
 }: GenerationRunnerSystemProviderProps) {
 	const client = useGiselleEngine();
 	const [generations, setGenerations] = useState<Generation[]>([]);
-	const [stopHandlers, setStopHandlers] = useState<
-		Record<GenerationId, () => void>
-	>({});
+	const stopHandlersRef = useRef<Record<GenerationId, () => void>>({});
 	const generationListener = useRef<Record<GenerationId, Generation>>({});
 
 	const nodeGenerationMap = useMemo(() => {
@@ -312,14 +310,14 @@ export function GenerationRunnerSystemProvider({
 
 	const addStopHandler = useCallback(
 		(generationId: GenerationId, handler: () => void) => {
-			setStopHandlers((prev) => ({ ...prev, [generationId]: handler }));
+			stopHandlersRef.current[generationId] = handler;
 		},
 		[],
 	);
 
 	const stopGeneration = useCallback(
 		async (generationId: GenerationId) => {
-			const handler = stopHandlers[generationId];
+			const handler = stopHandlersRef.current[generationId];
 			if (handler) {
 				handler();
 				setGenerations((prevGenerations) =>
@@ -346,7 +344,7 @@ export function GenerationRunnerSystemProvider({
 				cancelledAt: Date.now(),
 			} as CancelledGeneration;
 		},
-		[stopHandlers, client],
+		[client],
 	);
 
 	return (


### PR DESCRIPTION
## Summary
- Refactor stopHandlers from useState to useRef for better performance
- Implement proper generation timeout handling with graceful failure
- Update timeout handling to maintain UI state instead of throwing errors

## Test plan
- Start a generation and verify it completes successfully
- Start a generation and manually cancel it to verify cancel functionality 
- Start a generation with a short timeout to verify timeout handling displays the correct error state

### Preview

> [!NOTE]
> This video used local app modified timeout to 8s for testing

https://github.com/user-attachments/assets/2b84cf9f-b955-47d7-8068-27efadf87cd9

https://github.com/user-attachments/assets/0714300e-3772-4233-a846-8920295e81b3


🤖 Generated with [Claude Code](https://claude.ai/code)