### PR TITLE
proofreading: Workspace tour

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
@@ -9,7 +9,7 @@ export const tourSteps: TourStep[] = [
 	{
 		title: "Command Hub",
 		content:
-			"Add Gen nodes, access your knowledge base, manipulate files, invoke other agents, and orchestrate your workflow.",
+			"Add generation nodes, access your knowledge base, manipulate files, invoke other agents, and orchestrate your workflow.",
 		placement: "right" as const,
 		target: ".nav, .absolute.bottom-0, nav.rounded-\\[8px\\]", // 下部ナビゲーションバーを正確に指定
 	},

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
@@ -16,7 +16,7 @@ export const tourSteps: TourStep[] = [
 	{
 		title: "Node Settings",
 		content:
-			"Double-tap nodes to edit settings, craft prompts, configure references, and establish connections between nodes to create a seamless generation flow.",
+			"Click nodes to edit settings, craft prompts, configure references, and establish connections between nodes to create a seamless generation flow.",
 		placement: "left" as const,
 	},
 	{

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
@@ -7,7 +7,7 @@ export const tourSteps: TourStep[] = [
 		placement: "bottom" as const,
 	},
 	{
-		title: "Your command hub.",
+		title: "Command Hub",
 		content:
 			"Add Gen nodes, access your knowledge base, manipulate files, invoke other agents, and orchestrate your workflow.",
 		placement: "right" as const,

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/steps.ts
@@ -36,7 +36,7 @@ export const tourSteps: TourStep[] = [
 	{
 		title: "Resources & Support",
 		content:
-			'Get help when you need it. Explore our comprehensive <a href="https://docs.giselles.ai/introduction" style="text-decoration: underline; color: #0087f6;">Docs</a> for detailed guidance and best practices whenever you encounter challenges.',
+			"Get help when you need it. Explore our comprehensive Docs for detailed guidance and best practices whenever you encounter challenges.",
 		placement: "bottom" as const,
 	},
 ];

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
@@ -405,11 +405,13 @@ const TourStep1 = (props: TourStepComponentProps) => {
 								className="text-white/40 my-2 text-center"
 								style={{ fontSize: "12px" }}
 							>
-								Double-tap nodes to open
+								Click nodes to
 								<br />
-								setting Drag & drop
+								edit their settings
 								<br />
-								to connect
+								Click to connect an input
+								<br />
+								and output
 							</p>
 							<div className="flex w-full mt-1 justify-center">
 								<button
@@ -421,7 +423,7 @@ const TourStep1 = (props: TourStepComponentProps) => {
 										background: "rgba(255, 255, 255, 0.1)",
 									}}
 								>
-									Double-tap
+									Click
 								</button>
 							</div>
 						</div>
@@ -441,10 +443,11 @@ const TourStep1 = (props: TourStepComponentProps) => {
 								className="text-white/40 my-2 text-center"
 								style={{ fontSize: "12px" }}
 							>
-								⌘ + Enter to run a command
-								<br />⌘ + Shift + Enter to
+								⌘ + Enter to run a
 								<br />
-								run entire workflows
+								command when editing a
+								<br />
+								generation node
 							</p>
 							<div className="flex w-full mt-1 justify-center">
 								<button

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
@@ -459,7 +459,7 @@ const TourStep1 = (props: TourStepComponentProps) => {
 										background: "rgba(255, 255, 255, 0.1)",
 									}}
 								>
-									⌘ + ⇧ + ↵
+									⌘ + Enter
 								</button>
 							</div>
 						</div>

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
@@ -409,9 +409,9 @@ const TourStep1 = (props: TourStepComponentProps) => {
 								<br />
 								edit their settings
 								<br />
-								Click to connect an input
+								Click & drag to connect
 								<br />
-								and output
+								an input and output
 							</p>
 							<div className="flex w-full mt-1 justify-center">
 								<button
@@ -423,7 +423,7 @@ const TourStep1 = (props: TourStepComponentProps) => {
 										background: "rgba(255, 255, 255, 0.1)",
 									}}
 								>
-									Click
+									Click & Drag
 								</button>
 							</div>
 						</div>

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
@@ -370,7 +370,7 @@ const TourStep1 = (props: TourStepComponentProps) => {
 								className="text-white/40 my-2 text-center"
 								style={{ fontSize: "12px" }}
 							>
-								Drag to move canvas
+								Drag to move the canvas
 								<br />⌘ (Ctrl) + scroll to
 								<br />
 								zoom in/out

--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
@@ -371,8 +371,7 @@ const TourStep1 = (props: TourStepComponentProps) => {
 								style={{ fontSize: "12px" }}
 							>
 								Drag to move canvas
-								<br />
-								⌘(Ctrl) + scroll to
+								<br />⌘ (Ctrl) + scroll to
 								<br />
 								zoom in/out
 							</p>
@@ -442,7 +441,7 @@ const TourStep1 = (props: TourStepComponentProps) => {
 								className="text-white/40 my-2 text-center"
 								style={{ fontSize: "12px" }}
 							>
-								⌘ + Enter to Run
+								⌘ + Enter to run a command
 								<br />⌘ + Shift + Enter to
 								<br />
 								run entire workflows


### PR DESCRIPTION
## Summary
Various fixes to word choice/style/spacing and clarity for the newly added workspace tour. Also remove/change some outdated feature text.

## Related Issue
<!-- Mention the related issue number if applicable. -->
- https://github.com/giselles-ai/giselle/pull/654

## Changes
<!-- List the main changes made in this PR. -->
- Some minor spacing/article/clarification fixes.
- Remove outdated shortcut (ctrl+shift+enter) to run commands. Replace it with more detailed text to run commands on generation nodes.
- Change outdated double-click mention. Clarify node connections.

## Testing
<!-- Briefly describe the testing steps or results. -->
- Open the preview
- Go to the Apps page and create a new app
- Click through the workspace tour and review the text

## Other Information
<!-- Add any other relevant information for the reviewer. -->
