### PR TITLE
Feature/llm card pro plan cta

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -130,7 +130,7 @@ function LanguageModelListItem({
 				"data-[state=on]:bg-primary-900",
 				"focus:outline-none",
 				"**:data-icon:w-[16px] **:data-icon:h-[16px] **:data-icon:text-white-950 ",
-				disabled && "opacity-50 cursor-not-allowed"
+				disabled && "opacity-50 cursor-not-allowed",
 			)}
 			disabled={disabled}
 		>
@@ -245,14 +245,26 @@ export function Toolbar() {
 														provider: languageModel?.provider,
 														configurations: languageModel?.configurations,
 													};
-													if (isTextGenerationLanguageModelData(languageModelData)) {
+													if (
+														isTextGenerationLanguageModelData(
+															languageModelData,
+														)
+													) {
 														setSelectedTool(
-															addNodeTool(textGenerationNode(languageModelData)),
+															addNodeTool(
+																textGenerationNode(languageModelData),
+															),
 														);
 													}
-													if (isImageGenerationLanguageModelData(languageModelData)) {
+													if (
+														isImageGenerationLanguageModelData(
+															languageModelData,
+														)
+													) {
 														setSelectedTool(
-															addNodeTool(imageGenerationNode(languageModelData)),
+															addNodeTool(
+																imageGenerationNode(languageModelData),
+															),
 														);
 													}
 												}}

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -116,12 +116,10 @@ function ProUpgradeOverlay() {
 function LanguageModelListItem({
 	languageModel,
 	disabled,
-	isPro,
 	...props
 }: Omit<ToggleGroup.ToggleGroupItemProps, "value"> & {
 	languageModel: LanguageModel;
 	disabled?: boolean;
-	isPro?: boolean;
 }) {
 	return (
 		<button
@@ -282,7 +280,6 @@ export function Toolbar() {
 																	disabled={
 																		!languageModelAvailable(languageModel)
 																	}
-																	isPro={limits?.featureTier === "pro"}
 																/>
 															</ToggleGroup.Item>
 														),

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -94,14 +94,16 @@ function ProUpgradeOverlay() {
 		<div className="absolute inset-0 z-20 flex flex-col justify-center items-center bg-black-850/80 backdrop-blur-[4px] rounded-[8px] w-[334px] h-[200px]">
 			<div className="flex flex-col items-center justify-center gap-4 px-4 text-center">
 				<p className="text-primary-400 text-[16px] font-semibold">
-					Upgrade to Pro<br />
+					Upgrade to Pro
+					<br />
 					to unlock this feature!
 				</p>
 				<button
+					type="button"
 					className="bg-primary-200 text-black-900 border border-primary-200 rounded-[8px] px-4 py-2 font-semibold hover:bg-primary-100 transition-colors font-hubot"
 					onClick={() => {
 						// Redirect to upgrade page
-						window.open('/settings/team', '_blank');
+						window.open("/settings/team", "_blank");
 					}}
 				>
 					Upgrade
@@ -123,7 +125,7 @@ function LanguageModelListItem({
 }) {
 	// If this is a Pro model and the user doesn't have Pro access, don't allow selection
 	const freePlanRestriction = languageModel.tier === "pro" && !isPro;
-	
+
 	return (
 		<button
 			{...props}
@@ -131,7 +133,7 @@ function LanguageModelListItem({
 				"flex gap-[8px]",
 				"hover:bg-white-850/10 focus:bg-white-850/10 p-[4px] rounded-[4px]",
 				// Only add the selected state style if not restricted by plan
-				{"data-[state=on]:bg-primary-900": !freePlanRestriction},
+				{ "data-[state=on]:bg-primary-900": !freePlanRestriction },
 				"focus:outline-none",
 				"**:data-icon:w-[16px] **:data-icon:h-[16px] **:data-icon:text-white-950 ",
 				disabled && "opacity-50 cursor-not-allowed",
@@ -242,14 +244,17 @@ export function Toolbar() {
 													const languageModel = languageModels.find(
 														(model) => model.id === modelId,
 													);
-													
+
 													// Check if user has access to this model
-													if (languageModel?.tier === "pro" && limits?.featureTier !== "pro") {
+													if (
+														languageModel?.tier === "pro" &&
+														limits?.featureTier !== "pro"
+													) {
 														// If pro model and free user, do not create node
 														// The overlay is already shown on hover
 														return;
 													}
-													
+
 													const languageModelData = {
 														id: languageModel?.id,
 														provider: languageModel?.provider,
@@ -533,11 +538,12 @@ export function Toolbar() {
 																	</>
 																)}
 															</div>
-															
+
 															{/* Pro upgrade overlay - show for Pro models if user is not on Pro plan */}
-															{languageModelMouseHovered.tier === "pro" && limits?.featureTier !== "pro" && (
-																<ProUpgradeOverlay />
-															)}
+															{languageModelMouseHovered.tier === "pro" &&
+																limits?.featureTier !== "pro" && (
+																	<ProUpgradeOverlay />
+																)}
 														</div>
 													)}
 												</div>

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -246,9 +246,7 @@ export function Toolbar() {
 														configurations: languageModel?.configurations,
 													};
 													if (
-														isTextGenerationLanguageModelData(
-															languageModelData,
-														)
+														isTextGenerationLanguageModelData(languageModelData)
 													) {
 														setSelectedTool(
 															addNodeTool(
@@ -257,9 +255,7 @@ export function Toolbar() {
 														);
 													}
 													if (
-														isImageGenerationLanguageModelData(
-															languageModelData,
-														)
+														isImageGenerationLanguageModelData(languageModelData)
 													) {
 														setSelectedTool(
 															addNodeTool(

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -89,6 +89,28 @@ function ProTag() {
 	);
 }
 
+function ProUpgradeOverlay() {
+	return (
+		<div className="absolute inset-0 z-20 flex flex-col justify-center items-center bg-black-850/80 backdrop-blur-[4px] rounded-[8px] w-[334px] h-[200px]">
+			<div className="flex flex-col items-center justify-center gap-4 px-4 text-center">
+				<p className="text-primary-400 text-[16px] font-semibold">
+					Upgrade to Pro<br />
+					to unlock this feature!
+				</p>
+				<button
+					className="bg-primary-200 text-black-900 border border-primary-200 rounded-[8px] px-4 py-2 font-semibold hover:bg-primary-100 transition-colors font-hubot"
+					onClick={() => {
+						// アップグレードページへのリダイレクト処理
+						window.open('/settings/team', '_blank');
+					}}
+				>
+					Upgrade
+				</button>
+			</div>
+		</div>
+	);
+}
+
 function LanguageModelListItem({
 	languageModel,
 	disabled,
@@ -288,7 +310,7 @@ export function Toolbar() {
 												<div className="absolute z-0 rounded-[8px] inset-0 border mask-fill bg-gradient-to-br from-[hsla(232,37%,72%,0.2)] to-[hsla(218,58%,21%,0.9)] bg-origin-border bg-clip-boarder border-transparent" />
 												<div className="relative text-white-800 h-[200px]">
 													{languageModelMouseHovered && (
-														<div className="px-[16px] py-[16px] flex flex-col gap-[24px]">
+														<div className="px-[16px] py-[16px] flex flex-col gap-[24px] relative">
 															<div className="flex items-start gap-[16px]">
 																<div className="flex items-center shrink-0">
 																	{languageModelMouseHovered.provider ===
@@ -493,6 +515,9 @@ export function Toolbar() {
 																	</>
 																)}
 															</div>
+															
+															{/* Pro upgrade overlay - always shown for debugging */}
+															<ProUpgradeOverlay />
 														</div>
 													)}
 												</div>

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -123,21 +123,16 @@ function LanguageModelListItem({
 	disabled?: boolean;
 	isPro?: boolean;
 }) {
-	// If this is a Pro model and the user doesn't have Pro access, don't allow selection
-	const freePlanRestriction = languageModel.tier === "pro" && !isPro;
-
 	return (
 		<button
 			{...props}
 			className={clsx(
-				"flex gap-[8px]",
+				"flex gap-[8px] relative",
 				"hover:bg-white-850/10 focus:bg-white-850/10 p-[4px] rounded-[4px]",
-				// Only add the selected state style if not restricted by plan
-				{ "data-[state=on]:bg-primary-900": !freePlanRestriction },
+				"data-[state=on]:bg-primary-900",
 				"focus:outline-none",
 				"**:data-icon:w-[16px] **:data-icon:h-[16px] **:data-icon:text-white-950 ",
-				disabled && "opacity-50 cursor-not-allowed",
-				freePlanRestriction && "cursor-pointer", // Still shows as clickable for UX
+				disabled && "opacity-50 cursor-not-allowed"
 			)}
 			disabled={disabled}
 		>
@@ -178,7 +173,6 @@ export function Toolbar() {
 		useState<LanguageModel | null>(null);
 	const { llmProviders } = useWorkflowDesigner();
 	const limits = useUsageLimits();
-	const isProUser = limits?.featureTier === "pro";
 	const languageModelAvailable = (languageModel: LanguageModel) => {
 		if (limits === undefined) {
 			return true;
@@ -245,39 +239,22 @@ export function Toolbar() {
 														(model) => model.id === modelId,
 													);
 
-													// Check if user has access to this model
-													if (
-														languageModel?.tier === "pro" &&
-														limits?.featureTier !== "pro"
-													) {
-														// If pro model and free user, do not create node
-														// The overlay is already shown on hover
-														return;
-													}
+													// Ensure languageModel exists before proceeding
+													if (!languageModel) return;
 
 													const languageModelData = {
 														id: languageModel?.id,
 														provider: languageModel?.provider,
 														configurations: languageModel?.configurations,
 													};
-													if (
-														isTextGenerationLanguageModelData(languageModelData)
-													) {
+													if (isTextGenerationLanguageModelData(languageModelData)) {
 														setSelectedTool(
-															addNodeTool(
-																textGenerationNode(languageModelData),
-															),
+															addNodeTool(textGenerationNode(languageModelData)),
 														);
 													}
-													if (
-														isImageGenerationLanguageModelData(
-															languageModelData,
-														)
-													) {
+													if (isImageGenerationLanguageModelData(languageModelData)) {
 														setSelectedTool(
-															addNodeTool(
-																imageGenerationNode(languageModelData),
-															),
+															addNodeTool(imageGenerationNode(languageModelData)),
 														);
 													}
 												}}
@@ -305,7 +282,7 @@ export function Toolbar() {
 																	disabled={
 																		!languageModelAvailable(languageModel)
 																	}
-																	isPro={isProUser}
+																	isPro={limits?.featureTier === "pro"}
 																/>
 															</ToggleGroup.Item>
 														),

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -516,8 +516,10 @@ export function Toolbar() {
 																)}
 															</div>
 															
-															{/* Pro upgrade overlay - always shown for debugging */}
-															<ProUpgradeOverlay />
+															{/* Pro upgrade overlay - only shown for Pro models */}
+															{languageModelMouseHovered.tier === "pro" && (
+																<ProUpgradeOverlay />
+															)}
 														</div>
 													)}
 												</div>

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -255,7 +255,9 @@ export function Toolbar() {
 														);
 													}
 													if (
-														isImageGenerationLanguageModelData(languageModelData)
+														isImageGenerationLanguageModelData(
+															languageModelData,
+														)
 													) {
 														setSelectedTool(
 															addNodeTool(


### PR DESCRIPTION
## Summary
Implemented an upgrade lead for Free Plan users accessing Pro models - hovering over a Pro model will display an ‘Upgrade to Pro’ overlay, which when clicked on will take the user to the upgrade page.

## Related Issue
N/A

## Changes.
- ‘Upgrade to Pro’ overlay for Free Plan users only when hovering over a Pro model.
- Control that nodes are not created when a Free Plan user clicks on a Pro model
- Fixed so that Pro models do not become selected (blue background colour) when a Free Plan user selects them
- Upgrade button now has the same style as the login button
- Clicking the button leads to the settings page (/settings/team)

## Testing
- As a Free Plan user, hover over a Pro model card to see the ‘Upgrade to Pro’ overlay.
- As a Free Plan user, confirmed that clicking on a Pro model does not create a node in the workspace
- As a Pro user, confirmed that all models are available as normal
- Verified that the button design is consistent with the login button
- All Biome lint errors have been fixed

## Other Information
- Overlays have been designed to fit the capability card size (334x200px)
- The design is consistent with other UI components to maintain brand consistency