### PR TITLE
Fixed - Module not found: Can't resolve '@/components/ui/clicable-text'

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/join/error/[code]/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/error/[code]/page.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { ClickableText } from "@/components/ui/clicable-text";
+import { ClickableText } from "@/components/ui/clickable-text";
 import { teamInvitationViaEmailFlag } from "@/flags";
 import Link from "next/link";
 import { notFound } from "next/navigation";

--- a/apps/studio.giselles.ai/app/(auth)/join/not-found.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/not-found.tsx
@@ -1,4 +1,4 @@
-import { ClickableText } from "@/components/ui/clicable-text";
+import { ClickableText } from "@/components/ui/clickable-text";
 import Link from "next/link";
 import { ActionPrompt } from "../components/action-prompt";
 

--- a/apps/studio.giselles.ai/components/ui/clickable-text.tsx
+++ b/apps/studio.giselles.ai/components/ui/clickable-text.tsx
@@ -32,6 +32,6 @@ const ClickableText = forwardRef<HTMLButtonElement, ClickableTextProps>(
 		);
 	},
 );
-ClickableText.displayName = "ClicableText";
+ClickableText.displayName = "ClickableText";
 
 export { ClickableText, clickableTextVariant as linkTextVariants };


### PR DESCRIPTION
## Summary
I fixed  `Module not found: Can't resolve '@/components/ui/clicable-text'`

## Related Issue
ref: https://github.com/giselles-ai/giselle/issues/713

## Changes
fix typo.

## Testing
Please check the build success.

## Other Information
I overlooked this because another branch was merged first.





