### PR TITLE
Reduce file upload limit to 4.5MB due to Vercel constraints

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -19,7 +19,12 @@ export type FileTypeConfig = {
 	maxSize?: number;
 };
 
-const defaultMaxSize = 1024 * 1024 * 20;
+/**
+ * Hard limit to upload file since Vercel Serverless Functions have a 4.5MB body size limit
+ * @see https://vercel.com/guides/how-to-bypass-vercel-body-size-limit-serverless-functions#measure-response-body-size
+ * @todo implement streaming or alternative solution to support larger files (up to 20MB)
+ */
+const defaultMaxSize = 1024 * 1024 * 4.5;
 
 type FilePanelProps = {
 	node: FileNode;


### PR DESCRIPTION
## Summary
- Reduce file upload size limit from 20MB to 4.5MB to comply with Vercel Serverless Functions body size limit
- Add comments explaining the limitation and future improvement plans

## Test plan
- Verify file uploads under 4.5MB work correctly
- Verify uploads exceeding 4.5MB are properly rejected with a clear error message

🤖 Generated with [Claude Code](https://claude.ai/code)