### PR TITLE
fix: update giselle engine import path from next-internal to next

### DIFF
--- a/apps/studio.giselles.ai/app/giselle-engine.ts
+++ b/apps/studio.giselles.ai/app/giselle-engine.ts
@@ -2,7 +2,7 @@ import { waitForLangfuseFlush } from "@/instrumentation.node";
 import { fetchUsageLimits } from "@/packages/lib/fetch-usage-limits";
 import { onConsumeAgentTime } from "@/packages/lib/on-consume-agent-time";
 import { WorkspaceId } from "@giselle-sdk/data-type";
-import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next-internal";
+import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next";
 import { createStorage } from "unstorage";
 import fsDriver from "unstorage/drivers/fs";
 import vercelBlobDriver from "unstorage/drivers/vercel-blob";


### PR DESCRIPTION
## Summary
- Update the import path for NextGiselleEngine from @giselle-sdk/giselle-engine/next-internal to @giselle-sdk/giselle-engine/next

## Test plan
- Ensure the application builds successfully
- Verify that the giselle engine functionality continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)