### PR TITLE
feat(studio.giselles.ai): remove unnecessary setup text from signup page

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/signup/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/signup/page.tsx
@@ -18,9 +18,6 @@ export default function SignupPage() {
 				>
 					Unleash Your Potential
 				</h2>
-				<p className="text-[18px] font-hubot leading-[30.6px] tracking-normal text-left text-black-70">
-					• Easy setup, no coding required
-				</p>
 			</div>
 			<div className="mt-8 space-y-6 w-[320px]">
 				<PageHeader title="Get Started" />


### PR DESCRIPTION
## Summary
Remove text from /signup page.


before
<img width="1057" alt="スクリーンショット 2025-04-03 14 57 48" src="https://github.com/user-attachments/assets/2a352f06-9ed5-48c6-99f5-2f0b8739f602" />

after
<img width="1057" alt="スクリーンショット 2025-04-03 14 57 53" src="https://github.com/user-attachments/assets/f0a1e30e-e03a-4bf8-9a2b-cc7feb3227a5" />
