### PR TITLE
Improve canvas trackpad gestures for better UX

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/index.tsx
@@ -208,6 +208,9 @@ function NodeCanvas() {
 			onConnect={handleConnect}
 			onEdgesDelete={handleEdgesDelete}
 			isValidConnection={isValidConnection}
+			panOnScroll={true}
+			zoomOnScroll={false}
+			zoomOnPinch={true}
 			onMoveEnd={(_, viewport) => {
 				setUiViewport(viewport);
 			}}
@@ -242,14 +245,16 @@ function NodeCanvas() {
 					}
 				});
 			}}
-			onNodeDoubleClick={(_event, nodeDoubleClicked) => {
+			onNodeClick={(_event, nodeClicked) => {
 				for (const node of data.nodes) {
-					if (node.id === nodeDoubleClicked.id) {
+					if (node.id === nodeClicked.id) {
 						setUiNodeState(node.id, { selected: true });
 					} else {
 						setUiNodeState(node.id, { selected: false });
 					}
 				}
+			}}
+			onNodeDoubleClick={(_event, nodeDoubleClicked) => {
 				const viewport = reactFlowInstance.getViewport();
 				const screenPosition = reactFlowInstance.flowToScreenPosition(
 					nodeDoubleClicked.position,


### PR DESCRIPTION
## Summary
- Modified trackpad behavior in the canvas to match standard web applications and Figma/FigJam
- Changed interaction model so single click selects node and shows properties panel
- Double-click now only focuses the viewport on the node without affecting selection
- Two-finger trackpad scroll now pans the canvas instead of zooming (more intuitive)
- Pinch gestures still handle zooming as expected

## Test plan
- Open the workflow designer canvas in the playground
- Test single-clicking on nodes to verify selection and properties panel display
- Test double-clicking to verify viewport centering on nodes
- Test trackpad two-finger scroll to verify panning instead of zooming
- Test pinch gestures to verify zooming still works correctly

Resolves route06/giselle-division#2913

🤖 Generated with [Claude Code](https://claude.ai/code)