### PR TITLE
Fix workflow designer background brightness

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/background.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/background.tsx
@@ -294,7 +294,7 @@ export function Background() {
 	}, []);
 
 	return (
-		<div className="relative w-full h-full" ref={containerRef}>
+		<div className="relative w-full h-full bg-[#141414]" ref={containerRef}>
 			<canvas ref={canvasRef} className="absolute inset-0" />
 			<div className="absolute w-full h-full bg-radial-[45%_45%_at_50%_50%] from-[rgba(1,20,50,0.30)] to-[rgba(1,4,26,0.80)]" />
 		</div>


### PR DESCRIPTION
## Summary
- Add explicit background color (#141414) to workflow designer background component
- Fixes the background image brightness issue noted in PR #648

## Test plan
- Verify workflow designer background renders with proper brightness
- Check for visual consistency across browsers

🤖 Generated with [Claude Code](https://claude.ai/code)