### PR TITLE
Send Langfuse trace from `gpt-image-1` node to track its usage and cost

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-image.ts
+++ b/packages/giselle-engine/src/core/generations/generate-image.ts
@@ -536,7 +536,7 @@ export async function generateImageWithOpenAI({
 			(async () => {
 				const usage = usageCalculator.calculateUsage({
 					...imageSize,
-					n: languageModelData.configurations.n,
+					quality: languageModelData.configurations.quality,
 				});
 				generation.update({
 					usage,

--- a/packages/giselle-engine/src/core/generations/generate-image.ts
+++ b/packages/giselle-engine/src/core/generations/generate-image.ts
@@ -1,5 +1,5 @@
+import { fal } from "@ai-sdk/fal";
 import { openai } from "@ai-sdk/openai";
-import { fal } from "@fal-ai/client";
 import {
 	type CompletedGeneration,
 	type FailedGeneration,
@@ -19,7 +19,6 @@ import {
 	isImageGenerationNode,
 } from "@giselle-sdk/data-type";
 import {
-	type FalImageResult,
 	type GeneratedImageData,
 	createUsageCalculator,
 } from "@giselle-sdk/language-model";
@@ -51,9 +50,6 @@ type ProviderOptions = Parameters<
 	typeof generateImageAiSdk
 >[0]["providerOptions"];
 
-fal.config({
-	credentials: process.env.FAL_API_KEY,
-});
 export async function generateImage(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
@@ -283,6 +279,14 @@ export async function generateImage(args: {
 	});
 }
 
+function imageDimStringToSize(size: string): { width: number; height: number } {
+	const [width, height] = size.split("x").map(Number);
+	if (Number.isNaN(width) || Number.isNaN(height)) {
+		throw new Error(`Invalid image size format: ${size}`);
+	}
+	return { width, height };
+}
+
 async function generateImageWithFal({
 	operationNode,
 	generationContext,
@@ -301,12 +305,12 @@ async function generateImageWithFal({
 	context: GiselleEngineContext;
 }) {
 	const trace = langfuse.trace({
-		name: "fal-ai/client",
+		name: "ai-sdk/fal",
 		metadata: telemetry?.metadata,
 		input: { messages },
 	});
 	const generation = trace.generation({
-		name: "fal-ai/client.subscribe",
+		name: "ai-sdk/fal.generateImage",
 		model: operationNode.content.llm.id,
 		modelParameters: operationNode.content.llm.configurations,
 		input: { messages },
@@ -329,20 +333,13 @@ async function generateImageWithFal({
 			prompt += content.text;
 		}
 	}
-	const result = (await fal.subscribe(operationNode.content.llm.id, {
-		input: {
-			prompt,
-			image_size: {
-				width: Number.parseInt(
-					operationNode.content.llm.configurations.size.split("x")[0],
-				),
-				height: Number.parseInt(
-					operationNode.content.llm.configurations.size.split("x")[1],
-				),
-			},
-			num_images: operationNode.content.llm.configurations.n,
-		},
-	})) as unknown as FalImageResult;
+
+	const result = await generateImageAiSdk({
+		model: fal.image(operationNode.content.llm.id),
+		prompt,
+		n: operationNode.content.llm.configurations.n,
+		size: operationNode.content.llm.configurations.size,
+	});
 
 	const generationOutputs: GenerationOutput[] = [];
 
@@ -351,33 +348,27 @@ async function generateImageWithFal({
 	);
 	if (generatedImageOutput !== undefined) {
 		const contents = await Promise.all(
-			result.data.images.map(async (image) => {
-				const imageType = image.content_type;
+			result.images.map(async (image) => {
+				const imageType = detectImageType(image.uint8Array);
 				if (imageType === null) {
 					return null;
 				}
 				const id = ImageId.generate();
-				const ext = imageType.split("/")[1];
-				const filename = `${id}.${ext}`;
-
-				const response = await fetch(image.url);
-				const arrayBuffer = await response.arrayBuffer();
-				const uint8Array = new Uint8Array(arrayBuffer);
-				const base64 = Buffer.from(uint8Array).toString("base64");
+				const filename = `${id}.${imageType.ext}`;
 
 				await setGeneratedImage({
 					storage: context.storage,
 					generation: runningGeneration,
 					generatedImage: {
-						uint8Array,
-						base64,
+						uint8Array: image.uint8Array,
+						base64: image.base64,
 					} satisfies GeneratedImageData,
 					generatedImageFilename: filename,
 				});
 
 				return {
 					id,
-					contentType: imageType,
+					contentType: imageType.contentType,
 					filename,
 					pathname: `/generations/${runningGeneration.id}/generated-images/${filename}`,
 				} satisfies Image;
@@ -390,17 +381,17 @@ async function generateImageWithFal({
 			outputId: generatedImageOutput.id,
 		});
 	}
+
 	if (context.telemetry?.isEnabled && generatedImageOutput) {
 		const usageCalculator = createUsageCalculator(operationNode.content.llm.id);
+		const imageSize = imageDimStringToSize(
+			operationNode.content.llm.configurations.size,
+		);
 		await Promise.all([
-			...result.data.images.map(async (image) => {
-				const response = await fetch(image.url);
-				const arrayBuffer = await response.arrayBuffer();
-				const uint8Array = new Uint8Array(arrayBuffer);
-
+			...result.images.map(async (image) => {
 				const wrappedMedia = new LangfuseMedia({
-					contentType: image.content_type as ApiMediaContentType,
-					contentBytes: Buffer.from(uint8Array),
+					contentType: "image/png" as ApiMediaContentType,
+					contentBytes: Buffer.from(image.uint8Array),
 				});
 
 				generation.update({
@@ -410,7 +401,10 @@ async function generateImageWithFal({
 				});
 			}),
 			(async () => {
-				const usage = usageCalculator.calculateUsage(result.data.images);
+				const usage = usageCalculator.calculateUsage({
+					...imageSize,
+					n: operationNode.content.llm.configurations.n,
+				});
 				generation.update({
 					usage,
 				});

--- a/packages/language-model/src/base.ts
+++ b/packages/language-model/src/base.ts
@@ -29,7 +29,23 @@ export const LanguageModelBase = z.object({
 	capabilities: Capabilities,
 	tier: Tier,
 	experimental: z.boolean().optional(),
-	configurations: z.record(z.string(), z.any()),
+	configurations: z.unknown(),
 });
 
 export type LanguageModelBase = z.infer<typeof LanguageModelBase>;
+
+export type ImageGenerationParams = {
+	width: number;
+	height: number;
+	n: number;
+	quality?: "standard" | "hd";
+};
+
+export interface UsageCalculator {
+	calculateUsage(params: unknown): {
+		output: number;
+		unit: "IMAGES";
+		outputCost?: number;
+		totalCost?: number;
+	};
+}

--- a/packages/language-model/src/fal.ts
+++ b/packages/language-model/src/fal.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Capability, LanguageModelBase } from "./base";
+import { Capability, LanguageModelBase, type UsageCalculator } from "./base";
 
 const imageGenerationSize1x1 = z.literal("512x512");
 const imageGenerationSize1x1Hd = z.literal("1024x1024");
@@ -125,19 +125,14 @@ export function getImageGenerationModelProvider(
 	return undefined;
 }
 
-export interface UsageCalculator {
-	calculateUsage(params: { width: number; height: number; n: number }): {
-		output: number;
-		unit: "IMAGES";
-	};
+export interface FalImageGenerationParams {
+	width: number;
+	height: number;
+	n: number;
 }
 
 export class PixelBasedUsageCalculator implements UsageCalculator {
-	calculateUsage({
-		width,
-		height,
-		n,
-	}: { width: number; height: number; n: number }) {
+	calculateUsage({ width, height, n }: FalImageGenerationParams) {
 		const totalPixels = width * height * n;
 		return {
 			output: Math.ceil(totalPixels / 1_000_000) * 1_000_000,
@@ -156,15 +151,6 @@ export class ImageCountBasedUsageCalculator implements UsageCalculator {
 			output: n,
 			unit: "IMAGES" as const,
 		};
-	}
-}
-
-export function createUsageCalculator(modelId: string): UsageCalculator {
-	switch (modelId) {
-		case "fal-ai/stable-diffusion-v3-medium":
-			return new ImageCountBasedUsageCalculator();
-		default:
-			return new PixelBasedUsageCalculator();
 	}
 }
 

--- a/packages/language-model/src/fal.ts
+++ b/packages/language-model/src/fal.ts
@@ -1,4 +1,3 @@
-import type { Result } from "@fal-ai/client";
 import { z } from "zod";
 import { Capability, LanguageModelBase } from "./base";
 
@@ -126,26 +125,20 @@ export function getImageGenerationModelProvider(
 	return undefined;
 }
 
-export interface FalImage {
-	url: string;
-	width: number;
-	height: number;
-	content_type: string;
-}
-
 export interface UsageCalculator {
-	calculateUsage(images: FalImage[]): {
+	calculateUsage(params: { width: number; height: number; n: number }): {
 		output: number;
 		unit: "IMAGES";
 	};
 }
 
 export class PixelBasedUsageCalculator implements UsageCalculator {
-	calculateUsage(images: FalImage[]) {
-		const totalPixels = images.reduce(
-			(sum, image) => sum + image.height * image.width,
-			0,
-		);
+	calculateUsage({
+		width,
+		height,
+		n,
+	}: { width: number; height: number; n: number }) {
+		const totalPixels = width * height * n;
 		return {
 			output: Math.ceil(totalPixels / 1_000_000) * 1_000_000,
 			unit: "IMAGES" as const,
@@ -154,9 +147,13 @@ export class PixelBasedUsageCalculator implements UsageCalculator {
 }
 
 export class ImageCountBasedUsageCalculator implements UsageCalculator {
-	calculateUsage(images: FalImage[]) {
+	calculateUsage({
+		width,
+		height,
+		n,
+	}: { width: number; height: number; n: number }) {
 		return {
-			output: images.length,
+			output: n,
 			unit: "IMAGES" as const,
 		};
 	}
@@ -170,18 +167,6 @@ export function createUsageCalculator(modelId: string): UsageCalculator {
 			return new PixelBasedUsageCalculator();
 	}
 }
-
-interface FalImageData {
-	images: FalImage[];
-	timings: {
-		inference: number;
-	};
-	seed: number;
-	has_nsfw_concepts: boolean[];
-	prompt: string;
-}
-
-export type FalImageResult = Result<FalImageData>;
 
 export interface GeneratedImageData {
 	uint8Array: Uint8Array;

--- a/packages/language-model/src/index.ts
+++ b/packages/language-model/src/index.ts
@@ -28,8 +28,8 @@ export * from "./helper";
 export {
 	getImageGenerationModelProvider,
 	falImageGenerationSizes as imageGenerationSizes,
-	createUsageCalculator,
 } from "./fal";
+export { createUsageCalculator } from "./usage-factory";
 export type { GeneratedImageData } from "./fal";
 export {
 	size as openaiImageSize,

--- a/packages/language-model/src/index.ts
+++ b/packages/language-model/src/index.ts
@@ -30,7 +30,7 @@ export {
 	falImageGenerationSizes as imageGenerationSizes,
 	createUsageCalculator,
 } from "./fal";
-export type { FalImageResult, GeneratedImageData } from "./fal";
+export type { GeneratedImageData } from "./fal";
 export {
 	size as openaiImageSize,
 	quality as openaiImageQuality,

--- a/packages/language-model/src/openai-image.ts
+++ b/packages/language-model/src/openai-image.ts
@@ -57,6 +57,7 @@ const openAICostTable: Record<
 	"auto" | "low" | "medium" | "high",
 	Record<string, number>
 > = {
+	// pricing table: https://platform.openai.com/docs/pricing#image-generation
 	low: {
 		"1024x1024": 0.011,
 		"1024x1536": 0.016,

--- a/packages/language-model/src/openai-image.ts
+++ b/packages/language-model/src/openai-image.ts
@@ -50,11 +50,11 @@ export type LanguageModel = OpenAIImageLanguageModel;
 export interface OpenAIImageGenerationParams {
 	width: number;
 	height: number;
-	quality: "low" | "medium" | "high";
+	quality: "auto" | "low" | "medium" | "high";
 }
 
 const openAICostTable: Record<
-	"low" | "medium" | "high",
+	"auto" | "low" | "medium" | "high",
 	Record<string, number>
 > = {
 	low: {
@@ -71,6 +71,13 @@ const openAICostTable: Record<
 		"1024x1024": 0.167,
 		"1024x1536": 0.25,
 		"1536x1024": 0.25,
+	},
+	auto: {
+		// price is set same as "medium" because we cannot detect which quality is finaly adopted by OpenAI
+		// ref: https://platform.openai.com/docs/guides/image-generation?image-generation-model=gpt-image-1#customize-image-output
+		"1024x1024": 0.042,
+		"1024x1536": 0.063,
+		"1536x1024": 0.063,
 	},
 };
 

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { Capability, LanguageModelBase, Tier } from "./base";
+import {
+	Capability,
+	type ImageGenerationParams,
+	LanguageModelBase,
+	Tier,
+} from "./base";
 
 const OpenAILanguageModelConfigurations = z.object({
 	temperature: z.number(),

--- a/packages/language-model/src/usage-factory.ts
+++ b/packages/language-model/src/usage-factory.ts
@@ -1,0 +1,20 @@
+import type { UsageCalculator } from "./base";
+import {
+	ImageCountBasedUsageCalculator,
+	PixelBasedUsageCalculator,
+} from "./fal";
+import { OpenAIImageGenerationUsageCalculator } from "./openai-image";
+
+const usageCalculatorMap: Record<string, UsageCalculator> = {
+	"fal-ai/stable-diffusion-v3-medium": new ImageCountBasedUsageCalculator(),
+	"fal-ai/flux/schnell": new PixelBasedUsageCalculator(),
+	"fal-ai/flux-pro/v1.1": new PixelBasedUsageCalculator(),
+	"gpt-image-1": new OpenAIImageGenerationUsageCalculator(),
+};
+
+export function createUsageCalculator(modelId: string): UsageCalculator {
+	if (usageCalculatorMap[modelId]) {
+		return usageCalculatorMap[modelId];
+	}
+	throw new Error(`Unknown model: ${modelId}`);
+}


### PR DESCRIPTION
## Summary

Enables tracking usage and cost of `gpt-image-1` node
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue
<!-- Mention the related issue number if applicable. -->

- #823

## Changes

- Instrument Langfuse tracer to `generateImageWithOpenAI()` to send trace from `gpt-image-1` node
- Use fal.ai API via AI SDK to minimize dependency difference between providers

<!-- List the main changes made in this PR. -->

## Testing

Corresponding trace with calculated cost arrived at Langfuse ✅ 
<img width="720" alt="image" src="https://github.com/user-attachments/assets/45691dcf-77f7-4711-acee-781e22d41a7b" />


## Other Information
<!-- Add any other relevant information for the reviewer. -->

- I didn't introduce a generic function to unify provider-specific function calls to keep the code diff in this PR small