### PR TITLE
Fix: Update repository selection to use defaultValue

### DIFF
--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -176,7 +176,10 @@ function Installed({
 					</h3>
 					<div>
 						<fieldset className="flex flex-col gap-[4px]">
-							<Select value={data?.repositoryNodeId} name="repositoryNodeId">
+							<Select
+								defaultValue={data?.repositoryNodeId}
+								name="repositoryNodeId"
+							>
 								<SelectTrigger>
 									<SelectValue placeholder="Select a repository" />
 								</SelectTrigger>


### PR DESCRIPTION
## Summary
- Fixed GitHub integration repository selection by changing `value` prop to `defaultValue` for Select component
- This prevents controlled component warnings and ensures proper initialization

## Test plan
- Verify GitHub integration page loads correctly
- Verify repository selection works properly with default values

🤖 Generated with [Claude Code](https://claude.ai/code)