### PR TITLE
fix: replace node to text on buildGenerationMessageForTextGeneration

### DIFF
--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -107,10 +107,11 @@ async function buildGenerationMessageForTextGeneration(
 		const replaceKeyword = `{{${sourceKeyword.nodeId}:${sourceKeyword.outputId}}}`;
 		switch (contextNode.content.type) {
 			case "text": {
-				userMessage = userMessage.replace(
-					replaceKeyword,
-					jsonContentToText(JSON.parse(contextNode.content.text)),
-				);
+				const jsonOrText = contextNode.content.text;
+				const text = isJsonContent(jsonOrText)
+					? jsonContentToText(JSON.parse(jsonOrText))
+					: jsonOrText;
+				userMessage = userMessage.replace(replaceKeyword, text);
 				break;
 			}
 			case "textGeneration": {

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -109,7 +109,7 @@ async function buildGenerationMessageForTextGeneration(
 			case "text": {
 				userMessage = userMessage.replace(
 					replaceKeyword,
-					contextNode.content.text,
+					jsonContentToText(JSON.parse(contextNode.content.text)),
 				);
 				break;
 			}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

### before
`sources` are treated as JSON node.

<img width="679" alt="image" src="https://github.com/user-attachments/assets/83928b6b-1025-45bf-aafd-8040046bdefc" />

### after
`sources` are treated as Text related JSON node.

<img width="701" alt="image" src="https://github.com/user-attachments/assets/15d76872-6b96-47f8-9149-4f63e64b9b40" />

## Testing
<!-- Briefly describe the testing steps or results. -->

For example, Input "Hello, world" in text-node and "What does  `@text/Output` mean to a programmer?" Input related text-generate-node. and generate.

