### PR TITLE
Fix (workaround) Enable to properly unset next action in GitHub Integration Setting

### DIFF
--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -111,6 +111,16 @@ function Installed({
 		WorkspaceGitHubIntegrationPayloadNodeMap[]
 	>(data?.payloadMaps || []);
 
+	// Select component doesn't support resetting the value to undefined
+	// So we need to use a workaround
+	// https://github.com/radix-ui/primitives/issues/1569
+	// https://github.com/shadcn-ui/ui/discussions/638
+	const [nextActionKey, setNextActionKey] = useState(0);
+	const resetSelectedNextAction = useCallback(() => {
+		setSelectedNextAction(undefined);
+		setNextActionKey((prev) => prev + 1);
+	}, []);
+
 	useEffect(() => {
 		if (data) {
 			setSelectedTrigger(data.event);
@@ -126,8 +136,8 @@ function Installed({
 			if (!newTrigger.success) {
 				setSelectedTrigger(undefined);
 				setCallsign("");
-				setSelectedNextAction(undefined);
 				setPayloadMaps([]);
+				resetSelectedNextAction();
 				return;
 			}
 
@@ -145,11 +155,11 @@ function Installed({
 					selectedNextAction &&
 					!availableActions.includes(selectedNextAction)
 				) {
-					setSelectedNextAction(undefined);
+					resetSelectedNextAction();
 				}
 			}
 		},
-		[selectedTrigger, selectedNextAction],
+		[selectedTrigger, selectedNextAction, resetSelectedNextAction],
 	);
 	const availablePayloadFields = useMemo(
 		() => (selectedTrigger ? getAvailablePayloadFields(selectedTrigger) : []),
@@ -302,6 +312,7 @@ function Installed({
 					</h3>
 					<fieldset className="flex flex-col gap-[4px]">
 						<Select
+							key={nextActionKey}
 							name="nextAction"
 							value={selectedNextAction}
 							onValueChange={(value) => {
@@ -310,7 +321,7 @@ function Installed({
 								if (nextAction.success) {
 									setSelectedNextAction(nextAction.data);
 								} else {
-									setSelectedNextAction(undefined);
+									resetSelectedNextAction();
 								}
 							}}
 						>


### PR DESCRIPTION
## Summary
I've corrected the process that resets the nextAction appropriately based on the trigger value.

## Related Issue
- https://github.com/radix-ui/primitives/issues/1569
- https://github.com/shadcn-ui/ui/discussions/638
