### PR TITLE
Add Postgres Tool for database operations

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -26,6 +26,7 @@
 		"giselle-sdk": "workspace:^",
 		"lucide-react": "catalog:",
 		"next": "catalog:",
+		"pg": "catalog:",
 		"react": "catalog:",
 		"react-dom": "catalog:",
 		"unstorage": "catalog:"

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -131,7 +131,5 @@
 		"vite-tsconfig-paths": "5.1.4",
 		"vitest": "3.0.5"
 	},
-	"trustedDependencies": [
-		"@sentry/cli"
-	]
+	"trustedDependencies": ["@sentry/cli"]
 }

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -19,8 +19,8 @@
 		"@giselle-internal/workflow-designer-ui": "workspace:*",
 		"@giselle-sdk/data-type": "workspace:*",
 		"@giselle-sdk/giselle-engine": "workspace:*",
-		"@giselle-sdk/supabase-driver": "workspace:*",
 		"@giselle-sdk/integration": "workspace:*",
+		"@giselle-sdk/supabase-driver": "workspace:*",
 		"@icons-pack/react-simple-icons": "10.0.0",
 		"@lucide/lab": "0.1.2",
 		"@mendable/firecrawl-js": "1.6.1",
@@ -92,6 +92,7 @@
 		"next-themes": "0.3.0",
 		"nodemailer": "6.10.0",
 		"openai": "4.64.0",
+		"pg": "catalog:",
 		"pino": "9.5.0",
 		"posthog-js": "1.194.2",
 		"react": "catalog:",
@@ -130,5 +131,7 @@
 		"vite-tsconfig-paths": "5.1.4",
 		"vitest": "3.0.5"
 	},
-	"trustedDependencies": ["@sentry/cli"]
+	"trustedDependencies": [
+		"@sentry/cli"
+	]
 }

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2,7 +2,7 @@
 
 
 ## Summary
-* 1015 MIT
+* 1020 MIT
 * 107 Apache 2.0
 * 58 ISC
 * 34 New BSD
@@ -10528,6 +10528,39 @@ BlueOak-1.0.0 permitted
 
 
 
+<a name="pg"></a>
+### pg v8.14.1
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
+<a name="pg-cloudflare"></a>
+### pg-cloudflare v1.1.1
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
+<a name="pg-connection-string"></a>
+### pg-connection-string v2.7.0
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
 <a name="pg-int8"></a>
 ### pg-int8 v1.0.1
 #### 
@@ -10550,8 +10583,19 @@ BlueOak-1.0.0 permitted
 
 
 
+<a name="pg-pool"></a>
+### pg-pool v3.8.0
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
 <a name="pg-protocol"></a>
-### pg-protocol v1.7.0
+### pg-protocol v1.8.0
 #### 
 
 ##### Paths
@@ -10563,6 +10607,17 @@ BlueOak-1.0.0 permitted
 
 <a name="pg-types"></a>
 ### pg-types v2.2.0
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
+<a name="pgpass"></a>
+### pgpass v1.0.5
 #### 
 
 ##### Paths

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -33,7 +33,7 @@ import {
 } from "./model";
 import { useConnectedOutputs } from "./outputs";
 import { PromptPanel } from "./prompt-panel";
