### PR TITLE
proofreading: Change Plain text node to match other node titles

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-node-properties-panel/index.tsx
@@ -16,8 +16,8 @@ export function TextNodePropertiesPanel({ node }: { node: TextNode }) {
 			<PropertiesPanelHeader
 				icon={<PromptIcon className="size-[20px] text-black-900" />}
 				name={node.name}
-				fallbackName="Plain text"
-				description={"Plain text"}
+				fallbackName="Plain Text"
+				description={"Plain Text"}
 				onChangeName={(name) => {
 					updateNodeData(node, { name });
 				}}

--- a/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
@@ -60,7 +60,7 @@ export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 					return (
 						<fieldset className="flex gap-[8px] w-full" key={overrideNode.id}>
 							<p className="w-[100px] text-[14px] font-bold text-white-400">
-								{originalNode.name ?? "Plain text"}
+								{originalNode.name ?? "Plain Text"}
 							</p>
 							<TextEditor
 								value={overrideNode.content.text}


### PR DESCRIPTION
## Summary
- Minor capitalization fix for the `Plain Text` node title.

## Related Issue
<!-- Mention the related issue number if applicable. -->

- None

## Changes
<!-- List the main changes made in this PR. -->

- Changed `Plain text` -> `Plain Text`

## Testing
<!-- Briefly describe the testing steps or results. -->

- Open the preview.
- Go to the Apps page and create a new app or open an existing one.
- Click on the Plain Text node and open the editor.