### PR TITLE
Fix: Prevent duplicate file attachments in message generation

### DIFF
--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -96,6 +96,7 @@ async function buildGenerationMessageForTextGeneration(
 	}));
 
 	const attachedFiles: (FilePart | ImagePart)[] = [];
+	const attachedFileNodeIds: NodeId[] = [];
 	for (const sourceKeyword of sourceKeywords) {
 		const contextNode = contextNodes.find(
 			(contextNode) => contextNode.id === sourceKeyword.nodeId,
@@ -104,6 +105,7 @@ async function buildGenerationMessageForTextGeneration(
 			continue;
 		}
 		const replaceKeyword = `{{${sourceKeyword.nodeId}:${sourceKeyword.outputId}}}`;
+
 		switch (contextNode.content.type) {
 			case "text": {
 				const jsonOrText = contextNode.content.text;
@@ -124,6 +126,13 @@ async function buildGenerationMessageForTextGeneration(
 				break;
 			}
 			case "file":
+				if (
+					attachedFileNodeIds.some(
+						(attachedFileNodeId) => contextNode.id === attachedFileNodeId,
+					)
+				) {
+					continue;
+				}
 				switch (contextNode.content.category) {
 					case "text":
 					case "image":
@@ -138,6 +147,7 @@ async function buildGenerationMessageForTextGeneration(
 						);
 
 						attachedFiles.push(...fileContents);
+						attachedFileNodeIds.push(contextNode.id);
 						break;
 					}
 					default: {


### PR DESCRIPTION
## Summary
- Prevent duplicate file attachments when the same file is referenced multiple times in a prompt
- Add tracking of attached file node IDs in the text generation message builder
- Only attach each file once to avoid potential issues with LLM providers

## Test plan
- Create a prompt that references the same file multiple times
- Verify that the file is only attached once in the generated message
- Check that the placeholder text for the file is still correctly inserted in each reference

🤖 Generated with [Claude Code](https://claude.ai/code)