-import { GitHubToolsPanel } from "./tools";
+import { GitHubToolsPanel, PostgresToolsPanel } from "./tools";
 
 export function TextGenerationNodePropertiesPanel({
 	node,
@@ -316,9 +316,10 @@ export function TextGenerationNodePropertiesPanel({
 							</Tabs.Content>
 							<Tabs.Content
 								value="tools"
-								className="flex-1 flex flex-col overflow-y-auto p-[16px]"
+								className="flex-1 flex flex-col overflow-y-auto p-[16px] gap-[16px]"
 							>
 								<GitHubToolsPanel node={node} />
+								<PostgresToolsPanel node={node} />
 							</Tabs.Content>
 						</Tabs.Root>
 					</PropertiesPanelContent>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/index.tsx
@@ -1,1 +1,2 @@
 export { GitHubToolsPanel } from "./github-tools";
+export { PostgresToolsPanel } from "./postgres-tools";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/postgres-tools.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/postgres-tools.tsx
@@ -1,0 +1,150 @@
+import type { TextGenerationNode } from "@giselle-sdk/data-type";
+import { useGiselleEngine, useWorkflowDesigner } from "giselle-sdk/react";
+import { CheckIcon, DatabaseIcon, TrashIcon } from "lucide-react";
+import { Switch } from "../../../../ui/switch";
+
+const POSTGRES_TOOL_CATEGORIES = [
+	{
+		label: "Schema",
+		tools: ["getTableStructure"],
+	},
+	{
+		label: "Query",
+		tools: ["query"],
+	},
+];
+
+export function PostgresToolsPanel({ node }: { node: TextGenerationNode }) {
+	const { updateNodeDataContent } = useWorkflowDesigner();
+	const client = useGiselleEngine();
+
+	const toolsEnabled = !!node.content.tools?.postgres;
+	const selectedTools = node.content.tools?.postgres?.tools || [];
+
+	const handleToolToggle = (toolName: string) => {
+		if (!node.content.tools?.postgres) return;
+
+		const tools = selectedTools.includes(toolName)
+			? selectedTools.filter((t) => t !== toolName)
+			: [...selectedTools, toolName];
+
+		updateNodeDataContent(node, {
+			...node.content,
+			tools: {
+				...node.content.tools,
+				postgres: {
+					...node.content.tools.postgres,
+					tools,
+				},
+			},
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-[12px]">
+			<div className="flex items-center gap-[8px]">
+				<DatabaseIcon className="size-[20px] text-white-900" />
+				<div className="text-[14px]">Postgres Tools</div>
+			</div>
+			{!toolsEnabled && (
+				<form
+					className="bg-white-800/10 text-white-800 rounded-[4px] px-[12px] py-[8px] text-[12px] flex flex-col gap-[4px]"
+					onSubmit={async (e) => {
+						e.preventDefault();
+						const formData = new FormData(e.currentTarget);
+						const connectionString = formData.get("connectionString");
+						if (
+							typeof connectionString !== "string" ||
+							connectionString.length < 36
+						) {
+							alert("Invalid Connection String");
+							return;
+						}
+						const { encrypted } = await client.encryptSecret({
+							plaintext: connectionString,
+						});
+
+						updateNodeDataContent(node, {
+							...node.content,
+							tools: {
+								...node.content.tools,
+								postgres: {
+									connectionString: encrypted,
+									tools: [],
+								},
+							},
+						});
+					}}
+				>
+					<p>To use Postgres Tool, you need an connection string:</p>
+					<ul className="list-disc list-inside">
+						<li>
+							Paste your connection string below and hit enter to start using
+							the Postgres Tools
+						</li>
+					</ul>
+					<input
+						type="text"
+						name="connectionString"
+						className="border border-black-300 rounded-[4px] px-[4px] py-[4px] outline-none"
+						placeholder="postgres://default"
+					/>
+				</form>
+			)}
+			{toolsEnabled && (
+				<div className="bg-white-800/10 text-white-800 rounded-[4px] px-[12px] py-[8px] text-[12px] flex flex-col">
+					<div className="flex justify-between items-center">
+						<div className="flex gap-[6px] items-center">
+							<CheckIcon className="size-[14px] text-green-900" />
+							Tool configured.
+						</div>
+						<button
+							type="button"
+							className="text-white-800 flex items-center gap-[4px] cursor-pointer p-[2px] hover:bg-white-800/20 rounded-[4px] transition-colors"
+							onClick={() => {
+								updateNodeDataContent(node, {
+									...node.content,
+									tools: {
+										...node.content.tools,
+										postgres: undefined,
+									},
+								});
+							}}
+						>
+							<TrashIcon className="size-[12px]" />
+							Reset key
+						</button>
+					</div>
+					<div className="border-t border-white-800/10 my-[8px]" />
+
+					<div>
+						<div className="flex flex-col gap-[16px]">
+							<div className="flex flex-col gap-[8px]">
+								<div className="grid grid-cols-2 gap-[8px]">
+									<div className="flex items-center space-x-2 p-[4px] hover:bg-black-800/30 rounded-[4px]">
+										<Switch
+											name="getTableStructure"
+											label="getTableStructure"
+											checked={selectedTools.includes("getTableStructure")}
+											onCheckedChange={() =>
+												handleToolToggle("getTableStructure")
+											}
+										/>
+									</div>
+									<div className="flex items-center space-x-2 p-[4px] hover:bg-black-800/30 rounded-[4px]">
+										<Switch
+											name="query"
+											label="query"
+											checked={selectedTools.includes("query")}
+											onCheckedChange={() => handleToolToggle("query")}
+										/>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/data-type/src/node/actions/text-generation.ts
+++ b/packages/data-type/src/node/actions/text-generation.ts
@@ -75,6 +75,12 @@ export const GitHubTool = z.object({
 });
 export type GitHubTool = z.infer<typeof GitHubTool>;
 
+export const PostgresTool = z.object({
+	tools: z.string().array(),
+	connectionString: z.string(),
+});
+export type PostgresTool = z.infer<typeof PostgresTool>;
+
 export const TextGenerationContent = z.object({
 	type: z.literal("textGeneration"),
 	llm: TextGenerationLanguageModelData,
@@ -82,6 +88,7 @@ export const TextGenerationContent = z.object({
 	tools: z.optional(
 		z.object({
 			github: z.optional(GitHubTool),
+			postgres: z.optional(PostgresTool),
 		}),
 	),
 });

--- a/packages/giselle-engine/package.json
+++ b/packages/giselle-engine/package.json
@@ -45,6 +45,7 @@
 		"@giselle-sdk/utils": "workspace:*",
 		"@giselle/giselle-sdk-tsconfig": "workspace:*",
 		"@octokit/webhooks-types": "7.6.1",
+		"@types/pg": "catalog:",
 		"@types/react": "catalog:",
 		"tsup": "catalog:",
 		"vitest": "catalog:"
@@ -69,6 +70,7 @@
 		"langfuse-core": "catalog:",
 		"next": "catalog:",
 		"openai": "catalog:",
+		"pg": "catalog:",
 		"react": "catalog:",
 		"unstorage": "catalog:",
 		"zod": "catalog:"

--- a/packages/giselle-engine/src/core/generations/tools/postgres.ts
+++ b/packages/giselle-engine/src/core/generations/tools/postgres.ts
@@ -1,0 +1,45 @@
+import { tool } from "ai";
+import { Pool } from "pg";
+import { z } from "zod";
+
+export function createPostgresTools(connectionString: string) {
+	const pool = new Pool({ connectionString });
+	return {
+		toolSet: {
+			getTableStructure: tool({
+				description:
+					"Returns database table structure sorted by table and position.",
+				parameters: z.object({}),
+				execute: async () => {
+					const client = await pool.connect();
+					const res = await client.query(
+						`
+          SELECT table_name, column_name, data_type, is_nullable
+            FROM information_schema.columns
+           WHERE table_schema = 'public'
+           ORDER BY table_name, ordinal_position;`,
+					);
+					client.release();
+					return JSON.stringify(res.rows);
+				},
+			}),
+			query: tool({
+				description: "Run a SQL query",
+				parameters: z.object({
+					query: z.string().min(1).max(1000),
+				}),
+				execute: async ({ query }) => {
+					try {
+						const res = await pool.query(query);
+						return res.rows;
+					} catch (e) {
+						return e;
+					}
+				},
+			}),
+		} as const,
+		cleanup: async () => {
+			await pool.end();
+		},
+	};
+}

--- a/packages/giselle-engine/src/core/generations/types.ts
+++ b/packages/giselle-engine/src/core/generations/types.ts
@@ -1,5 +1,10 @@
-import type { TelemetrySettings as AI_TelemetrySettings } from "ai";
+import type { TelemetrySettings as AI_TelemetrySettings, ToolSet } from "ai";
 
 export interface TelemetrySettings {
 	metadata?: AI_TelemetrySettings["metadata"];
 }
+
+export type PreparedToolSet = {
+	toolSet: ToolSet;
+	cleanupFunctions: Array<() => void | Promise<void>>;
+};

--- a/packages/giselle-engine/src/http/create-handler.ts
+++ b/packages/giselle-engine/src/http/create-handler.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
-import { type GiselleEngineContext, UsageLimitError } from "../core";
+import type { GiselleEngineContext } from "../core";
+import { UsageLimitError } from "../core/error";
 
 /**
  * Type definition for handler arguments that conditionally includes input

--- a/packages/giselle-engine/tsup.config.ts
+++ b/packages/giselle-engine/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig([
 		banner: {
 			js: "'use client'",
 		},
+		external: ["react", "zod"],
 		format: ["cjs", "esm"],
 		dts: true,
 		sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ catalogs:
     '@types/node':
       specifier: 22.14.0
       version: 22.14.0
+    '@types/pg':
+      specifier: 8.11.13
+      version: 8.11.13
     '@types/pluralize':
       specifier: 0.0.33
       version: 0.0.33
@@ -180,6 +183,9 @@ catalogs:
     openai:
       specifier: 5.0.0-alpha.0
       version: 5.0.0-alpha.0
+    pg:
+      specifier: 8.14.1
+      version: 8.14.1
     pluralize:
       specifier: 8.0.0
       version: 8.0.0
@@ -274,7 +280,7 @@ importers:
         version: 12.4.1(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       geist:
         specifier: 1.3.1
-        version: 1.3.1(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.3.1(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       giselle-sdk:
         specifier: workspace:^
         version: link:../../packages/giselle-sdk
@@ -284,6 +290,9 @@ importers:
       next:
         specifier: 'catalog:'
         version: 15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      pg:
+        specifier: 'catalog:'
+        version: 8.14.1
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -503,7 +512,7 @@ importers:
         version: 1.0.0-beta.1(typescript@5.7.3)
       drizzle-orm:
         specifier: 0.32.1
-        version: 0.32.1(@neondatabase/serverless@0.9.5)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.1.0)(@vercel/postgres@0.9.0)(react@19.1.0)
+        version: 0.32.1(@neondatabase/serverless@0.9.5)(@opentelemetry/api@1.9.0)(@types/pg@8.11.13)(@types/react@19.1.0)(@vercel/postgres@0.9.0)(pg@8.14.1)(react@19.1.0)
       flags:
         specifier: 3.1.1
         version: 3.1.1(@opentelemetry/api@1.9.0)(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -512,7 +521,7 @@ importers:
         version: 6.7.1
       geist:
         specifier: 1.3.1
-        version: 1.3.1(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.3.1(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       giselle-sdk:
         specifier: workspace:*
         version: link:../../packages/giselle-sdk
@@ -552,6 +561,9 @@ importers:
       openai:
         specifier: 4.64.0
         version: 4.64.0(zod@3.24.1)
+      pg:
+        specifier: 'catalog:'
+        version: 8.14.1
       pino:
         specifier: 9.5.0
         version: 9.5.0
@@ -844,6 +856,9 @@ importers:
       openai:
         specifier: 'catalog:'
         version: 5.0.0-alpha.0(zod@3.24.1)
+      pg:
+        specifier: 'catalog:'
+        version: 8.14.1
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -866,6 +881,9 @@ importers:
       '@octokit/webhooks-types':
         specifier: 7.6.1
         version: 7.6.1
+      '@types/pg':
+        specifier: 'catalog:'
+        version: 8.11.13
       '@types/react':
         specifier: 'catalog:'
         version: 19.1.0
@@ -4762,6 +4780,9 @@ packages:
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
 
+  '@types/pg@8.11.13':
+    resolution: {integrity: sha512-6kXByGkvRvwXLuyaWzsebs2du6+XuAB2CuMsuzP7uaihQahshVgSmB22Pmh0vQMkQ1h5+PZU0d+Di1o+WpVWJg==}
+
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
 
@@ -7492,6 +7513,12 @@ packages:
   pdf-lib@1.17.1:
     resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
+  pg-cloudflare@1.1.1:
+    resolution: {integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==}
+
+  pg-connection-string@2.7.0:
+    resolution: {integrity: sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -7500,8 +7527,13 @@ packages:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
     engines: {node: '>=4'}
 
-  pg-protocol@1.7.0:
-    resolution: {integrity: sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==}
+  pg-pool@3.8.0:
+    resolution: {integrity: sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.8.0:
+    resolution: {integrity: sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -7510,6 +7542,18 @@ packages:
   pg-types@4.0.2:
     resolution: {integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==}
     engines: {node: '>=10'}
+
+  pg@8.14.1:
+    resolution: {integrity: sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
@@ -13080,18 +13124,24 @@ snapshots:
 
   '@types/pg-pool@2.0.6':
     dependencies:
-      '@types/pg': 8.11.6
+      '@types/pg': 8.11.13
+
+  '@types/pg@8.11.13':
+    dependencies:
+      '@types/node': 22.14.0
+      pg-protocol: 1.8.0
+      pg-types: 4.0.2
 
   '@types/pg@8.11.6':
     dependencies:
       '@types/node': 22.14.0
-      pg-protocol: 1.7.0
+      pg-protocol: 1.8.0
       pg-types: 4.0.2
 
   '@types/pg@8.6.1':
     dependencies:
       '@types/node': 22.14.0
-      pg-protocol: 1.7.0
+      pg-protocol: 1.8.0
       pg-types: 2.2.0
 
   '@types/phoenix@1.6.6': {}
@@ -14100,13 +14150,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.32.1(@neondatabase/serverless@0.9.5)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.1.0)(@vercel/postgres@0.9.0)(react@19.1.0):
+  drizzle-orm@0.32.1(@neondatabase/serverless@0.9.5)(@opentelemetry/api@1.9.0)(@types/pg@8.11.13)(@types/react@19.1.0)(@vercel/postgres@0.9.0)(pg@8.14.1)(react@19.1.0):
     optionalDependencies:
       '@neondatabase/serverless': 0.9.5
       '@opentelemetry/api': 1.9.0
-      '@types/pg': 8.11.6
+      '@types/pg': 8.11.13
       '@types/react': 19.1.0
       '@vercel/postgres': 0.9.0
+      pg: 8.14.1
       react: 19.1.0
 
   dset@3.1.4: {}
@@ -14486,7 +14537,7 @@ snapshots:
       - encoding
       - supports-color
 
-  geist@1.3.1(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  geist@1.3.1(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
       next: 15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
@@ -16030,11 +16081,20 @@ snapshots:
       pako: 1.0.11
       tslib: 1.14.1
 
+  pg-cloudflare@1.1.1:
+    optional: true
+
+  pg-connection-string@2.7.0: {}
+
   pg-int8@1.0.1: {}
 
   pg-numeric@1.0.2: {}
 
-  pg-protocol@1.7.0: {}
+  pg-pool@3.8.0(pg@8.14.1):
+    dependencies:
+      pg: 8.14.1
+
+  pg-protocol@1.8.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -16053,6 +16113,20 @@ snapshots:
       postgres-date: 2.1.0
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
+
+  pg@8.14.1:
+    dependencies:
+      pg-connection-string: 2.7.0
+      pg-pool: 3.8.0(pg@8.14.1)
+      pg-protocol: 1.8.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.1.1
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,3 +80,5 @@ catalog:
   langfuse-core: 3.37.0
   "@vercel/edge-config": 1.4.0
   "@supabase/supabase-js": 2.45.0
+  pg: 8.14.1
+  "@types/pg": 8.11.13


### PR DESCRIPTION
## Summary
- Add PostgreSQL tools that enable Claude to interact with PostgreSQL databases directly from workflows
- Support for basic query operations and schema exploration
- Secure handling of connection strings with proper cleanup after operations

## Test plan
- Connect to a PostgreSQL database using the connection string dialog
- Enable the available Postgres tools in the UI
- Test querying database structure and running SQL queries
- Verify proper connection cleanup after operations complete

🤖 Generated with [Claude Code](https://claude.ai/code)