### PR TITLE
Tag Langfuse trace with provider tool config

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -534,7 +534,9 @@ function isVertexAiHost(urlString: string): boolean {
 	// }
 }
 
-function getProviderOptions(languageModelData: TextGenerationLanguageModelData) {
+function getProviderOptions(
+	languageModelData: TextGenerationLanguageModelData,
+) {
 	const languageModel = languageModels.find(
 		(model) => model.id === languageModelData.id,
 	);

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -34,6 +34,7 @@ import {
 import { UsageLimitError } from "../error";
 import { filePath } from "../files/utils";
 import type { GiselleEngineContext } from "../types";
+import { generateTelemetryTags } from "./telemetry";
 import { createPostgresTools } from "./tools/postgres";
 import type { PreparedToolSet, TelemetrySettings } from "./types";
 import {
@@ -484,9 +485,12 @@ export async function generateText(args: {
 			isEnabled: args.context.telemetry?.isEnabled,
 			metadata: {
 				...args.telemetry?.metadata,
-				...(preparedToolSet.toolSet.openaiWebSearch
-					? { tags: ["web-search"] }
-					: {}),
+				tags: generateTelemetryTags({
+					provider: operationNode.content.llm.provider,
+					languageModel,
+					toolSet: preparedToolSet.toolSet,
+					configurations: operationNode.content.llm.configurations,
+				}),
 			},
 		},
 	});

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -332,9 +332,10 @@ export async function generateText(args: {
 	// 	}
 	// }
 
+	const providerOptions = getProviderOptions(operationNode.content.llm);
 	const streamTextResult = streamText({
 		model: generationModel(operationNode.content.llm),
-		providerOptions: providerOptions(operationNode.content.llm),
+		providerOptions,
 		messages,
 		maxSteps: 5, // enable multi-step calls
 		tools: preparedToolSet.toolSet,
@@ -490,6 +491,7 @@ export async function generateText(args: {
 					languageModel,
 					toolSet: preparedToolSet.toolSet,
 					configurations: operationNode.content.llm.configurations,
+					providerOptions,
 				}),
 			},
 		},
@@ -532,7 +534,7 @@ function isVertexAiHost(urlString: string): boolean {
 	// }
 }
 
-function providerOptions(languageModelData: TextGenerationLanguageModelData) {
+function getProviderOptions(languageModelData: TextGenerationLanguageModelData) {
 	const languageModel = languageModels.find(
 		(model) => model.id === languageModelData.id,
 	);

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -3,10 +3,13 @@ import type { LanguageModel } from "@giselle-sdk/language-model";
 import type { ToolSet } from "ai";
 
 type TelemetryTag =
+	// generic name
 	| "web-search"
-	| "search-grounding"
-	| "reasoning"
-	| "thinking";
+	// provider-specific function name
+	| "openai:web-search"
+	| "google:search-grounding"
+	| "anthropic:reasoning"
+	| "anthropic:thinking";
 
 export function generateTelemetryTags(args: {
 	provider: string;

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -35,6 +35,8 @@ export function generateTelemetryTags(args: {
 			tags.push("anthropic:reasoning");
 		}
 		if (args.providerOptions?.anthropic?.thinking?.type === "enabled") {
+			// treat as an independent tag because extended thinking is available only on specific models
+			// ref: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			tags.push("anthropic:thinking");
 		}
 	}

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -26,7 +26,7 @@ export function generateTelemetryTags(args: {
 
 	// Google Search Grounding
 	if (args.provider === "google" && args.configurations.searchGrounding) {
-		tags.push("search-grounding");
+		tags.push("web-search");
 	}
 
 	// Anthropic Reasoning/Thinking

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -1,5 +1,6 @@
 import type { LanguageModel } from "@giselle-sdk/language-model";
 import type { ToolSet } from "ai";
+import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
 
 type TelemetryTag =
 	| "web-search"
@@ -12,6 +13,9 @@ export function generateTelemetryTags(args: {
 	languageModel: LanguageModel;
 	toolSet: ToolSet;
 	configurations: Record<string, unknown>;
+	providerOptions?: {
+		anthropic?: AnthropicProviderOptions;
+	};
 }): TelemetryTag[] {
 	const tags: TelemetryTag[] = [];
 
@@ -30,7 +34,7 @@ export function generateTelemetryTags(args: {
 		if (args.configurations.reasoning) {
 			tags.push("reasoning");
 		}
-		if (args.configurations.thinking) {
+		if (args.providerOptions?.anthropic?.thinking?.type === "enabled") {
 			tags.push("thinking");
 		}
 	}

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -1,0 +1,39 @@
+import type { LanguageModel } from "@giselle-sdk/language-model";
+import type { ToolSet } from "ai";
+
+type TelemetryTag =
+	| "web-search"
+	| "search-grounding"
+	| "reasoning"
+	| "thinking";
+
+export function generateTelemetryTags(args: {
+	provider: string;
+	languageModel: LanguageModel;
+	toolSet: ToolSet;
+	configurations: Record<string, unknown>;
+}): TelemetryTag[] {
+	const tags: TelemetryTag[] = [];
+
+	// OpenAI Web Search
+	if (args.provider === "openai" && args.toolSet.openaiWebSearch) {
+		tags.push("web-search");
+	}
+
+	// Google Search Grounding
+	if (args.provider === "google" && args.configurations.searchGrounding) {
+		tags.push("search-grounding");
+	}
+
+	// Anthropic Reasoning/Thinking
+	if (args.provider === "anthropic") {
+		if (args.configurations.reasoning) {
+			tags.push("reasoning");
+		}
+		if (args.configurations.thinking) {
+			tags.push("thinking");
+		}
+	}
+
+	return tags;
+}

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -21,21 +21,21 @@ export function generateTelemetryTags(args: {
 
 	// OpenAI Web Search
 	if (args.provider === "openai" && args.toolSet.openaiWebSearch) {
-		tags.push("web-search");
+		tags.push("web-search", "openai:web-search");
 	}
 
 	// Google Search Grounding
 	if (args.provider === "google" && args.configurations.searchGrounding) {
-		tags.push("web-search");
+		tags.push("web-search", "google:search-grounding");
 	}
 
 	// Anthropic Reasoning/Thinking
 	if (args.provider === "anthropic") {
 		if (args.configurations.reasoning) {
-			tags.push("reasoning");
+			tags.push("anthropic:reasoning");
 		}
 		if (args.providerOptions?.anthropic?.thinking?.type === "enabled") {
-			tags.push("thinking");
+			tags.push("anthropic:thinking");
 		}
 	}
 

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -1,6 +1,6 @@
+import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
 import type { LanguageModel } from "@giselle-sdk/language-model";
 import type { ToolSet } from "ai";
-import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
 
 type TelemetryTag =
 	| "web-search"


### PR DESCRIPTION
## Summary

Tag Langfuse trace with tool configuration info to gather basic usage data on Langfuse

## Related Issue
<!-- Mention the related issue number if applicable. -->
- #815

## Testing

Tags corresponding to each functionality are added ✅ 
<img width="883" alt="image" src="https://github.com/user-attachments/assets/2ee0b40f-9d53-4cc1-b597-39e6836125e6" />

<!-- Briefly describe the testing steps or results. -->

