### PR TITLE
Update OpenAI models to use OptionalSearchGrounding capability

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
@@ -175,7 +175,10 @@ export function OpenAIModelPanel({
 						note={
 							languageModel &&
 							tools?.openaiWebSearch &&
-							!hasCapability(languageModel, Capability.SearchGrounding) &&
+							!hasCapability(
+								languageModel,
+								Capability.OptionalSearchGrounding,
+							) &&
 							"Web search will not use since the current model does not support web search"
 						}
 					/>

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -274,7 +274,7 @@ export async function generateText(args: {
 	if (
 		actionNode.content.llm.provider === "openai" &&
 		actionNode.content.tools?.openaiWebSearch &&
-		hasCapability(languageModel, Capability.SearchGrounding)
+		hasCapability(languageModel, Capability.OptionalSearchGrounding)
 	)
 		preparedToolSet = {
 			...preparedToolSet,

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -30,7 +30,7 @@ const gpt4o: OpenAILanguageModel = {
 	capabilities:
 		Capability.ImageFileInput |
 		Capability.TextGeneration |
-		Capability.SearchGrounding,
+		Capability.OptionalSearchGrounding,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
 };
@@ -41,7 +41,7 @@ const gpt4oMini: OpenAILanguageModel = {
 	capabilities:
 		Capability.ImageFileInput |
 		Capability.TextGeneration |
-		Capability.SearchGrounding,
+		Capability.OptionalSearchGrounding,
 	tier: Tier.enum.free,
 	configurations: defaultConfigurations,
 };
@@ -76,7 +76,7 @@ const gpt41: OpenAILanguageModel = {
 	capabilities:
 		Capability.ImageFileInput |
 		Capability.TextGeneration |
-		Capability.SearchGrounding,
+		Capability.OptionalSearchGrounding,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
 };
@@ -87,7 +87,7 @@ const gpt41mini: OpenAILanguageModel = {
 	capabilities:
 		Capability.ImageFileInput |
 		Capability.TextGeneration |
-		Capability.SearchGrounding,
+		Capability.OptionalSearchGrounding,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
 };


### PR DESCRIPTION
## Summary
- Changed several OpenAI model definitions to use OptionalSearchGrounding instead of SearchGrounding capability flag
- This change indicates that web search is optional for these models rather than mandatory

## Test plan
- Verify that GPT-4o, GPT-4o-mini, GPT-4.1, and GPT-4.1-mini models correctly show web search as an optional capability
- Ensure the web search toggle functionality works correctly with these models

🤖 Generated with [Claude Code](https://claude.ai/code)