### PR TITLE
Fix: Reduce app card height and remove thumbnail placeholder

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/page.tsx
@@ -52,7 +52,7 @@ async function AgentList() {
 				{dbAgents.map((agent) => (
 					<div
 						key={agent.id}
-						className="relative group flex-grow basis-[280px] min-w-[280px] max-w-[376px] h-[354px]"
+						className="relative group flex-grow basis-[280px] min-w-[280px] max-w-[376px] h-[160px]"
 					>
 						{/* Menu buttons - positioned absolutely on top of the card */}
 						<div className="absolute top-0 right-[8px] z-10 opacity-60 group-hover:opacity-100 transition-opacity flex">
@@ -72,7 +72,7 @@ async function AgentList() {
 								<div className="h-[20px] mb-1.5" />
 
 								{/* Thumbnail */}
-								<div className="h-[150px] bg-black-80 rounded-[8px] mb-4" />
+								{/* <div className="h-[150px] bg-black-80 rounded-[8px] mb-4" /> */}
 
 								<div className="flex-grow">
 									<h3 className="font-hubot text-white-400 text-[16px] font-semibold mb-1 line-clamp-2">


### PR DESCRIPTION
## Summary
- Reduces the app card height from 354px to 160px for a more compact UI
- Comments out the unused thumbnail placeholder to improve focus on essential information

## Test plan
- Verify the app cards display correctly with reduced height
- Confirm the UI looks clean without the thumbnail placeholder
- Check that all functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)