### PR TITLE
Fix overflow issue in run params form

### DIFF
--- a/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/viewer/run-with-override-params-form.tsx
@@ -57,7 +57,7 @@ export function RunWithOverrideParamsForm({ flow }: { flow: Workflow }) {
 				</h2>
 			</div>
 			<form
-				className="flex-1 flex flex-col gap-[24px] relative text-white-800"
+				className="flex-1 flex flex-col gap-[24px] relative text-white-800 overflow-y-hidden"
 				onSubmit={handleSubmit}
 			>
 				<Tabs.Root


### PR DESCRIPTION
## Summary
- Add overflow-y-hidden to run params form container to prevent double scrollbars and improve UI experience

## Test plan
- Open a workflow with multiple text nodes
- Click "Run with params" button
- Verify the form displays correctly without double scrollbars

🤖 Generated with [Claude Code](https://claude.ai/code)