### PR TITLE
feat(studio.giselles.ai): Add guide link to /apps page

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/components/navigation-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/components/navigation-item.tsx
@@ -9,10 +9,12 @@ export function NavigationItem({
 	href,
 	icon,
 	label,
+	openInNewTab = false,
 }: {
 	href: string;
 	icon: ReactNode;
 	label: string;
+	openInNewTab?: boolean;
 }) {
 	const pathname = usePathname();
 	const isActive = pathname === href;
@@ -20,6 +22,10 @@ export function NavigationItem({
 	return (
 		<Link
 			href={href}
+			{...(openInNewTab && {
+				target: "_blank",
+				rel: "noopener noreferrer",
+			})}
 			className="flex items-center gap-2 text-white-400 hover:text-white"
 		>
 			{icon}

--- a/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
@@ -70,6 +70,7 @@ export default function Layout({
 						href="https://docs.giselles.ai/"
 						icon={<BookIcon className="w-5 h-5" />}
 						label="Guide"
+						openInNewTab={true}
 					/>
 				</div>
 			</div>

--- a/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
@@ -5,12 +5,10 @@ import { putGraph } from "@giselles-ai/actions";
 import { WilliIcon } from "@giselles-ai/icons/willi";
 import { initGraph } from "@giselles-ai/lib/utils";
 import { createId } from "@paralleldrive/cuid2";
-import { Clock, User } from "lucide-react";
-import Link from "next/link";
+import { BookIcon, Clock } from "lucide-react";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { giselleEngine } from "../../giselle-engine";
-import { CreateAgentButton } from "./components";
 import { NavigationItem } from "./components/navigation-item";
 
 export default function Layout({
@@ -66,6 +64,12 @@ export default function Layout({
 						href="/apps/myapps"
 						icon={<WilliIcon className="w-5 h-5 fill-current" />}
 						label="My Apps"
+					/>
+
+					<NavigationItem
+						href="https://docs.giselles.ai/"
+						icon={<BookIcon className="w-5 h-5" />}
+						label="Guide"
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
Add link to docs on `/apps` page.

<img width="702" alt="スクリーンショット 2025-04-03 15 03 50" src="https://github.com/user-attachments/assets/e0aedbed-61bb-40f8-8c4c-f947a9358f56" />
