### PR TITLE
Enhance invitation system to prevent duplicate invitations

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/error-components.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/error-components.tsx
@@ -9,7 +9,6 @@ const errorMessages: Record<ErrorCode, string> = {
 	expired: "This invitation has expired.",
 	wrong_email:
 		"The email address you're currently using doesn't match the email this invitation was intended for. To join this workspace, please sign out and then either sign in with the email address specified in the invitation or create a new account using that email address.",
-	already_member: "You're already a member of this team.",
 } as const;
 
 function ErrorPageLayout({ children }: { children: React.ReactNode }) {
@@ -54,23 +53,6 @@ export function ExpiredError() {
 						/>
 					</div>
 				</div>
-			</div>
-		</ErrorPageLayout>
-	);
-}
-
-export function AlreadyMemberError() {
-	return (
-		<ErrorPageLayout>
-			<div className="flex flex-col items-center justify-center gap-6">
-				<h2 className="text-[28px] font-[500] text-white font-hubot text-center">
-					{errorMessages.already_member}
-				</h2>
-				<Link href="/settings/team" className="w-full">
-					<Button className="w-full font-medium bg-blue-200 hover:bg-blue-300 text-black-900">
-						Go to team
-					</Button>
-				</Link>
 			</div>
 		</ErrorPageLayout>
 	);

--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/errors.ts
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/errors.ts
@@ -1,4 +1,4 @@
-export type ErrorCode = "expired" | "wrong_email" | "already_member";
+export type ErrorCode = "expired" | "wrong_email";
 
 export class JoinError extends Error {
 	code: ErrorCode;

--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/invitation.ts
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/invitation.ts
@@ -98,11 +98,14 @@ export async function acceptInvitation(token: string) {
 			throw new JoinError("wrong_email");
 		}
 
-		await tx.insert(teamMemberships).values({
-			userDbId,
-			teamDbId: invitation.teamDbId,
-			role: invitation.role,
-		});
+		await tx
+			.insert(teamMemberships)
+			.values({
+				userDbId,
+				teamDbId: invitation.teamDbId,
+				role: invitation.role,
+			})
+			.onConflictDoNothing(); // ignore if the user is already a member of the team
 		await tx
 			.update(invitations)
 			.set({ revokedAt: new Date() })

--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/invitation.ts
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/invitation.ts
@@ -98,20 +98,6 @@ export async function acceptInvitation(token: string) {
 			throw new JoinError("wrong_email");
 		}
 
-		const membership = await tx
-			.select()
-			.from(teamMemberships)
-			.where(
-				and(
-					eq(teamMemberships.userDbId, userDbId),
-					eq(teamMemberships.teamDbId, invitation.teamDbId),
-				),
-			)
-			.limit(1);
-		if (membership.length > 0) {
-			throw new JoinError("already_member");
-		}
-
 		await tx.insert(teamMemberships).values({
 			userDbId,
 			teamDbId: invitation.teamDbId,

--- a/apps/studio.giselles.ai/app/(main)/settings/team/invitation.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/invitation.ts
@@ -21,7 +21,7 @@ export async function createInvitation(
 	const expiredAt = new Date(Date.now() + 1000 * 60 * 60 * 24); // 24 hours
 
 	return db.transaction(async (tx) => {
-		// aquire advisory lock
+		// acquire advisory lock
 		await tx.execute(sql`
         SELECT pg_advisory_xact_lock(
           ${currentTeam.dbId},

--- a/apps/studio.giselles.ai/app/(main)/settings/team/invitation.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/invitation.ts
@@ -1,9 +1,9 @@
 import type { TeamRole, UserId } from "@/drizzle";
 import { db } from "@/drizzle";
-import { invitations, teams, users } from "@/drizzle/schema";
+import { invitations, teamMemberships, teams, users } from "@/drizzle/schema";
 import { sendEmail } from "@/services/external/email";
 import { type CurrentTeam, fetchCurrentTeam } from "@/services/teams";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 export type Invitation = typeof invitations.$inferSelect;
 
@@ -16,32 +16,80 @@ export async function createInvitation(
 		id: UserId;
 	},
 ): Promise<Invitation> {
+	const normalizedEmail = email.trim().toLowerCase();
 	const token = crypto.randomUUID();
-	const expiredAt = new Date(Date.now() + 1000 * 60 * 60 * 24); // 24 hours
+	const expiredAt = new Date(Date.now() + 1000 * 60 * 60 * 24); // 24 hours
 
-	const result = await db
-		.insert(invitations)
-		.values({
-			token,
-			teamDbId: currentTeam.dbId,
-			email,
-			role,
-			inviterUserDbId: currentUser.dbId,
-			expiredAt,
-			revokedAt: null,
-		})
-		.returning({
-			token: invitations.token,
-			teamDbId: invitations.teamDbId,
-			email: invitations.email,
-			role: invitations.role,
-			inviterUserDbId: invitations.inviterUserDbId,
-			expiredAt: invitations.expiredAt,
-			createdAt: invitations.createdAt,
-			revokedAt: invitations.revokedAt,
-		});
+	return db.transaction(async (tx) => {
+		// aquire advisory lock
+		await tx.execute(sql`
+        SELECT pg_advisory_xact_lock(
+          ${currentTeam.dbId},
+          hashtext(${normalizedEmail})
+        )
+      `);
 
-	return result[0];
+		// block invite if the user is already a team member
+		const existingMember = await tx
+			.select({ userDbId: users.dbId })
+			.from(users)
+			.innerJoin(
+				teamMemberships,
+				and(
+					eq(teamMemberships.userDbId, users.dbId),
+					eq(teamMemberships.teamDbId, currentTeam.dbId),
+				),
+			)
+			.where(eq(users.email, normalizedEmail))
+			.limit(1);
+
+		if (existingMember.length > 0) {
+			throw new Error("User is already a member of this team");
+		}
+
+		// block invite if an active invitation already exists
+		const existingActiveInvitation = await tx
+			.select()
+			.from(invitations)
+			.where(
+				and(
+					eq(invitations.teamDbId, currentTeam.dbId),
+					eq(invitations.email, normalizedEmail),
+					isNull(invitations.revokedAt),
+					sql`${invitations.expiredAt} > now()`, // not expired
+				),
+			)
+			.limit(1);
+
+		if (existingActiveInvitation.length > 0) {
+			throw new Error("An active invitation already exists");
+		}
+
+		// insert the invitation
+		const result = await tx
+			.insert(invitations)
+			.values({
+				token,
+				teamDbId: currentTeam.dbId,
+				email: normalizedEmail,
+				role,
+				inviterUserDbId: currentUser.dbId,
+				expiredAt,
+				revokedAt: null,
+			})
+			.returning({
+				token: invitations.token,
+				teamDbId: invitations.teamDbId,
+				email: invitations.email,
+				role: invitations.role,
+				inviterUserDbId: invitations.inviterUserDbId,
+				expiredAt: invitations.expiredAt,
+				createdAt: invitations.createdAt,
+				revokedAt: invitations.revokedAt,
+			});
+
+		return result[0];
+	});
 }
 
 export async function sendInvitationEmail(invitation: Invitation) {

--- a/apps/studio.giselles.ai/app/(main)/settings/team/invite-member-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/invite-member-dialog.tsx
@@ -22,10 +22,14 @@ import {
 
 type InviteMemberDialogProps = {
 	teamInvitationViaEmailEnabled: boolean;
+	memberEmails: string[];
+	invitationEmails: string[];
 };
 
 export function InviteMemberDialog({
 	teamInvitationViaEmailEnabled,
+	memberEmails,
+	invitationEmails,
 }: InviteMemberDialogProps) {
 	const [open, setOpen] = useState(false);
 	const [emailInput, setEmailInput] = useState("");
@@ -64,7 +68,11 @@ export function InviteMemberDialog({
 		try {
 			parse(pipe(string(), emailValidator()), trimmedEmail);
 			// Check for duplicates
-			if (!emailList.includes(trimmedEmail)) {
+			if (
+				!emailList.includes(trimmedEmail) &&
+				!memberEmails.includes(trimmedEmail) &&
+				!invitationEmails.includes(trimmedEmail)
+			) {
 				setEmailList((prev) => [...prev, trimmedEmail]);
 			}
 			setEmailInput("");

--- a/apps/studio.giselles.ai/app/(main)/settings/team/members/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/members/page.tsx
@@ -83,7 +83,7 @@ export default async function TeamMembersPage() {
 						teamInvitationViaEmailEnabled={teamInvitationViaEmailEnabled}
 						memberEmails={members
 							.map((member) => member.email)
-							.filter((email) => email !== null)}
+							.filter((email) => email != null)}
 						invitationEmails={invitations.map((invitation) => invitation.email)}
 					/>
 				)}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/members/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/members/page.tsx
@@ -81,6 +81,10 @@ export default async function TeamMembersPage() {
 				{hasProPlan && currentUserRole === "admin" && (
 					<InviteMemberDialog
 						teamInvitationViaEmailEnabled={teamInvitationViaEmailEnabled}
+						memberEmails={members
+							.map((member) => member.email)
+							.filter((email) => email !== null)}
+						invitationEmails={invitations.map((invitation) => invitation.email)}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
## Summary
This PR improves the team member invitation process to solve potential issues with duplicate invitations.

### Changes
1. Use advisory locking when creating invitations to prevent concurrent creation of invitations to the same user
2. Add validation that checks for existing members and active invitations before sending new ones
3. Remove `already_member` error handling and related components for a more streamlined flow
4. Add `ON CONFLICT DO NOTHING` to membership insertion to prevent future duplicates
5. Update InviteMemberDialog to include member and invitation email checks

These changes ensure users receive an error message when attempting to re-invite an already invited member, preventing duplicate entries in the database. Database-level safeguards have also been added to reduce the risk of future issues.