### PR TITLE
Add override dialog with tabbed interface for workflow inputs

### DIFF
--- a/internal-packages/workflow-designer-ui/src/viewer/dialog-with-override-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/dialog-with-override-form.tsx
@@ -1,0 +1,93 @@
+import type {
+	OverrideNode,
+	Workflow,
+	WorkflowId,
+} from "@giselle-sdk/data-type";
+import { PencilIcon, X } from "lucide-react";
+import { Dialog } from "radix-ui";
+import { useCallback, useState } from "react";
+import { Button } from "../ui/button";
+import { RunWithOverrideParamsForm } from "./run-with-override-params-form";
+
+// Global variable to store override nodes
+let currentOverrideNodes: OverrideNode[] = [];
+
+export function DialogWithOverrideForm({
+	flow,
+	perform,
+}: {
+	flow: Workflow;
+	perform: (
+		flowId: WorkflowId,
+		options?: { overrideNodes?: OverrideNode[] },
+	) => void;
+}) {
+	// Dialog open/close state
+	const [isOpen, setIsOpen] = useState(false);
+	// Override nodes state
+	const [overrideNodes, setOverrideNodes] = useState<OverrideNode[]>([]);
+
+	// Initialize state when modal opens
+	const handleOpenChange = useCallback((open: boolean) => {
+		setIsOpen(open);
+		// Set initial data when modal is opened
+		if (open) {
+			console.log("Dialog opened, initializing data...");
+		}
+	}, []);
+
+	// Function to update override nodes
+	const updateOverrideNodes = useCallback((nodes: OverrideNode[]) => {
+		setOverrideNodes(nodes);
+		currentOverrideNodes = [...nodes];
+	}, []);
+
+	// Handle Run with override button click
+	const handleRunWithOverride = useCallback(() => {
+		perform(flow.id, {
+			overrideNodes: currentOverrideNodes,
+		});
+		setIsOpen(false);
+	}, [flow.id, perform]);
+
+	return (
+		<Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+			<Dialog.Trigger asChild>
+				<button type="button" className="hover:bg-black-800/20 rounded-[4px]">
+					<PencilIcon className="size-[18px]" />
+				</button>
+			</Dialog.Trigger>
+			<Dialog.Portal>
+				<Dialog.Overlay className="fixed inset-0 bg-black/25 z-50" />
+				<Dialog.Content className="fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] w-[900px] h-[600px] bg-black-900 rounded-[12px] p-[24px] shadow-xl z-50 overflow-hidden border border-black-400">
+					<Dialog.Title className="sr-only">
+						Override inputs to test workflow
+					</Dialog.Title>
+					<div className="flex justify-between items-center mb-[24px]">
+						<h2 className="font-accent text-[18px] font-bold text-primary-100 drop-shadow-[0_0_10px_#0087F6]">
+							Override inputs to test workflow
+						</h2>
+						<div className="flex gap-[12px]">
+							<Dialog.Close asChild>
+								<button
+									type="button"
+									className="text-white-400 hover:text-white-900"
+								>
+									<X className="size-[20px]" />
+								</button>
+							</Dialog.Close>
+							<Button
+								type="button"
+								className="bg-primary-900 hover:bg-primary-800"
+								onClick={handleRunWithOverride}
+							>
+								Run with override
+							</Button>
+						</div>
+					</div>
+					{flow && <RunWithOverrideParamsForm flow={flow} />}
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/viewer/dialog-with-override-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/dialog-with-override-form.tsx
@@ -5,12 +5,12 @@ import type {
 } from "@giselle-sdk/data-type";
 import { PencilIcon, X } from "lucide-react";
 import { Dialog } from "radix-ui";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { Button } from "../ui/button";
 import { RunWithOverrideParamsForm } from "./run-with-override-params-form";
 
 // Global variable to store override nodes
-let currentOverrideNodes: OverrideNode[] = [];
+const currentOverrideNodes: OverrideNode[] = [];
 
 export function DialogWithOverrideForm({
 	flow,
@@ -22,36 +22,15 @@ export function DialogWithOverrideForm({
 		options?: { overrideNodes?: OverrideNode[] },
 	) => void;
 }) {
-	// Dialog open/close state
-	const [isOpen, setIsOpen] = useState(false);
-	// Override nodes state
-	const [overrideNodes, setOverrideNodes] = useState<OverrideNode[]>([]);
-
-	// Initialize state when modal opens
-	const handleOpenChange = useCallback((open: boolean) => {
-		setIsOpen(open);
-		// Set initial data when modal is opened
-		if (open) {
-			console.log("Dialog opened, initializing data...");
-		}
-	}, []);
-
-	// Function to update override nodes
-	const updateOverrideNodes = useCallback((nodes: OverrideNode[]) => {
-		setOverrideNodes(nodes);
-		currentOverrideNodes = [...nodes];
-	}, []);
-
 	// Handle Run with override button click
 	const handleRunWithOverride = useCallback(() => {
 		perform(flow.id, {
 			overrideNodes: currentOverrideNodes,
 		});
-		setIsOpen(false);
 	}, [flow.id, perform]);
 
 	return (
-		<Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+		<Dialog.Root>
 			<Dialog.Trigger asChild>
 				<button type="button" className="hover:bg-black-800/20 rounded-[4px]">
 					<PencilIcon className="size-[18px]" />

--- a/internal-packages/workflow-designer-ui/src/viewer/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/index.tsx
@@ -128,28 +128,21 @@ export function Viewer() {
 															<Dialog.Title className="sr-only">
 																Override inputs to test workflow
 															</Dialog.Title>
-															<div className="flex justify-between items-center mb-[24px]">
-																<h2 className="font-accent text-[18px] font-bold text-primary-100 drop-shadow-[0_0_10px_#0087F6]">
-																	Override inputs to test workflow
-																</h2>
-																<div className="flex gap-[12px]">
-																	<Dialog.Close asChild>
+															{/* <Dialog.Close asChild>
 																		<button
 																			type="button"
 																			className="text-white-400 hover:text-white-900"
 																		>
 																			<X className="size-[20px]" />
 																		</button>
-																	</Dialog.Close>
-																	{/* <Button
+																	</Dialog.Close> */}
+															{/* <Button
 																		type="button"
 																		className="bg-primary-900 hover:bg-primary-800"
 																		onClick={handleRunWithOverride}
 																	>
 																		Run with override
 																	</Button> */}
-																</div>
-															</div>
 															<RunWithOverrideParamsForm flow={flow} />
 														</Dialog.Content>
 													</Dialog.Portal>

--- a/internal-packages/workflow-designer-ui/src/viewer/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/index.tsx
@@ -8,12 +8,13 @@ import {
 	useWorkflowDesigner,
 } from "giselle-sdk/react";
 import {
-	ChevronDownIcon,
 	CircleCheckIcon,
 	CircleSlashIcon,
+	PencilIcon,
+	X,
 	XCircleIcon,
 } from "lucide-react";
-import { Popover, Tabs } from "radix-ui";
+import { Dialog, Tabs } from "radix-ui";
 import { useMemo, useState } from "react";
 import { useUsageLimitsReached } from "../hooks/usage-limits";
 import { SpinnerIcon, WilliIcon } from "../icons";
@@ -112,27 +113,47 @@ export function Viewer() {
 											</Button>
 											<div className="absolute right-0 pr-[8px] top-[50%] translate-y-[-50%] h-full flex items-center justify-center">
 												<div className="w-[1px] h-full border-l border-white-800/40 mr-[6px]" />
-												<Popover.Root>
-													<Popover.Trigger asChild>
+												<Dialog.Root>
+													<Dialog.Trigger asChild>
 														<button
 															type="button"
 															className="hover:bg-black-800/20 rounded-[4px]"
 														>
-															<ChevronDownIcon className="size-[18px]" />
+															<PencilIcon className="size-[18px]" />
 														</button>
-													</Popover.Trigger>
-													<Popover.Portal>
-														<Popover.Content
-															className="w-[360px] rounded bg-black-900/20 backdrop-blur-[8px] rounded-[8px] px-[16px] py-[16px]"
-															sideOffset={12}
-															align="start"
-															alignOffset={-160}
-														>
-															<div className="absolute z-0 rounded-[8px] inset-0 border mask-fill bg-gradient-to-br from-[hsla(232,37%,72%,0.2)] to-[hsla(218,58%,21%,0.9)] bg-origin-border bg-clip-boarder border-transparent" />
+													</Dialog.Trigger>
+													<Dialog.Portal>
+														<Dialog.Overlay className="fixed inset-0 bg-black/25 z-50" />
+														<Dialog.Content className="fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] w-[900px] h-[600px] bg-black-900 rounded-[12px] p-[24px] shadow-xl z-50 overflow-hidden border border-black-400">
+															<Dialog.Title className="sr-only">
+																Override inputs to test workflow
+															</Dialog.Title>
+															<div className="flex justify-between items-center mb-[24px]">
+																<h2 className="font-accent text-[18px] font-bold text-primary-100 drop-shadow-[0_0_10px_#0087F6]">
+																	Override inputs to test workflow
+																</h2>
+																<div className="flex gap-[12px]">
+																	<Dialog.Close asChild>
+																		<button
+																			type="button"
+																			className="text-white-400 hover:text-white-900"
+																		>
+																			<X className="size-[20px]" />
+																		</button>
+																	</Dialog.Close>
+																	{/* <Button
+																		type="button"
+																		className="bg-primary-900 hover:bg-primary-800"
+																		onClick={handleRunWithOverride}
+																	>
+																		Run with override
+																	</Button> */}
+																</div>
+															</div>
 															<RunWithOverrideParamsForm flow={flow} />
-														</Popover.Content>
-													</Popover.Portal>
-												</Popover.Root>
+														</Dialog.Content>
+													</Dialog.Portal>
+												</Dialog.Root>
 											</div>
 										</div>
 									))}

--- a/internal-packages/workflow-designer-ui/src/viewer/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/index.tsx
@@ -128,21 +128,17 @@ export function Viewer() {
 															<Dialog.Title className="sr-only">
 																Override inputs to test workflow
 															</Dialog.Title>
-															{/* <Dialog.Close asChild>
-																		<button
-																			type="button"
-																			className="text-white-400 hover:text-white-900"
-																		>
-																			<X className="size-[20px]" />
-																		</button>
-																	</Dialog.Close> */}
-															{/* <Button
-																		type="button"
-																		className="bg-primary-900 hover:bg-primary-800"
-																		onClick={handleRunWithOverride}
-																	>
-																		Run with override
-																	</Button> */}
+															<Dialog.Close
+																asChild
+																className="absolute right-[24px] cursor-pointer"
+															>
+																<button
+																	type="button"
+																	className="text-white-400 hover:text-white-900"
+																>
+																	<X className="size-[20px]" />
+																</button>
+															</Dialog.Close>
 															<RunWithOverrideParamsForm flow={flow} />
 														</Dialog.Content>
 													</Dialog.Portal>

--- a/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
@@ -5,12 +5,17 @@ import {
 	isTextNode,
 } from "@giselle-sdk/data-type";
 import { TextEditor } from "@giselle-sdk/text-editor/react-internal";
+import clsx from "clsx/lite";
 import { useRunController } from "giselle-sdk/react";
+import { Tabs } from "radix-ui";
 import { type FormEventHandler, useCallback, useState } from "react";
+import { NodeIcon } from "../icons/node";
 import { Button } from "../ui/button";
 
 export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 	const { perform } = useRunController();
+	// Track the currently selected node
+	const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
 	const [overrideVariableNodes, setOverrideVariableNodes] = useState<
 		OverrideVariableNode[]
 	>(
@@ -29,6 +34,13 @@ export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 			)
 			.filter((node) => node !== null),
 	);
+
+	// Active node change handler
+	const handleNodeSelect = useCallback((nodeId: string) => {
+		console.log("Node selected:", nodeId);
+		setActiveNodeId(nodeId);
+	}, []);
+
 	const handleSubmit = useCallback<FormEventHandler<HTMLFormElement>>(
 		(e) => {
 			e.preventDefault();
@@ -49,49 +61,115 @@ export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 				className="flex-1 flex flex-col gap-[24px] relative text-white-800"
 				onSubmit={handleSubmit}
 			>
-				<div className="flex flex-col gap-[16px] flex-1">
-					{overrideVariableNodes?.map((overrideNode) => {
-						if (!isOverrideTextContent(overrideNode.content)) {
-							return null;
-						}
-						const originalNode = flow.nodes.find(
-							(node) => node.id === overrideNode.id,
-						);
-						if (originalNode === undefined) {
-							return null;
-						}
-						return (
-							<fieldset
-								className="flex gap-[8px] w-full h-full"
-								key={overrideNode.id}
-							>
-								<p className="w-[100px] text-[14px] font-bold text-white-400">
-									{originalNode.name ?? "Plain Text"}
-								</p>
-								<TextEditor
-									value={overrideNode.content.text}
-									onValueChange={(value) => {
-										setOverrideVariableNodes((prevOverrideVariableNodes) =>
-											prevOverrideVariableNodes.map(
-												(prevOverrideVariableNode) =>
-													prevOverrideVariableNode.id === overrideNode.id
-														? {
-																id: prevOverrideVariableNode.id,
-																type: prevOverrideVariableNode.type,
-																content: {
-																	type: "text",
-																	text: value,
-																},
-															}
-														: prevOverrideVariableNode,
-											),
-										);
-									}}
-								/>
-							</fieldset>
-						);
-					})}
-				</div>
+				<Tabs.Root className="flex flex-row gap-[24px] flex-1 overflow-hidden h-[calc(100%-60px)]">
+					{/* Left side: Node list */}
+					<Tabs.List className="w-[250px] overflow-y-auto pr-[8px] h-full">
+						<h3 className="text-[12px] mb-[8px] text-black-400 font-hubot font-semibold">
+							Input information
+						</h3>
+						<div className="flex flex-col gap-[8px]">
+							{overrideVariableNodes.map((overrideNode) => {
+								// Find original node (for icon and name)
+								const originalNode = flow.nodes.find(
+									(node) => node.id === overrideNode.id,
+								);
+								if (!originalNode) return null;
+
+								return (
+									<Tabs.Trigger
+										key={overrideNode.id}
+										value={overrideNode.id}
+										className={clsx(
+											"flex items-center p-[12px] rounded-[8px] border cursor-pointer transition-all duration-200 w-full text-left",
+											activeNodeId === overrideNode.id
+												? "border-primary-900 bg-black-800/30"
+												: "border-black-400/40 hover:border-primary-900/50 hover:bg-black-800/10",
+										)}
+										onClick={() => handleNodeSelect(overrideNode.id)}
+										aria-pressed={activeNodeId === overrideNode.id}
+										type="button"
+									>
+										{/* Node icon (using original icon) */}
+										<div className="flex items-center justify-center w-[36px] h-[36px] mr-[12px] rounded-[4px] bg-white-950 text-black-950">
+											<NodeIcon node={originalNode} className="size-[20px]" />
+										</div>
+
+										{/* Node name */}
+										<div className="flex-1">
+											<p className="text-[14px] font-medium text-white-900">
+												{originalNode.name || "Unnamed Node"}
+											</p>
+											<div className="flex items-center gap-1 mt-1">
+												<svg
+													width="10"
+													height="10"
+													viewBox="0 0 24 24"
+													fill="none"
+													xmlns="http://www.w3.org/2000/svg"
+													className="text-black-400"
+													aria-hidden="true"
+												>
+													<title>Link icon</title>
+													<path
+														d="M6.56961 16.0501C6.76961 16.2501 7.01961 16.3401 7.27961 16.3401C7.53961 16.3401 7.78961 16.2401 7.98961 16.0501L15.9196 8.1201C16.3096 7.7301 16.3096 7.1001 15.9196 6.7101C15.5296 6.3201 14.8996 6.3201 14.5096 6.7101L6.57961 14.6401C6.18961 15.0301 6.18961 15.6601 6.57961 16.0501H6.56961Z"
+														fill="currentColor"
+													/>
+													<path
+														d="M19.6298 2.98009C17.3598 0.710088 13.6698 0.710088 11.3998 2.98009L8.2098 6.17009H8.2198C7.8698 6.57009 7.8698 7.17009 8.2498 7.55009C8.6298 7.93009 9.2298 7.93009 9.6198 7.58009L9.6498 7.56009L12.7998 4.41009C14.2898 2.92009 16.7098 2.92009 18.1998 4.41009C19.6898 5.90009 19.6898 8.32009 18.1998 9.81009L15.0098 13.0001H15.0198C14.6698 13.4001 14.6698 14.0001 15.0498 14.3801C15.4298 14.7601 16.0298 14.7601 16.4198 14.4101L16.4498 14.3801L19.6098 11.2201C21.8798 8.95009 21.8798 5.26009 19.6098 2.99009L19.6298 2.98009Z"
+														fill="currentColor"
+													/>
+													<path
+														d="M14.5798 14.8601C14.2198 14.5001 13.6698 14.4901 13.2798 14.7801L13.2598 14.7601L10.2698 17.7501C8.77981 19.2401 6.35981 19.2401 4.8698 17.7501C3.3798 16.2601 3.3798 13.8401 4.8698 12.3501L7.7598 9.46006L7.8498 9.37006L7.82981 9.35006C8.12981 8.96006 8.10981 8.41006 7.74981 8.05006C7.38981 7.69006 6.83981 7.68006 6.44981 7.97006L6.42981 7.95006L3.4398 10.9401C1.1698 13.2101 1.1698 16.9001 3.4398 19.1701C5.7098 21.4401 9.3998 21.4401 11.6698 19.1701L14.5598 16.2801L14.6498 16.1901L14.6298 16.1701C14.9298 15.7801 14.9098 15.2301 14.5498 14.8701L14.5798 14.8601Z"
+														fill="currentColor"
+													/>
+												</svg>
+												<span className="text-[10px] text-black-400">
+													Connected node
+												</span>
+											</div>
+										</div>
+									</Tabs.Trigger>
+								);
+							})}
+						</div>
+					</Tabs.List>
+
+					{/* Right side: Text editor */}
+
+					{overrideVariableNodes.map(
+						(overrideNode) =>
+							overrideNode.content.type === "text" && (
+								<Tabs.Content
+									value={overrideNode.id}
+									className="flex-1 h-full"
+									key={overrideNode.id}
+								>
+									<div className="w-full h-full [&_.prompt-editor]:text-white [&_svg]:text-white [&_button]:text-white">
+										<TextEditor
+											value={overrideNode.content.text}
+											onValueChange={(value) => {
+												setOverrideVariableNodes((prevOverrideVariableNodes) =>
+													prevOverrideVariableNodes.map(
+														(prevOverrideVariableNode) =>
+															prevOverrideVariableNode.id === overrideNode.id
+																? {
+																		id: prevOverrideVariableNode.id,
+																		type: prevOverrideVariableNode.type,
+																		content: {
+																			type: "text",
+																			text: value,
+																		},
+																	}
+																: prevOverrideVariableNode,
+													),
+												);
+											}}
+										/>
+									</div>
+								</Tabs.Content>
+							),
+					)}
+				</Tabs.Root>
 				<div className="flex justify-end">
 					<Button type="submit">Run with params</Button>
 				</div>

--- a/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
@@ -39,53 +39,63 @@ export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 		[flow.id, perform, overrideVariableNodes],
 	);
 	return (
-		<form
-			className="flex flex-col gap-[24px] relative text-white-800"
-			onSubmit={handleSubmit}
-		>
-			<p className="font-accent text-[16px] font-bold text-white-400">
-				Run app with override parameters
-			</p>
-			<div className="flex flex-col gap-[16px]">
-				{overrideVariableNodes?.map((overrideNode) => {
-					if (!isOverrideTextContent(overrideNode.content)) {
-						return null;
-					}
-					const originalNode = flow.nodes.find(
-						(node) => node.id === overrideNode.id,
-					);
-					if (originalNode === undefined) {
-						return null;
-					}
-					return (
-						<fieldset className="flex gap-[8px] w-full" key={overrideNode.id}>
-							<p className="w-[100px] text-[14px] font-bold text-white-400">
-								{originalNode.name ?? "Plain Text"}
-							</p>
-							<TextEditor
-								value={overrideNode.content.text}
-								onValueChange={(value) => {
-									setOverrideVariableNodes((prevOverrideVariableNodes) =>
-										prevOverrideVariableNodes.map((prevOverrideVariableNode) =>
-											prevOverrideVariableNode.id === overrideNode.id
-												? {
-														id: prevOverrideVariableNode.id,
-														type: prevOverrideVariableNode.type,
-														content: {
-															type: "text",
-															text: value,
-														},
-													}
-												: prevOverrideVariableNode,
-										),
-									);
-								}}
-							/>
-						</fieldset>
-					);
-				})}
+		<div className="flex flex-col h-full">
+			<div className="flex justify-between items-center mb-[24px]">
+				<h2 className="font-accent text-[18px] font-bold text-primary-100 drop-shadow-[0_0_10px_#0087F6]">
+					Override inputs to test workflow
+				</h2>
 			</div>
-			<Button type="submit">Run with params</Button>
-		</form>
+			<form
+				className="flex-1 flex flex-col gap-[24px] relative text-white-800"
+				onSubmit={handleSubmit}
+			>
+				<div className="flex flex-col gap-[16px] flex-1">
+					{overrideVariableNodes?.map((overrideNode) => {
+						if (!isOverrideTextContent(overrideNode.content)) {
+							return null;
+						}
+						const originalNode = flow.nodes.find(
+							(node) => node.id === overrideNode.id,
+						);
+						if (originalNode === undefined) {
+							return null;
+						}
+						return (
+							<fieldset
+								className="flex gap-[8px] w-full h-full"
+								key={overrideNode.id}
+							>
+								<p className="w-[100px] text-[14px] font-bold text-white-400">
+									{originalNode.name ?? "Plain Text"}
+								</p>
+								<TextEditor
+									value={overrideNode.content.text}
+									onValueChange={(value) => {
+										setOverrideVariableNodes((prevOverrideVariableNodes) =>
+											prevOverrideVariableNodes.map(
+												(prevOverrideVariableNode) =>
+													prevOverrideVariableNode.id === overrideNode.id
+														? {
+																id: prevOverrideVariableNode.id,
+																type: prevOverrideVariableNode.type,
+																content: {
+																	type: "text",
+																	text: value,
+																},
+															}
+														: prevOverrideVariableNode,
+											),
+										);
+									}}
+								/>
+							</fieldset>
+						);
+					})}
+				</div>
+				<div className="flex justify-end">
+					<Button type="submit">Run with params</Button>
+				</div>
+			</form>
+		</div>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
@@ -61,7 +61,10 @@ export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 				className="flex-1 flex flex-col gap-[24px] relative text-white-800"
 				onSubmit={handleSubmit}
 			>
-				<Tabs.Root className="flex flex-row gap-[24px] flex-1 overflow-hidden h-[calc(100%-60px)]">
+				<Tabs.Root
+					className="flex flex-row gap-[24px] flex-1 overflow-hidden h-[calc(100%-60px)]"
+					defaultValue={overrideVariableNodes?.[0]?.id}
+				>
 					{/* Left side: Node list */}
 					<Tabs.List className="w-[250px] overflow-y-auto pr-[8px] h-full">
 						<h3 className="text-[12px] mb-[8px] text-black-400 font-hubot font-semibold">
@@ -81,9 +84,8 @@ export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 										value={overrideNode.id}
 										className={clsx(
 											"flex items-center p-[12px] rounded-[8px] border cursor-pointer transition-all duration-200 w-full text-left",
-											activeNodeId === overrideNode.id
-												? "border-primary-900 bg-black-800/30"
-												: "border-black-400/40 hover:border-primary-900/50 hover:bg-black-800/10",
+											"data-[state=active]:border-primary-900 data-[state=active]:bg-black-800/30",
+											"data-[state=inactive]:border-black-400/40 data-[state=inactive]hover:border-primary-900/50 data-[state=inactive]:hover:bg-black-800/10",
 										)}
 										onClick={() => handleNodeSelect(overrideNode.id)}
 										aria-pressed={activeNodeId === overrideNode.id}

--- a/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
@@ -1,7 +1,6 @@
 import {
 	type OverrideVariableNode,
 	type Workflow,
-	isOverrideTextContent,
 	isTextNode,
 } from "@giselle-sdk/data-type";
 import { TextEditor } from "@giselle-sdk/text-editor/react-internal";


### PR DESCRIPTION
## Summary
- Builds on PR #631 to enhance the workflow override dialog UI
- Adds a tabbed interface for better organization of multiple input parameters
- Improves state management with persistent values across node selections
- Enhances visual consistency with proper Radix state attributes

## Test plan
- Verify that workflow inputs can be overridden using the new tabbed interface
- Confirm that tabbed navigation works correctly between different input nodes
- Check that the form submits override parameters properly to the workflow runner

🤖 Generated with [Claude Code](https://claude.ai/code)