### PR TITLE
Remove a bit odd text

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/page.tsx
@@ -118,9 +118,6 @@ async function BillingInfoForProPlan({ team }: BillingInfoProps) {
 		<>
 			<div className="flex flex-col gap-y-[2px]">
 				<div className="flex flex-col gap-0.5">
-					<p className="text-[14px] leading-[16px] font-medium tracking-wide font-hubot text-white-400">
-						Thank you for being
-					</p>
 					<p className="text-[22px] leading-[26.4px] tracking-[-0.04em] font-medium font-hubot">
 						<span className="text-primary-400">Pro Plan</span>
 					</p>


### PR DESCRIPTION
## Summary
I remove a bit odd text.

## Related Issue
None.

## Changes
I remove the text `​Thank you for being`.

| main branch | this pr |
|--------|--------|
| <img width="948" alt="image" src="https://github.com/user-attachments/assets/bff382c8-f070-4f2f-91a4-e61ea1f6ea60" /> | <img width="947" alt="image" src="https://github.com/user-attachments/assets/c3f2e614-2d0d-4f8d-aa97-4e8533e7b6df" /> | 

## Testing
1. Vist /settings/team page

## Other Information
### Feedback by proofreader

Thank you for being Pro Plan seems a bit odd. I think Thank you for being Pro would be more natural, but the style is a bit different from other menus and titles, so it seems like it would be fine without it, just like Free.
