### PR TITLE
proofreading: Update app creation button to match empty state message

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
@@ -45,7 +45,7 @@ export default function Layout({
 							type="submit"
 							className="w-full bg-primary-200 hover:bg-primary-100 text-black-900 font-bold py-2 px-4 rounded-md font-hubot cursor-pointer"
 						>
-							Create new
+							New App +
 						</button>
 					</form>
 				</div>


### PR DESCRIPTION
## Summary
The current button title for creating new apps (`Create new`) doesn't match the empty state message (`Please create a new app with the 'New App +' button in the left sidebar.`). Changed so they match.

## Related Issue
<!-- Mention the related issue number if applicable. -->

None

## Changes
<!-- List the main changes made in this PR. -->

- Change `Create new` -> `New App +`

## Testing
<!-- Briefly describe the testing steps or results. -->

- Open the deployment preview.
- Go to the Apps page and check the `New App +` button.

![image](https://github.com/user-attachments/assets/5167607e-793e-45ad-b999-7257149fd96d)

## Other Information
<!-- Add any other relevant information for the reviewer. -->

Please let me know if a different style is preferred. For example, `Create New App`/`Create App` or similar.