### PR TITLE
Add OpenAI o3 and 4o-mini models to available models

### DIFF
--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -56,10 +56,18 @@ const o1Mini: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
+const o3: OpenAILanguageModel = {
+	provider: "openai",
+	id: "o3",
+	capabilities: Capability.ImageFileInput | Capability.TextGeneration,
+	tier: Tier.enum.pro,
+	configurations: defaultConfigurations,
++};
+
 const o3Mini: OpenAILanguageModel = {
 	provider: "openai",
 	id: "o3-mini",
-	capabilities: Capability.TextGeneration,
+	capabilities: Capability.ImageFileInput | Capability.TextGeneration,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
 };

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -67,7 +67,7 @@ const o3: OpenAILanguageModel = {
 const o3Mini: OpenAILanguageModel = {
 	provider: "openai",
 	id: "o3-mini",
-	capabilities: Capability.ImageFileInput | Capability.TextGeneration,
+	capabilities: Capability.TextGeneration,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
 };

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -72,6 +72,14 @@ const o3Mini: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
+const o4Mini: OpenAILanguageModel = {
+	provider: "openai",
+	id: "o4-mini",
+	capabilities: Capability.ImageFileInput | Capability.TextGeneration,
+	tier: Tier.enum.pro,
+	configurations: defaultConfigurations,
+};
+
 const gpt41: OpenAILanguageModel = {
 	provider: "openai",
 	id: "gpt-4.1",
@@ -96,7 +104,7 @@ const gpt41nano: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-export const models = [gpt4o, gpt4oMini, o3, o3Mini, gpt41, gpt41mini, gpt41nano];
+export const models = [gpt4o, gpt4oMini, o3, o3Mini, o4Mini, gpt41, gpt41mini, gpt41nano];
 
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -96,7 +96,7 @@ const gpt41nano: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-export const models = [gpt4o, gpt4oMini, o3Mini, gpt41, gpt41mini, gpt41nano];
+export const models = [gpt4o, gpt4oMini, o3, o3Mini, gpt41, gpt41mini, gpt41nano];
 
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -104,7 +104,16 @@ const gpt41nano: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-export const models = [gpt4o, gpt4oMini, o3, o3Mini, o4Mini, gpt41, gpt41mini, gpt41nano];
+export const models = [
+	gpt4o,
+	gpt4oMini,
+	o3,
+	o3Mini,
+	o4Mini,
+	gpt41,
+	gpt41mini,
+	gpt41nano,
+];
 
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -62,7 +62,7 @@ const o3: OpenAILanguageModel = {
 	capabilities: Capability.ImageFileInput | Capability.TextGeneration,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
-+};
+};
 
 const o3Mini: OpenAILanguageModel = {
 	provider: "openai",


### PR DESCRIPTION
## Changes

This PR adds the new OpenAI o3 and o4-mini modesl to the list of available language models in the application:

- Added OpenAI o3 and o4-mini models with appropriate provider, ID, capabilities, and tier configuration
- Added o3 and  o4-mini to the exported models array

These changes will enable users to access the new o3 and  o4-mini models through our language model interface alongside the existing models like gpt4o, gpt41, and their variants.