### PR TITLE
Added Reasoning option for Claude 3.7

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
@@ -10,6 +10,7 @@ import {
 	SelectValue,
 } from "../../../../ui/select";
 import { Slider } from "../../../../ui/slider";
+import { Switch } from "../../../../ui/switch";
 import { languageModelAvailable } from "./utils";
 
 export function AnthropicModelPanel({
@@ -86,6 +87,23 @@ export function AnthropicModelPanel({
 									configurations: {
 										...anthropicLanguageModel.configurations,
 										topP: value,
+									},
+								}),
+							);
+						}}
+					/>
+
+					<Switch
+						label="Reasoning"
+						name="reasoning"
+						checked={anthropicLanguageModel.configurations.reasoning}
+						onCheckedChange={(checked) => {
+							onModelChange(
+								AnthropicLanguageModelData.parse({
+									...anthropicLanguageModel,
+									configurations: {
+										...anthropicLanguageModel.configurations,
+										reasoning: checked,
 									},
 								}),
 							);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
@@ -1,6 +1,11 @@
 import { AnthropicLanguageModelData } from "@giselle-sdk/data-type";
-import { anthropicLanguageModels } from "@giselle-sdk/language-model";
+import {
+	Capability,
+	anthropicLanguageModels,
+	hasCapability,
+} from "@giselle-sdk/language-model";
 import { useUsageLimits } from "giselle-sdk/react";
+import { useMemo } from "react";
 import {
 	Select,
 	SelectContent,
@@ -21,6 +26,11 @@ export function AnthropicModelPanel({
 	onModelChange: (changedValue: AnthropicLanguageModelData) => void;
 }) {
 	const limits = useUsageLimits();
+	const languageModel = useMemo(
+		() =>
+			anthropicLanguageModels.find((lm) => lm.id === anthropicLanguageModel.id),
+		[anthropicLanguageModel.id],
+	);
 
 	return (
 		<div className="flex flex-col gap-[34px]">
@@ -108,6 +118,12 @@ export function AnthropicModelPanel({
 								}),
 							);
 						}}
+						note={
+							languageModel &&
+							anthropicLanguageModel.configurations.reasoning &&
+							!hasCapability(languageModel, Capability.Reasoning) &&
+							"Reasoning will not use since the current model does not support reasoning"
+						}
 					/>
 				</div>
 			</div>

--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -8,6 +8,8 @@ import {
 	isFailedGeneration,
 } from "@giselle-sdk/data-type";
 import { useGiselleEngine } from "giselle-sdk/react";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { Accordion } from "radix-ui";
 import { useMemo } from "react";
 import { WilliIcon } from "../icons";
 import { MemoizedMarkdown } from "./memoized-markdown";
@@ -68,10 +70,60 @@ export function GenerationView({
 				})}
 			{generatedMessages.map((message) => (
 				<div key={message.id}>
-					{message.parts?.map((part) => {
+					{message.parts?.map((part, index) => {
+						const lastPart = message.parts?.length === index + 1;
 						switch (part.type) {
 							case "reasoning":
-								return <p key={part.reasoning}>{part.reasoning}</p>;
+								if (lastPart) {
+									return (
+										<Accordion.Root
+											key={`messages.${message.id}.parts.[${index}].reasoning`}
+											type="single"
+											collapsible
+											className="my-[8px]"
+											defaultValue={`messages.${message.id}.parts.[${index}].reasoning`}
+										>
+											<Accordion.Item
+												value={`messages.${message.id}.parts.[${index}].reasoning`}
+											>
+												<Accordion.Trigger className="group text-white-400 text-[14px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none">
+													<ChevronRightIcon
+														className="size-[16px] transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-90"
+														aria-hidden
+													/>
+													Thinking
+												</Accordion.Trigger>
+												<Accordion.Content className="markdown-renderer overflow-hidden italic text-[14px] text-white-400 ml-[8px] pl-[12px] mb-[8px] data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown border-l border-l-white-400/20">
+													<MemoizedMarkdown content={part.reasoning} />
+												</Accordion.Content>
+											</Accordion.Item>
+										</Accordion.Root>
+									);
+								}
+								return (
+									<Accordion.Root
+										key={`messages.${message.id}.parts.[${index}].reason`}
+										type="single"
+										collapsible
+										className="my-[8px]"
+										defaultValue=""
+									>
+										<Accordion.Item
+											value={`messages.${message.id}.parts.[${index}].reason`}
+										>
+											<Accordion.Trigger className="group text-white-400 text-[14px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none">
+												<ChevronRightIcon
+													className="size-[16px] transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-90"
+													aria-hidden
+												/>
+												Thought Process
+											</Accordion.Trigger>
+											<Accordion.Content className="markdown-renderer overflow-hidden italic text-[14px] text-white-400 ml-[8px] pl-[12px] mb-[8px] data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown border-l border-l-white-400/20">
+												<MemoizedMarkdown content={part.reasoning} />
+											</Accordion.Content>
+										</Accordion.Item>
+									</Accordion.Root>
+								);
 
 							case "text":
 								return (

--- a/internal-packages/workflow-designer-ui/src/workflow-designer-ui.css
+++ b/internal-packages/workflow-designer-ui/src/workflow-designer-ui.css
@@ -62,6 +62,25 @@
 			transform: rotate(-360deg);
 		}
 	}
+
+	@keyframes slideDown {
+		from {
+			height: 0px;
+		}
+		to {
+			height: var(--radix-accordion-content-height);
+		}
+	}
+	@keyframes slideUp {
+		from {
+			height: var(--radix-accordion-content-height);
+		}
+		to {
+			height: 0px;
+		}
+	}
+	--animate-slideDown: slideDown 300ms cubic-bezier(0.87, 0, 0.13, 1);
+	--animate-slideUp: slideUp 300ms cubic-bezier(0.87, 0, 0.13, 1);
 }
 
 @property --button-gradient-angle {

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -1,5 +1,5 @@
 import { URL } from "node:url";
-import { anthropic } from "@ai-sdk/anthropic";
+import { type AnthropicProviderOptions, anthropic } from "@ai-sdk/anthropic";
 import { google } from "@ai-sdk/google";
 import { openai } from "@ai-sdk/openai";
 import { perplexity } from "@ai-sdk/perplexity";
@@ -333,6 +333,7 @@ export async function generateText(args: {
 
 	const streamTextResult = streamText({
 		model: generationModel(actionNode.content.llm),
+		providerOptions: providerOptions(actionNode.content.llm),
 		messages,
 		maxSteps: 5, // enable multi-step calls
 		tools: preparedToolSet.toolSet,
@@ -520,4 +521,21 @@ function isVertexAiHost(urlString: string): boolean {
 	// } catch (e) {
 	// 	return false;
 	// }
+}
+
+function providerOptions(languageModel: TextGenerationLanguageModelData) {
+	if (
+		languageModel.provider === "anthropic" &&
+		languageModel.configurations.reasoning
+	) {
+		return {
+			anthropic: {
+				thinking: {
+					type: "enabled",
+					// Based on Zed's configuration: https://github.com/zed-industries/zed/blob/9d10489607df700c544c48cf09fea82f5d5aacf8/crates/anthropic/src/anthropic.rs#L212
+					budgetTokens: 4096,
+				},
+			} satisfies AnthropicProviderOptions,
+		};
+	}
 }

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -523,10 +523,15 @@ function isVertexAiHost(urlString: string): boolean {
 	// }
 }
 
-function providerOptions(languageModel: TextGenerationLanguageModelData) {
+function providerOptions(languageModelData: TextGenerationLanguageModelData) {
+	const languageModel = languageModels.find(
+		(model) => model.id === languageModelData.id,
+	);
 	if (
-		languageModel.provider === "anthropic" &&
-		languageModel.configurations.reasoning
+		languageModel &&
+		languageModelData.provider === "anthropic" &&
+		languageModelData.configurations.reasoning &&
+		hasCapability(languageModel, Capability.Reasoning)
 	) {
 		return {
 			anthropic: {

--- a/packages/giselle-engine/src/http/router.ts
+++ b/packages/giselle-engine/src/http/router.ts
@@ -65,7 +65,9 @@ export const createJsonRouters = {
 						input.generation,
 						input.telemetry,
 					);
-					return stream.toDataStreamResponse();
+					return stream.toDataStreamResponse({
+						sendReasoning: true,
+					});
 				},
 			}),
 		),

--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -4,6 +4,7 @@ import { Capability, LanguageModelBase, Tier } from "./base";
 const AnthropicLanguageModelConfigurations = z.object({
 	temperature: z.number(),
 	topP: z.number(),
+	reasoning: z.boolean().default(false),
 });
 type AnthropicLanguageModelConfigurations = z.infer<
 	typeof AnthropicLanguageModelConfigurations
@@ -12,6 +13,7 @@ type AnthropicLanguageModelConfigurations = z.infer<
 const defaultConfigurations: AnthropicLanguageModelConfigurations = {
 	temperature: 0.7,
 	topP: 1.0,
+	reasoning: false,
 };
 
 const AnthropicLanguageModel = LanguageModelBase.extend({


### PR DESCRIPTION
This PR adds support for the Reasoning option (called "Thinking" by Anthropic) when using Claude 3.7. The property name has been set as "Reasoning" to maintain consistency with the AI SDK naming convention.

Note that this option is silently ignored when using Claude models that don't support this feature.