### PR TITLE
fix: update navigation labels and simplify menu structure

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/layout.tsx
@@ -82,15 +82,15 @@ export default function Layout({
 					<NavigationItem
 						href="/apps"
 						icon={<Clock className="w-5 h-5" />}
-						label="Recent"
+						label="Apps"
 					/>
 
 					{/* My Apps menu item */}
-					<NavigationItem
+					{/* <NavigationItem
 						href="/apps/myapps"
 						icon={<WilliIcon className="w-5 h-5 fill-current" />}
 						label="My Apps"
-					/>
+					/> */}
 
 					<NavigationItem
 						href="https://docs.giselles.ai/"

--- a/apps/studio.giselles.ai/app/(main)/apps/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/page.tsx
@@ -108,7 +108,7 @@ export default function AgentListV2Page() {
 		<ToastProvider>
 			<div className="w-full">
 				<h1 className="text-[28px] font-hubot font-medium mb-8 text-primary-100 drop-shadow-[0_0_20px_#0087f6]">
-					My Apps
+					Apps
 				</h1>
 				<Suspense fallback={<p className="text-center py-8">Loading...</p>}>
 					<AgentList />


### PR DESCRIPTION
## Summary
Simplify the navigation structure by consolidating "Recent" and "My Apps" sections into a single "Apps" section for better user experience and clearer navigation.

## Related Issue
N/A

## Changes
- Changed navigation label from "Recent" to "Apps"
- Updated page title from "My Apps" to "Apps"
- Removed redundant "My Apps" navigation item
- Simplified navigation structure to improve user flow