### PR TITLE
Add reasoning styles

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
@@ -5,7 +5,7 @@ import {
 	hasCapability,
 } from "@giselle-sdk/language-model";
 import { useUsageLimits } from "giselle-sdk/react";
-import { useMemo, useState, useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
 	Select,
 	SelectContent,
@@ -31,30 +31,33 @@ export function AnthropicModelPanel({
 			anthropicLanguageModels.find((lm) => lm.id === anthropicLanguageModel.id),
 		[anthropicLanguageModel.id],
 	);
-	
-	const supportsReasoning = languageModel && hasCapability(languageModel, Capability.Reasoning);
-	
+
+	const supportsReasoning =
+		languageModel && hasCapability(languageModel, Capability.Reasoning);
+
 	// UIのスイッチ状態を追跡するための内部ステート
 	const [reasoningEnabled, setReasoningEnabled] = useState(
-		supportsReasoning ? anthropicLanguageModel.configurations.reasoning : false
+		supportsReasoning ? anthropicLanguageModel.configurations.reasoning : false,
 	);
-	
+
 	// エラーメッセージ表示用の状態
 	const [showError, setShowError] = useState(false);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-	
+
 	// モデルまたは設定が変更されたときにUIの状態を更新
 	useEffect(() => {
 		setReasoningEnabled(
-			supportsReasoning ? anthropicLanguageModel.configurations.reasoning : false
+			supportsReasoning
+				? anthropicLanguageModel.configurations.reasoning
+				: false,
 		);
-		
+
 		// モデルが変わったらエラー表示をリセット
 		setShowError(false);
 		if (timeoutRef.current) {
 			clearTimeout(timeoutRef.current);
 		}
-	}, [anthropicLanguageModel.id, anthropicLanguageModel.configurations.reasoning, supportsReasoning]);
+	}, [anthropicLanguageModel.configurations.reasoning, supportsReasoning]);
 
 	return (
 		<div className="flex flex-col gap-[34px]">
@@ -137,37 +140,37 @@ export function AnthropicModelPanel({
 								// 一瞬ONにして、すぐにOFFに戻す
 								setReasoningEnabled(true);
 								setShowError(true);
-								
+
 								// 既存のタイマーがあればクリア
 								if (timeoutRef.current) {
 									clearTimeout(timeoutRef.current);
 								}
-								
+
 								// 少し遅延してOFFに戻す（UXのため）
 								timeoutRef.current = setTimeout(() => {
 									setReasoningEnabled(false);
 									// エラーメッセージは表示したまま
 								}, 300);
-								
+
 								return;
 							}
-							
+
 							// サポート対応モデルの場合は通常の動作
 							setReasoningEnabled(checked);
 							setShowError(false);
-							
+
 							onModelChange(
 								AnthropicLanguageModelData.parse({
 									...anthropicLanguageModel,
 									configurations: {
 										...anthropicLanguageModel.configurations,
-										reasoning: checked && supportsReasoning,  // サポートしていない場合は常にfalse
+										reasoning: checked && supportsReasoning, // サポートしていない場合は常にfalse
 									},
 								}),
 							);
 						}}
 						note={
-							!supportsReasoning && 
+							!supportsReasoning &&
 							showError &&
 							"Current model does not support reasoning features."
 						}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/anthropic.tsx
@@ -5,7 +5,7 @@ import {
 	hasCapability,
 } from "@giselle-sdk/language-model";
 import { useUsageLimits } from "giselle-sdk/react";
