### PR TITLE
Fix: Remove unused bun unsafe import from header component

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/component.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { WorkspaceId } from "@giselle-sdk/data-type";
-import { unsafe } from "bun";
 import clsx from "clsx";
 import { ViewState, useWorkflowDesigner } from "giselle-sdk/react";
 import { CableIcon, EyeIcon, GanttChartIcon, PlayIcon } from "lucide-react";

--- a/internal-packages/workflow-designer-ui/src/header/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/component.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { WorkspaceId } from "@giselle-sdk/data-type";
+import { unsafe } from "bun";
 import clsx from "clsx";
 import { ViewState, useWorkflowDesigner } from "giselle-sdk/react";
 import { CableIcon, EyeIcon, GanttChartIcon, PlayIcon } from "lucide-react";
@@ -20,10 +21,6 @@ export function Header({
 }) {
 	const { data, updateName, view, setView } = useWorkflowDesigner();
 	const [openSettings, setOpenSettings] = useState(false);
-
-	const toggleView = () => {
-		setView(view === "editor" ? "viewer" : "editor");
-	};
 
 	const updateWorkflowName = (value?: string) => {
 		if (!value) {
@@ -107,8 +104,11 @@ export function Header({
 				<ToggleGroup.Root
 					type="single"
 					className="flex items-center py-[4px] px-[8px] rounded-[8px] overflow-hidden bg-black-200/20"
-					onValueChange={(value) => {
-						setView(ViewState.parse(value));
+					onValueChange={(unsafeValue) => {
+						const parse = ViewState.safeParse(unsafeValue);
+						if (parse.success) {
+							setView(ViewState.parse(parse.data));
+						}
 					}}
 				>
 					<ToggleGroup.Item
@@ -125,7 +125,6 @@ export function Header({
 					</ToggleGroup.Item>
 					<ToggleGroup.Item
 						value="viewer"
-						onClick={toggleView}
 						className={clsx(
 							"flex items-center gap-[4px] px-[8px] py-[4px] text-[12px] rounded-[4px] border-[1px] transition-colors font-[700]",
 							view === "viewer"
@@ -138,7 +137,6 @@ export function Header({
 					</ToggleGroup.Item>
 					<ToggleGroup.Item
 						value="integrator"
-						onClick={toggleView}
 						className={clsx(
 							"flex items-center gap-[4px] px-[8px] py-[4px] text-[12px] rounded-[4px] border-[1px] transition-colors font-[700]",
 							view === "integrator"


### PR DESCRIPTION
## Summary
- Removes an unused import statement from the header component
- Refactors the toggle view implementation to use ViewState's safeParse method for better type safety

## Test plan
- Verify the header component works as expected
- Verify the toggle group continues to function properly

🤖 Generated with [Claude Code](https://claude.ai/code)