### PR TITLE
fix(studio): rename check to format

### DIFF
--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -10,7 +10,7 @@
 		"dev-debug": "LOGLEVEL=debug pnpm run dev",
 		"build": "next build --turbopack",
 		"start": "next start",
-		"check": "biome check --write .",
+		"format": "biome check --write .",
 		"lint": "next lint",
 		"test": "vitest run"
 	},


### PR DESCRIPTION
## Summary

studio has "check" script but all packages have "format" and the root turbo command is also "format"
