### PR TITLE
Add GitHub app installation flow

### DIFF
--- a/apps/studio.giselles.ai/app/github/installed/page.tsx
+++ b/apps/studio.giselles.ai/app/github/installed/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function () {
+	useEffect(() => {
+		// Send a message to the opener window
+		if (window.opener && !window.opener.closed) {
+			window.opener.postMessage(
+				{ type: "github-app-installed", success: true },
+				"*",
+			);
+		}
+		// Close the popup window after 2 seconds
+		const timer = setTimeout(() => {
+			window.close();
+		}, 600);
+
+		// Clean up the timer when component unmounts
+		return () => {
+			clearTimeout(timer);
+		};
+	}, []);
+	return (
+		<div className="h-screen flex items-center justify-center text-white-900 flex-col">
+			<p className="text-[24px] mb-[24px]">GitHub Installation Completed</p>
+			<p className="text-[14px]">This window will close automatically.</p>
+		</div>
+	);
+}

--- a/apps/studio.giselles.ai/packages/lib/github.ts
+++ b/apps/studio.giselles.ai/packages/lib/github.ts
@@ -2,6 +2,7 @@
 
 import { db, type githubIntegrationSettings } from "@/drizzle";
 import { getGitHubIdentityState } from "@/services/accounts";
+import { gitHubAppInstallURL } from "@/services/external/github";
 import type {
 	GitHubIntegrationInstalledState,
 	GitHubIntegrationInvalidCredentialState,
@@ -30,6 +31,7 @@ export async function getGitHubIntegrationState(
 	if (installations.length === 0) {
 		return {
 			status: "not-installed",
+			installationUrl: await gitHubAppInstallURL(),
 		};
 	}
 

--- a/packages/integration/src/github/index.ts
+++ b/packages/integration/src/github/index.ts
@@ -19,6 +19,7 @@ export type GitHubIntegrationInvalidCredentialState = z.infer<
 >;
 export const GitHubIntegrationNotInstalledState = z.object({
 	status: z.literal("not-installed"),
+	installationUrl: z.string().url(),
 });
 export type GitHubIntegrationNotInstalledState = z.infer<
 	typeof GitHubIntegrationNotInstalledState


### PR DESCRIPTION
## Summary
- Implement popup-based GitHub app installation flow with success confirmation page
- Add installation URL to GitHub integration "not-installed" state
- Create React component to handle GitHub app installation with popup window

## Test plan
1. Navigate to GitHub integration settings page with a fresh account
2. Verify "Install" button appears when GitHub app is not installed
3. Click "Install" button and verify popup window opens with GitHub app installation page
4. Complete installation in popup and verify it communicates back to main window
5. Confirm installation page shows success message and closes automatically
6. Verify main window refreshes GitHub integration state after installation

🤖 Generated with [Claude Code](https://claude.ai/code)