-import { useMemo } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import {
 	Select,
 	SelectContent,
@@ -31,6 +31,30 @@ export function AnthropicModelPanel({
 			anthropicLanguageModels.find((lm) => lm.id === anthropicLanguageModel.id),
 		[anthropicLanguageModel.id],
 	);
+	
+	const supportsReasoning = languageModel && hasCapability(languageModel, Capability.Reasoning);
+	
+	// UIのスイッチ状態を追跡するための内部ステート
+	const [reasoningEnabled, setReasoningEnabled] = useState(
+		supportsReasoning ? anthropicLanguageModel.configurations.reasoning : false
+	);
+	
+	// エラーメッセージ表示用の状態
+	const [showError, setShowError] = useState(false);
+	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+	
+	// モデルまたは設定が変更されたときにUIの状態を更新
+	useEffect(() => {
+		setReasoningEnabled(
+			supportsReasoning ? anthropicLanguageModel.configurations.reasoning : false
+		);
+		
+		// モデルが変わったらエラー表示をリセット
+		setShowError(false);
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+		}
+	}, [anthropicLanguageModel.id, anthropicLanguageModel.configurations.reasoning, supportsReasoning]);
 
 	return (
 		<div className="flex flex-col gap-[34px]">
@@ -106,23 +130,46 @@ export function AnthropicModelPanel({
 					<Switch
 						label="Reasoning"
 						name="reasoning"
-						checked={anthropicLanguageModel.configurations.reasoning}
+						checked={reasoningEnabled}
 						onCheckedChange={(checked) => {
+							if (!supportsReasoning && checked) {
+								// 非対応モデルでONにしようとした場合
+								// 一瞬ONにして、すぐにOFFに戻す
+								setReasoningEnabled(true);
+								setShowError(true);
+								
+								// 既存のタイマーがあればクリア
+								if (timeoutRef.current) {
+									clearTimeout(timeoutRef.current);
+								}
+								
+								// 少し遅延してOFFに戻す（UXのため）
+								timeoutRef.current = setTimeout(() => {
+									setReasoningEnabled(false);
+									// エラーメッセージは表示したまま
+								}, 300);
+								
+								return;
+							}
+							
+							// サポート対応モデルの場合は通常の動作
+							setReasoningEnabled(checked);
+							setShowError(false);
+							
 							onModelChange(
 								AnthropicLanguageModelData.parse({
 									...anthropicLanguageModel,
 									configurations: {
 										...anthropicLanguageModel.configurations,
-										reasoning: checked,
+										reasoning: checked && supportsReasoning,  // サポートしていない場合は常にfalse
 									},
 								}),
 							);
 						}}
 						note={
-							languageModel &&
-							anthropicLanguageModel.configurations.reasoning &&
-							!hasCapability(languageModel, Capability.Reasoning) &&
-							"Reasoning will not be used because the current model does not support it"
+							!supportsReasoning && 
+							showError &&
+							"Current model does not support reasoning features."
 						}
 					/>
 				</div>

--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -158,12 +158,13 @@ export function GenerationView({
 				</div>
 			))}
 			{generation.status !== "completed" &&
-				generation.status !== "cancelled" && 
+				generation.status !== "cancelled" &&
 				// reasoning部分がない場合のみSpinnerを表示
-				!generatedMessages.some(message => 
-					message.parts?.some(part => 
-						part.type === "reasoning" && generation.status === "running"
-					)
+				!generatedMessages.some((message) =>
+					message.parts?.some(
+						(part) =>
+							part.type === "reasoning" && generation.status === "running",
+					),
 				) && (
 					<div className="pt-[8px]">
 						<Spinner />

--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -92,8 +92,6 @@ export function GenerationView({
 														className="size-[16px] transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-90"
 														aria-hidden
 													/>
-													<WilliIcon className="w-[16px] h-[16px] ml-[1px] mr-[2px]" />
-													<span className="mr-[2px]">{"{"}</span>
 													<span className="bg-[length:200%_100%] bg-clip-text bg-gradient-to-r from-[rgba(255,_255,_255,_1)] via-[rgba(255,_255,_255,_0.5)] to-[rgba(255,_255,_255,_1)] text-transparent animate-shimmer">
 														Thinking...
 													</span>
@@ -160,7 +158,13 @@ export function GenerationView({
 				</div>
 			))}
 			{generation.status !== "completed" &&
-				generation.status !== "cancelled" && (
+				generation.status !== "cancelled" && 
+				// reasoning部分がない場合のみSpinnerを表示
+				!generatedMessages.some(message => 
+					message.parts?.some(part => 
+						part.type === "reasoning" && generation.status === "running"
+					)
+				) && (
 					<div className="pt-[8px]">
 						<Spinner />
 					</div>

--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -72,9 +72,10 @@ export function GenerationView({
 				<div key={message.id}>
 					{message.parts?.map((part, index) => {
 						const lastPart = message.parts?.length === index + 1;
+						const isRunning = generation.status === "running";
 						switch (part.type) {
 							case "reasoning":
-								if (lastPart) {
+								if (lastPart && isRunning) {
 									return (
 										<Accordion.Root
 											key={`messages.${message.id}.parts.[${index}].reasoning`}
@@ -87,7 +88,11 @@ export function GenerationView({
 												value={`messages.${message.id}.parts.[${index}].reasoning`}
 											>
 												<Accordion.Trigger className="group text-white-400 text-[12px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none font-hubot">
-													<WilliIcon className="w-[16px] h-[16px]" />
+													<ChevronRightIcon
+														className="size-[16px] transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-90"
+														aria-hidden
+													/>
+													<WilliIcon className="w-[16px] h-[16px] ml-[1px] mr-[2px]" />
 													<span className="mr-[2px]">{"{"}</span>
 													<span className="bg-[length:200%_100%] bg-clip-text bg-gradient-to-r from-[rgba(255,_255,_255,_1)] via-[rgba(255,_255,_255,_0.5)] to-[rgba(255,_255,_255,_1)] text-transparent animate-shimmer">Thinking...</span>
 												</Accordion.Trigger>
@@ -110,9 +115,11 @@ export function GenerationView({
 											value={`messages.${message.id}.parts.[${index}].reason`}
 										>
 											<Accordion.Trigger className="group text-white-400 text-[12px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none font-hubot">
-												<WilliIcon className="w-[16px] h-[16px]" />
-												<span className="mr-[2px]">{"{"}</span>
-												<span className="bg-[length:200%_100%] bg-clip-text bg-gradient-to-r from-[rgba(255,_255,_255,_1)] via-[rgba(255,_255,_255,_0.5)] to-[rgba(255,_255,_255,_1)] text-transparent animate-shimmer">Thinking...</span>
+												<ChevronRightIcon
+													className="size-[16px] transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-90"
+													aria-hidden
+												/>
+												<span>Thinking Process</span>
 											</Accordion.Trigger>
 											<Accordion.Content className="markdown-renderer overflow-hidden italic text-[14px] text-white-400 ml-[8px] pl-[12px] mb-[8px] data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown border-l border-l-white-400/20">
 												<MemoizedMarkdown content={part.reasoning} />

--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -94,7 +94,9 @@ export function GenerationView({
 													/>
 													<WilliIcon className="w-[16px] h-[16px] ml-[1px] mr-[2px]" />
 													<span className="mr-[2px]">{"{"}</span>
-													<span className="bg-[length:200%_100%] bg-clip-text bg-gradient-to-r from-[rgba(255,_255,_255,_1)] via-[rgba(255,_255,_255,_0.5)] to-[rgba(255,_255,_255,_1)] text-transparent animate-shimmer">Thinking...</span>
+													<span className="bg-[length:200%_100%] bg-clip-text bg-gradient-to-r from-[rgba(255,_255,_255,_1)] via-[rgba(255,_255,_255,_0.5)] to-[rgba(255,_255,_255,_1)] text-transparent animate-shimmer">
+														Thinking...
+													</span>
 												</Accordion.Trigger>
 												<Accordion.Content className="markdown-renderer overflow-hidden italic text-[14px] text-white-400 ml-[8px] pl-[12px] mb-[8px] data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown border-l border-l-white-400/20">
 													<MemoizedMarkdown content={part.reasoning} />

--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -86,12 +86,10 @@ export function GenerationView({
 											<Accordion.Item
 												value={`messages.${message.id}.parts.[${index}].reasoning`}
 											>
-												<Accordion.Trigger className="group text-white-400 text-[14px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none">
-													<ChevronRightIcon
-														className="size-[16px] transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-90"
-														aria-hidden
-													/>
-													Thinking
+												<Accordion.Trigger className="group text-white-400 text-[12px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none font-hubot">
+													<WilliIcon className="w-[16px] h-[16px]" />
+													<span className="mr-[2px]">{"{"}</span>
+													<span className="bg-[length:200%_100%] bg-clip-text bg-gradient-to-r from-[rgba(255,_255,_255,_1)] via-[rgba(255,_255,_255,_0.5)] to-[rgba(255,_255,_255,_1)] text-transparent animate-shimmer">Thinking...</span>
 												</Accordion.Trigger>
 												<Accordion.Content className="markdown-renderer overflow-hidden italic text-[14px] text-white-400 ml-[8px] pl-[12px] mb-[8px] data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown border-l border-l-white-400/20">
 													<MemoizedMarkdown content={part.reasoning} />
@@ -111,12 +109,10 @@ export function GenerationView({
 										<Accordion.Item
 											value={`messages.${message.id}.parts.[${index}].reason`}
 										>
-											<Accordion.Trigger className="group text-white-400 text-[14px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none">
-												<ChevronRightIcon
-													className="size-[16px] transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-90"
-													aria-hidden
-												/>
-												Thought Process
+											<Accordion.Trigger className="group text-white-400 text-[12px] flex items-center gap-[4px] cursor-pointer hover:text-white-800 transition-colors data-[state=open]:text-white-800 outline-none font-hubot">
+												<WilliIcon className="w-[16px] h-[16px]" />
+												<span className="mr-[2px]">{"{"}</span>
+												<span className="bg-[length:200%_100%] bg-clip-text bg-gradient-to-r from-[rgba(255,_255,_255,_1)] via-[rgba(255,_255,_255,_0.5)] to-[rgba(255,_255,_255,_1)] text-transparent animate-shimmer">Thinking...</span>
 											</Accordion.Trigger>
 											<Accordion.Content className="markdown-renderer overflow-hidden italic text-[14px] text-white-400 ml-[8px] pl-[12px] mb-[8px] data-[state=closed]:animate-slideUp data-[state=open]:animate-slideDown border-l border-l-white-400/20">
 												<MemoizedMarkdown content={part.reasoning} />

--- a/internal-packages/workflow-designer-ui/src/ui/switch.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/switch.tsx
@@ -15,15 +15,15 @@ export const Switch = ({
 	onCheckedChange?: (checked: boolean) => void;
 	note?: ReactNode;
 }) => (
-	<div className="flex flex-row items-center justify-between">
-		<label className="text-[14px]" htmlFor={name}>
-			{label}
-		</label>
-		
-		{/* 区切り線 */}
-		<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30"></div>
-		
-		<div className="flex flex-col">
+	<div className="flex flex-col">
+		<div className="flex flex-row items-center justify-between">
+			<label className="text-[14px]" htmlFor={name}>
+				{label}
+			</label>
+			
+			{/* 区切り線 */}
+			<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30"></div>
+			
 			<RadixSwitch.Root
 				className={clsx(
 					"h-[15px] w-[27px] rounded-full outline-none",
@@ -42,7 +42,7 @@ export const Switch = ({
 					)}
 				/>
 			</RadixSwitch.Root>
-			{note && <p className="text-[12px] text-black-200 mt-[2px]">{note}</p>}
 		</div>
+		{note && <p className="text-[12px] text-red-900 mt-[4px]">{note}</p>}
 	</div>
 );

--- a/internal-packages/workflow-designer-ui/src/ui/switch.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/switch.tsx
@@ -15,28 +15,34 @@ export const Switch = ({
 	onCheckedChange?: (checked: boolean) => void;
 	note?: ReactNode;
 }) => (
-	<div className="flex flex-col">
-		<label className="text-[14px] py-[1.5px]" htmlFor={name}>
+	<div className="flex flex-row items-center justify-between">
+		<label className="text-[14px]" htmlFor={name}>
 			{label}
 		</label>
-		<RadixSwitch.Root
-			className={clsx(
-				"h-[15px] w-[27px] rounded-full outline-none",
-				"border border-black-300 data-[state=checked]:border-primary-900",
-				"bg-transparent data-[state=checked]:bg-primary-900",
-			)}
-			id={name}
-			checked={checked}
-			onCheckedChange={onCheckedChange}
-		>
-			<RadixSwitch.Thumb
+		
+		{/* 区切り線 */}
+		<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30"></div>
+		
+		<div className="flex flex-col">
+			<RadixSwitch.Root
 				className={clsx(
-					"block size-[11px] translate-x-[1px] rounded-full",
-					"bg-black-300 data-[state=checked]:bg-white-900",
-					"transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[13px]",
+					"h-[15px] w-[27px] rounded-full outline-none",
+					"border border-white-400 data-[state=checked]:border-primary-900",
+					"bg-transparent data-[state=checked]:bg-primary-900",
 				)}
-			/>
-		</RadixSwitch.Root>
-		{note && <p className="text-[14px] text-black-200">{note}</p>}
+				id={name}
+				checked={checked}
+				onCheckedChange={onCheckedChange}
+			>
+				<RadixSwitch.Thumb
+					className={clsx(
+						"block size-[11px] translate-x-[2px] rounded-full",
+						"bg-white-400 data-[state=checked]:bg-white-900",
+						"transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[13px]"
+					)}
+				/>
+			</RadixSwitch.Root>
+			{note && <p className="text-[12px] text-black-200 mt-[2px]">{note}</p>}
+		</div>
 	</div>
 );

--- a/internal-packages/workflow-designer-ui/src/ui/switch.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/switch.tsx
@@ -20,10 +20,10 @@ export const Switch = ({
 			<label className="text-[14px]" htmlFor={name}>
 				{label}
 			</label>
-			
+
 			{/* 区切り線 */}
-			<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30"></div>
-			
+			<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30" />
+
 			<RadixSwitch.Root
 				className={clsx(
 					"h-[15px] w-[27px] rounded-full outline-none",
@@ -38,7 +38,7 @@ export const Switch = ({
 					className={clsx(
 						"block size-[11px] translate-x-[2px] rounded-full",
 						"bg-white-400 data-[state=checked]:bg-white-900",
-						"transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[13px]"
+						"transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[13px]",
 					)}
 				/>
 			</RadixSwitch.Root>


### PR DESCRIPTION

## Summary
Improve UI styling for the Thinking Process display by removing unnecessary visual elements for better readability and cleaner appearance.
<img width="938" alt="スクリーンショット 2025-05-01 20 56 23" src="https://github.com/user-attachments/assets/3283454a-6b52-45d0-932f-1a5563c5707c" />

<img width="939" alt="スクリーンショット 2025-05-01 20 57 16" src="https://github.com/user-attachments/assets/1f406ae7-e55a-4876-8d91-5f05ed693f8b" />


<img width="939" alt="スクリーンショット 2025-05-01 20 57 24" src="https://github.com/user-attachments/assets/c8a1f168-935b-49ce-8f19-38032f0ab99c" />

## Related Issue
N/A

## Changes
- Improved styling for the Reasoning switch in the property panel
- Added alert for models that don't support reasoning
- Implemented progressive styling for Thinking Process display:

## Testing
- Tested the UI changes by confirming that:
  - Active reasoning still shows the Willi icon and curly brace with "Thinking..." text
  - Completed reasoning shows only "Thinking Process" text without icon or brace
  - Alert appears properly for non-supported models
  - Transitions between states work correctly
  - Property panel switch styling displays correctly

## Other Information
This change is part of ongoing UI improvements to make the reasoning feature more intuitive and visually appealing.