### PR TITLE
Add connector animation for running input nodes

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/connector/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/connector/component.tsx
@@ -1,4 +1,4 @@
-import type { Connection } from "@giselle-sdk/data-type";
+import type { Connection, NodeId } from "@giselle-sdk/data-type";
 import {
 	BaseEdge,
 	type EdgeProps,
@@ -6,8 +6,30 @@ import {
 	getBezierPath,
 } from "@xyflow/react";
 import clsx from "clsx/lite";
+import { useNodeGenerations, useWorkflowDesigner } from "giselle-sdk/react";
+import type { PropsWithChildren } from "react";
 
 export type ConnectorType = XYFlowEdge<{ connection: Connection }>;
+
+function ConnectedNodeRunning({
+	inputNodeId,
+	children,
+}: PropsWithChildren<{
+	inputNodeId: NodeId;
+}>) {
+	const { data } = useWorkflowDesigner();
+	const { currentGeneration: inputNodeCurrentGeneration } = useNodeGenerations({
+		nodeId: inputNodeId,
+		origin: { type: "workspace", id: data.id },
+	});
+	if (
+		inputNodeCurrentGeneration?.status === "queued" ||
+		inputNodeCurrentGeneration?.status === "running"
+	) {
+		return children;
+	}
+	return null;
+}
 
 export function Connector({
 	id,
@@ -52,14 +74,16 @@ export function Connector({
 				)}
 				filter="url(#white-glow-filter)"
 			/>
-			{/* <path
-				d={edgePath}
-				stroke="url(#connector-gradient-animation)"
-				strokeWidth="2"
-				fill="none"
-				strokeLinecap="round"
-				filter="url(#white-glow-filter)"
-			/> */}
+			<ConnectedNodeRunning inputNodeId={data.connection.inputNode.id}>
+				<path
+					d={edgePath}
+					stroke="url(#connector-gradient-animation)"
+					strokeWidth="2"
+					fill="none"
+					strokeLinecap="round"
+					filter="url(#white-glow-filter)"
+				/>
+			</ConnectedNodeRunning>
 		</g>
 	);
 }


### PR DESCRIPTION
## Summary
- Add visual feedback to connectors by showing an animated gradient when the input node is in 'queued' or 'running' state
- Implement conditional rendering based on node generation status using existing hooks from the SDK
- Improve user experience by making the workflow process state more visible


https://github.com/user-attachments/assets/2f5fe23e-d3f3-460e-9a2c-a89ac07ad33c



## Test plan
- Run the workflow designer and verify that connectors show animation when their input node is in running or queued state
- Confirm the animation disappears when the node is no longer processing
- Test with multiple connected nodes to ensure correct behavior across the workflow

🤖 Generated with [Claude Code](https://claude.ai/code)