### PR TITLE
Disable "Generate" Button

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -84,8 +84,8 @@ export function TextGenerationNodePropertiesPanel({
 	const text = isJsonContent(jsonOrText)
 		? jsonContentToText(JSON.parse(jsonOrText))
 		: jsonOrText;
-	const space = text?.replace(/[\s\u3000]+/g, "");
-	const disabled = usageLimitsReached || !text || !space;
+	const noWhitespaceText = text?.replace(/[\s\u3000]+/g, "");
+	const disabled = usageLimitsReached || !noWhitespaceText;
 
 	return (
 		<PropertiesPanelRoot>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -31,6 +31,7 @@ import {
 } from "./model";
 import { PromptPanel } from "./prompt-panel";
 import { useConnectedSources } from "./sources";
+import { isJsonContent, jsonContentToText } from "@giselle-sdk/text-editor";
 
 export function TextGenerationNodePropertiesPanel({
 	node,
@@ -79,6 +80,11 @@ export function TextGenerationNodePropertiesPanel({
 		error,
 	]);
 
+	const jsonOrText = node.content.prompt;
+	const text = isJsonContent(jsonOrText) ? jsonContentToText(JSON.parse(jsonOrText)) : jsonOrText;
+	const space = text?.replace(/[\s\u3000]+/g, "");
+	const disabled = usageLimitsReached || !text || !space;
+
 	return (
 		<PropertiesPanelRoot>
 			{usageLimitsReached && <UsageLimitWarning />}
@@ -109,7 +115,7 @@ export function TextGenerationNodePropertiesPanel({
 					<Button
 						loading={isGenerating}
 						type="button"
-						disabled={usageLimitsReached}
+						disabled={disabled}
 						onClick={() => {
 							if (isGenerating) {
 								stopGeneration();

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -1,4 +1,5 @@
 import { OutputId, type TextGenerationNode } from "@giselle-sdk/data-type";
+import { isJsonContent, jsonContentToText } from "@giselle-sdk/text-editor";
 import clsx from "clsx/lite";
 import { useNodeGenerations, useWorkflowDesigner } from "giselle-sdk/react";
 import { CommandIcon, CornerDownLeft } from "lucide-react";
@@ -31,7 +32,6 @@ import {
 } from "./model";
 import { PromptPanel } from "./prompt-panel";
 import { useConnectedSources } from "./sources";
-import { isJsonContent, jsonContentToText } from "@giselle-sdk/text-editor";
 
 export function TextGenerationNodePropertiesPanel({
 	node,
@@ -81,7 +81,9 @@ export function TextGenerationNodePropertiesPanel({
 	]);
 
 	const jsonOrText = node.content.prompt;
-	const text = isJsonContent(jsonOrText) ? jsonContentToText(JSON.parse(jsonOrText)) : jsonOrText;
+	const text = isJsonContent(jsonOrText)
+		? jsonContentToText(JSON.parse(jsonOrText))
+		: jsonOrText;
 	const space = text?.replace(/[\s\u3000]+/g, "");
 	const disabled = usageLimitsReached || !text || !space;
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Disable the "Generate" button on the Generator Node when the Prompt input field is empty

## Related Issue
<!-- Mention the related issue number if applicable. -->
https://github.com/giselles-ai/giselle/issues/478

## Changes
<!-- List the main changes made in this PR. -->
Added code to disable the button in the following cases.
- undefined
- null
- ""
- Whitespace characters
  - Half-width space
  - Full-width space
  - Line break, etc.

![名称未設定](https://github.com/user-attachments/assets/753e0b4a-e7c0-47a9-bb08-bb4560bb8f16)
![名称未設定2](https://github.com/user-attachments/assets/b7110b0d-e659-4685-8689-f52a2fbc5c43)
![名称未設定3](https://github.com/user-attachments/assets/f012979d-73ee-466b-b2fb-1cce56c18ebc)

## Testing
<!-- Briefly describe the testing steps or results. -->

1. Open [Preview](https://giselle-git-fork-okky-hi-feature-toggle-generat-37a473-r06-edge.vercel.app/apps)
2. Create a new app or open one you've already created.
3. Create a new Generator Node or open one you've already created. 

## Other Information
<!-- Add any other relevant information for the reviewer. -->
