### PR TITLE
(Fix) Module not found: Can't resolve '@giselles-ai/icons/willi'

### DIFF
--- a/apps/studio.giselles.ai/tsconfig.json
+++ b/apps/studio.giselles.ai/tsconfig.json
@@ -22,7 +22,7 @@
 			"@/*": ["./*"],
 			"@giselles-ai/*": ["./packages/*"],
 			"@giselles-ai/icons/*": [
-				"./app/(playground)/p/[agentId]/prev/beta-proto/components/icons/*"
+				"../../internal-packages/workflow-designer-ui/src/icons/*"
 			]
 		},
 		"target": "ES2017"


### PR DESCRIPTION
### Ref:
❌ Deployment error on main branch: [studio.giselles.ai:build: Module not found: Can't resolve '@giselles-ai/icons/willi'](https://vercel.com/r06-edge/giselle/EB7s5g313hJ8faC1FJa1vENKz4h4?filter=errors)

