### PR TITLE
Refactor Anthropic model panel reasoning capability UI for improved extensibility

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -72,10 +72,9 @@ export function GenerationView({
 				<div key={message.id}>
 					{message.parts?.map((part, index) => {
 						const lastPart = message.parts?.length === index + 1;
-						const isRunning = generation.status === "running";
 						switch (part.type) {
 							case "reasoning":
-								if (lastPart && isRunning) {
+								if (lastPart) {
 									return (
 										<Accordion.Root
 											key={`messages.${message.id}.parts.[${index}].reasoning`}


### PR DESCRIPTION
This PR addresses issues with the reasoning component implementation in the Anthropic model panel:

## Changes
- Refactored the reasoning component to eliminate the use of useEffect and complex inline callbacks
- Improved the architecture for better future extensibility and performance
- Made subtle enhancements to the UI appearance for better user experience
- Removed generation running check for reasoning part

## Reasoning
The previous implementation was tightly coupled and relied heavily on side effects, which could become difficult to maintain and extend as new features are added. This refactoring creates a more maintainable approach while preserving all existing functionality.

## Visual Changes

https://github.com/user-attachments/assets/1a90c9c8-f8fc-4b18-8b15-7384464914c7


