### PR TITLE
Feat/improve profile image style

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
@@ -1,26 +1,11 @@
 "use client";
 
-import {
-	Dialog,
-	DialogContent,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import type { users } from "@/drizzle";
 import { useState } from "react";
-import { maxLength, minLength, parse, pipe, string } from "valibot";
-import { AccountImageForm } from "../components/account-image-form";
 import { Button } from "../components/button";
-import { updateDisplayName } from "./actions";
-
-const DisplayNameSchema = pipe(
-	string(),
-	minLength(1, "Display name is required"),
-	maxLength(256, "Display name must be 256 characters or less"),
-);
+import { ProfileEditModal } from "../components/profile-edit-modal";
+import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
+import { Camera } from "lucide-react";
 
 export function AccountDisplayNameForm({
 	displayName: _displayName,
@@ -31,53 +16,18 @@ export function AccountDisplayNameForm({
 	avatarUrl: typeof users.$inferSelect.avatarUrl;
 	alt?: string;
 }) {
-	const [isEditingName, setIsEditingName] = useState(false);
 	const [displayName, setDisplayName] = useState(
-		_displayName ?? "No display name",
+		_displayName ?? "No display name"
 	);
-	const [tempDisplayName, setTempDisplayName] = useState(displayName);
-	const [isLoading, setIsLoading] = useState(false);
-	const [error, setError] = useState<string>("");
+	const [currentAvatarUrl, setCurrentAvatarUrl] = useState<string | null>(
+		avatarUrl
+	);
+	const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
-	const handleSaveDisplayName = async () => {
-		setError("");
-
-		try {
-			const validatedDisplayName = parse(DisplayNameSchema, tempDisplayName);
-
-			setIsLoading(true);
-
-			const formData = new FormData();
-			formData.append("displayName", validatedDisplayName);
-
-			const result = await updateDisplayName(formData);
-
-			if (result.success) {
-				setDisplayName(validatedDisplayName);
-				setIsEditingName(false);
-			} else {
-				setError("Failed to update display name");
-				console.error("Failed to update display name");
-			}
-		} catch (error) {
-			if (error instanceof Error) {
-				setError(error.message);
-			}
-			console.error("Error:", error);
-		} finally {
-			setIsLoading(false);
-		}
-	};
-
-	const handleCancelDislayName = () => {
-		setTempDisplayName(displayName);
-		setIsEditingName(false);
-		setError("");
-	};
-
-	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setError("");
-		setTempDisplayName(e.target.value);
+	const handleProfileUpdate = () => {
+		// We don't need to update state here as the page will be revalidated
+		// after successful update through the server actions
+		window.location.reload();
 	};
 
 	return (
@@ -94,82 +44,33 @@ export function AccountDisplayNameForm({
 				</div>
 				<div className="flex justify-between items-center gap-2">
 					<div className="flex items-center gap-4">
-						<AccountImageForm avatarUrl={avatarUrl} alt={alt} />
+						{/* Avatar image (no longer clickable) */}
+						<div className="relative h-[60px] w-[60px] rounded-full overflow-hidden">
+							<AvatarImage
+								avatarUrl={currentAvatarUrl}
+								width={60}
+								height={60}
+								alt={alt}
+							/>
+						</div>
 						<span className="text-primary-100 font-normal text-[18px] leading-[21.6px] tracking-[-0.011em] font-hubot px-3 py-2 border-[0.5px] border-black-750 rounded-[4px] bg-black-900 w-[360px] truncate">
 							{displayName}
 						</span>
 					</div>
 
-					<Dialog open={isEditingName} onOpenChange={setIsEditingName}>
-						<DialogTrigger asChild>
-							<Button>Edit</Button>
-						</DialogTrigger>
-						<DialogContent
-							className="gap-y-6 px-[57px] py-[40px] max-w-[380px] w-full bg-black-900 border-none rounded-[16px] bg-linear-to-br/hsl from-black-600 to-black-250 sm:rounded-[16px]"
-							style={{
-								animation: "fadeIn 0.2s ease-out",
-								transformOrigin: "center",
-							}}
-						>
-							<style jsx global>{`
-								@keyframes fadeIn {
-									from {
-										opacity: 0;
-										transform: scale(0.95);
-									}
-									to {
-										opacity: 1;
-										transform: scale(1);
-									}
-								}
-							`}</style>
-							<div
-								aria-hidden="true"
-								className="absolute inset-0 rounded-[16px] border-[0.5px] border-transparent bg-black-900 bg-clip-padding"
-							/>
-							<DialogHeader className="relative z-10">
-								<DialogTitle className="text-white-800 font-semibold text-[20px] leading-[28px] font-hubot text-center">
-									Change your Display Name
-								</DialogTitle>
-							</DialogHeader>
-							<form className="flex flex-col gap-y-4 relative z-10">
-								<div className="flex flex-col gap-y-2">
-									<Input
-										id="tempDisplayName"
-										value={tempDisplayName}
-										onChange={handleChange}
-										className="py-2 rounded-[8px] w-full bg-white-30/30 text-black-800 font-medium text-[12px] leading-[20.4px] font-geist shadow-none focus:text-white"
-										disabled={isLoading}
-									/>
-									{error && (
-										<p className="text-[12px] leading-[20.4px] text-error-900 font-geist">
-											{error}
-										</p>
-									)}
-								</div>
-								<div className="flex justify-end space-x-4">
-									<Button
-										type="button"
-										onClick={handleCancelDislayName}
-										disabled={isLoading}
-										className="w-full h-[38px] bg-transparent border-black-400 text-black-400 text-[16px] leading-[19.2px] tracking-[-0.04em] hover:bg-transparent hover:text-black-400"
-									>
-										Cancel
-									</Button>
-									<Button
-										type="submit"
-										disabled={isLoading || !!error}
-										onClick={handleSaveDisplayName}
-										className="w-full h-[38px] text-[16px] leading-[19.2px] tracking-[-0.04em] "
-									>
-										Save
-									</Button>
-								</div>
-							</form>
-						</DialogContent>
-					</Dialog>
+					<Button onClick={() => setIsEditModalOpen(true)}>Edit</Button>
 				</div>
 			</div>
+
+			{/* Use the new integrated ProfileEditModal */}
+			<ProfileEditModal
+				isOpen={isEditModalOpen}
+				onClose={() => setIsEditModalOpen(false)}
+				displayName={_displayName}
+				avatarUrl={avatarUrl}
+				alt={alt}
+				onSuccess={handleProfileUpdate}
+			/>
 		</div>
 	);
 }

--- a/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/account-display-name-form.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import type { users } from "@/drizzle";
+import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
+import { Camera } from "lucide-react";
 import { useState } from "react";
 import { Button } from "../components/button";
 import { ProfileEditModal } from "../components/profile-edit-modal";
-import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
-import { Camera } from "lucide-react";
 
 export function AccountDisplayNameForm({
 	displayName: _displayName,
@@ -17,10 +17,10 @@ export function AccountDisplayNameForm({
 	alt?: string;
 }) {
 	const [displayName, setDisplayName] = useState(
-		_displayName ?? "No display name"
+		_displayName ?? "No display name",
 	);
 	const [currentAvatarUrl, setCurrentAvatarUrl] = useState<string | null>(
-		avatarUrl
+		avatarUrl,
 	);
 	const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
@@ -51,6 +51,7 @@ export function AccountDisplayNameForm({
 								width={60}
 								height={60}
 								alt={alt}
+								className="object-cover w-full h-full"
 							/>
 						</div>
 						<span className="text-primary-100 font-normal text-[18px] leading-[21.6px] tracking-[-0.011em] font-hubot px-3 py-2 border-[0.5px] border-black-750 rounded-[4px] bg-black-900 w-[360px] truncate">

--- a/apps/studio.giselles.ai/app/(main)/settings/components/avatar-upload.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/avatar-upload.tsx
@@ -139,34 +139,40 @@ export function AvatarUpload({ isOpen, onClose, onUpload }: AvatarUploadProps) {
 					/>
 
 					{preview ? (
-						<div className="flex flex-col items-center gap-4">
-							<div className="relative w-32 h-32 rounded-full overflow-hidden border-2 border-primary-100/30">
+						<div className="flex flex-col gap-[30px]">
+							<div className="relative w-[80px] h-[80px] mx-auto rounded-full overflow-hidden border border-primary-100/30 mb-auto">
 								<Image
 									src={preview}
-									alt="アバタープレビュー"
+									alt="Avatar preview"
 									fill
-									className="object-cover"
+									sizes="80px"
+									className="object-cover w-full h-full scale-[1.02]"
+									style={{ objectPosition: 'center' }}
 								/>
 							</div>
-							<Button 
-								type="button" 
-								onClick={handleButtonClick} 
+							<Button
+								type="button"
+								onClick={handleButtonClick}
 								className="w-full h-[38px] text-[16px] leading-[19.2px] tracking-[-0.04em] bg-primary-200 text-black-800 font-bold hover:bg-transparent hover:text-primary-200 hover:border-primary-200 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
 							>
-								Select Another Image
+								Change Image
 							</Button>
 						</div>
 					) : (
-						<Button 
-							type="button" 
-							onClick={handleButtonClick} 
+						<Button
+							type="button"
+							onClick={handleButtonClick}
 							className="w-full h-[38px] text-[16px] leading-[19.2px] tracking-[-0.04em] bg-primary-200 text-black-800 font-bold hover:bg-transparent hover:text-primary-200 hover:border-primary-200 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
 						>
 							Select Image
 						</Button>
 					)}
 
-					{error && <p className="text-error-900 text-[12px] leading-[20.4px] font-geist text-center">{error}</p>}
+					{error && (
+						<p className="text-error-900 text-[12px] leading-[20.4px] font-geist text-center">
+							{error}
+						</p>
+					)}
 
 					<div className="flex justify-end gap-4 w-full">
 						<Button

--- a/apps/studio.giselles.ai/app/(main)/settings/components/avatar-upload.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/avatar-upload.tsx
@@ -147,7 +147,7 @@ export function AvatarUpload({ isOpen, onClose, onUpload }: AvatarUploadProps) {
 									fill
 									sizes="80px"
 									className="object-cover w-full h-full scale-[1.02]"
-									style={{ objectPosition: 'center' }}
+									style={{ objectPosition: "center" }}
 								/>
 							</div>
 							<Button

--- a/apps/studio.giselles.ai/app/(main)/settings/components/avatar-upload.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/avatar-upload.tsx
@@ -100,16 +100,32 @@ export function AvatarUpload({ isOpen, onClose, onUpload }: AvatarUploadProps) {
 	return (
 		<Dialog open={isOpen} onOpenChange={onClose}>
 			<DialogContent
-				className="gap-y-6 px-[57px] py-[40px] max-w-[380px] w-full bg-black-900 border-none rounded-[16px] bg-linear-to-br/hsl from-black-600 to-black-250"
+				className="gap-y-6 px-[57px] py-[40px] max-w-[380px] w-full bg-black-900 border-none rounded-[16px] bg-linear-to-br/hsl from-black-600 to-black-250 sm:rounded-[16px]"
+				style={{
+					animation: "fadeIn 0.2s ease-out",
+					transformOrigin: "center",
+				}}
 				aria-describedby={undefined}
 			>
+				<style jsx global>{`
+					@keyframes fadeIn {
+						from {
+							opacity: 0;
+							transform: scale(0.95);
+						}
+						to {
+							opacity: 1;
+							transform: scale(1);
+						}
+					}
+				`}</style>
 				<div
 					aria-hidden="true"
 					className="absolute inset-0 rounded-[16px] border-[0.5px] border-transparent bg-black-900 bg-clip-padding"
 				/>
 				<DialogHeader className="relative z-10">
 					<DialogTitle className="text-white-800 font-semibold text-[20px] leading-[28px] font-hubot text-center">
-						Upload Avatar
+						Change your Profiles
 					</DialogTitle>
 				</DialogHeader>
 
@@ -122,29 +138,42 @@ export function AvatarUpload({ isOpen, onClose, onUpload }: AvatarUploadProps) {
 						onChange={handleFileSelect}
 					/>
 
-					<Button type="button" onClick={handleButtonClick} className="w-full">
-						Select Image
-					</Button>
-
-					{preview && (
-						<div className="relative w-32 h-32 rounded-full overflow-hidden">
-							<Image
-								src={preview}
-								alt="Avatar preview"
-								fill
-								className="object-cover"
-							/>
+					{preview ? (
+						<div className="flex flex-col items-center gap-4">
+							<div className="relative w-32 h-32 rounded-full overflow-hidden border-2 border-primary-100/30">
+								<Image
+									src={preview}
+									alt="アバタープレビュー"
+									fill
+									className="object-cover"
+								/>
+							</div>
+							<Button 
+								type="button" 
+								onClick={handleButtonClick} 
+								className="w-full h-[38px] text-[16px] leading-[19.2px] tracking-[-0.04em] bg-primary-200 text-black-800 font-bold hover:bg-transparent hover:text-primary-200 hover:border-primary-200 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
+							>
+								Select Another Image
+							</Button>
 						</div>
+					) : (
+						<Button 
+							type="button" 
+							onClick={handleButtonClick} 
+							className="w-full h-[38px] text-[16px] leading-[19.2px] tracking-[-0.04em] bg-primary-200 text-black-800 font-bold hover:bg-transparent hover:text-primary-200 hover:border-primary-200 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
+						>
+							Select Image
+						</Button>
 					)}
 
-					{error && <p className="text-red-500 text-sm text-center">{error}</p>}
+					{error && <p className="text-error-900 text-[12px] leading-[20.4px] font-geist text-center">{error}</p>}
 
 					<div className="flex justify-end gap-4 w-full">
 						<Button
 							type="button"
 							onClick={onClose}
 							disabled={isUploading}
-							className="w-full bg-transparent border-black-400 text-black-400 hover:bg-transparent hover:text-black-400"
+							className="w-full h-[38px] bg-transparent border-black-400 text-black-400 text-[16px] leading-[19.2px] tracking-[-0.04em] hover:bg-transparent hover:text-black-400 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
 						>
 							Cancel
 						</Button>
@@ -152,12 +181,12 @@ export function AvatarUpload({ isOpen, onClose, onUpload }: AvatarUploadProps) {
 							type="button"
 							onClick={handleUpdate}
 							disabled={!preview || !!error || isUploading}
-							className="w-full"
+							className="w-full h-[38px] text-[16px] leading-[19.2px] tracking-[-0.04em] bg-primary-200 text-black-800 font-bold hover:bg-transparent hover:text-primary-200 hover:border-primary-200 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
 						>
 							{isUploading ? (
 								<div className="h-5 w-5 animate-spin rounded-full border-2 border-white-800 border-t-transparent" />
 							) : (
-								"Upload"
+								"Save"
 							)}
 						</Button>
 					</div>

--- a/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
@@ -3,20 +3,20 @@
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
+	DialogClose,
 	DialogContent,
 	DialogHeader,
 	DialogTitle,
-	DialogClose,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import type { users } from "@/drizzle";
+import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
+import { Camera, ImageIcon } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { maxLength, minLength, parse, pipe, string } from "valibot";
 import { updateAvatar, updateDisplayName } from "../account/actions";
 import { IMAGE_CONSTRAINTS } from "../constants";
-import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
-import { Camera, ImageIcon } from "lucide-react";
 
 const ACCEPTED_FILE_TYPES = IMAGE_CONSTRAINTS.formats.join(",");
 
@@ -45,19 +45,22 @@ export function ProfileEditModal({
 }: ProfileEditModalProps) {
 	// Avatar state
 	const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
-	const [selectedAvatarFile, setSelectedAvatarFile] = useState<File | null>(null);
+	const [selectedAvatarFile, setSelectedAvatarFile] = useState<File | null>(
+		null,
+	);
 	const avatarInputRef = useRef<HTMLInputElement>(null);
-	
+
 	// Display name state
 	const [displayName, setDisplayName] = useState(
-		initialDisplayName ?? "No display name"
+		initialDisplayName ?? "No display name",
 	);
-	
+
 	// Shared state
 	const [error, setError] = useState<string>("");
 	const [avatarError, setAvatarError] = useState<string>("");
 	const [isLoading, setIsLoading] = useState(false);
-	const hasChanges = selectedAvatarFile !== null || displayName !== initialDisplayName;
+	const hasChanges =
+		selectedAvatarFile !== null || displayName !== initialDisplayName;
 
 	// Reset when the modal opens/closes
 	useEffect(() => {
@@ -66,14 +69,14 @@ export function ProfileEditModal({
 			if (avatarPreview) {
 				URL.revokeObjectURL(avatarPreview);
 			}
-			
+
 			// Reset state
 			setAvatarPreview(null);
 			setSelectedAvatarFile(null);
 			setDisplayName(initialDisplayName ?? "No display name");
 			setError("");
 			setAvatarError("");
-			
+
 			// Reset file input
 			if (avatarInputRef.current) {
 				avatarInputRef.current.value = "";
@@ -100,7 +103,7 @@ export function ProfileEditModal({
 
 		if (file.size > IMAGE_CONSTRAINTS.maxSize) {
 			setAvatarError(
-				`Please select an image under ${IMAGE_CONSTRAINTS.maxSize / (1024 * 1024)}MB in size`
+				`Please select an image under ${IMAGE_CONSTRAINTS.maxSize / (1024 * 1024)}MB in size`,
 			);
 			if (avatarPreview) {
 				URL.revokeObjectURL(avatarPreview);
@@ -136,7 +139,7 @@ export function ProfileEditModal({
 			setIsLoading(true);
 			setError("");
 			setAvatarError("");
-			
+
 			// Validate display name if changed
 			if (displayName !== initialDisplayName) {
 				try {
@@ -149,17 +152,17 @@ export function ProfileEditModal({
 					}
 				}
 			}
-			
+
 			// Save changes
 			const promises = [];
-			
+
 			// Update display name if changed
 			if (displayName !== initialDisplayName) {
 				const formData = new FormData();
 				formData.append("displayName", displayName);
 				promises.push(updateDisplayName(formData));
 			}
-			
+
 			// Update avatar if changed
 			if (selectedAvatarFile) {
 				const formData = new FormData();
@@ -167,18 +170,17 @@ export function ProfileEditModal({
 				formData.append("avatarUrl", selectedAvatarFile.name);
 				promises.push(updateAvatar(formData));
 			}
-			
+
 			// Wait for all updates to complete
 			await Promise.all(promises);
-			
+
 			// Call success callback if provided
 			if (onSuccess) {
 				onSuccess();
 			}
-			
+
 			// Close the modal
 			onClose();
-			
 		} catch (error) {
 			console.error("Failed to save profile changes:", error);
 			if (error instanceof Error) {
@@ -221,13 +223,25 @@ export function ProfileEditModal({
 					<DialogTitle className="text-white-800 font-semibold text-[20px] leading-[28px] font-hubot text-center">
 						Change your Profiles
 					</DialogTitle>
-					<DialogClose 
-						className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none" 
+					<DialogClose
+						className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none"
 						onClick={onClose}
 					>
-						<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-white-800">
+						<svg
+							width="15"
+							height="15"
+							viewBox="0 0 15 15"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+							className="h-4 w-4 text-white-800"
+						>
 							<title>Close</title>
-							<path d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path>
+							<path
+								d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z"
+								fill="currentColor"
+								fillRule="evenodd"
+								clipRule="evenodd"
+							/>
 						</svg>
 					</DialogClose>
 				</DialogHeader>
@@ -241,7 +255,7 @@ export function ProfileEditModal({
 						className="hidden"
 						onChange={handleFileSelect}
 					/>
-					
+
 					{/* Avatar Profile Images */}
 					<div className="flex items-center justify-center gap-4 w-full">
 						<div className="flex flex-row gap-4">
@@ -266,7 +280,7 @@ export function ProfileEditModal({
 									</div>
 								</button>
 							)}
-							
+
 							{/* 左側 - プレビュー画像 */}
 							{avatarPreview && (
 								<div className="relative w-[80px] h-[80px] rounded-full overflow-hidden border border-primary-100/30">
@@ -276,11 +290,11 @@ export function ProfileEditModal({
 										fill
 										sizes="80px"
 										className="object-cover w-full h-full scale-[1.02]"
-										style={{ objectPosition: 'center' }}
+										style={{ objectPosition: "center" }}
 									/>
 								</div>
 							)}
-							
+
 							{/* 左側 - 画像アイコン（初期アバターがない場合） */}
 							{!initialAvatarUrl && !avatarPreview && (
 								<button
@@ -293,10 +307,10 @@ export function ProfileEditModal({
 							)}
 						</div>
 					</div>
-					
+
 					{/* Display name input */}
 					<div className="w-full">
-						<label 
+						<label
 							htmlFor="displayName"
 							className="block text-white-800 text-left font-medium text-[12px] leading-[170%] font-geist mb-2"
 						>
@@ -312,14 +326,14 @@ export function ProfileEditModal({
 							/>
 						</div>
 					</div>
-					
+
 					{/* Error message */}
 					{(error || avatarError) && (
 						<p className="text-[12px] leading-[20.4px] text-error-900 font-geist">
 							{error || avatarError}
 						</p>
 					)}
-					
+
 					{/* Action buttons */}
 					<div className="flex justify-end gap-2 w-full">
 						<Button
@@ -347,4 +361,4 @@ export function ProfileEditModal({
 			</DialogContent>
 		</Dialog>
 	);
-} 
+}

--- a/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
@@ -226,6 +226,7 @@ export function ProfileEditModal({
 						onClick={onClose}
 					>
 						<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-white-800">
+							<title>Close</title>
 							<path d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path>
 						</svg>
 					</DialogClose>
@@ -295,11 +296,15 @@ export function ProfileEditModal({
 					
 					{/* Display name input */}
 					<div className="w-full">
-						<label className="block text-white-800 text-left font-medium text-[12px] leading-[170%] font-geist mb-2">
+						<label 
+							htmlFor="displayName"
+							className="block text-white-800 text-left font-medium text-[12px] leading-[170%] font-geist mb-2"
+						>
 							Your Display Name
 						</label>
 						<div className="flex flex-col items-start p-2 rounded-[8px] bg-white/[0.29] w-full">
 							<Input
+								id="displayName"
 								value={displayName}
 								onChange={handleDisplayNameChange}
 								className="w-full bg-transparent text-white-800 font-medium text-[12px] leading-[170%] font-geist shadow-none focus:text-white border-0 p-0 focus-visible:ring-0 focus-visible:ring-offset-0"

--- a/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import type { users } from "@/drizzle";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+import { maxLength, minLength, parse, pipe, string } from "valibot";
+import { updateAvatar, updateDisplayName } from "../account/actions";
+import { IMAGE_CONSTRAINTS } from "../constants";
+import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
+import { Camera } from "lucide-react";
+
+const ACCEPTED_FILE_TYPES = IMAGE_CONSTRAINTS.formats.join(",");
+
+const DisplayNameSchema = pipe(
+	string(),
+	minLength(1, "Display name is required"),
+	maxLength(256, "Display name must be 256 characters or less"),
+);
+
+interface ProfileEditModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+	displayName: typeof users.$inferSelect.displayName;
+	avatarUrl: typeof users.$inferSelect.avatarUrl;
+	alt?: string;
+	onSuccess?: () => void;
+}
+
+export function ProfileEditModal({
+	isOpen,
+	onClose,
+	displayName: initialDisplayName,
+	avatarUrl: initialAvatarUrl,
+	alt,
+	onSuccess,
+}: ProfileEditModalProps) {
+	// Avatar state
+	const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+	const [selectedAvatarFile, setSelectedAvatarFile] = useState<File | null>(null);
+	const avatarInputRef = useRef<HTMLInputElement>(null);
+	
+	// Display name state
+	const [displayName, setDisplayName] = useState(
+		initialDisplayName ?? "No display name"
+	);
+	
+	// Shared state
+	const [error, setError] = useState<string>("");
+	const [avatarError, setAvatarError] = useState<string>("");
+	const [isLoading, setIsLoading] = useState(false);
+	const hasChanges = selectedAvatarFile !== null || displayName !== initialDisplayName;
+
+	// Reset when the modal opens/closes
+	useEffect(() => {
+		if (!isOpen) {
+			// Clean up preview URL
+			if (avatarPreview) {
+				URL.revokeObjectURL(avatarPreview);
+			}
+			
+			// Reset state
+			setAvatarPreview(null);
+			setSelectedAvatarFile(null);
+			setDisplayName(initialDisplayName ?? "No display name");
+			setError("");
+			setAvatarError("");
+			
+			// Reset file input
+			if (avatarInputRef.current) {
+				avatarInputRef.current.value = "";
+			}
+		}
+	}, [isOpen, initialDisplayName, avatarPreview]);
+
+	// Handle avatar file selection
+	const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setAvatarError("");
+		const file = event.target.files?.[0];
+
+		if (!file) return;
+
+		if (!IMAGE_CONSTRAINTS.formats.includes(file.type)) {
+			setAvatarError("Please select a JPG, PNG, GIF, SVG, or WebP image");
+			if (avatarPreview) {
+				URL.revokeObjectURL(avatarPreview);
+				setAvatarPreview(null);
+			}
+			setSelectedAvatarFile(null);
+			return;
+		}
+
+		if (file.size > IMAGE_CONSTRAINTS.maxSize) {
+			setAvatarError(
+				`Please select an image under ${IMAGE_CONSTRAINTS.maxSize / (1024 * 1024)}MB in size`
+			);
+			if (avatarPreview) {
+				URL.revokeObjectURL(avatarPreview);
+				setAvatarPreview(null);
+			}
+			setSelectedAvatarFile(null);
+			return;
+		}
+
+		if (avatarPreview) {
+			URL.revokeObjectURL(avatarPreview);
+		}
+
+		const objectUrl = URL.createObjectURL(file);
+		setAvatarPreview(objectUrl);
+		setSelectedAvatarFile(file);
+	};
+
+	// Handle display name change
+	const handleDisplayNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setError("");
+		setDisplayName(e.target.value);
+	};
+
+	// Open file selector
+	const handleSelectImageClick = () => {
+		avatarInputRef.current?.click();
+	};
+
+	// Save all changes
+	const handleSave = async () => {
+		try {
+			setIsLoading(true);
+			setError("");
+			setAvatarError("");
+			
+			// Validate display name if changed
+			if (displayName !== initialDisplayName) {
+				try {
+					parse(DisplayNameSchema, displayName);
+				} catch (valError) {
+					if (valError instanceof Error) {
+						setError(valError.message);
+						setIsLoading(false);
+						return;
+					}
+				}
+			}
+			
+			// Save changes
+			const promises = [];
+			
+			// Update display name if changed
+			if (displayName !== initialDisplayName) {
+				const formData = new FormData();
+				formData.append("displayName", displayName);
+				promises.push(updateDisplayName(formData));
+			}
+			
+			// Update avatar if changed
+			if (selectedAvatarFile) {
+				const formData = new FormData();
+				formData.append("avatar", selectedAvatarFile, selectedAvatarFile.name);
+				formData.append("avatarUrl", selectedAvatarFile.name);
+				promises.push(updateAvatar(formData));
+			}
+			
+			// Wait for all updates to complete
+			await Promise.all(promises);
+			
+			// Call success callback if provided
+			if (onSuccess) {
+				onSuccess();
+			}
+			
+			// Close the modal
+			onClose();
+			
+		} catch (error) {
+			console.error("Failed to save profile changes:", error);
+			if (error instanceof Error) {
+				setError(error.message);
+			} else {
+				setError("Failed to save changes.");
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={onClose}>
+			<DialogContent
+				className="flex flex-col items-center p-0 max-w-[380px] w-full bg-black-900 border-none rounded-[16px] bg-linear-to-br/hsl from-black-600 to-black-250 sm:rounded-[16px]"
+				style={{
+					animation: "fadeIn 0.2s ease-out",
+					transformOrigin: "center",
+				}}
+				aria-describedby={undefined}
+			>
+				<style jsx global>{`
+					@keyframes fadeIn {
+						from {
+							opacity: 0;
+							transform: scale(0.95);
+						}
+						to {
+							opacity: 1;
+							transform: scale(1);
+						}
+					}
+				`}</style>
+				<div
+					aria-hidden="true"
+					className="absolute inset-0 rounded-[16px] border-[0.5px] border-transparent bg-black-900 bg-clip-padding"
+				/>
+				<DialogHeader className="relative z-10 w-full pt-[40px] mb-4 px-[24px]">
+					<DialogTitle className="text-white-800 font-semibold text-[20px] leading-[28px] font-hubot text-center">
+						Change your Profiles
+					</DialogTitle>
+				</DialogHeader>
+
+				<div className="relative z-10 flex flex-col items-center gap-6 w-full px-[24px] pb-[30px]">
+					{/* Hidden file input */}
+					<Input
+						ref={avatarInputRef}
+						type="file"
+						accept={ACCEPTED_FILE_TYPES}
+						className="hidden"
+						onChange={handleFileSelect}
+					/>
+					
+					{/* Avatar Profile Images */}
+					<div className="flex items-center justify-center gap-4 w-full">
+						{/* Current avatar */}
+						{initialAvatarUrl && !avatarPreview && (
+							<button
+								type="button"
+								onClick={handleSelectImageClick}
+								className="group relative w-[47px] h-[47px] rounded-full overflow-hidden cursor-pointer focus:outline-none focus:ring-2 focus:ring-white-400 border border-primary-100/20"
+							>
+								<AvatarImage
+									avatarUrl={initialAvatarUrl}
+									width={47}
+									height={47}
+									alt={alt}
+								/>
+								<div className="absolute inset-0 flex items-center justify-center bg-black-900/60 opacity-0 group-hover:opacity-100 transition-opacity">
+									<Camera className="w-5 h-5 text-white-800" />
+								</div>
+							</button>
+						)}
+						
+						{/* Selected avatar preview */}
+						{avatarPreview && (
+							<div className="relative w-[47px] h-[47px] rounded-full overflow-hidden border border-primary-100/30">
+								<Image
+									src={avatarPreview}
+									alt="Avatar preview"
+									fill
+									className="object-cover"
+								/>
+							</div>
+						)}
+						
+						{/* Image placeholder */}
+						{!initialAvatarUrl && !avatarPreview && (
+							<button
+								type="button"
+								onClick={handleSelectImageClick}
+								className="group relative w-[47px] h-[47px] rounded-full overflow-hidden cursor-pointer focus:outline-none focus:ring-2 focus:ring-white-400 bg-black-800 border border-primary-100/20 flex items-center justify-center"
+							>
+								<Camera className="w-5 h-5 text-white-600" />
+							</button>
+						)}
+					</div>
+					
+					{/* Display name input */}
+					<div className="w-full">
+						<label className="block text-white-800 text-left font-medium text-[12px] leading-[170%] font-geist mb-2">
+							Your Display Name
+						</label>
+						<div className="flex flex-col items-start p-2 rounded-[8px] bg-white/[0.29] w-full">
+							<Input
+								value={displayName}
+								onChange={handleDisplayNameChange}
+								className="w-full bg-transparent text-white-800 font-medium text-[12px] leading-[170%] font-geist shadow-none focus:text-white border-0 p-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+								disabled={isLoading}
+							/>
+						</div>
+					</div>
+					
+					{/* Error message */}
+					{(error || avatarError) && (
+						<p className="text-[12px] leading-[20.4px] text-error-900 font-geist">
+							{error || avatarError}
+						</p>
+					)}
+					
+					{/* Action buttons */}
+					<div className="flex justify-end gap-2 w-full">
+						<Button
+							type="button"
+							onClick={onClose}
+							disabled={isLoading}
+							className="w-full h-[38px] bg-transparent border-black-400 text-black-400 text-[16px] leading-[19.2px] tracking-[-0.04em] hover:bg-transparent hover:text-black-400 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
+						>
+							Cancel
+						</Button>
+						<Button
+							type="button"
+							onClick={handleSave}
+							disabled={!hasChanges || isLoading}
+							className="w-full h-[38px] text-[16px] leading-[19.2px] tracking-[-0.04em] bg-primary-200 text-black-800 font-bold hover:bg-transparent hover:text-primary-200 hover:border-primary-200 transition-colors disabled:border-0 disabled:bg-black-400 disabled:text-black-600"
+						>
+							{isLoading ? (
+								<div className="h-5 w-5 animate-spin rounded-full border-2 border-white-800 border-t-transparent" />
+							) : (
+								"Save"
+							)}
+						</Button>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+} 

--- a/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
@@ -6,6 +6,7 @@ import {
 	DialogContent,
 	DialogHeader,
 	DialogTitle,
+	DialogClose,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import type { users } from "@/drizzle";
@@ -15,7 +16,7 @@ import { maxLength, minLength, parse, pipe, string } from "valibot";
 import { updateAvatar, updateDisplayName } from "../account/actions";
 import { IMAGE_CONSTRAINTS } from "../constants";
 import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
-import { Camera } from "lucide-react";
+import { Camera, ImageIcon } from "lucide-react";
 
 const ACCEPTED_FILE_TYPES = IMAGE_CONSTRAINTS.formats.join(",");
 
@@ -220,6 +221,14 @@ export function ProfileEditModal({
 					<DialogTitle className="text-white-800 font-semibold text-[20px] leading-[28px] font-hubot text-center">
 						Change your Profiles
 					</DialogTitle>
+					<DialogClose 
+						className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none" 
+						onClick={onClose}
+					>
+						<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-white-800">
+							<path d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z" fill="currentColor" fillRule="evenodd" clipRule="evenodd"></path>
+						</svg>
+					</DialogClose>
 				</DialogHeader>
 
 				<div className="relative z-10 flex flex-col items-center gap-6 w-full px-[24px] pb-[30px]">
@@ -234,47 +243,54 @@ export function ProfileEditModal({
 					
 					{/* Avatar Profile Images */}
 					<div className="flex items-center justify-center gap-4 w-full">
-						{/* Current avatar */}
-						{initialAvatarUrl && !avatarPreview && (
-							<button
-								type="button"
-								onClick={handleSelectImageClick}
-								className="group relative w-[47px] h-[47px] rounded-full overflow-hidden cursor-pointer focus:outline-none focus:ring-2 focus:ring-white-400 border border-primary-100/20"
-							>
-								<AvatarImage
-									avatarUrl={initialAvatarUrl}
-									width={47}
-									height={47}
-									alt={alt}
-								/>
-								<div className="absolute inset-0 flex items-center justify-center bg-black-900/60 opacity-0 group-hover:opacity-100 transition-opacity">
-									<Camera className="w-5 h-5 text-white-800" />
+						<div className="flex flex-row gap-4">
+							{/* 左側 - クリックできるアバター */}
+							{initialAvatarUrl && !avatarPreview && (
+								<button
+									type="button"
+									onClick={handleSelectImageClick}
+									className="group relative w-[80px] h-[80px] rounded-full overflow-hidden cursor-pointer focus:outline-none focus:ring-0 border border-primary-100/20 hover:before:content-[''] hover:before:absolute hover:before:inset-0 hover:before:bg-black-900/40 hover:before:z-10"
+								>
+									<AvatarImage
+										avatarUrl={initialAvatarUrl}
+										width={80}
+										height={80}
+										alt={alt}
+										className="object-cover w-full h-full"
+									/>
+									<div className="absolute inset-0 flex items-center justify-center bg-black-900/50 opacity-0 group-hover:opacity-100 transition-opacity">
+										<div className="w-[40px] h-[40px] rounded-full flex items-center justify-center">
+											<ImageIcon className="w-7 h-7 text-white-800 transform group-hover:scale-110 transition-transform" />
+										</div>
+									</div>
+								</button>
+							)}
+							
+							{/* 左側 - プレビュー画像 */}
+							{avatarPreview && (
+								<div className="relative w-[80px] h-[80px] rounded-full overflow-hidden border border-primary-100/30">
+									<Image
+										src={avatarPreview}
+										alt="Avatar preview"
+										fill
+										sizes="80px"
+										className="object-cover w-full h-full scale-[1.02]"
+										style={{ objectPosition: 'center' }}
+									/>
 								</div>
-							</button>
-						)}
-						
-						{/* Selected avatar preview */}
-						{avatarPreview && (
-							<div className="relative w-[47px] h-[47px] rounded-full overflow-hidden border border-primary-100/30">
-								<Image
-									src={avatarPreview}
-									alt="Avatar preview"
-									fill
-									className="object-cover"
-								/>
-							</div>
-						)}
-						
-						{/* Image placeholder */}
-						{!initialAvatarUrl && !avatarPreview && (
-							<button
-								type="button"
-								onClick={handleSelectImageClick}
-								className="group relative w-[47px] h-[47px] rounded-full overflow-hidden cursor-pointer focus:outline-none focus:ring-2 focus:ring-white-400 bg-black-800 border border-primary-100/20 flex items-center justify-center"
-							>
-								<Camera className="w-5 h-5 text-white-600" />
-							</button>
-						)}
+							)}
+							
+							{/* 左側 - 画像アイコン（初期アバターがない場合） */}
+							{!initialAvatarUrl && !avatarPreview && (
+								<button
+									type="button"
+									onClick={handleSelectImageClick}
+									className="group relative w-[80px] h-[80px] rounded-full overflow-hidden cursor-pointer focus:outline-none focus:ring-0 bg-transparent border border-primary-100/20 flex items-center justify-center hover:before:content-[''] hover:before:absolute hover:before:inset-0 hover:before:bg-black-900/50 hover:before:z-10"
+								>
+									<ImageIcon className="w-7 h-7 text-white-800 transform group-hover:scale-110 transition-transform" />
+								</button>
+							)}
+						</div>
 					</div>
 					
 					{/* Display name input */}

--- a/apps/studio.giselles.ai/services/accounts/components/user-button/avatar-image.tsx
+++ b/apps/studio.giselles.ai/services/accounts/components/user-button/avatar-image.tsx
@@ -22,7 +22,8 @@ export function AvatarImage({
 			width={width}
 			height={height}
 			alt={alt}
-			className={cn("rounded-full", className)}
+			className={cn("rounded-full object-cover w-full h-full", className)}
+			style={{ objectPosition: "center" }}
 		/>
 	) : (
 		<Avatar
@@ -31,6 +32,7 @@ export function AvatarImage({
 			width={width}
 			height={height}
 			colors={["#413e4a", "#73626e", "#b38184", "#f0b49e", "#f7e4be"]}
+			className={cn("w-full h-full", className)}
 		/>
 	);
 }

--- a/apps/studio.giselles.ai/services/teams/components/team-selection-form.tsx
+++ b/apps/studio.giselles.ai/services/teams/components/team-selection-form.tsx
@@ -2,6 +2,11 @@
 
 import { FreeTag } from "@/components/free-tag";
 import { ProTag } from "@/components/pro-tag";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
 	Select,
 	SelectContent,
@@ -9,6 +14,7 @@ import {
 	SelectSeparator,
 	SelectTrigger,
 } from "@/components/ui/select";
+import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
 import { ChevronsUpDown, Plus } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useMemo, useRef } from "react";

--- a/services/accounts/components/user-button/avatar-image.tsx
+++ b/services/accounts/components/user-button/avatar-image.tsx
@@ -1,0 +1,38 @@
+import type { users } from "@/drizzle";
+import { cn } from "@/lib/utils";
+import Avatar from "boring-avatars";
+import Image from "next/image";
+
+export function AvatarImage({
+	avatarUrl,
+	width,
+	height,
+	className = "",
+	alt = "",
+}: {
+	avatarUrl: typeof users.$inferSelect.avatarUrl;
+	width: number;
+	height: number;
+	className?: string;
+	alt?: string;
+}) {
+	return avatarUrl ? (
+		<Image
+			src={avatarUrl}
+			width={width}
+			height={height}
+			alt={alt}
+			className={cn("rounded-full object-cover w-full h-full", className)}
+			style={{ objectPosition: "center" }}
+		/>
+	) : (
+		<Avatar
+			name={alt}
+			variant="marble"
+			width={width}
+			height={height}
+			colors={["#413e4a", "#73626e", "#b38184", "#f0b49e", "#f7e4be"]}
+			className={cn("w-full h-full", className)}
+		/>
+	);
+}


### PR DESCRIPTION
## Summary
Improved the avatar preview display in the profile edit modal and changed it to a more modern and intuitive UI/UX.

## Related Issue
None

<img width="1122" alt="スクリーンショット 2025-04-24 11 51 26" src="https://github.com/user-attachments/assets/2a9df8d1-3e22-4853-96a2-55eef884dec3" />


## Changes
- Made the icon background of the avatar preview display transparent (removed the grey circle).
- Changed the hover background to semi-transparent black (50% transparency) so that the image can be seen through.
- Adjusted the icon size on hover (w-6 → w-7) and added an expansion animation
- Unified the icon colour to white-800 to improve visibility
- Added a smooth transition to the hover effect

## Testing
- Open the profile edit modal in a browser and confirm the display with and without an avatar
- Confirm that all hover effects work properly
- Confirm that icon visibility and usability have been improved

## Other Information
We have improved the UI to provide a consistent visual experience regardless of whether an avatar is set. Hover effects are now more interactive, intuitively communicating to users that elements are actionable.