### PR TITLE
fix: enable removing files stuck in uploading and failed status

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -1,10 +1,7 @@
-import type {
-	FileData,
-	FileNode,
-	UploadedFileData,
-} from "@giselle-sdk/data-type";
+import type { FileData, FileNode } from "@giselle-sdk/data-type";
 import clsx from "clsx/lite";
 import { ArrowUpFromLineIcon, FileXIcon, TrashIcon } from "lucide-react";
+import { Dialog } from "radix-ui";
 import { useCallback, useState } from "react";
 import { toRelativeTime } from "../../../helper/datetime";
 import { TriangleAlert } from "../../../icons";
@@ -216,7 +213,7 @@ export function FilePanel({ node, config }: FilePanelProps) {
 							<FileListItem
 								key={file.id}
 								fileData={file}
-								onRemove={(uploadedFile) => removeFile(uploadedFile)}
+								onRemove={removeFile}
 							/>
 						))}
 					</div>
@@ -308,8 +305,29 @@ function FileListItem({
 	onRemove,
 }: {
 	fileData: FileData;
-	onRemove: (file: UploadedFileData) => void;
+	onRemove: (file: FileData) => void;
 }) {
+	const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+
+	const handleRemove = useCallback(() => {
+		// Only show confirmation dialog for uploading files
+		if (fileData.status === "uploading") {
+			setIsConfirmDialogOpen(true);
+		} else {
+			onRemove(fileData);
+		}
+	}, [fileData, onRemove]);
+
+	const handleConfirmRemove = useCallback(() => {
+		onRemove(fileData);
+		setIsConfirmDialogOpen(false);
+	}, [fileData, onRemove]);
+
+	// Create a separate cancel handler for clarity
+	const handleCancelRemove = useCallback(() => {
+		setIsConfirmDialogOpen(false);
+	}, []);
+
 	return (
 		<div className="flex items-center overflow-x-hidden group justify-between bg-black-100 hover:bg-white-900/10 transition-colors p-[8px] rounded-[8px]">
 			<div className="flex items-center overflow-x-hidden">
@@ -324,17 +342,50 @@ function FileListItem({
 					{fileData.status === "failed" && <p>Failed</p>}
 				</div>
 			</div>
-			{fileData.status === "uploaded" && (
-				<Tooltip text="Remove">
-					<button
-						type="button"
-						className="hidden group-hover:block px-[4px] py-[4px] bg-transparent hover:bg-white-900/10 rounded-[8px] transition-colors mr-[2px] flex-shrink-0"
-						onClick={() => onRemove(fileData)}
-					>
-						<TrashIcon className="w-[24px] h-[24px] stroke-current stroke-[1px] " />
-					</button>
-				</Tooltip>
-			)}
+			<Tooltip text="Remove">
+				<button
+					type="button"
+					className="hidden group-hover:block px-[4px] py-[4px] bg-transparent hover:bg-white-900/10 rounded-[8px] transition-colors mr-[2px] flex-shrink-0"
+					onClick={handleRemove}
+				>
+					<TrashIcon className="w-[24px] h-[24px] stroke-current stroke-[1px] " />
+				</button>
+			</Tooltip>
+
+			{/* Confirmation Dialog - Only for uploading files */}
+			<Dialog.Root
+				open={isConfirmDialogOpen}
+				onOpenChange={setIsConfirmDialogOpen}
+			>
+				<Dialog.Portal>
+					<Dialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-[2px] z-50" />
+					<Dialog.Content className="fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] w-[400px] bg-black-900 rounded-[12px] p-[24px] shadow-xl z-50 border border-black-400">
+						<Dialog.Title className="text-[18px] font-semibold text-white-800 mb-4">
+							Confirm Removal
+						</Dialog.Title>
+						<Dialog.Description className="text-[14px] text-white-400 mb-6">
+							This file is still uploading. Are you sure you want to remove it?
+						</Dialog.Description>
+						<div className="flex justify-end gap-[12px]">
+							<button
+								type="button"
+								className="py-[8px] px-[16px] rounded-[8px] text-[14px] font-medium bg-transparent text-white-800 border border-black-400 hover:bg-white-900/10"
+								onClick={handleCancelRemove}
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								className="py-[8px] px-[16px] rounded-[8px] text-[14px] font-medium bg-error-900 text-white-800 hover:bg-error-900/80"
+								onClick={handleConfirmRemove}
+							>
+								Remove
+							</button>
+						</div>
+						<Dialog.Close className="hidden" />
+					</Dialog.Content>
+				</Dialog.Portal>
+			</Dialog.Root>
 		</div>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -382,7 +382,7 @@ function FileListItem({
 								Remove
 							</button>
 						</div>
-						<Dialog.Close className="hidden" />
+						<Dialog.Close className="hidden" tabIndex={-1} aria-hidden="true" />
 					</Dialog.Content>
 				</Dialog.Portal>
 			</Dialog.Root>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -2,12 +2,12 @@ import type { FileData, FileNode } from "@giselle-sdk/data-type";
 import clsx from "clsx/lite";
 import { ArrowUpFromLineIcon, FileXIcon, TrashIcon } from "lucide-react";
 import { Dialog } from "radix-ui";
-import { useCallback, useState } from "react";
+import { type ButtonHTMLAttributes, useCallback, useState } from "react";
 import { toRelativeTime } from "../../../helper/datetime";
 import { TriangleAlert } from "../../../icons";
 import { FileNodeIcon } from "../../../icons/node";
 import { useToasts } from "../../../ui/toast";
-import { Tooltip } from "../../../ui/tooltip";
+import { Tooltip, type TooltipProps } from "../../../ui/tooltip";
 import { useFileNode } from "./use-file-node";
 
 export type FileTypeConfig = {
@@ -300,6 +300,23 @@ export function FilePanel({ node, config }: FilePanelProps) {
 	);
 }
 
+function RemoveButton({
+	onClick,
+	...props
+}: Omit<TooltipProps, "text" | "children">) {
+	return (
+		<Tooltip text="Remove" {...props}>
+			<button
+				type="button"
+				className="hidden group-hover:block px-[4px] py-[4px] bg-transparent hover:bg-white-900/10 rounded-[8px] transition-colors mr-[2px] flex-shrink-0"
+				onClick={onClick}
+			>
+				<TrashIcon className="w-[24px] h-[24px] stroke-current stroke-[1px] " />
+			</button>
+		</Tooltip>
+	);
+}
+
 function FileListItem({
 	fileData,
 	onRemove,
@@ -307,27 +324,6 @@ function FileListItem({
 	fileData: FileData;
 	onRemove: (file: FileData) => void;
 }) {
-	const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
-
-	const handleRemove = useCallback(() => {
-		// Only show confirmation dialog for uploading files
-		if (fileData.status === "uploading") {
-			setIsConfirmDialogOpen(true);
-		} else {
-			onRemove(fileData);
-		}
-	}, [fileData, onRemove]);
-
-	const handleConfirmRemove = useCallback(() => {
-		onRemove(fileData);
-		setIsConfirmDialogOpen(false);
-	}, [fileData, onRemove]);
-
-	// Create a separate cancel handler for clarity
-	const handleCancelRemove = useCallback(() => {
-		setIsConfirmDialogOpen(false);
-	}, []);
-
 	return (
 		<div className="flex items-center overflow-x-hidden group justify-between bg-black-100 hover:bg-white-900/10 transition-colors p-[8px] rounded-[8px]">
 			<div className="flex items-center overflow-x-hidden">
@@ -342,50 +338,50 @@ function FileListItem({
 					{fileData.status === "failed" && <p>Failed</p>}
 				</div>
 			</div>
-			<Tooltip text="Remove">
-				<button
-					type="button"
-					className="hidden group-hover:block px-[4px] py-[4px] bg-transparent hover:bg-white-900/10 rounded-[8px] transition-colors mr-[2px] flex-shrink-0"
-					onClick={handleRemove}
-				>
-					<TrashIcon className="w-[24px] h-[24px] stroke-current stroke-[1px] " />
-				</button>
-			</Tooltip>
 
-			{/* Confirmation Dialog - Only for uploading files */}
-			<Dialog.Root
-				open={isConfirmDialogOpen}
-				onOpenChange={setIsConfirmDialogOpen}
-			>
-				<Dialog.Portal>
-					<Dialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-[2px] z-50" />
-					<Dialog.Content className="fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] w-[400px] bg-black-900 rounded-[12px] p-[24px] shadow-xl z-50 border border-black-400">
-						<Dialog.Title className="text-[18px] font-semibold text-white-800 mb-4">
-							Confirm Removal
-						</Dialog.Title>
-						<Dialog.Description className="text-[14px] text-white-400 mb-6">
-							This file is still uploading. Are you sure you want to remove it?
-						</Dialog.Description>
-						<div className="flex justify-end gap-[12px]">
-							<button
-								type="button"
-								className="py-[8px] px-[16px] rounded-[8px] text-[14px] font-medium bg-transparent text-white-800 border border-black-400 hover:bg-white-900/10"
-								onClick={handleCancelRemove}
-							>
-								Cancel
-							</button>
-							<button
-								type="button"
-								className="py-[8px] px-[16px] rounded-[8px] text-[14px] font-medium bg-error-900 text-white-800 hover:bg-error-900/80"
-								onClick={handleConfirmRemove}
-							>
-								Remove
-							</button>
-						</div>
-						<Dialog.Close className="hidden" tabIndex={-1} aria-hidden="true" />
-					</Dialog.Content>
-				</Dialog.Portal>
-			</Dialog.Root>
+			{fileData.status === "failed" ? (
+				<RemoveButton onClick={() => onRemove(fileData)} />
+			) : (
+				<Dialog.Root>
+					<Dialog.Trigger asChild>
+						<RemoveButton />
+					</Dialog.Trigger>
+					<Dialog.Portal>
+						<Dialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-[2px] z-50" />
+						<Dialog.Content className="fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] w-[400px] bg-black-900 rounded-[12px] p-[24px] shadow-xl z-50 border border-black-400">
+							<Dialog.Title className="text-[18px] font-semibold text-white-800 mb-4">
+								Confirm Removal
+							</Dialog.Title>
+							<Dialog.Description className="text-[14px] text-white-400 mb-6">
+								This file is still uploading. Are you sure you want to remove
+								it?
+							</Dialog.Description>
+							<div className="flex justify-end gap-[12px]">
+								<Dialog.Close asChild>
+									<button
+										type="button"
+										className="py-[8px] px-[16px] rounded-[8px] text-[14px] font-medium bg-transparent text-white-800 border border-black-400 hover:bg-white-900/10"
+									>
+										Cancel
+									</button>
+								</Dialog.Close>
+								<button
+									type="button"
+									className="py-[8px] px-[16px] rounded-[8px] text-[14px] font-medium bg-error-900 text-white-800 hover:bg-error-900/80"
+									onClick={() => onRemove(fileData)}
+								>
+									Remove
+								</button>
+							</div>
+							<Dialog.Close
+								className="hidden"
+								tabIndex={-1}
+								aria-hidden="true"
+							/>
+						</Dialog.Content>
+					</Dialog.Portal>
+				</Dialog.Root>
+			)}
 		</div>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-file-node.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-file-node.ts
@@ -1,4 +1,8 @@
-import type { FileNode, UploadedFileData } from "@giselle-sdk/data-type";
+import type {
+	FileData,
+	FileNode,
+	UploadedFileData,
+} from "@giselle-sdk/data-type";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { useCallback } from "react";
 import { useToasts } from "../../../ui/toast";
@@ -22,11 +26,13 @@ export function useFileNode(node: FileNode) {
 	);
 
 	const removeFile = useCallback(
-		async (file: UploadedFileData) => {
+		async (file: FileData) => {
+			// Update node content for all file statuses
 			updateNodeDataContent(node, {
 				files: node.content.files.filter((f) => f.id !== file.id),
 			});
-			await removeFileInternal(file);
+
+			await removeFileInternal(file as UploadedFileData);
 		},
 		[node, updateNodeDataContent, removeFileInternal],
 	);

--- a/internal-packages/workflow-designer-ui/src/ui/tooltip.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/tooltip.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx/lite";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import type { ComponentProps, ReactNode } from "react";
 
-type TooltipProps = Omit<
+export type TooltipProps = Omit<
 	ComponentProps<typeof TooltipPrimitive.Trigger>,
 	"asChild"
 > & {


### PR DESCRIPTION
## Summary
I enabled removing files stuck in uploading and failed status

## Related Issue
close https://github.com/giselles-ai/giselle/issues/733

## Changes

- Add confirmation dialog for files in uploading status
- Skip removeFileInternal API call for non-uploaded files
- Improve dialog handling with dedicated callback functions
- Add Dialog.Close component to ensure proper closure
- Fix potential TypeScript errors with status-based type casting


https://github.com/user-attachments/assets/8e9a0d9e-c6e4-460b-b975-b0ba551ddf62


## Testing
1. Upload pdf files to file node
2. Download workspace.json from supabase storage
3. Edit file status in workspace.json
4. Upload workspace.json to supabase storage
5. Try to remove files in /workspaces/wrks-your-id

## Other Information
