### PR TITLE
Redesign trigger icon and update node colors

### DIFF
--- a/apps/playground/app/globals.css
+++ b/apps/playground/app/globals.css
@@ -59,8 +59,8 @@
 	--color-generation-node-1: hsl(219, 90%, 52%);
 	--color-generation-node-2: hsl(219, 98%, 23%);
 
-	--color-trigger-node-1: var(--color-deep-purple-900);
-	--color-trigger-node-2: hsl(275, 91%, 26%);
+	--color-trigger-node-1: var(--color-black-400);
+	--color-trigger-node-2: var(--color-black-400);
 
 	--color-action-node-1: var(--color-deep-purple-900);
 	--color-action-node-2: hsl(275, 91%, 26%);

--- a/apps/studio.giselles.ai/app/globals.css
+++ b/apps/studio.giselles.ai/app/globals.css
@@ -248,8 +248,8 @@
 	--color-generation-node-1: hsl(219, 90%, 52%);
 	--color-generation-node-2: hsl(219, 98%, 23%);
 
-	--color-trigger-node-1: var(--color-deep-purple-900);
-	--color-trigger-node-2: hsl(275, 91%, 26%);
+	--color-trigger-node-1: var(--color-black-400);
+	--color-trigger-node-2: var(--color-black-400);
 
 	--color-github-node-1: var(--color-deep-purple-900);
 	--color-github-node-2: hsl(275, 91%, 26%);

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -20,11 +20,7 @@ import {
 import clsx from "clsx/lite";
 import { useFeatureFlag } from "giselle-sdk/react";
 import { useUsageLimits, useWorkflowDesigner } from "giselle-sdk/react";
-import {
-	MousePointerClickIcon,
-	SquareFunctionIcon,
-	WorkflowIcon,
-} from "lucide-react";
+import { WorkflowIcon } from "lucide-react";
 import { Dialog, Popover, ToggleGroup } from "radix-ui";
 import { type ReactNode, useState } from "react";
 import {
@@ -44,6 +40,7 @@ import {
 	SearchIcon,
 	SourceLinkIcon,
 	TextFileIcon,
+	TriggerIcon,
 	UploadIcon,
 	VideoIcon,
 	WilliIcon,
@@ -211,7 +208,7 @@ export function Toolbar() {
 								className="relative"
 							>
 								<Tooltip text={<TooltipAndHotkey text="Trigger" hotkey="t" />}>
-									<MousePointerClickIcon data-icon />
+									<TriggerIcon data-icon />
 								</Tooltip>
 								{selectedTool?.action === "selectTrigger" && (
 									<Popover.Root open={true}>
@@ -245,7 +242,7 @@ export function Toolbar() {
 																value={manualTrigger.id}
 																data-tool
 															>
-																<MousePointerClickIcon className="w-[20px] h-[20px] shrink-0" />
+																<TriggerIcon className="size-[20px] shrink-0" />
 																<p className="text-[14px]">
 																	{manualTrigger.label}
 																</p>

--- a/internal-packages/workflow-designer-ui/src/icons/index.ts
+++ b/internal-packages/workflow-designer-ui/src/icons/index.ts
@@ -43,3 +43,4 @@ export { SearchIcon } from "./generate-text";
 export { AudioIcon } from "./audio";
 export { VideoIcon } from "./video";
 export { GenerateImageIcon } from "./generate-image";
+export * from "./trigger";

--- a/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
@@ -1,6 +1,5 @@
 import type { Node } from "@giselle-sdk/data-type";
 import { getImageGenerationModelProvider } from "@giselle-sdk/language-model";
-import { GithubIcon, MousePointerClickIcon } from "lucide-react";
 import type { SVGProps } from "react";
 import { AnthropicIcon } from "../anthropic";
 import { Flux1Icon } from "../flux1";
@@ -15,6 +14,7 @@ import { PromptIcon } from "../prompt";
 import { RecraftIcon } from "../recraft";
 import { StableDiffusionIcon } from "../stable-diffusion";
 import { TextFileIcon } from "../text-file";
+import { TriggerIcon } from "../trigger";
 export * from "./file-node";
 export * from "./image-generation-node";
 export * from "./text-generation-node";
@@ -87,9 +87,7 @@ export function NodeIcon({
 						case "github":
 							return <GitHubIcon {...props} data-content-type-icon />;
 						case "manual":
-							return (
-								<MousePointerClickIcon {...props} data-content-type-icon />
-							);
+							return <TriggerIcon {...props} data-content-type-icon />;
 						default: {
 							throw new Error(
 								`Unhandled TriggerProviderType: ${node.content.provider.type}`,

--- a/internal-packages/workflow-designer-ui/src/icons/trigger.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/trigger.tsx
@@ -1,0 +1,18 @@
+import clsx from "clsx/lite";
+import type { SVGProps } from "react";
+
+export function TriggerIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+	return (
+		<svg
+			width="6"
+			height="10"
+			viewBox="0 0 15 21"
+			xmlns="http://www.w3.org/2000/svg"
+			role="graphics-symbol"
+			className={clsx("fill-current", className)}
+			{...props}
+		>
+			<path d="M4.39934 0L11.4302 0.739924C11.8899 0.784098 12.1738 1.19271 11.971 1.53507L8.00942 8.6803C7.79308 9.07787 8.18519 9.53066 8.72602 9.48649L14.229 9.00057C14.8375 8.94535 15.2296 9.51962 14.851 9.91719L4.64272 20.7731C4.14245 21.3032 3.12838 20.8173 3.43936 20.2099L6.68437 13.8377C6.88718 13.4401 6.49508 13.0094 5.96777 13.0536L0.775753 13.5285C0.289001 13.5726 -0.0895829 13.2192 0.018584 12.8327L3.62866 0.441746C3.70978 0.154611 4.0478 -0.0331309 4.39934 0.0110436V0Z" />
+		</svg>
+	);
+}


### PR DESCRIPTION
## Summary
- Add new lightning bolt TriggerIcon component to replace MousePointerClickIcon
- Replace MousePointerClickIcon with TriggerIcon in toolbar and node components
- Update trigger node colors to black for better contrast

## Test plan
- Verify trigger icon appears correctly in toolbar and node components
- Confirm trigger node colors are displaying as expected
- Check that the lightning bolt design is visually consistent

🤖 Generated with [Claude Code](https://claude.ai/code)