### PR TITLE
Add image file input capability to OpenAI image model

### DIFF
--- a/packages/language-model/src/openai-image.ts
+++ b/packages/language-model/src/openai-image.ts
@@ -37,7 +37,7 @@ type OpenAIImageLanguageModel = z.infer<typeof OpenAIImageLanguageModel>;
 const openaiGptImage1: OpenAIImageLanguageModel = {
 	provider: "openai",
 	id: "gpt-image-1",
-	capabilities: Capability.ImageGeneration,
+	capabilities: Capability.ImageGeneration | Capability.ImageFileInput,
 	tier: "pro",
 	configurations: defaultConfiguration,
 };

--- a/packages/workflow-designer/src/is-supported-connection.test.ts
+++ b/packages/workflow-designer/src/is-supported-connection.test.ts
@@ -139,8 +139,8 @@ describe("isSupportedConnection", () => {
 	});
 
 	describe("File node restrictions", () => {
-		test("should reject file node as input for image generation", () => {
-			const fileNode = createFileNode("nd-test8");
+		test("should reject pdf file node as input for image generation", () => {
+			const fileNode = createFileNode("nd-test8", "pdf");
 			const inputNode = createImageGenerationNode("nd-test9");
 
 			const result = isSupportedConnection(fileNode, inputNode);
@@ -148,12 +148,12 @@ describe("isSupportedConnection", () => {
 			expect(result.canConnect).toBe(false);
 			expect(result).toHaveProperty(
 				"message",
-				"File node is not supported as an input for Image Generation",
+				"File node is not supported as an input for this node",
 			);
 		});
 
-		test("should reject file node as input for OpenAI", () => {
-			const fileNode = createFileNode("nd-test10");
+		test("should reject pdf file node as input for OpenAI", () => {
+			const fileNode = createFileNode("nd-test10", "pdf");
 			const inputNode = createTextGenerationNode(
 				"nd-test11",
 				openaiLanguageModels[0],
@@ -164,12 +164,12 @@ describe("isSupportedConnection", () => {
 			expect(result.canConnect).toBe(false);
 			expect(result).toHaveProperty(
 				"message",
-				"File node is not supported as an input for OpenAI",
+				"File node is not supported as an input for this node",
 			);
 		});
 
-		test("should reject file node as input for Perplexity", () => {
-			const fileNode = createFileNode("nd-test12");
+		test("should reject image file node as input for Perplexity", () => {
+			const fileNode = createFileNode("nd-test12", "image");
 			const inputNode = createTextGenerationNode(
 				"nd-test13",
 				perplexityLanguageModels[0],
@@ -180,7 +180,7 @@ describe("isSupportedConnection", () => {
 			expect(result.canConnect).toBe(false);
 			expect(result).toHaveProperty(
 				"message",
-				"File node is not supported as an input for Perplexity",
+				"File node is not supported as an input for this node",
 			);
 		});
 


### PR DESCRIPTION
## Summary
- Add Capability.ImageFileInput to OpenAI GPT Image model
- Refactor connection validation to use capability-based approach for file nodes
- Improve file type validation based on language model capabilities

## Test plan
- Verify OpenAI GPT Image model now accepts image file inputs
- Test connections between file nodes (image category) and OpenAI image nodes
- Verify other file type validations work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)