### PR TITLE
Fix language model toolbar positioning

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -340,7 +340,11 @@ export function Toolbar() {
 						</>
 					)}
 
-					<ToggleGroup.Item value="selectLanguageModel" data-tool>
+					<ToggleGroup.Item
+						value="selectLanguageModel"
+						data-tool
+						className="relative"
+					>
 						<Tooltip text={<TooltipAndHotkey text="Generation" hotkey="G" />}>
 							<GenNodeIcon data-icon />
 						</Tooltip>
@@ -512,7 +516,7 @@ export function Toolbar() {
 								</Dialog.Portal>
 							</Dialog.Root>
 						)}
-						<div className="absolute left-[calc(var(--language-model-detail-panel-width)_+_56px)]">
+						<div className="absolute left-[calc(var(--language-model-detail-panel-width)/2_+_var(--language-model-toggle-group-popover-width)/2_-_var(--language-model-detail-panel-width)/2_+_10px)]">
 							<div className="relative">
 								{selectedTool?.action === "selectLanguageModel" && (
 									<Popover.Root open={true}>
@@ -521,7 +525,6 @@ export function Toolbar() {
 											<Popover.Content
 												className="bg-black-900/10 w-[var(--language-model-detail-panel-width)] backdrop-blur-[4px] rounded-[8px] px-[8px] py-[8px] "
 												sideOffset={42}
-												align="end"
 												onOpenAutoFocus={(e) => {
 													e.preventDefault();
 												}}


### PR DESCRIPTION
## Summary
- Fixed positioning of the language model toolbar popover for better UI alignment
- Added relative class to toggle group item for proper positioning context
- Adjusted calculation for left positioning to center the popover correctly
- Removed end alignment property that was causing misalignment

Before|After
------|-------
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/bc682874-7482-4b53-bba8-3ddece7bb668" />|<img width="871" alt="image" src="https://github.com/user-attachments/assets/9db1a313-9891-4035-a3df-89df4527c23a" />



## Test plan
- Verify that the language model toolbar popover now appears correctly centered
- Confirm that the positioning is visually aligned with the toggle button
- Test in different viewport sizes to ensure consistent alignment

🤖 Generated with [Claude Code](https://claude.ai/code)