### PR TITLE
Include team subscription ID to telemetry to query trace

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -47,6 +47,7 @@ export default async function Layout({
 				metadata: {
 					isProPlan: isProPlan(currentTeam),
 					teamType: currentTeam.type,
+					subscriptionId: currentTeam.activeSubscriptionId ?? "",
 				},
 			}}
 		>


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

This PR adds `subscriptionId` to Langfuse trace to enable coss analysis on BI

## Related Issue

- resolve #740 
<!-- Mention the related issue number if applicable. -->

## Changes

- added `subscriptionId` to Langfuse metadata
<!-- List the main changes made in this PR. -->

## Testing

### The new metadata arrived at Langfuse ✅ 

```
{
    "isProPlan": true,
    "teamType": "internal",
    "subscriptionId": ""
}
```
<img width="197" alt="image" src="https://github.com/user-attachments/assets/d30b03b3-ac7b-4323-927e-347641c8df08" />


### We can query observations by `subscriptionId` on our BI ✅ 

<!-- Briefly describe the testing steps or results. -->

## Other Information

- The new field `subscriptionId` did not appear on trace-level metadata 🤔
  - It only appears on generation-level (under each trace) metadata
- This does not matter because we can query **observations** (not traces)  by `subscriptionId`


<!-- Add any other relevant information for the reviewer. -->
