### PR TITLE
Tag Langfuse trace with web-search info

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -482,7 +482,12 @@ export async function generateText(args: {
 		},
 		experimental_telemetry: {
 			isEnabled: args.context.telemetry?.isEnabled,
-			metadata: args.telemetry?.metadata,
+			metadata: {
+				...args.telemetry?.metadata,
+				...(preparedToolSet.toolSet.openaiWebSearch
+					? { tags: ["web-search"] }
+					: {}),
+			},
 		},
 	});
 	return streamTextResult;


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Tag Langfuse trace if user executes OpenAI node with "Web Search" enabled

## Related Issue
<!-- Mention the related issue number if applicable. -->

- https://github.com/giselles-ai/giselle/pull/743

## Testing
<!-- Briefly describe the testing steps or results. -->

The trace is tagged with `web-search` if the functionality is used ✅ 
<img width="169" alt="image" src="https://github.com/user-attachments/assets/cd4cc4a9-6bf4-47e9-bce7-26efc1d7c947" />


