### PR TITLE
fix(studio.giselles.ai): fallback to the first team if the specified team is not found

### DIFF
--- a/apps/studio.giselles.ai/services/teams/set-current-team.ts
+++ b/apps/studio.giselles.ai/services/teams/set-current-team.ts
@@ -4,6 +4,9 @@ import type { TeamId } from "./types";
 
 export async function setCurrentTeam(teamId: TeamId) {
 	const teams = await fetchUserTeams();
+	if (teams.length === 0) {
+		throw new Error("No teams found");
+	}
 	let team = teams.find((t) => t.id === teamId);
 	if (team == null) {
 		// fallback to the first team

--- a/apps/studio.giselles.ai/services/teams/set-current-team.ts
+++ b/apps/studio.giselles.ai/services/teams/set-current-team.ts
@@ -4,9 +4,10 @@ import type { TeamId } from "./types";
 
 export async function setCurrentTeam(teamId: TeamId) {
 	const teams = await fetchUserTeams();
-	const team = teams.find((t) => t.id === teamId);
+	let team = teams.find((t) => t.id === teamId);
 	if (team == null) {
-		throw new Error("Team not found");
+		// fallback to the first team
+		team = teams[0];
 	}
-	await updateGiselleSession({ teamId });
+	await updateGiselleSession({ teamId: team.id });
 }


### PR DESCRIPTION
## Summary
Issue occurs when selecting a team from the team selector in the top-right corner.

Potential scenarios causing the error:
1. User is removed from the team membership between team list fetch and team selection
2. Team is deleted between team list fetch and team selection
3. User is removed due to team downgrade to free plan

The issue is related to race conditions between fetching the team list and selecting a team.
