### PR TITLE
Fix URL resolution for non-Google search sources

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -266,12 +266,25 @@ export async function generateText(args: {
 			if (sourceOutput !== undefined && event.sources.length > 0) {
 				const sources = await Promise.all(
 					event.sources.map(async (source) => {
-						const redirected = await getRedirectedUrlAndTitle(source.url);
+						// When using Gemini search grounding, source provides a proxy URL
+						// We need to access and resolve this proxy URL to get the actual redirect URL
+						if (
+							source.url.startsWith("https://vertexaisearch.cloud.google.com")
+						) {
+							const redirected = await getRedirectedUrlAndTitle(source.url);
+							return {
+								sourceType: "url",
+								id: source.id,
+								url: redirected.redirectedUrl,
+								title: redirected.title,
+								providerMetadata: source.providerMetadata,
+							} satisfies UrlSource;
+						}
 						return {
 							sourceType: "url",
 							id: source.id,
-							url: redirected.redirectedUrl,
-							title: redirected.title,
+							url: source.url,
+							title: source.title ?? source.url,
 							providerMetadata: source.providerMetadata,
 						} satisfies UrlSource;
 					}),

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -1,4 +1,5 @@
 import { anthropic } from "@ai-sdk/anthropic";
+import { URL } from "url";
 import { google } from "@ai-sdk/google";
 import { openai } from "@ai-sdk/openai";
 import { perplexity } from "@ai-sdk/perplexity";
@@ -269,7 +270,7 @@ export async function generateText(args: {
 						// When using Gemini search grounding, source provides a proxy URL
 						// We need to access and resolve this proxy URL to get the actual redirect URL
 						if (
-							source.url.startsWith("https://vertexaisearch.cloud.google.com")
+							isAllowedHost(source.url, ["vertexaisearch.cloud.google.com"])
 						) {
 							const redirected = await getRedirectedUrlAndTitle(source.url);
 							return {
@@ -367,5 +368,14 @@ function generationModel(languageModel: TextGenerationLanguageModelData) {
 			const _exhaustiveCheck: never = llmProvider;
 			throw new Error(`Unknown LLM provider: ${_exhaustiveCheck}`);
 		}
+	}
+}
+
+function isAllowedHost(urlString: string, allowedHosts: string[]): boolean {
+	try {
+		const parsedUrl = new URL(urlString);
+		return allowedHosts.includes(parsedUrl.host);
+	} catch (e) {
+		return false;
 	}
 }

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -269,9 +269,7 @@ export async function generateText(args: {
 					event.sources.map(async (source) => {
 						// When using Gemini search grounding, source provides a proxy URL
 						// We need to access and resolve this proxy URL to get the actual redirect URL
-						if (
-							isAllowedHost(source.url, ["vertexaisearch.cloud.google.com"])
-						) {
+						if (isVertexAiHost(source.url)) {
 							const redirected = await getRedirectedUrlAndTitle(source.url);
 							return {
 								sourceType: "url",
@@ -371,10 +369,10 @@ function generationModel(languageModel: TextGenerationLanguageModelData) {
 	}
 }
 
-function isAllowedHost(urlString: string, allowedHosts: string[]): boolean {
+function isVertexAiHost(urlString: string): boolean {
 	try {
 		const parsedUrl = new URL(urlString);
-		return allowedHosts.includes(parsedUrl.host);
+		return ["vertexaisearch.cloud.google.com"].includes(parsedUrl.host);
 	} catch (e) {
 		return false;
 	}

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -1,5 +1,5 @@
+import { URL } from "node:url";
 import { anthropic } from "@ai-sdk/anthropic";
-import { URL } from "url";
 import { google } from "@ai-sdk/google";
 import { openai } from "@ai-sdk/openai";
 import { perplexity } from "@ai-sdk/perplexity";


### PR DESCRIPTION
## Summary
- Only apply URL redirection for Gemini search grounding proxy URLs
- Preserve original URLs and titles for other source providers

## Test plan
- Test with Google sources to ensure proxy URLs are correctly resolved
- Test with non-Google sources to ensure URLs remain unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)