### PR TITLE
Upgrade Flags SDK to v4

### DIFF
--- a/apps/studio.giselles.ai/app/.well-known/vercel/flags/route.ts
+++ b/apps/studio.giselles.ai/app/.well-known/vercel/flags/route.ts
@@ -1,4 +1,4 @@
-import { getProviderData, createFlagsDiscoveryEndpoint } from "flags/next";
+import { createFlagsDiscoveryEndpoint, getProviderData } from "flags/next";
 import * as flags from "../../../../flags";
 
 export const runtime = "edge";

--- a/apps/studio.giselles.ai/app/.well-known/vercel/flags/route.ts
+++ b/apps/studio.giselles.ai/app/.well-known/vercel/flags/route.ts
@@ -1,14 +1,14 @@
-import { type ApiData, verifyAccess } from "flags";
-import { getProviderData } from "flags/next";
-import { type NextRequest, NextResponse } from "next/server";
+import { getProviderData, createFlagsDiscoveryEndpoint } from "flags/next";
 import * as flags from "../../../../flags";
 
 export const runtime = "edge";
 export const dynamic = "force-dynamic"; // defaults to auto
 
-export async function GET(request: NextRequest) {
-	const access = await verifyAccess(request.headers.get("Authorization"));
-	if (!access) return NextResponse.json(null, { status: 401 });
+// This function handles the authorization check for you
+export const GET = createFlagsDiscoveryEndpoint(async (request) => {
+	// Get provider data for feature flags
+	const apiData = await getProviderData(flags);
 
-	return NextResponse.json<ApiData>(getProviderData(flags));
-}
+	// Return the ApiData directly, without a NextResponse.json object
+	return apiData;
+});

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -76,7 +76,7 @@
 		"cmdk": "1.0.4",
 		"cva": "1.0.0-beta.1",
 		"drizzle-orm": "0.32.1",
-		"flags": "3.1.1",
+		"flags": "4.0.0",
 		"gaxios": "6.7.1",
 		"geist": "1.3.1",
 		"giselle-sdk": "workspace:*",

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -7295,7 +7295,7 @@ CC-BY-4.0 permitted
 
 
 <a name="flags"></a>
-### flags v3.1.1
+### flags v4.0.0
 #### 
 
 ##### Paths

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,8 +520,8 @@ importers:
         specifier: 0.32.1
         version: 0.32.1(@neondatabase/serverless@0.9.5)(@opentelemetry/api@1.9.0)(@types/pg@8.11.13)(@types/react@19.1.0)(@vercel/postgres@0.9.0)(pg@8.14.1)(react@19.1.0)
       flags:
-        specifier: 3.1.1
-        version: 3.1.1(@opentelemetry/api@1.9.0)(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 4.0.0
+        version: 4.0.0(@opentelemetry/api@1.9.0)(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       gaxios:
         specifier: 6.7.1
         version: 6.7.1
@@ -6157,8 +6157,8 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  flags@3.1.1:
-    resolution: {integrity: sha512-UWxZ61y25rJCOId54unQ4Htc+u9fcpwbaYJ7nqoo7Yg0GZ/dVD7Bmw3srMHFuE52kDWHNnnly+6cscmTGaJ6QA==}
+  flags@4.0.0:
+    resolution: {integrity: sha512-CpONOK/nflKfaTT36r+Y4SP5rb9mv3AdqY/2Ws+TScrEGlT4PK+PZNiKJgIH87HooTXDblz31807q7lZ3LpuYQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.7.0
       '@sveltejs/kit': '*'
@@ -14663,7 +14663,7 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flags@3.1.1(@opentelemetry/api@1.9.0)(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  flags@4.0.0(@opentelemetry/api@1.9.0)(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       jose: 5.9.6


### PR DESCRIPTION
## Summary
I upgraded Flags SDK to v4.

## Related Issue
None.

## Changes
- Upgrade Flags SDK to v4
- Adjust flags discovery endpoint

## Testing
1. Visit https://giselle-git-upgrade-flags-sdk-to-v4-r06-edge.vercel.app/
2. Enable/Disable flags

## Other Information
- [Upgrade Flags SDK to v4](https://github.com/vercel/flags/blob/flags%404.0.0/packages/flags/guides/upgrade-to-v4.md)

I cannot use flags in production env.

<img width="567" alt="image" src="https://github.com/user-attachments/assets/c27cc184-d136-43da-b8ec-72214fd11634" />
