### PR TITLE
fix: improve GitHub error handling for error objects with status property

### DIFF
--- a/apps/studio.giselles.ai/services/external/github/user-client.ts
+++ b/apps/studio.giselles.ai/services/external/github/user-client.ts
@@ -65,7 +65,7 @@ export function needsAuthorization(error: unknown) {
 	if (error instanceof GitHubTokenRefreshError) {
 		return true;
 	}
-	if (error instanceof RequestError) {
+	if (typeof error === "object" && error !== null && "status" in error) {
 		return error.status === 401 || error.status === 403 || error.status === 404;
 	}
 	return false;


### PR DESCRIPTION
## Summary
- Improves the `needsAuthorization` function in GitHub client to handle any error object with a status property
- Makes error handling more robust by removing strict dependency on RequestError class

## Test plan
- Verify GitHub authorization still works correctly when encountering API errors
- Ensure error handling remains consistent across different error types

🤖 Generated with [Claude Code](https://claude.ai/code)