### PR TITLE
Add integration view to workflow designer

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/page.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Editor, Header, Viewer } from "@giselle-internal/workflow-designer-ui";
+import {
+	Editor,
+	Header,
+	SettingsView,
+	Viewer,
+} from "@giselle-internal/workflow-designer-ui";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 
 export default function Page() {
@@ -9,7 +14,10 @@ export default function Page() {
 	return (
 		<div className="flex flex-col h-screen bg-black-900">
 			<Header />
-			{view === "editor" ? <Editor /> : <Viewer />}
+
+			{view === "editor" && <Editor />}
+			{view === "viewer" && <Viewer />}
+			{view === "integrator" && <SettingsView />}
 		</div>
 	);
 }

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/page.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Editor, Header, Viewer } from "@giselle-internal/workflow-designer-ui";
+import {
+	Editor,
+	Header,
+	SettingsView,
+	Viewer,
+} from "@giselle-internal/workflow-designer-ui";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { updateAgentName } from "./actions";
 
@@ -10,7 +15,9 @@ export default function Page() {
 	return (
 		<div className="flex flex-col h-screen bg-black-900">
 			<Header onWorkflowNameChange={updateAgentName} />
-			{view === "editor" ? <Editor /> : <Viewer />}
+			{view === "editor" && <Editor />}
+			{view === "viewer" && <Viewer />}
+			{view === "integrator" && <SettingsView />}
 		</div>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/header/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/component.tsx
@@ -2,15 +2,10 @@
 
 import type { WorkspaceId } from "@giselle-sdk/data-type";
 import clsx from "clsx";
-import { useWorkflowDesigner } from "giselle-sdk/react";
-import {
-	ChevronDownIcon,
-	EyeIcon,
-	GanttChartIcon,
-	PlayIcon,
-} from "lucide-react";
+import { ViewState, useWorkflowDesigner } from "giselle-sdk/react";
+import { CableIcon, EyeIcon, GanttChartIcon, PlayIcon } from "lucide-react";
 import Link from "next/link";
-import { Dialog, DropdownMenu, VisuallyHidden } from "radix-ui";
+import { Dialog, ToggleGroup, VisuallyHidden } from "radix-ui";
 import { type ReactNode, useState } from "react";
 import { EditableText } from "../editor/properties-panel/ui";
 import { GiselleLogo } from "../icons";
@@ -56,6 +51,8 @@ export function Header({
 						value={data.name}
 					/>
 
+					{/*
+					Setting menu is moved to main view
 					<DropdownMenu.Root>
 						<DropdownMenu.Trigger asChild>
 							<button
@@ -102,15 +99,20 @@ export function Header({
 								</div>
 							</DropdownMenu.Content>
 						</DropdownMenu.Portal>
-					</DropdownMenu.Root>
+					</DropdownMenu.Root> */}
 				</div>
 			</div>
 
 			<div className="flex items-center gap-[12px]">
-				<div className="flex items-center py-[4px] px-[8px] rounded-[8px] overflow-hidden bg-black-200/20">
-					<button
-						type="button"
-						onClick={toggleView}
+				<ToggleGroup.Root
+					type="single"
+					className="flex items-center py-[4px] px-[8px] rounded-[8px] overflow-hidden bg-black-200/20"
+					onValueChange={(value) => {
+						setView(ViewState.parse(value));
+					}}
+				>
+					<ToggleGroup.Item
+						value="editor"
 						className={clsx(
 							"flex items-center gap-[4px] px-[8px] py-[4px] text-[12px] rounded-[4px] border-[1px] transition-colors font-[700]",
 							view === "editor"
@@ -120,9 +122,9 @@ export function Header({
 					>
 						<GanttChartIcon className="size-[16px]" />
 						<span>Builder</span>
-					</button>
-					<button
-						type="button"
+					</ToggleGroup.Item>
+					<ToggleGroup.Item
+						value="viewer"
 						onClick={toggleView}
 						className={clsx(
 							"flex items-center gap-[4px] px-[8px] py-[4px] text-[12px] rounded-[4px] border-[1px] transition-colors font-[700]",
@@ -133,8 +135,21 @@ export function Header({
 					>
 						<EyeIcon className="size-[16px]" />
 						<span>Preview</span>
-					</button>
-				</div>
+					</ToggleGroup.Item>
+					<ToggleGroup.Item
+						value="integrator"
+						onClick={toggleView}
+						className={clsx(
+							"flex items-center gap-[4px] px-[8px] py-[4px] text-[12px] rounded-[4px] border-[1px] transition-colors font-[700]",
+							view === "integrator"
+								? "bg-primary-950/20 text-primary-200 border-primary-900"
+								: "bg-transparent text-white-900/70 hover:text-white-900 hover:bg-black-800/20 border-transparent cursor-pointer",
+						)}
+					>
+						<CableIcon className="size-[16px]" />
+						<span>Integrate</span>
+					</ToggleGroup.Item>
+				</ToggleGroup.Root>
 
 				{action && <div className="flex items-center">{action}</div>}
 			</div>

--- a/internal-packages/workflow-designer-ui/src/header/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/component.tsx
@@ -3,7 +3,6 @@
 import type { WorkspaceId } from "@giselle-sdk/data-type";
 import clsx from "clsx";
 import { useWorkflowDesigner } from "giselle-sdk/react";
-import { ViewState } from "giselle-sdk/react";
 import {
 	ChevronDownIcon,
 	EyeIcon,

--- a/internal-packages/workflow-designer-ui/src/index.ts
+++ b/internal-packages/workflow-designer-ui/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./editor";
 export * from "./viewer";
 export * from "./header";
+export * from "./settings";

--- a/internal-packages/workflow-designer-ui/src/settings/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/component.tsx
@@ -1,7 +1,8 @@
 import clsx from "clsx/lite";
 import { Tabs } from "radix-ui";
 import type { ReactNode } from "react";
-import { GitHubIcon, LayersIcon } from "../icons";
+import { GitHubIcon } from "../icons";
+import { Background } from "../ui/background";
 import { GitHubIntegrationSettingForm } from "./github-integration";
 
 type TabTriggerProps = Omit<
@@ -54,6 +55,37 @@ export function SettingsPanel() {
 					<GitHubIntegrationSettingForm />
 				</Tabs.Content>
 			</Tabs.Root>
+		</div>
+	);
+}
+
+export function SettingsView() {
+	return (
+		<div className="bg-black-850 flex flex-col gap-[16px] text-white-800 flex-1 relative">
+			<div className="relative z-1 pt-[24px] px-[24px]">
+				<Tabs.Root
+					orientation="horizontal"
+					className="flex gap-[24px]"
+					defaultValue="github"
+				>
+					<Tabs.List
+						className={clsx("flex flex-col gap-[10px] px-[8px] w-[240px]")}
+					>
+						<Tabs.Trigger value="github" asChild>
+							<TabTrigger
+								label="GitHub Integration"
+								icon={<GitHubIcon className="size-[16px]" />}
+							/>
+						</Tabs.Trigger>
+					</Tabs.List>
+					<Tabs.Content value="github" className="flex-1">
+						<GitHubIntegrationSettingForm />
+					</Tabs.Content>
+				</Tabs.Root>
+			</div>
+			<div className="absolute h-full w-full z-0">
+				<Background />
+			</div>
 		</div>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { WorkspaceGitHubNextIntegrationAction } from "@giselle-sdk/data-type";
 import {
 	WorkspaceGitHubIntegrationNextAction,

--- a/internal-packages/workflow-designer-ui/src/ui/background.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/background.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 
 const gridWidth = "0.3px";

--- a/packages/giselle-sdk/package.json
+++ b/packages/giselle-sdk/package.json
@@ -38,6 +38,7 @@
 	"dependencies": {
 		"@giselle-sdk/giselle-engine": "workspace:^",
 		"@giselle-sdk/language-model": "workspace:^",
+		"@giselle-sdk/workflow-designer": "workspace:^",
 		"@giselle-sdk/workspace": "workspace:^"
 	}
 }

--- a/packages/giselle-sdk/src/react/index.ts
+++ b/packages/giselle-sdk/src/react/index.ts
@@ -1,2 +1,3 @@
 export * from "@giselle-sdk/workspace/react";
 export * from "@giselle-sdk/giselle-engine/react";
+export { ViewState } from "@giselle-sdk/workflow-designer/react";

--- a/packages/workflow-designer/src/react/state/use-view.ts
+++ b/packages/workflow-designer/src/react/state/use-view.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { z } from "zod";
 
-export const ViewState = z.enum(["editor", "viewer"]);
+export const ViewState = z.enum(["editor", "viewer", "integrator"]);
 export type ViewState = z.infer<typeof ViewState>;
 export function useView() {
 	const [view, setView] = useState<ViewState>("editor");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,9 @@ importers:
       '@giselle-sdk/language-model':
         specifier: workspace:^
         version: link:../language-model
+      '@giselle-sdk/workflow-designer':
+        specifier: workspace:^
+        version: link:../workflow-designer
       '@giselle-sdk/workspace':
         specifier: workspace:^
         version: link:../workspace


### PR DESCRIPTION
## Summary
- Add integrator view state and tab to the workflow designer
- Enhance header with toggleable views for Editor, Viewer, and Integrator
- Add settings view for GitHub integration configuration

## Test plan
- Verify the Integrate tab appears in the workflow designer header
- Check that clicking between tabs properly changes the view state
- Confirm GitHub integration settings display correctly in the new view

🤖 Generated with [Claude Code](https://claude.ai/code)