### PR TITLE
Fix: Skip non-uploaded files in copyFiles function

### DIFF
--- a/packages/giselle-engine/src/core/runs/add-run.ts
+++ b/packages/giselle-engine/src/core/runs/add-run.ts
@@ -68,6 +68,9 @@ async function copyFiles({
 			continue;
 		}
 		for (const file of node.content.files) {
+			if (file.status !== "uploaded") {
+				continue;
+			}
 			fileIds.push(file.id);
 		}
 	}


### PR DESCRIPTION
## Summary
- Add condition to skip files that don't have 'uploaded' status in the copyFiles function
- Prevents errors when trying to copy non-existent files during run creation

## Test plan
- Create a workflow with file nodes having different status values
- Verify that only files with 'uploaded' status are copied to the run
- Check that no errors occur when processing file nodes with non-uploaded files

🤖 Generated with [Claude Code](https://claude.ai/code)