### PR TITLE
Feat/amazing feature

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/memoized-markdown.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/memoized-markdown.tsx
@@ -3,49 +3,49 @@ import { memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 
 function parseMarkdownIntoBlocks(markdown: string): string[] {
-    const tokens = marked.lexer(markdown);
-    return tokens.map((token) => token.raw);
+        const tokens = marked.lexer(markdown);
+        return tokens.map((token) => token.raw);
 }
 
 const MemoizedMarkdownBlock = memo(
-    ({ content }: { content: string }) => {
-        return (
-            <ReactMarkdown
-                components={{
-                    a: ({ node, ...props }) => (
-                        <a
-                            {...props}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-blue-500 hover:text-blue-700 underline"
-                        />
-                    ),
-                }}
-            >
-                {content}
-            </ReactMarkdown>
-        );
-    },
-    (prevProps, nextProps) => {
-        if (prevProps.content !== nextProps.content) return false;
-        return true;
-    },
+        ({ content }: { content: string }) => {
+            return (
+                <ReactMarkdown
+                    components={{
+                        a: ({ node, ...props }) => (
+                            <a
+                                {...props}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-500 hover:text-blue-700 underline"
+                            />
+                        ),
+                    }}
+                >
+                    {content}
+                </ReactMarkdown>
+            );
+        },
+        (prevProps, nextProps) => {
+            if (prevProps.content !== nextProps.content) return false;
+            return true;
+        },
 );
 
 MemoizedMarkdownBlock.displayName = "MemoizedMarkdownBlock";
 
 export const MemoizedMarkdown = memo(({ content }: { content: string }) => {
-    const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
+        const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
 
-    return blocks.map((block, index) => (
-        <MemoizedMarkdownBlock
-            content={block}
-            key={`block_${
-                // biome-ignore lint/suspicious/noArrayIndexKey: for internal use
-                index
-            }`}
-        />
-    ));
+        return blocks.map((block, index) => (
+            <MemoizedMarkdownBlock
+                content={block}
+                key={`block_${
+                    // biome-ignore lint/suspicious/noArrayIndexKey: for internal use
+                    index
+                }`}
+            />
+        ));
 });
 
 MemoizedMarkdown.displayName = "MemoizedMarkdown";

--- a/internal-packages/workflow-designer-ui/src/ui/memoized-markdown.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/memoized-markdown.tsx
@@ -3,34 +3,49 @@ import { memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 
 function parseMarkdownIntoBlocks(markdown: string): string[] {
-	const tokens = marked.lexer(markdown);
-	return tokens.map((token) => token.raw);
+    const tokens = marked.lexer(markdown);
+    return tokens.map((token) => token.raw);
 }
 
 const MemoizedMarkdownBlock = memo(
-	({ content }: { content: string }) => {
-		return <ReactMarkdown>{content}</ReactMarkdown>;
-	},
-	(prevProps, nextProps) => {
-		if (prevProps.content !== nextProps.content) return false;
-		return true;
-	},
+    ({ content }: { content: string }) => {
+        return (
+            <ReactMarkdown
+                components={{
+                    a: ({ node, ...props }) => (
+                        <a
+                            {...props}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-500 hover:text-blue-700 underline"
+                        />
+                    ),
+                }}
+            >
+                {content}
+            </ReactMarkdown>
+        );
+    },
+    (prevProps, nextProps) => {
+        if (prevProps.content !== nextProps.content) return false;
+        return true;
+    },
 );
 
 MemoizedMarkdownBlock.displayName = "MemoizedMarkdownBlock";
 
 export const MemoizedMarkdown = memo(({ content }: { content: string }) => {
-	const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
+    const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
 
-	return blocks.map((block, index) => (
-		<MemoizedMarkdownBlock
-			content={block}
-			key={`block_${
-				// biome-ignore lint/suspicious/noArrayIndexKey: for internal use
-				index
-			}`}
-		/>
-	));
+    return blocks.map((block, index) => (
+        <MemoizedMarkdownBlock
+            content={block}
+            key={`block_${
+                // biome-ignore lint/suspicious/noArrayIndexKey: for internal use
+                index
+            }`}
+        />
+    ));
 });
 
 MemoizedMarkdown.displayName = "MemoizedMarkdown";


### PR DESCRIPTION
## Summary
Added proper hyperlink rendering support to the Generation View component by configuring the ReactMarkdown component to handle links with appropriate styling and security attributes.

## Related Issue
Fixes the issue where hyperlinks in Markdown content were not being rendered as clickable links in the Generation View.
Changes  Issue number 469  --> https://github.com/giselles-ai/giselle/issues/469

## Changes
Enhanced MemoizedMarkdownBlock component with custom link rendering configuration
Added styling for hyperlinks using Tailwind classes:
Base color: text-blue-500
Hover state: text-blue-700
Visual indicator: underline
Implemented security best practices for external links:
Added target="_blank" to open links in new tabs
Included rel="noopener noreferrer" to prevent potential security vulnerabilities
Maintained the existing block-based rendering optimization

## Testing
Verify that Markdown content containing links like [Example](https://example.com) renders as clickable links
Confirm links are visually distinct with blue color and underline
Check that hovering over links shows a darker blue color
Validate that clicking links opens them in a new tab
Test with various Markdown content containing multiple links and mixed content

## Other Information
This change improves the usability of the Generation View by making links easily identifiable and interactive, while maintaining security best practices for external link handling. The implementation preserves the existing performance optimizations through memoization.