### PR TITLE
Fix node layout scrolling issue

### DIFF
--- a/internal-packages/workflow-designer-ui/src/viewer/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/index.tsx
@@ -60,7 +60,7 @@ export function Viewer() {
 					}}
 				>
 					<Tabs.Root orientation="horizontal" className="flex h-full">
-						<Tabs.List className="w-[180px] flex flex-col gap-[16px]">
+						<Tabs.List className="w-[180px] flex flex-col gap-[16px] overflow-y-auto">
 							<div className="flex flex-col gap-[8px]">
 								{data.editingWorkflows.length > 1 && (
 									<Select


### PR DESCRIPTION
## Summary
- Fixed layout issue where connected nodes appeared outside the viewport and users couldn't scroll to see them

## Test plan
- Verify that all nodes in workflows are visible and can be scrolled to
- Check that UI layout remains consistent across different viewport sizes

🤖 Generated with [Claude Code](https://claude.ai/code)