### PR TITLE
feat(studio.giselles.ai): update teamInvitationViaEmailFlag to always return true

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -68,7 +68,7 @@ export const githubToolsFlag = flag<boolean>({
 export const teamInvitationViaEmailFlag = flag<boolean>({
 	key: "teamInvitationViaEmail",
 	async decide() {
-		return takeLocalEnv("TEAM_INVITATION_VIA_EMAIL_FLAG");
+		return true;
 	},
 	description: "Enable team invitation via email",
 	defaultValue: false,


### PR DESCRIPTION
## Summary
Enable team invitation via email feature.