### PR TITLE
Extend GitHub Webhook Event Handling: `pull_request.opened`, `pull_request.ready_for_review`, `pull_request.closed`

### DIFF
--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -36,6 +36,7 @@ const TRIGGER_TO_ACTIONS: Record<
 	"github.issue_comment.created": ["github.issue_comment.create"],
 	"github.pull_request_comment.created": ["github.pull_request_comment.create"],
 	"github.issues.closed": ["github.issue_comment.create"],
+	"github.pull_request.opened": ["github.pull_request_comment.create"],
 } as const;
 
 const TRIGGERS_REQUIRING_CALLSIGN: readonly WorkspaceGitHubIntegrationTrigger[] =
@@ -224,6 +225,15 @@ function Installed({
 										}
 									>
 										issue_comment.created
+									</SelectItem>
+									<SelectItem
+										value={
+											WorkspaceGitHubIntegrationTrigger.Enum[
+												"github.pull_request.opened"
+											]
+										}
+									>
+										pull_request.opened
 									</SelectItem>
 									<SelectItem
 										value={

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -37,6 +37,9 @@ const TRIGGER_TO_ACTIONS: Record<
 	"github.pull_request_comment.created": ["github.pull_request_comment.create"],
 	"github.issues.closed": ["github.issue_comment.create"],
 	"github.pull_request.opened": ["github.pull_request_comment.create"],
+	"github.pull_request.ready_for_review": [
+		"github.pull_request_comment.create",
+	],
 } as const;
 
 const TRIGGERS_REQUIRING_CALLSIGN: readonly WorkspaceGitHubIntegrationTrigger[] =
@@ -243,6 +246,15 @@ function Installed({
 										}
 									>
 										pull_request_comment.created
+									</SelectItem>
+									<SelectItem
+										value={
+											WorkspaceGitHubIntegrationTrigger.Enum[
+												"github.pull_request.ready_for_review"
+											]
+										}
+									>
+										pull_request.ready_for_review
 									</SelectItem>
 								</SelectContent>
 							</Select>

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -242,15 +242,6 @@ function Installed({
 									<SelectItem
 										value={
 											WorkspaceGitHubIntegrationTrigger.Enum[
-												"github.pull_request_comment.created"
-											]
-										}
-									>
-										pull_request_comment.created
-									</SelectItem>
-									<SelectItem
-										value={
-											WorkspaceGitHubIntegrationTrigger.Enum[
 												"github.pull_request.ready_for_review"
 											]
 										}
@@ -265,6 +256,15 @@ function Installed({
 										}
 									>
 										pull_request.closed
+									</SelectItem>
+									<SelectItem
+										value={
+											WorkspaceGitHubIntegrationTrigger.Enum[
+												"github.pull_request_comment.created"
+											]
+										}
+									>
+										pull_request_comment.created
 									</SelectItem>
 								</SelectContent>
 							</Select>

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -40,6 +40,7 @@ const TRIGGER_TO_ACTIONS: Record<
 	"github.pull_request.ready_for_review": [
 		"github.pull_request_comment.create",
 	],
+	"github.pull_request.closed": ["github.pull_request_comment.create"],
 } as const;
 
 const TRIGGERS_REQUIRING_CALLSIGN: readonly WorkspaceGitHubIntegrationTrigger[] =
@@ -255,6 +256,15 @@ function Installed({
 										}
 									>
 										pull_request.ready_for_review
+									</SelectItem>
+									<SelectItem
+										value={
+											WorkspaceGitHubIntegrationTrigger.Enum[
+												"github.pull_request.closed"
+											]
+										}
+									>
+										pull_request.closed
 									</SelectItem>
 								</SelectContent>
 							</Select>

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -61,7 +61,7 @@ const getAvailablePayloadFields = (
 ) => {
 	const fields = Object.values(WorkspaceGitHubIntegrationPayloadField.Enum);
 	const triggerParts = trigger.split(".");
-	const triggerPrefix = `${triggerParts[0]}.${triggerParts[1]}`;
+	const triggerPrefix = `${triggerParts[0]}.${triggerParts[1]}.`;
 	return fields.filter((field) => field.startsWith(triggerPrefix));
 };
 

--- a/packages/data-type/src/workspace/integrations/github.ts
+++ b/packages/data-type/src/workspace/integrations/github.ts
@@ -13,6 +13,7 @@ export const WorkspaceGitHubIntegrationTrigger = z.enum([
 	"github.issue_comment.created",
 	"github.pull_request_comment.created",
 	"github.pull_request.opened",
+	"github.pull_request.ready_for_review",
 ]);
 export type WorkspaceGitHubIntegrationTrigger = z.infer<
 	typeof WorkspaceGitHubIntegrationTrigger

--- a/packages/data-type/src/workspace/integrations/github.ts
+++ b/packages/data-type/src/workspace/integrations/github.ts
@@ -12,6 +12,7 @@ export const WorkspaceGitHubIntegrationTrigger = z.enum([
 	"github.issues.closed",
 	"github.issue_comment.created",
 	"github.pull_request_comment.created",
+	"github.pull_request.opened",
 ]);
 export type WorkspaceGitHubIntegrationTrigger = z.infer<
 	typeof WorkspaceGitHubIntegrationTrigger
@@ -47,6 +48,9 @@ export const WorkspaceGitHubIntegrationPayloadField = z.enum([
 	"github.pull_request_comment.pull_request.body",
 	"github.pull_request_comment.body",
 	"github.pull_request_comment.pull_request.diff",
+	"github.pull_request.title",
+	"github.pull_request.body",
+	"github.pull_request.diff",
 ]);
 export type WorkspaceGitHubIntegrationPayloadField = z.infer<
 	typeof WorkspaceGitHubIntegrationPayloadField

--- a/packages/data-type/src/workspace/integrations/github.ts
+++ b/packages/data-type/src/workspace/integrations/github.ts
@@ -14,6 +14,7 @@ export const WorkspaceGitHubIntegrationTrigger = z.enum([
 	"github.pull_request_comment.created",
 	"github.pull_request.opened",
 	"github.pull_request.ready_for_review",
+	"github.pull_request.closed",
 ]);
 export type WorkspaceGitHubIntegrationTrigger = z.infer<
 	typeof WorkspaceGitHubIntegrationTrigger

--- a/packages/giselle-engine/src/core/github/events/types.ts
+++ b/packages/giselle-engine/src/core/github/events/types.ts
@@ -5,6 +5,7 @@ import type {
 	IssuesClosedEvent,
 	IssuesOpenedEvent,
 	PullRequestOpenedEvent,
+	PullRequestReadyForReviewEvent,
 } from "@octokit/webhooks-types";
 
 export enum GitHubEventType {
@@ -12,6 +13,7 @@ export enum GitHubEventType {
 	ISSUES_OPENED = "issues.opened",
 	ISSUES_CLOSED = "issues.closed",
 	PULL_REQUEST_OPENED = "pull_request.opened",
+	PULL_REQUEST_READY_FOR_REVIEW = "pull_request.ready_for_review",
 }
 
 export type GitHubEvent =
@@ -34,4 +36,9 @@ export type GitHubEvent =
 			type: GitHubEventType.PULL_REQUEST_OPENED;
 			event: "pull_request";
 			payload: PullRequestOpenedEvent;
+	  }
+	| {
+			type: GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW;
+			event: "pull_request";
+			payload: PullRequestReadyForReviewEvent;
 	  };

--- a/packages/giselle-engine/src/core/github/events/types.ts
+++ b/packages/giselle-engine/src/core/github/events/types.ts
@@ -4,6 +4,7 @@ import type {
 	IssueCommentCreatedEvent,
 	IssuesClosedEvent,
 	IssuesOpenedEvent,
+	PullRequestClosedEvent,
 	PullRequestOpenedEvent,
 	PullRequestReadyForReviewEvent,
 } from "@octokit/webhooks-types";
@@ -14,6 +15,7 @@ export enum GitHubEventType {
 	ISSUES_CLOSED = "issues.closed",
 	PULL_REQUEST_OPENED = "pull_request.opened",
 	PULL_REQUEST_READY_FOR_REVIEW = "pull_request.ready_for_review",
+	PULL_REQUEST_CLOSED = "pull_request.closed",
 }
 
 export type GitHubEvent =
@@ -41,4 +43,9 @@ export type GitHubEvent =
 			type: GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW;
 			event: "pull_request";
 			payload: PullRequestReadyForReviewEvent;
+	  }
+	| {
+			type: GitHubEventType.PULL_REQUEST_CLOSED;
+			event: "pull_request";
+			payload: PullRequestClosedEvent;
 	  };

--- a/packages/giselle-engine/src/core/github/events/types.ts
+++ b/packages/giselle-engine/src/core/github/events/types.ts
@@ -4,12 +4,14 @@ import type {
 	IssueCommentCreatedEvent,
 	IssuesClosedEvent,
 	IssuesOpenedEvent,
+	PullRequestOpenedEvent,
 } from "@octokit/webhooks-types";
 
 export enum GitHubEventType {
 	ISSUE_COMMENT_CREATED = "issue_comment.created",
 	ISSUES_OPENED = "issues.opened",
 	ISSUES_CLOSED = "issues.closed",
+	PULL_REQUEST_OPENED = "pull_request.opened",
 }
 
 export type GitHubEvent =
@@ -27,4 +29,9 @@ export type GitHubEvent =
 			type: GitHubEventType.ISSUES_CLOSED;
 			event: "issues";
 			payload: IssuesClosedEvent;
+	  }
+	| {
+			type: GitHubEventType.PULL_REQUEST_OPENED;
+			event: "pull_request";
+			payload: PullRequestOpenedEvent;
 	  };

--- a/packages/giselle-engine/src/core/github/events/utils.ts
+++ b/packages/giselle-engine/src/core/github/events/utils.ts
@@ -2,6 +2,7 @@ import type {
 	IssueCommentCreatedEvent,
 	IssuesClosedEvent,
 	IssuesOpenedEvent,
+	PullRequestOpenedEvent,
 } from "@octokit/webhooks-types";
 import { type GitHubEvent, GitHubEventType } from "./types";
 
@@ -62,6 +63,25 @@ function isIssuesClosedPayload(
 	);
 }
 
+function isPullRequestOpenedPayload(
+	event: string,
+	payload: unknown,
+): payload is PullRequestOpenedEvent {
+	return (
+		event === "pull_request" &&
+		typeof payload === "object" &&
+		payload !== null &&
+		"action" in payload &&
+		payload.action === "opened" &&
+		"pull_request" in payload &&
+		typeof payload.pull_request === "object" &&
+		payload.pull_request !== null &&
+		"repository" in payload &&
+		typeof payload.repository === "object" &&
+		payload.repository !== null
+	);
+}
+
 export function determineGitHubEvent(
 	event: string,
 	payload: unknown,
@@ -86,6 +106,14 @@ export function determineGitHubEvent(
 		return {
 			type: GitHubEventType.ISSUES_CLOSED,
 			event: "issues",
+			payload,
+		};
+	}
+
+	if (isPullRequestOpenedPayload(event, payload)) {
+		return {
+			type: GitHubEventType.PULL_REQUEST_OPENED,
+			event: "pull_request",
 			payload,
 		};
 	}

--- a/packages/giselle-engine/src/core/github/events/utils.ts
+++ b/packages/giselle-engine/src/core/github/events/utils.ts
@@ -2,6 +2,7 @@ import type {
 	IssueCommentCreatedEvent,
 	IssuesClosedEvent,
 	IssuesOpenedEvent,
+	PullRequestClosedEvent,
 	PullRequestOpenedEvent,
 	PullRequestReadyForReviewEvent,
 } from "@octokit/webhooks-types";
@@ -102,6 +103,25 @@ function isPullRequestReadyForReviewPayload(
 	);
 }
 
+function isPullRequestClosedPayload(
+	event: string,
+	payload: unknown,
+): payload is PullRequestClosedEvent {
+	return (
+		event === "pull_request" &&
+		typeof payload === "object" &&
+		payload !== null &&
+		"action" in payload &&
+		payload.action === "closed" &&
+		"pull_request" in payload &&
+		typeof payload.pull_request === "object" &&
+		payload.pull_request !== null &&
+		"repository" in payload &&
+		typeof payload.repository === "object" &&
+		payload.repository !== null
+	);
+}
+
 export function determineGitHubEvent(
 	event: string,
 	payload: unknown,
@@ -141,6 +161,14 @@ export function determineGitHubEvent(
 	if (isPullRequestReadyForReviewPayload(event, payload)) {
 		return {
 			type: GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW,
+			event: "pull_request",
+			payload,
+		};
+	}
+
+	if (isPullRequestClosedPayload(event, payload)) {
+		return {
+			type: GitHubEventType.PULL_REQUEST_CLOSED,
 			event: "pull_request",
 			payload,
 		};

--- a/packages/giselle-engine/src/core/github/events/utils.ts
+++ b/packages/giselle-engine/src/core/github/events/utils.ts
@@ -3,6 +3,7 @@ import type {
 	IssuesClosedEvent,
 	IssuesOpenedEvent,
 	PullRequestOpenedEvent,
+	PullRequestReadyForReviewEvent,
 } from "@octokit/webhooks-types";
 import { type GitHubEvent, GitHubEventType } from "./types";
 
@@ -82,6 +83,25 @@ function isPullRequestOpenedPayload(
 	);
 }
 
+function isPullRequestReadyForReviewPayload(
+	event: string,
+	payload: unknown,
+): payload is PullRequestReadyForReviewEvent {
+	return (
+		event === "pull_request" &&
+		typeof payload === "object" &&
+		payload !== null &&
+		"action" in payload &&
+		payload.action === "ready_for_review" &&
+		"pull_request" in payload &&
+		typeof payload.pull_request === "object" &&
+		payload.pull_request !== null &&
+		"repository" in payload &&
+		typeof payload.repository === "object" &&
+		payload.repository !== null
+	);
+}
+
 export function determineGitHubEvent(
 	event: string,
 	payload: unknown,
@@ -113,6 +133,14 @@ export function determineGitHubEvent(
 	if (isPullRequestOpenedPayload(event, payload)) {
 		return {
 			type: GitHubEventType.PULL_REQUEST_OPENED,
+			event: "pull_request",
+			payload,
+		};
+	}
+
+	if (isPullRequestReadyForReviewPayload(event, payload)) {
+		return {
+			type: GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW,
 			event: "pull_request",
 			payload,
 		};

--- a/packages/giselle-engine/src/core/github/handle-webhook.test.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.test.ts
@@ -662,4 +662,47 @@ describe("isMatchingIntegrationSetting", () => {
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
 		});
 	});
+
+	// --- Tests for github.pull_request.ready_for_review ---
+	describe("when setting.event is github.pull_request.ready_for_review", () => {
+		const setting = {
+			...mockSettingBase,
+			event: "github.pull_request.ready_for_review" as const,
+		};
+
+		const pullRequestReadyForReviewEvent = {
+			type: GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW,
+			event: "pull_request",
+			payload: {
+				number: 1,
+				action: "ready_for_review",
+				repository: mockRepository,
+				pull_request: {
+					...mockPullRequest,
+					draft: false,
+				},
+				sender: mockUser,
+			},
+		} satisfies GitHubEvent;
+
+		it("should return true if event type is PULL_REQUEST_READY_FOR_REVIEW", () => {
+			const event = pullRequestReadyForReviewEvent;
+			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(true);
+		});
+
+		it("should return false if event type is not PULL_REQUEST_READY_FOR_REVIEW (using PULL_REQUEST_OPENED)", () => {
+			const event = {
+				type: GitHubEventType.PULL_REQUEST_OPENED,
+				event: "pull_request",
+				payload: {
+					number: 1,
+					action: "opened",
+					repository: mockRepository,
+					pull_request: mockPullRequest,
+					sender: mockUser,
+				},
+			} satisfies GitHubEvent;
+			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
+		});
+	});
 });

--- a/packages/giselle-engine/src/core/github/handle-webhook.test.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.test.ts
@@ -1,8 +1,10 @@
 import type { WorkspaceGitHubIntegrationSetting } from "@giselle-sdk/data-type";
 import type {
-	IssueCommentCreatedEvent,
-	IssuesClosedEvent,
-	IssuesOpenedEvent,
+	Issue,
+	IssueComment,
+	PullRequest,
+	Repository,
+	User,
 } from "@octokit/webhooks-types";
 import { describe, expect, it } from "vitest";
 import type { GitHubEvent } from "./events/types";
@@ -21,302 +23,386 @@ describe("isMatchingIntegrationSetting", () => {
 		callsign: "/giselle", // Default, will be overridden if null
 	};
 
-	const mockEventBase: GitHubEvent = {
-		type: GitHubEventType.ISSUE_COMMENT_CREATED,
-		event: "issue_comment",
-		payload: {
-			action: "created",
-			repository: {
-				id: 1,
-				node_id: "repo-node-1",
-				name: "TEST_REPO",
-				full_name: "giselles-ai/TEST_REPO",
-				private: false,
-				owner: {
-					id: 1,
-					node_id: "user-node-1",
-					login: "giselles-ai",
-					avatar_url: "https://example.com/avatar.png",
-					gravatar_id: "",
-					url: "https://api.github.com/users/giselles-ai",
-					html_url: "https://github.com/giselles-ai",
-					followers_url: "https://api.github.com/users/giselles-ai/followers",
-					following_url:
-						"https://api.github.com/users/giselles-ai/following{/other_user}",
-					gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
-					starred_url:
-						"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
-					subscriptions_url:
-						"https://api.github.com/users/giselles-ai/subscriptions",
-					organizations_url: "https://api.github.com/users/giselles-ai/orgs",
-					repos_url: "https://api.github.com/users/giselles-ai/repos",
-					events_url:
-						"https://api.github.com/users/giselles-ai/events{/privacy}",
-					received_events_url:
-						"https://api.github.com/users/giselles-ai/received_events",
-					type: "User",
-					site_admin: false,
-				},
-				html_url: "https://github.com/giselles-ai/TEST_REPO",
-				description: "Test repository",
-				fork: false,
-				url: "https://api.github.com/repos/giselles-ai/TEST_REPO",
-				forks_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/forks",
-				keys_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/keys{/key_id}",
-				collaborators_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/collaborators{/collaborator}",
-				teams_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/teams",
-				hooks_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/hooks",
-				issue_events_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/events{/number}",
-				events_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/events",
-				assignees_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/assignees{/user}",
-				branches_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/branches{/branch}",
-				tags_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/tags",
-				blobs_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/git/blobs{/sha}",
-				git_tags_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/git/tags{/sha}",
-				git_refs_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/git/refs{/sha}",
-				trees_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/git/trees{/sha}",
-				statuses_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/statuses/{sha}",
-				languages_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/languages",
-				stargazers_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/stargazers",
-				contributors_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/contributors",
-				subscribers_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/subscribers",
-				subscription_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/subscription",
-				commits_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/commits{/sha}",
-				git_commits_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/git/commits{/sha}",
-				comments_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/comments{/number}",
-				issue_comment_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/comments{/number}",
-				contents_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/contents/{+path}",
-				compare_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/compare/{base}...{head}",
-				merges_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/merges",
-				archive_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/{archive_format}{/ref}",
-				downloads_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/downloads",
-				issues_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/issues{/number}",
-				pulls_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/pulls{/number}",
-				milestones_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/milestones{/number}",
-				notifications_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/notifications{?since,all,participating}",
-				labels_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/labels{/name}",
-				releases_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/releases{/id}",
-				deployments_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/deployments",
-				created_at: "2024-04-01T00:00:00Z",
-				updated_at: "2024-04-01T00:00:00Z",
-				pushed_at: "2024-04-01T00:00:00Z",
-				git_url: "git://github.com/giselles-ai/TEST_REPO.git",
-				ssh_url: "git@github.com:giselles-ai/TEST_REPO.git",
-				clone_url: "https://github.com/giselles-ai/TEST_REPO.git",
-				svn_url: "https://github.com/giselles-ai/TEST_REPO",
-				homepage: null,
-				size: 0,
-				stargazers_count: 0,
-				watchers_count: 0,
-				language: "TypeScript",
-				has_issues: true,
-				has_projects: true,
-				has_downloads: true,
-				has_wiki: true,
-				has_pages: false,
-				has_discussions: false,
-				forks_count: 0,
-				mirror_url: null,
-				archived: false,
-				disabled: false,
-				open_issues_count: 0,
-				license: null,
-				allow_forking: true,
-				is_template: false,
-				web_commit_signoff_required: false,
-				topics: [],
-				visibility: "public",
-				forks: 0,
-				open_issues: 0,
-				watchers: 0,
-				default_branch: "main",
-				allow_squash_merge: true,
-				allow_merge_commit: true,
-				allow_rebase_merge: true,
-				allow_auto_merge: false,
-				delete_branch_on_merge: false,
-				custom_properties: {},
+	const mockRepository = {
+		id: 1,
+		node_id: "repo-node-1",
+		name: "TEST_REPO",
+		full_name: "giselles-ai/TEST_REPO",
+		private: false,
+		owner: {
+			id: 1,
+			node_id: "user-node-1",
+			login: "giselles-ai",
+			avatar_url: "https://example.com/avatar.png",
+			gravatar_id: "",
+			url: "https://api.github.com/users/giselles-ai",
+			html_url: "https://github.com/giselles-ai",
+			followers_url: "https://api.github.com/users/giselles-ai/followers",
+			following_url:
+				"https://api.github.com/users/giselles-ai/following{/other_user}",
+			gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
+			starred_url:
+				"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
+			subscriptions_url:
+				"https://api.github.com/users/giselles-ai/subscriptions",
+			organizations_url: "https://api.github.com/users/giselles-ai/orgs",
+			repos_url: "https://api.github.com/users/giselles-ai/repos",
+			events_url: "https://api.github.com/users/giselles-ai/events{/privacy}",
+			received_events_url:
+				"https://api.github.com/users/giselles-ai/received_events",
+			type: "User",
+			site_admin: false,
+		},
+		html_url: "https://github.com/giselles-ai/TEST_REPO",
+		description: "Test repository",
+		fork: false,
+		url: "https://api.github.com/repos/giselles-ai/TEST_REPO",
+		forks_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/forks",
+		keys_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/keys{/key_id}",
+		collaborators_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/collaborators{/collaborator}",
+		teams_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/teams",
+		hooks_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/hooks",
+		issue_events_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/events{/number}",
+		events_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/events",
+		assignees_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/assignees{/user}",
+		branches_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/branches{/branch}",
+		tags_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/tags",
+		blobs_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/git/blobs{/sha}",
+		git_tags_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/git/tags{/sha}",
+		git_refs_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/git/refs{/sha}",
+		trees_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/git/trees{/sha}",
+		statuses_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/statuses/{sha}",
+		languages_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/languages",
+		stargazers_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/stargazers",
+		contributors_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/contributors",
+		subscribers_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/subscribers",
+		subscription_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/subscription",
+		commits_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/commits{/sha}",
+		git_commits_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/git/commits{/sha}",
+		comments_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/comments{/number}",
+		issue_comment_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/comments{/number}",
+		contents_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/contents/{+path}",
+		compare_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/compare/{base}...{head}",
+		merges_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/merges",
+		archive_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/{archive_format}{/ref}",
+		downloads_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/downloads",
+		issues_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/issues{/number}",
+		pulls_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/pulls{/number}",
+		milestones_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/milestones{/number}",
+		notifications_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/notifications{?since,all,participating}",
+		labels_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/labels{/name}",
+		releases_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/releases{/id}",
+		deployments_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/deployments",
+		created_at: "2024-04-01T00:00:00Z",
+		updated_at: "2024-04-01T00:00:00Z",
+		pushed_at: "2024-04-01T00:00:00Z",
+		git_url: "git://github.com/giselles-ai/TEST_REPO.git",
+		ssh_url: "git@github.com:giselles-ai/TEST_REPO.git",
+		clone_url: "https://github.com/giselles-ai/TEST_REPO.git",
+		svn_url: "https://github.com/giselles-ai/TEST_REPO",
+		homepage: null,
+		size: 0,
+		stargazers_count: 0,
+		watchers_count: 0,
+		language: "TypeScript",
+		has_issues: true,
+		has_projects: true,
+		has_downloads: true,
+		has_wiki: true,
+		has_pages: false,
+		has_discussions: false,
+		forks_count: 0,
+		mirror_url: null,
+		archived: false,
+		disabled: false,
+		open_issues_count: 0,
+		license: null,
+		allow_forking: true,
+		is_template: false,
+		web_commit_signoff_required: false,
+		topics: [],
+		visibility: "public",
+		forks: 0,
+		open_issues: 0,
+		watchers: 0,
+		default_branch: "main",
+		allow_squash_merge: true,
+		allow_merge_commit: true,
+		allow_rebase_merge: true,
+		allow_auto_merge: false,
+		delete_branch_on_merge: false,
+		custom_properties: {},
+	} satisfies Repository;
+
+	const mockIssue = {
+		number: 1,
+		title: "Test Issue",
+		body: "Test body",
+		url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1",
+		repository_url: "https://api.github.com/repos/giselles-ai/TEST_REPO",
+		labels_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/labels{/name}",
+		comments_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/comments",
+		events_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/events",
+		html_url: "https://github.com/giselles-ai/TEST_REPO/issues/1",
+		id: 1,
+		node_id: "issue-node-1",
+		user: {
+			id: 1,
+			node_id: "user-node-1",
+			login: "giselles-ai",
+			avatar_url: "https://example.com/avatar.png",
+			gravatar_id: "",
+			url: "https://api.github.com/users/giselles-ai",
+			html_url: "https://github.com/giselles-ai",
+			followers_url: "https://api.github.com/users/giselles-ai/followers",
+			following_url:
+				"https://api.github.com/users/giselles-ai/following{/other_user}",
+			gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
+			starred_url:
+				"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
+			subscriptions_url:
+				"https://api.github.com/users/giselles-ai/subscriptions",
+			organizations_url: "https://api.github.com/users/giselles-ai/orgs",
+			repos_url: "https://api.github.com/users/giselles-ai/repos",
+			events_url: "https://api.github.com/users/giselles-ai/events{/privacy}",
+			received_events_url:
+				"https://api.github.com/users/giselles-ai/received_events",
+			type: "User",
+			site_admin: false,
+		},
+		state: "open",
+		locked: false,
+		assignee: null,
+		assignees: [],
+		milestone: null,
+		comments: 0,
+		created_at: "2024-04-01T00:00:00Z",
+		updated_at: "2024-04-01T00:00:00Z",
+		closed_at: null,
+		author_association: "OWNER",
+		active_lock_reason: null,
+		draft: false,
+		pull_request: {
+			url: "https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1",
+			html_url: "https://github.com/giselles-ai/TEST_REPO/pull/1",
+			diff_url: "https://github.com/giselles-ai/TEST_REPO/pull/1.diff",
+			patch_url: "https://github.com/giselles-ai/TEST_REPO/pull/1.patch",
+			merged_at: null,
+		},
+		labels: [],
+		reactions: {
+			url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/reactions",
+			total_count: 0,
+			"+1": 0,
+			"-1": 0,
+			laugh: 0,
+			hooray: 0,
+			confused: 0,
+			heart: 0,
+			rocket: 0,
+			eyes: 0,
+		},
+	} satisfies Issue;
+
+	const mockIssueComment = {
+		id: 1,
+		node_id: "comment-node-1",
+		url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/comments/1",
+		html_url:
+			"https://github.com/giselles-ai/TEST_REPO/issues/1#issuecomment-1",
+		body: "/giselle do something",
+		user: {
+			id: 1,
+			node_id: "user-node-1",
+			login: "giselles-ai",
+			avatar_url: "https://example.com/avatar.png",
+			gravatar_id: "",
+			url: "https://api.github.com/users/giselles-ai",
+			html_url: "https://github.com/giselles-ai",
+			followers_url: "https://api.github.com/users/giselles-ai/followers",
+			following_url:
+				"https://api.github.com/users/giselles-ai/following{/other_user}",
+			gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
+			starred_url:
+				"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
+			subscriptions_url:
+				"https://api.github.com/users/giselles-ai/subscriptions",
+			organizations_url: "https://api.github.com/users/giselles-ai/orgs",
+			repos_url: "https://api.github.com/users/giselles-ai/repos",
+			events_url: "https://api.github.com/users/giselles-ai/events{/privacy}",
+			received_events_url:
+				"https://api.github.com/users/giselles-ai/received_events",
+			type: "User",
+			site_admin: false,
+		},
+		created_at: "2024-04-01T00:00:00Z",
+		updated_at: "2024-04-01T00:00:00Z",
+		issue_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1",
+		author_association: "OWNER",
+		reactions: {
+			url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/comments/1/reactions",
+			total_count: 0,
+			"+1": 0,
+			"-1": 0,
+			laugh: 0,
+			hooray: 0,
+			confused: 0,
+			heart: 0,
+			rocket: 0,
+			eyes: 0,
+		},
+		performed_via_github_app: null,
+	} satisfies IssueComment;
+
+	const mockUser = {
+		id: 1,
+		node_id: "user-node-1",
+		login: "giselles-ai",
+		avatar_url: "https://example.com/avatar.png",
+		gravatar_id: "",
+		url: "https://api.github.com/users/giselles-ai",
+		html_url: "https://github.com/giselles-ai",
+		followers_url: "https://api.github.com/users/giselles-ai/followers",
+		following_url:
+			"https://api.github.com/users/giselles-ai/following{/other_user}",
+		gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
+		starred_url:
+			"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
+		subscriptions_url: "https://api.github.com/users/giselles-ai/subscriptions",
+		organizations_url: "https://api.github.com/users/giselles-ai/orgs",
+		repos_url: "https://api.github.com/users/giselles-ai/repos",
+		events_url: "https://api.github.com/users/giselles-ai/events{/privacy}",
+		received_events_url:
+			"https://api.github.com/users/giselles-ai/received_events",
+		type: "User",
+		site_admin: false,
+	} satisfies User;
+
+	const mockPullRequest = {
+		id: 1234,
+		node_id: "pr-node-1",
+		number: 1,
+		title: "Test Pull Request",
+		body: "Test body",
+		url: "https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1",
+		html_url: "https://github.com/giselles-ai/TEST_REPO/pull/1",
+		diff_url: "https://github.com/giselles-ai/TEST_REPO/pull/1.diff",
+		patch_url: "https://github.com/giselles-ai/TEST_REPO/pull/1.patch",
+		issue_url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1",
+		user: mockUser,
+		labels: [],
+		state: "open",
+		locked: false,
+		assignee: null,
+		assignees: [],
+		milestone: null,
+		created_at: "2024-04-01T00:00:00Z",
+		updated_at: "2024-04-01T00:00:00Z",
+		closed_at: null,
+		merged_at: null,
+		merge_commit_sha: null,
+		draft: false,
+		head: {
+			label: "giselles-ai:feature-branch",
+			ref: "feature-branch",
+			sha: "abcdef1234567890",
+			user: mockUser,
+			repo: mockRepository,
+		},
+		base: {
+			label: "giselles-ai:main",
+			ref: "main",
+			sha: "0987654321fedcba",
+			user: mockUser,
+			repo: mockRepository,
+		},
+		_links: {
+			self: {
+				href: "https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1",
+			},
+			html: {
+				href: "https://github.com/giselles-ai/TEST_REPO/pull/1",
 			},
 			issue: {
-				number: 1,
-				title: "Test Issue",
-				body: "Test body",
-				url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1",
-				repository_url: "https://api.github.com/repos/giselles-ai/TEST_REPO",
-				labels_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/labels{/name}",
-				comments_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/comments",
-				events_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/events",
-				html_url: "https://github.com/giselles-ai/TEST_REPO/issues/1",
-				id: 1,
-				node_id: "issue-node-1",
-				user: {
-					id: 1,
-					node_id: "user-node-1",
-					login: "giselles-ai",
-					avatar_url: "https://example.com/avatar.png",
-					gravatar_id: "",
-					url: "https://api.github.com/users/giselles-ai",
-					html_url: "https://github.com/giselles-ai",
-					followers_url: "https://api.github.com/users/giselles-ai/followers",
-					following_url:
-						"https://api.github.com/users/giselles-ai/following{/other_user}",
-					gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
-					starred_url:
-						"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
-					subscriptions_url:
-						"https://api.github.com/users/giselles-ai/subscriptions",
-					organizations_url: "https://api.github.com/users/giselles-ai/orgs",
-					repos_url: "https://api.github.com/users/giselles-ai/repos",
-					events_url:
-						"https://api.github.com/users/giselles-ai/events{/privacy}",
-					received_events_url:
-						"https://api.github.com/users/giselles-ai/received_events",
-					type: "User",
-					site_admin: false,
-				},
-				state: "open",
-				locked: false,
-				assignee: null,
-				assignees: [],
-				milestone: null,
-				comments: 0,
-				created_at: "2024-04-01T00:00:00Z",
-				updated_at: "2024-04-01T00:00:00Z",
-				closed_at: null,
-				author_association: "OWNER",
-				active_lock_reason: null,
-				draft: false,
-				pull_request: {
-					url: "https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1",
-					html_url: "https://github.com/giselles-ai/TEST_REPO/pull/1",
-					diff_url: "https://github.com/giselles-ai/TEST_REPO/pull/1.diff",
-					patch_url: "https://github.com/giselles-ai/TEST_REPO/pull/1.patch",
-					merged_at: null,
-				},
-				labels: [],
-				reactions: {
-					url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/reactions",
-					total_count: 0,
-					"+1": 0,
-					"-1": 0,
-					laugh: 0,
-					hooray: 0,
-					confused: 0,
-					heart: 0,
-					rocket: 0,
-					eyes: 0,
-				},
+				href: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1",
 			},
-			comment: {
-				id: 1,
-				node_id: "comment-node-1",
-				url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/comments/1",
-				html_url:
-					"https://github.com/giselles-ai/TEST_REPO/issues/1#issuecomment-1",
-				body: "/giselle do something",
-				user: {
-					id: 1,
-					node_id: "user-node-1",
-					login: "giselles-ai",
-					avatar_url: "https://example.com/avatar.png",
-					gravatar_id: "",
-					url: "https://api.github.com/users/giselles-ai",
-					html_url: "https://github.com/giselles-ai",
-					followers_url: "https://api.github.com/users/giselles-ai/followers",
-					following_url:
-						"https://api.github.com/users/giselles-ai/following{/other_user}",
-					gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
-					starred_url:
-						"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
-					subscriptions_url:
-						"https://api.github.com/users/giselles-ai/subscriptions",
-					organizations_url: "https://api.github.com/users/giselles-ai/orgs",
-					repos_url: "https://api.github.com/users/giselles-ai/repos",
-					events_url:
-						"https://api.github.com/users/giselles-ai/events{/privacy}",
-					received_events_url:
-						"https://api.github.com/users/giselles-ai/received_events",
-					type: "User",
-					site_admin: false,
-				},
-				created_at: "2024-04-01T00:00:00Z",
-				updated_at: "2024-04-01T00:00:00Z",
-				issue_url:
-					"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1",
-				author_association: "OWNER",
-				reactions: {
-					url: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/comments/1/reactions",
-					total_count: 0,
-					"+1": 0,
-					"-1": 0,
-					laugh: 0,
-					hooray: 0,
-					confused: 0,
-					heart: 0,
-					rocket: 0,
-					eyes: 0,
-				},
-				performed_via_github_app: null,
+			comments: {
+				href: "https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/comments",
 			},
-			sender: {
-				id: 1,
-				node_id: "user-node-1",
-				login: "giselles-ai",
-				avatar_url: "https://example.com/avatar.png",
-				gravatar_id: "",
-				url: "https://api.github.com/users/giselles-ai",
-				html_url: "https://github.com/giselles-ai",
-				followers_url: "https://api.github.com/users/giselles-ai/followers",
-				following_url:
-					"https://api.github.com/users/giselles-ai/following{/other_user}",
-				gists_url: "https://api.github.com/users/giselles-ai/gists{/gist_id}",
-				starred_url:
-					"https://api.github.com/users/giselles-ai/starred{/owner}{/repo}",
-				subscriptions_url:
-					"https://api.github.com/users/giselles-ai/subscriptions",
-				organizations_url: "https://api.github.com/users/giselles-ai/orgs",
-				repos_url: "https://api.github.com/users/giselles-ai/repos",
-				events_url: "https://api.github.com/users/giselles-ai/events{/privacy}",
-				received_events_url:
-					"https://api.github.com/users/giselles-ai/received_events",
-				type: "User",
-				site_admin: false,
+			review_comments: {
+				href: "https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1/comments",
 			},
-		} as IssueCommentCreatedEvent,
-	};
+			review_comment: {
+				href: "https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/comments{/number}",
+			},
+			commits: {
+				href: "https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1/commits",
+			},
+			statuses: {
+				href: "https://api.github.com/repos/giselles-ai/TEST_REPO/statuses/abcdef1234567890",
+			},
+		},
+		author_association: "OWNER",
+		auto_merge: null,
+		active_lock_reason: null,
+		requested_reviewers: [],
+		requested_teams: [],
+		commits_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1/commits",
+		review_comments_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/1/comments",
+		review_comment_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/pulls/comments{/number}",
+		comments_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/issues/1/comments",
+		statuses_url:
+			"https://api.github.com/repos/giselles-ai/TEST_REPO/statuses/abcdef1234567890",
+		merged: false,
+		mergeable: true,
+		rebaseable: true,
+		mergeable_state: "clean",
+		merged_by: null,
+		comments: 0,
+		review_comments: 0,
+		maintainer_can_modify: false,
+		commits: 1,
+		additions: 10,
+		deletions: 5,
+		changed_files: 2,
+	} satisfies PullRequest;
 
 	const mockCommand: Command = {
 		callsign: "/giselle",
@@ -331,15 +417,27 @@ describe("isMatchingIntegrationSetting", () => {
 			callsign: "/giselle",
 		};
 
+		const issueCommentCreatedEvent = {
+			type: GitHubEventType.ISSUE_COMMENT_CREATED,
+			event: "issue_comment",
+			payload: {
+				action: "created",
+				repository: mockRepository,
+				issue: mockIssue,
+				comment: mockIssueComment,
+				sender: mockUser,
+			},
+		} satisfies GitHubEvent;
+
 		it("should return true if event type is ISSUE_COMMENT_CREATED and callsigns match", () => {
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			expect(isMatchingIntegrationSetting(setting, event, mockCommand)).toBe(
 				true,
 			);
 		});
 
 		it("should return false if event type is ISSUE_COMMENT_CREATED but callsigns do not match", () => {
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			const differentCommand: Command = { ...mockCommand, callsign: "/other" };
 			expect(
 				isMatchingIntegrationSetting(setting, event, differentCommand),
@@ -348,14 +446,14 @@ describe("isMatchingIntegrationSetting", () => {
 
 		it("should return false if event type is ISSUE_COMMENT_CREATED but setting.callsign is null", () => {
 			const nullCallsignSetting = { ...setting, callsign: null };
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			expect(
 				isMatchingIntegrationSetting(nullCallsignSetting, event, mockCommand),
 			).toBe(false);
 		});
 
 		it("should return false if event type is ISSUE_COMMENT_CREATED but command is null", () => {
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
 		});
 
@@ -365,11 +463,11 @@ describe("isMatchingIntegrationSetting", () => {
 				event: "issues",
 				payload: {
 					action: "opened",
-					repository: mockEventBase.payload.repository,
-					issue: mockEventBase.payload.issue,
-					sender: mockEventBase.payload.sender,
-				} as IssuesOpenedEvent,
-			} as GitHubEvent;
+					repository: mockRepository,
+					issue: mockIssue,
+					sender: mockUser,
+				},
+			} satisfies GitHubEvent;
 			expect(isMatchingIntegrationSetting(setting, event, mockCommand)).toBe(
 				false,
 			);
@@ -384,16 +482,28 @@ describe("isMatchingIntegrationSetting", () => {
 			callsign: "/giselle",
 		};
 
+		const issueCommentCreatedEvent = {
+			type: GitHubEventType.ISSUE_COMMENT_CREATED,
+			event: "issue_comment",
+			payload: {
+				action: "created",
+				repository: mockRepository,
+				issue: mockIssue,
+				comment: mockIssueComment,
+				sender: mockUser,
+			},
+		} satisfies GitHubEvent;
+
 		// These tests are identical to issue_comment.created logic
 		it("should return true if event type is ISSUE_COMMENT_CREATED and callsigns match", () => {
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			expect(isMatchingIntegrationSetting(setting, event, mockCommand)).toBe(
 				true,
 			);
 		});
 
 		it("should return false if event type is ISSUE_COMMENT_CREATED but callsigns do not match", () => {
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			const differentCommand: Command = { ...mockCommand, callsign: "/other" };
 			expect(
 				isMatchingIntegrationSetting(setting, event, differentCommand),
@@ -402,14 +512,14 @@ describe("isMatchingIntegrationSetting", () => {
 
 		it("should return false if event type is ISSUE_COMMENT_CREATED but setting.callsign is null", () => {
 			const nullCallsignSetting = { ...setting, callsign: null };
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			expect(
 				isMatchingIntegrationSetting(nullCallsignSetting, event, mockCommand),
 			).toBe(false);
 		});
 
 		it("should return false if event type is ISSUE_COMMENT_CREATED but command is null", () => {
-			const event = { ...mockEventBase };
+			const event = issueCommentCreatedEvent;
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
 		});
 
@@ -419,11 +529,11 @@ describe("isMatchingIntegrationSetting", () => {
 				event: "issues",
 				payload: {
 					action: "opened",
-					repository: mockEventBase.payload.repository,
-					issue: mockEventBase.payload.issue,
-					sender: mockEventBase.payload.sender,
-				} as IssuesOpenedEvent,
-			} as GitHubEvent;
+					repository: mockRepository,
+					issue: mockIssue,
+					sender: mockUser,
+				},
+			} satisfies GitHubEvent;
 			expect(isMatchingIntegrationSetting(setting, event, mockCommand)).toBe(
 				false,
 			);
@@ -437,35 +547,37 @@ describe("isMatchingIntegrationSetting", () => {
 			event: "github.issues.opened" as const,
 		};
 
+		const issuesOpenedEvent = {
+			type: GitHubEventType.ISSUES_OPENED,
+			event: "issues",
+			payload: {
+				action: "opened",
+				repository: mockRepository,
+				issue: mockIssue,
+				sender: mockUser,
+			},
+		} satisfies GitHubEvent;
+
 		it("should return true if event type is ISSUES_OPENED", () => {
-			const event = {
-				type: GitHubEventType.ISSUES_OPENED,
-				event: "issues",
-				payload: {
-					action: "opened",
-					repository: mockEventBase.payload.repository,
-					issue: mockEventBase.payload.issue,
-					sender: mockEventBase.payload.sender,
-				} as IssuesOpenedEvent,
-			} as GitHubEvent;
+			const event = issuesOpenedEvent;
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(true);
 		});
 
-		it("should return false if event type is not ISSUES_OPENED", () => {
-			const event = { ...mockEventBase };
-			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
-		});
 		it("should return false if event type is not ISSUES_OPENED (using ISSUES_CLOSED)", () => {
 			const event = {
 				type: GitHubEventType.ISSUES_CLOSED,
 				event: "issues",
 				payload: {
 					action: "closed",
-					repository: mockEventBase.payload.repository,
-					issue: mockEventBase.payload.issue,
-					sender: mockEventBase.payload.sender,
-				} as IssuesClosedEvent,
-			} as GitHubEvent;
+					repository: mockRepository,
+					issue: {
+						...mockIssue,
+						state: "closed",
+						closed_at: new Date().toISOString(),
+					},
+					sender: mockUser,
+				},
+			} satisfies GitHubEvent;
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
 		});
 	});
@@ -477,35 +589,76 @@ describe("isMatchingIntegrationSetting", () => {
 			event: "github.issues.closed" as const,
 		};
 
+		const issuesClosedEvent = {
+			type: GitHubEventType.ISSUES_CLOSED,
+			event: "issues",
+			payload: {
+				action: "closed",
+				repository: mockRepository,
+				issue: {
+					...mockIssue,
+					state: "closed",
+					closed_at: new Date().toISOString(),
+				},
+				sender: mockUser,
+			},
+		} satisfies GitHubEvent;
+
 		it("should return true if event type is ISSUES_CLOSED", () => {
-			const event = {
-				type: GitHubEventType.ISSUES_CLOSED,
-				event: "issues",
-				payload: {
-					action: "closed",
-					repository: mockEventBase.payload.repository,
-					issue: mockEventBase.payload.issue,
-					sender: mockEventBase.payload.sender,
-				} as IssuesClosedEvent,
-			} as GitHubEvent;
+			const event = issuesClosedEvent;
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(true);
 		});
 
-		it("should return false if event type is not ISSUES_CLOSED", () => {
-			const event = { ...mockEventBase };
-			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
-		});
 		it("should return false if event type is not ISSUES_CLOSED (using ISSUES_OPENED)", () => {
 			const event = {
 				type: GitHubEventType.ISSUES_OPENED,
 				event: "issues",
 				payload: {
 					action: "opened",
-					repository: mockEventBase.payload.repository,
-					issue: mockEventBase.payload.issue,
-					sender: mockEventBase.payload.sender,
-				} as IssuesOpenedEvent,
-			} as GitHubEvent;
+					repository: mockRepository,
+					issue: mockIssue,
+					sender: mockUser,
+				},
+			} satisfies GitHubEvent;
+			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
+		});
+	});
+
+	// --- Tests for github.pull_request.opened ---
+	describe("when setting.event is github.pull_request.opened", () => {
+		const setting = {
+			...mockSettingBase,
+			event: "github.pull_request.opened" as const,
+		};
+
+		const pullRequestOpenedEvent = {
+			type: GitHubEventType.PULL_REQUEST_OPENED,
+			event: "pull_request",
+			payload: {
+				number: 1,
+				action: "opened",
+				repository: mockRepository,
+				pull_request: mockPullRequest,
+				sender: mockUser,
+			},
+		} satisfies GitHubEvent;
+
+		it("should return true if event type is PULL_REQUEST_OPENED", () => {
+			const event = pullRequestOpenedEvent;
+			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(true);
+		});
+
+		it("should return false if event type is not PULL_REQUEST_OPENED (using ISSUES_OPENED)", () => {
+			const event = {
+				type: GitHubEventType.ISSUES_OPENED,
+				event: "issues",
+				payload: {
+					action: "opened",
+					repository: mockRepository,
+					issue: mockIssue,
+					sender: mockUser,
+				},
+			} satisfies GitHubEvent;
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
 		});
 	});

--- a/packages/giselle-engine/src/core/github/handle-webhook.test.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.test.ts
@@ -705,4 +705,49 @@ describe("isMatchingIntegrationSetting", () => {
 			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
 		});
 	});
+
+	// --- Tests for github.pull_request.closed ---
+	describe("when setting.event is github.pull_request.closed", () => {
+		const setting = {
+			...mockSettingBase,
+			event: "github.pull_request.closed" as const,
+		};
+
+		const pullRequestClosedEvent = {
+			type: GitHubEventType.PULL_REQUEST_CLOSED,
+			event: "pull_request",
+			payload: {
+				number: 1,
+				action: "closed",
+				repository: mockRepository,
+				pull_request: {
+					...mockPullRequest,
+					state: "closed",
+					closed_at: new Date().toISOString(),
+					merged: true,
+				},
+				sender: mockUser,
+			},
+		} satisfies GitHubEvent;
+
+		it("should return true if event type is PULL_REQUEST_CLOSED", () => {
+			const event = pullRequestClosedEvent;
+			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(true);
+		});
+
+		it("should return false if event type is not PULL_REQUEST_CLOSED (using PULL_REQUEST_OPENED)", () => {
+			const event = {
+				type: GitHubEventType.PULL_REQUEST_OPENED,
+				event: "pull_request",
+				payload: {
+					number: 1,
+					action: "opened",
+					repository: mockRepository,
+					pull_request: mockPullRequest,
+					sender: mockUser,
+				},
+			} satisfies GitHubEvent;
+			expect(isMatchingIntegrationSetting(setting, event, null)).toBe(false);
+		});
+	});
 });

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -288,6 +288,8 @@ export function isMatchingIntegrationSetting(
 			return event.type === GitHubEventType.PULL_REQUEST_OPENED;
 		case "github.pull_request.ready_for_review":
 			return event.type === GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW;
+		case "github.pull_request.closed":
+			return event.type === GitHubEventType.PULL_REQUEST_CLOSED;
 		default: {
 			const _exhaustiveCheck: never = setting.event;
 			throw new Error(`Unhandled setting event type: ${_exhaustiveCheck}`);
@@ -319,6 +321,7 @@ async function handleReaction(
 			break;
 		case GitHubEventType.PULL_REQUEST_OPENED:
 		case GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW:
+		case GitHubEventType.PULL_REQUEST_CLOSED:
 			if (options?.addReactionToIssue) {
 				await options.addReactionToIssue(
 					event.payload.repository.owner.login,
@@ -397,6 +400,7 @@ async function getPayloadValue(
 
 		case GitHubEventType.PULL_REQUEST_OPENED:
 		case GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW:
+		case GitHubEventType.PULL_REQUEST_CLOSED:
 			switch (field) {
 				case "github.pull_request.title":
 					return event.payload.pull_request.title;

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -229,7 +229,7 @@ async function processIntegration(
 								owner: repository.owner,
 								name: repository.name,
 							},
-							// Some GitHub events treats pull requests as issues.
+							// Some GitHub events treat pull requests as issues.
 							number:
 								"issue" in gitHubEvent.payload
 									? gitHubEvent.payload.issue.number

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -286,6 +286,8 @@ export function isMatchingIntegrationSetting(
 			return event.type === GitHubEventType.ISSUES_CLOSED;
 		case "github.pull_request.opened":
 			return event.type === GitHubEventType.PULL_REQUEST_OPENED;
+		case "github.pull_request.ready_for_review":
+			return event.type === GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW;
 		default: {
 			const _exhaustiveCheck: never = setting.event;
 			throw new Error(`Unhandled setting event type: ${_exhaustiveCheck}`);
@@ -316,6 +318,7 @@ async function handleReaction(
 			}
 			break;
 		case GitHubEventType.PULL_REQUEST_OPENED:
+		case GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW:
 			if (options?.addReactionToIssue) {
 				await options.addReactionToIssue(
 					event.payload.repository.owner.login,
@@ -393,6 +396,7 @@ async function getPayloadValue(
 			}
 
 		case GitHubEventType.PULL_REQUEST_OPENED:
+		case GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW:
 			switch (field) {
 				case "github.pull_request.title":
 					return event.payload.pull_request.title;

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -247,7 +247,7 @@ async function processIntegration(
 								owner: repository.owner,
 								name: repository.name,
 							},
-							// Some GitHub events treats pull requests as issues.
+							// Some GitHub events treat pull requests as issues.
 							number:
 								"issue" in gitHubEvent.payload
 									? gitHubEvent.payload.issue.number


### PR DESCRIPTION
## Summary
Extended GitHub Webhook event handling functionality to support the following events:
- `pull_request.closed`
- `pull_request.ready_for_review`
- `pull_request.opened`

Additionally, added tests for Issue and Pull Request events and fixed trigger filtering issues on the integration setting form.

## Related Issue
- https://github.com/giselles-ai/giselle/pull/598

## Changes
- Extended GitHub Webhook event types
- Implemented handling logic for each event
- Added test cases
- Fixed trigger filtering in workflow designer UI
