### PR TITLE
Fix large card height

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/workspace-tour/workspace-tour.tsx
@@ -122,7 +122,7 @@ const CARD_STYLES = {
 	},
 	large: {
 		width: "483px",
-		height: "423px",
+		height: "435px",
 	},
 	wide: {
 		width: "792px",


### PR DESCRIPTION
## Summary
Fixed Node Settings card navigation overlap by adjusting height

## Related Issue
N/A
