### PR TITLE
Refactor node name handling in UI components

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/editable-text.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/editable-text.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import clsx from "clsx/lite";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function EditableText({
+	value,
+	onValueChange,
+	onClickToEditMode,
+}: {
+	value?: string;
+	onValueChange?: (value?: string) => void;
+	onClickToEditMode?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}) {
+	const [edit, setEdit] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (edit) {
+			inputRef.current?.select();
+			inputRef.current?.focus();
+		}
+	}, [edit]);
+
+	const updateValue = useCallback(() => {
+		if (!inputRef.current) {
+			return;
+		}
+		setEdit(false);
+		const currentValue = inputRef.current.value;
+
+		onValueChange?.(currentValue);
+		inputRef.current.value = currentValue;
+	}, [onValueChange]);
+
+	return (
+		<div>
+			<input
+				type="text"
+				className={clsx(
+					"w-[200px] py-[2px] px-[4px] rounded-[4px] hidden data-[editing=true]:block",
+					"outline-none ring-[1px] ring-primary-900",
+					"text-white-900 text-[14px]",
+				)}
+				ref={inputRef}
+				data-editing={edit}
+				defaultValue={value}
+				onBlur={() => updateValue()}
+				onKeyDown={(e) => {
+					if (e.key === "Enter") {
+						e.preventDefault();
+						updateValue();
+					}
+				}}
+			/>
+			<button
+				type="button"
+				className={clsx(
+					"py-[2px] px-[4px] rounded-l-[4px] last:rounded-r-[4px] data-[editing=true]:hidden",
+					"hover:bg-white-900/20",
+					"text-white-900 text-[14px]",
+					"cursor-default",
+				)}
+				data-editing={edit}
+				onClick={(e) => {
+					onClickToEditMode?.(e);
+					if (e.isDefaultPrevented()) {
+						return;
+					}
+					setEdit(true);
+				}}
+			>
+				{value}
+			</button>
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -16,11 +16,10 @@ import {
 } from "@xyflow/react";
 import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { NodeIcon } from "../../icons/node";
+import { EditableText } from "../../ui/editable-text";
 import { defaultName } from "../../utils";
-import { EditableText } from "./editable-text";
-import { NodeNameEditable } from "./node-name-editable";
 
 type GiselleWorkflowDesignerTextGenerationNode = XYFlowNode<
 	{ nodeData: TextGenerationNode; preview?: boolean },
@@ -97,6 +96,7 @@ export function NodeComponent({
 	preview?: boolean;
 	connectedOutputIds?: OutputId[];
 }) {
+	const { updateNodeData } = useWorkflowDesigner();
 	return (
 		<div
 			data-type={node.type}
@@ -153,7 +153,18 @@ export function NodeComponent({
 					</div>
 					<div>
 						<EditableText
-							value={defaultName(node)}
+							className="data-[selected=false]:pointer-events-none **:data-input:w-full"
+							text={defaultName(node)}
+							onValueChange={(value) => {
+								if (value === defaultName(node)) {
+									return;
+								}
+								if (value.trim().length === 0) {
+									updateNodeData(node, { name: undefined });
+									return;
+								}
+								updateNodeData(node, { name: value });
+							}}
 							onClickToEditMode={(e) => {
 								if (!selected) {
 									e.preventDefault();
@@ -161,31 +172,8 @@ export function NodeComponent({
 								}
 								e.stopPropagation();
 							}}
+							data-selected={selected}
 						/>
-						{/* {editName ? (
-							<input
-								type="text"
-								// onChange={(e) => setNodeName(e.target.value)}
-								onBlur={() => setEditName(false)}
-								className="text-[14px] text-white-900 outline-none"
-								defaultValue={defaultName(node)}
-							/>
-						) : (
-							<button
-								type="button"
-								onClick={(e) => {
-									if (!selected) {
-										return;
-									}
-									e.preventDefault();
-									e.stopPropagation();
-									setEditName(true);
-								}}
-								className="text-[14px] text-white-900"
-							>
-								{defaultName(node)}
-							</button>
-							)} */}
 						{node.type === "action" && (
 							<div className="text-[10px] text-white-400">
 								{node.content.llm.provider}

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -16,9 +16,11 @@ import {
 } from "@xyflow/react";
 import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { NodeIcon } from "../../icons/node";
 import { defaultName } from "../../utils";
+import { EditableText } from "./editable-text";
+import { NodeNameEditable } from "./node-name-editable";
 
 type GiselleWorkflowDesignerTextGenerationNode = XYFlowNode<
 	{ nodeData: TextGenerationNode; preview?: boolean },
@@ -125,13 +127,7 @@ export function NodeComponent({
 				)}
 			/>
 
-			{/* <NodeNameEditable
-				name={data.nodeData.name}
-				onNodeNameChange={(name) => {
-					updateNodeData(data.nodeData, { name });
-				}}
-			/> */}
-			<div className={clsx("px-[16px]")}>
+			<div className={clsx("px-[16px] relative")}>
 				<div className="flex items-center gap-[8px]">
 					<div
 						className={clsx(
@@ -156,9 +152,40 @@ export function NodeComponent({
 						/>
 					</div>
 					<div>
-						<div className="font-rosart text-[14px] text-white-900">
-							{defaultName(node)}
-						</div>
+						<EditableText
+							value={defaultName(node)}
+							onClickToEditMode={(e) => {
+								if (!selected) {
+									e.preventDefault();
+									return;
+								}
+								e.stopPropagation();
+							}}
+						/>
+						{/* {editName ? (
+							<input
+								type="text"
+								// onChange={(e) => setNodeName(e.target.value)}
+								onBlur={() => setEditName(false)}
+								className="text-[14px] text-white-900 outline-none"
+								defaultValue={defaultName(node)}
+							/>
+						) : (
+							<button
+								type="button"
+								onClick={(e) => {
+									if (!selected) {
+										return;
+									}
+									e.preventDefault();
+									e.stopPropagation();
+									setEditName(true);
+								}}
+								className="text-[14px] text-white-900"
+							>
+								{defaultName(node)}
+							</button>
+							)} */}
 						{node.type === "action" && (
 							<div className="text-[10px] text-white-400">
 								{node.content.llm.provider}

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -153,7 +153,7 @@ export function NodeComponent({
 					</div>
 					<div>
 						<EditableText
-							className="data-[selected=false]:pointer-events-none **:data-input:w-full"
+							className="group-data-[selected=false]:pointer-events-none **:data-input:w-full"
 							text={defaultName(node)}
 							onValueChange={(value) => {
 								if (value === defaultName(node)) {
@@ -172,7 +172,6 @@ export function NodeComponent({
 								}
 								e.stopPropagation();
 							}}
-							data-selected={selected}
 						/>
 						{node.type === "action" && (
 							<div className="text-[10px] text-white-400">

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -32,7 +32,7 @@ export function FileNodePropertiesPanel({ node }: { node: FileNode }) {
 				icon={
 					<FileNodeIcon node={node} className="size-[20px] text-black-900" />
 				}
-				name={node.name}
+				node={node}
 				onChangeName={(name) => {
 					updateNodeData(node, { name });
 				}}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/github-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/github-node-properties-panel/index.tsx
@@ -15,8 +15,7 @@ export function GitHubNodePropertiesPanel({ node }: { node: GitHubNode }) {
 		<PropertiesPanelRoot>
 			<PropertiesPanelHeader
 				icon={<GitHubIcon className="size-[20px] text-black-900" />}
-				name={node.name}
-				fallbackName="GitHub"
+				node={node}
 				description={"GitHub"}
 				onChangeName={(name) => {
 					updateNodeData(node, { name });

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -74,8 +74,7 @@ export function ImageGenerationNodePropertiesPanel({
 			{usageLimitsReached && <UsageLimitWarning />}
 			<PropertiesPanelHeader
 				icon={<NodeIcon node={node} className="size-[20px] text-black-900" />}
-				name={node.name}
-				fallbackName={node.content.llm.id}
+				node={node}
 				description={node.content.llm.provider}
 				onChangeName={(name) => {
 					updateNodeData(node, { name });

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -107,8 +107,7 @@ export function TextGenerationNodePropertiesPanel({
 						)}
 					</>
 				}
-				name={node.name}
-				fallbackName={node.content.llm.id}
+				node={node}
 				description={node.content.llm.provider}
 				onChangeName={(name) => {
 					updateNodeData(node, { name });

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-node-properties-panel/index.tsx
@@ -15,8 +15,7 @@ export function TextNodePropertiesPanel({ node }: { node: TextNode }) {
 		<PropertiesPanelRoot>
 			<PropertiesPanelHeader
 				icon={<PromptIcon className="size-[20px] text-black-900" />}
-				name={node.name}
-				fallbackName="Plain Text"
+				node={node}
 				description={"Plain Text"}
 				onChangeName={(name) => {
 					updateNodeData(node, { name });

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/properties-panel.tsx
@@ -1,14 +1,9 @@
 "use client";
 
-import {
-	type ReactNode,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
-import { EditableText } from "./editable-text";
+import type { Node } from "@giselle-sdk/data-type";
+import type { ReactNode } from "react";
+import { EditableText } from "../../../ui/editable-text";
+import { defaultName } from "../../../utils";
 
 export function PropertiesPanelRoot({
 	children,
@@ -23,45 +18,18 @@ export function PropertiesPanelRoot({
 }
 
 export function PropertiesPanelHeader({
-	name,
-	fallbackName: propsFallbackName,
+	node,
 	description,
 	icon,
 	onChangeName,
 	action,
 }: {
-	name?: string;
-	fallbackName?: string;
+	node: Node;
 	description?: string;
 	icon: ReactNode;
 	onChangeName?: (name?: string) => void;
 	action?: ReactNode;
 }) {
-	const [edit, setEdit] = useState(false);
-	const inputRef = useRef<HTMLInputElement>(null);
-	useEffect(() => {
-		if (edit) {
-			inputRef.current?.select();
-			inputRef.current?.focus();
-		}
-	}, [edit]);
-	const fallbackName = useMemo(
-		() => propsFallbackName ?? "Untitled Node",
-		[propsFallbackName],
-	);
-	const updateName = useCallback(() => {
-		if (!inputRef.current) {
-			return;
-		}
-		setEdit(false);
-		const currentValue =
-			inputRef.current.value.length === 0 ? undefined : inputRef.current.value;
-		if (fallbackName === currentValue) {
-			return;
-		}
-		onChangeName?.(currentValue);
-		inputRef.current.value = currentValue ?? fallbackName;
-	}, [onChangeName, fallbackName]);
 	return (
 		<div className="h-[48px] flex justify-between items-center pl-0 pr-[16px] shrink-0">
 			<div className="flex gap-[8px] items-center">
@@ -71,9 +39,17 @@ export function PropertiesPanelHeader({
 				<div>
 					<div>
 						<EditableText
-							onChange={(value) => onChangeName?.(value)}
-							value={name}
-							fallbackValue={fallbackName}
+							onValueChange={(value) => {
+								if (value === defaultName(node)) {
+									return;
+								}
+								if (value.trim().length === 0) {
+									onChangeName?.();
+									return;
+								}
+								onChangeName?.(value);
+							}}
+							text={defaultName(node)}
 						/>
 					</div>
 					{description && (

--- a/internal-packages/workflow-designer-ui/src/ui/editable-text.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/editable-text.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 import clsx from "clsx/lite";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	type HTMLAttributes,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 
 export function EditableText({
-	value,
+	className,
+	text,
 	onValueChange,
 	onClickToEditMode,
-}: {
-	value?: string;
-	onValueChange?: (value?: string) => void;
+	...props
+}: HTMLAttributes<HTMLDivElement> & {
+	text?: string;
+	onValueChange?: (value: string) => void;
 	onClickToEditMode?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
 	const [edit, setEdit] = useState(false);
@@ -22,34 +30,35 @@ export function EditableText({
 		}
 	}, [edit]);
 
-	const updateValue = useCallback(() => {
-		if (!inputRef.current) {
-			return;
+	useEffect(() => {
+		if (inputRef.current) {
+			inputRef.current.value = text ?? "";
 		}
-		setEdit(false);
-		const currentValue = inputRef.current.value;
+	}, [text]);
 
-		onValueChange?.(currentValue);
-		inputRef.current.value = currentValue;
+	const updateText = useCallback(() => {
+		setEdit(false);
+		const newTextValue = inputRef.current?.value ?? "";
+		onValueChange?.(newTextValue);
 	}, [onValueChange]);
 
 	return (
-		<div>
+		<div className={className} {...props}>
 			<input
 				type="text"
 				className={clsx(
-					"w-[200px] py-[2px] px-[4px] rounded-[4px] hidden data-[editing=true]:block",
+					"py-[2px] px-[4px] rounded-[4px] hidden data-[editing=true]:block",
 					"outline-none ring-[1px] ring-primary-900",
 					"text-white-900 text-[14px]",
 				)}
 				ref={inputRef}
+				data-input
 				data-editing={edit}
-				defaultValue={value}
-				onBlur={() => updateValue()}
+				onBlur={() => updateText()}
 				onKeyDown={(e) => {
 					if (e.key === "Enter") {
 						e.preventDefault();
-						updateValue();
+						updateText();
 					}
 				}}
 			/>
@@ -61,6 +70,7 @@ export function EditableText({
 					"text-white-900 text-[14px]",
 					"cursor-default",
 				)}
+				data-button
 				data-editing={edit}
 				onClick={(e) => {
 					onClickToEditMode?.(e);
@@ -70,7 +80,7 @@ export function EditableText({
 					setEdit(true);
 				}}
 			>
-				{value}
+				{text}
 			</button>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Refactors the EditableText component for improved node name editing
- Simplifies properties panel header by using the node prop directly instead of separate name and fallbackName props
- Adds inline name editing functionality to node components in the workflow designer

## Test plan
- Verify that node names can be edited both in the properties panel and directly on nodes
- Confirm that default names display correctly when custom names are not set
- Test that editing behavior works as expected (clicking to edit, pressing Enter, and clicking outside)

🤖 Generated with [Claude Code](https://claude.ai/code)