### PR TITLE
refactor(teams): replace Boring Avatars with AvatarImage component in team selection

### DIFF
--- a/apps/studio.giselles.ai/services/teams/components/team-selection.tsx
+++ b/apps/studio.giselles.ai/services/teams/components/team-selection.tsx
@@ -1,6 +1,5 @@
 import { getAccountInfo } from "@/app/(main)/settings/account/actions";
-import { getUser } from "@/lib/supabase";
-import Avatar from "boring-avatars";
+import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
 import { fetchCurrentTeam, fetchUserTeams } from "../";
 import { isProPlan } from "../utils";
 import TeamCreation from "./team-creation";
@@ -9,8 +8,7 @@ import { TeamSelectionForm } from "./team-selection-form";
 export async function TeamSelection() {
 	const allTeams = await fetchUserTeams();
 	const currentTeam = await fetchCurrentTeam();
-	const user = await getUser();
-	const { displayName } = await getAccountInfo();
+	const { displayName, email, avatarUrl } = await getAccountInfo();
 
 	const formattedAllTeams = allTeams.map((team) => ({
 		id: team.id,
@@ -31,14 +29,14 @@ export async function TeamSelection() {
 			key={currentTeam.id}
 			currentUser={
 				<>
-					<Avatar
-						name={user.email}
-						variant="marble"
-						size={24}
-						colors={["#413e4a", "#73626e", "#b38184", "#f0b49e", "#f7e4be"]}
+					<AvatarImage
+						width={24}
+						height={24}
+						avatarUrl={avatarUrl}
+						alt={displayName || email || ""}
 					/>
 					<span className="text-white-400 font-medium text-[14px] leading-[20.4px] font-hubot">
-						{displayName}
+						{displayName || "No display name"}
 					</span>
 				</>
 			}


### PR DESCRIPTION
## Summary
Implements user avatar functionality in the header navigation using the AvatarImage component from #711. This change ensures consistent avatar display across the application and adds proper fallback handling for missing profile information.

## Related Issue
- #750

## Changes
- Added AvatarImage component to header navigation
- Removed Boring Avatars dependency in team selection
- Added proper fallback for missing display names
- Implemented dynamic avatar URL handling from account info
- Improved accessibility with proper alt text

## Testing
- Verified avatar display with existing profile pictures
- Confirmed fallback behavior when no avatar is set
- Tested display name fallback functionality
- Ensured proper sizing and styling in header navigation

## Other Information
N/A