### PR TITLE
feat: add auto-dismiss behavior to toasts after 5 seconds

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/toast.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/toast.tsx
@@ -43,7 +43,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
 
 	const error = useCallback(
 		(message: string) => {
-			addToast({ message, type: "error", preserve: true });
+			addToast({ message, type: "error", preserve: false });
 		},
 		[addToast],
 	);
@@ -61,7 +61,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
 							"data-[type=error]:bg-error-900/60",
 						)}
 						data-type={toast.type}
-						duration={toast.preserve ? Number.POSITIVE_INFINITY : undefined}
+						duration={toast.preserve ? Number.POSITIVE_INFINITY : 5000}
 					>
 						<div
 							className={clsx(


### PR DESCRIPTION
Implementing global event handling to dismiss error messages on click events would require complex state management across the application. To avoid this, we opted for a simpler solution of auto-dismissing toast messages after 5 seconds.

This change:
- Adds automatic dismissal of toast messages after 5 seconds
- Simplifies error state management
- Maintains application architecture without introducing global event handlers