### PR TITLE
Added Feature Flag `RunV2` for New Run Button Implementation

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -15,6 +15,7 @@ export default async function Layout({
 			workspaceId={workspaceId}
 			featureFlag={{
 				flowNode: true,
+				runV2: true,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -1,5 +1,5 @@
 import { db } from "@/drizzle";
-import { flowNodeFlag } from "@/flags";
+import { flowNodeFlag, runV2Flag } from "@/flags";
 import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
 import { fetchCurrentTeam, isProPlan } from "@/services/teams";
@@ -31,6 +31,7 @@ export default async function Layout({
 	}
 	const usageLimits = await getUsageLimitsForTeam(currentTeam);
 	const flowNode = await flowNodeFlag();
+	const runV2 = await runV2Flag();
 
 	return (
 		<WorkspaceProvider
@@ -54,6 +55,7 @@ export default async function Layout({
 			}}
 			featureFlag={{
 				flowNode,
+				runV2,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -90,3 +90,16 @@ export const flowNodeFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const runV2Flag = flag<boolean>({
+	key: "run-v2",
+	async decide() {
+		return takeLocalEnv("RUN_V2_FLAG");
+	},
+	description: "Enable Run v2",
+	defaultValue: false,
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -248,7 +248,7 @@ export function NodeComponent({
 										"group-data-[content-type=videoGeneration]:!border-video-generation-node-1",
 									)}
 								/>
-								<div className="absolute left-[-45px] text-[12px] text-black-400 whitespace-nowrap">
+								<div className="absolute left-[-12px] text-[12px] text-black-400 whitespace-nowrap -translate-x-[100%]">
 									Input
 								</div>
 							</div>
@@ -299,7 +299,7 @@ export function NodeComponent({
 									className={clsx(
 										"text-[12px]",
 										"group-data-[state=connected]:px-[16px]",
-										"group-data-[state=disconnected]:absolute group-data-[state=disconnected]:left-[12px] group-data-[state=disconnected]:whitespace-nowrap",
+										"group-data-[state=disconnected]:absolute group-data-[state=disconnected]:-right-[12px] group-data-[state=disconnected]:whitespace-nowrap group-data-[state=disconnected]:translate-x-[100%]",
 										"group-data-[state=connected]:text-white-900 group-data-[state=disconnected]:text-black-400",
 									)}
 								>

--- a/internal-packages/workflow-designer-ui/src/header/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/component.tsx
@@ -2,8 +2,18 @@
 
 import type { WorkspaceId } from "@giselle-sdk/data-type";
 import clsx from "clsx";
-import { ViewState, useWorkflowDesigner } from "giselle-sdk/react";
-import { CableIcon, EyeIcon, GanttChartIcon, PlayIcon } from "lucide-react";
+import {
+	ViewState,
+	useFeatureFlag,
+	useWorkflowDesigner,
+} from "giselle-sdk/react";
+import {
+	CableIcon,
+	CirclePlayIcon,
+	EyeIcon,
+	GanttChartIcon,
+	PlayIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { Dialog, ToggleGroup, VisuallyHidden } from "radix-ui";
 import { type ReactNode, useState } from "react";
@@ -31,6 +41,7 @@ export function Header({
 	const { data, updateName, view, setView } = useWorkflowDesigner();
 	const [openSettings, setOpenSettings] = useState(false);
 	const [openShareModal, setOpenShareModal] = useState(false);
+	const { runV2 } = useFeatureFlag();
 
 	const updateWorkflowName = (value?: string) => {
 		if (!value) {
@@ -74,128 +85,138 @@ export function Header({
 			</div>
 
 			<div className="flex items-center gap-[12px]">
-				{shareFeatureFlag && (
+				{runV2 && (
+					<button
+						type="button"
+						className="rounded-[4px] bg-white-800 px-[12px] flex items-center justify-center py-[4px] text-[14px] gap-[4px] flex items-center justify-center cursor-pointer text-black-800"
+					>
+						<PlayIcon className="size-[14px]" />
+						<span>Run</span>
+					</button>
+				)}
+				{!runV2 && shareFeatureFlag && (
 					<>
 						<UserPresence />
 
 						<ShareButton onClick={() => setOpenShareModal(true)} />
 					</>
 				)}
-
-				<ToggleGroup.Root
-					type="single"
-					className="flex h-[33px] px-[8px] py-0 items-center justify-center rounded-[29px] overflow-hidden border border-[#20222F] bg-[rgba(18,23,35,0.20)]"
-					onValueChange={(unsafeValue) => {
-						const parse = ViewState.safeParse(unsafeValue);
-						if (parse.success) {
-							setView(ViewState.parse(parse.data));
-						}
-					}}
-				>
-					<ToggleGroup.Item
-						value="editor"
-						className={clsx(
-							"relative rounded-[24px] transition-colors duration-300 ease-out",
-							view === "editor"
-								? "p-[1px]"
-								: "inline-flex h-[25px] py-[4px] items-center gap-[4px] flex-shrink-0 rounded-[4px] text-[#616779] font-[700] font-accent text-[12px] hover:text-[#8990a5]",
-						)}
-						style={
-							view === "editor"
-								? {
-										background: "linear-gradient(135deg, #64759B, #222835)",
-									}
-								: undefined
-						}
-						disabled={isReadOnly}
+				{!runV2 && (
+					<ToggleGroup.Root
+						type="single"
+						className="flex h-[33px] px-[8px] py-0 items-center justify-center rounded-[29px] overflow-hidden border border-[#20222F] bg-[rgba(18,23,35,0.20)]"
+						onValueChange={(unsafeValue) => {
+							const parse = ViewState.safeParse(unsafeValue);
+							if (parse.success) {
+								setView(ViewState.parse(parse.data));
+							}
+						}}
 					>
-						{view === "editor" && (
-							<span className="absolute inset-[1px] bg-[#1B2333] rounded-[23px] z-0 animate-softFade" />
-						)}
-						<span
-							className={
+						<ToggleGroup.Item
+							value="editor"
+							className={clsx(
+								"relative rounded-[24px] transition-colors duration-300 ease-out",
 								view === "editor"
-									? "relative z-10 text-primary-200 font-[700] font-accent text-[12px] py-[4px] px-[10px] inline-flex items-center"
-									: ""
+									? "p-[1px]"
+									: "inline-flex h-[25px] py-[4px] items-center gap-[4px] flex-shrink-0 rounded-[4px] text-[#616779] font-[700] font-accent text-[12px] hover:text-[#8990a5]",
+							)}
+							style={
+								view === "editor"
+									? {
+											background: "linear-gradient(135deg, #64759B, #222835)",
+										}
+									: undefined
 							}
+							disabled={isReadOnly}
 						>
-							Build
+							{view === "editor" && (
+								<span className="absolute inset-[1px] bg-[#1B2333] rounded-[23px] z-0 animate-softFade" />
+							)}
+							<span
+								className={
+									view === "editor"
+										? "relative z-10 text-primary-200 font-[700] font-accent text-[12px] py-[4px] px-[10px] inline-flex items-center"
+										: ""
+								}
+							>
+								Build
+							</span>
+						</ToggleGroup.Item>
+
+						<span className="text-[#616779] font-[700] font-accent text-[12px] mx-1">
+							,
 						</span>
-					</ToggleGroup.Item>
 
-					<span className="text-[#616779] font-[700] font-accent text-[12px] mx-1">
-						,
-					</span>
-
-					<ToggleGroup.Item
-						value="viewer"
-						className={clsx(
-							"relative rounded-[24px] transition-colors duration-300 ease-out",
-							view === "viewer"
-								? "p-[1px]"
-								: "inline-flex h-[25px] py-[4px] items-center gap-[4px] flex-shrink-0 rounded-[4px] text-[#616779] font-[700] font-accent text-[12px] hover:text-[#8990a5]",
-						)}
-						style={
-							view === "viewer"
-								? {
-										background: "linear-gradient(135deg, #64759B, #222835)",
-									}
-								: undefined
-						}
-					>
-						{view === "viewer" && (
-							<span className="absolute inset-[1px] bg-[#1B2333] rounded-[23px] z-0 animate-softFade" />
-						)}
-						<span
-							className={
+						<ToggleGroup.Item
+							value="viewer"
+							className={clsx(
+								"relative rounded-[24px] transition-colors duration-300 ease-out",
 								view === "viewer"
-									? "relative z-10 text-primary-200 font-[700] font-accent text-[12px] py-[4px] px-[10px] inline-flex items-center"
-									: ""
+									? "p-[1px]"
+									: "inline-flex h-[25px] py-[4px] items-center gap-[4px] flex-shrink-0 rounded-[4px] text-[#616779] font-[700] font-accent text-[12px] hover:text-[#8990a5]",
+							)}
+							style={
+								view === "viewer"
+									? {
+											background: "linear-gradient(135deg, #64759B, #222835)",
+										}
+									: undefined
 							}
 						>
-							Preview
+							{view === "viewer" && (
+								<span className="absolute inset-[1px] bg-[#1B2333] rounded-[23px] z-0 animate-softFade" />
+							)}
+							<span
+								className={
+									view === "viewer"
+										? "relative z-10 text-primary-200 font-[700] font-accent text-[12px] py-[4px] px-[10px] inline-flex items-center"
+										: ""
+								}
+							>
+								Preview
+							</span>
+						</ToggleGroup.Item>
+
+						<span className="text-[#616779] font-[700] font-accent text-[12px] mx-1">
+							,
 						</span>
-					</ToggleGroup.Item>
 
-					<span className="text-[#616779] font-[700] font-accent text-[12px] mx-1">
-						,
-					</span>
-
-					<ToggleGroup.Item
-						value="integrator"
-						className={clsx(
-							"relative rounded-[24px] transition-colors duration-300 ease-out",
-							view === "integrator"
-								? "p-[1px]"
-								: "inline-flex h-[25px] py-[4px] items-center gap-[4px] flex-shrink-0 rounded-[4px] text-[#616779] font-[700] font-accent text-[12px] hover:text-[#8990a5]",
-						)}
-						style={
-							view === "integrator"
-								? {
-										background: "linear-gradient(135deg, #64759B, #222835)",
-									}
-								: undefined
-						}
-						disabled={isReadOnly}
-					>
-						{view === "integrator" && (
-							<span className="absolute inset-[1px] bg-[#1B2333] rounded-[23px] z-0 animate-softFade" />
-						)}
-						<span
-							className={
+						<ToggleGroup.Item
+							value="integrator"
+							className={clsx(
+								"relative rounded-[24px] transition-colors duration-300 ease-out",
 								view === "integrator"
-									? "relative z-10 text-primary-200 font-[700] font-accent text-[12px] py-[4px] px-[10px] inline-flex items-center"
-									: ""
+									? "p-[1px]"
+									: "inline-flex h-[25px] py-[4px] items-center gap-[4px] flex-shrink-0 rounded-[4px] text-[#616779] font-[700] font-accent text-[12px] hover:text-[#8990a5]",
+							)}
+							style={
+								view === "integrator"
+									? {
+											background: "linear-gradient(135deg, #64759B, #222835)",
+										}
+									: undefined
 							}
+							disabled={isReadOnly}
 						>
-							Integrate
-						</span>
-					</ToggleGroup.Item>
+							{view === "integrator" && (
+								<span className="absolute inset-[1px] bg-[#1B2333] rounded-[23px] z-0 animate-softFade" />
+							)}
+							<span
+								className={
+									view === "integrator"
+										? "relative z-10 text-primary-200 font-[700] font-accent text-[12px] py-[4px] px-[10px] inline-flex items-center"
+										: ""
+								}
+							>
+								Integrate
+							</span>
+						</ToggleGroup.Item>
 
-					<span className="text-[#616779] font-[700] font-accent text-[12px] mx-1">
-						.
-					</span>
-				</ToggleGroup.Root>
+						<span className="text-[#616779] font-[700] font-accent text-[12px] mx-1">
+							.
+						</span>
+					</ToggleGroup.Root>
+				)}
 
 				{action && <div className="flex items-center">{action}</div>}
 			</div>

--- a/packages/data-type/src/node/actions/index.ts
+++ b/packages/data-type/src/node/actions/index.ts
@@ -10,7 +10,7 @@ import {
 	TextGenerationContent,
 	TextGenerationContentReference,
 } from "./text-generation";
-import { TriggerContent } from "./trigger";
+import { TriggerContent, TriggerContentReference } from "./trigger";
 export * from "./image-generation";
 export * from "./text-generation";
 export * from "./trigger";
@@ -74,6 +74,7 @@ export type OverrideActionNode = z.infer<typeof OverrideActionNode>;
 const ActionNodeContentReference = z.discriminatedUnion("type", [
 	TextGenerationContentReference,
 	ImageGenerationContentReference,
+	TriggerContentReference,
 ]);
 export const ActionNodeReference = NodeReferenceBase.extend({
 	type: ActionNode.shape.type,

--- a/packages/data-type/src/node/actions/trigger.ts
+++ b/packages/data-type/src/node/actions/trigger.ts
@@ -39,3 +39,8 @@ export const TriggerContent = z.object({
 	provider: TriggerProviderLike,
 });
 export type TriggerContent = z.infer<typeof TriggerContent>;
+
+export const TriggerContentReference = z.object({
+	type: TriggerContent.shape.type,
+});
+export type TriggerContentReference = z.infer<typeof TriggerContentReference>;

--- a/packages/workspace/src/react/feature-flag.ts
+++ b/packages/workspace/src/react/feature-flag.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from "react";
 
 export interface FeatureFlagContextValue {
 	flowNode: boolean;
+	runV2: boolean;
 }
 export const FeatureFlagContext = createContext<
 	FeatureFlagContextValue | undefined

--- a/packages/workspace/src/react/workspace.tsx
+++ b/packages/workspace/src/react/workspace.tsx
@@ -59,7 +59,10 @@ export function WorkspaceProvider({
 						<GenerationRunnerSystemProvider>
 							<RunSystemContextProvider workspaceId={workspaceId}>
 								<FeatureFlagContext
-									value={{ flowNode: featureFlag?.flowNode ?? false }}
+									value={{
+										flowNode: featureFlag?.flowNode ?? false,
+										runV2: featureFlag?.runV2 ?? false,
+									}}
 								>
 									{children}
 								</FeatureFlagContext>


### PR DESCRIPTION
I've added a new Feature Flag called `RunV2` that allows us to toggle between the current header display and a new implementation for the Run button. This PR sets up the infrastructure for the new Run button functionality, though the actual implementation of the new button is not included in this PR and will be developed separately.

Enable RUN_V2|Disable Run V2
---------------|----------------
<img width="771" alt="image" src="https://github.com/user-attachments/assets/b58c3327-d9eb-4a96-b16e-3bfcac3581ef" />|<img width="769" alt="image" src="https://github.com/user-attachments/assets/8fa039c1-bfb6-49ec-afd0-378b12d70741" />


This change enables us to:
- Safely develop the new Run button behind a feature flag
- Test both implementations in parallel
- Gradually roll out the new feature when ready

The current functionality remains unchanged when the feature flag is disabled.