### PR TITLE
Filter out unconfigured trigger nodes from the header

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/component.tsx
@@ -121,10 +121,19 @@ function TriggerButton({ triggerNode }: { triggerNode: TriggerNode }) {
 function Trigger() {
 	const { data } = useWorkflowDesigner();
 
-	const triggerNodes = useMemo(
-		() => data.nodes.filter((node) => isTriggerNode(node)),
-		[data.nodes],
-	);
+	const triggerNodes = useMemo(() => {
+		const tmp: TriggerNode[] = [];
+		for (const node of data.nodes) {
+			if (!isTriggerNode(node)) {
+				continue;
+			}
+			if (node.content.state.status === "unconfigured") {
+				continue;
+			}
+			tmp.push(node);
+		}
+		return tmp;
+	}, [data.nodes]);
 	if (triggerNodes.length === 0) {
 		return null;
 	}


### PR DESCRIPTION
## Description
This PR filters out unconfigured trigger nodes from being displayed in the workflow header. Only trigger nodes that have been properly configured will now appear in the header section.

## Implementation Details
- Modified the trigger nodes filtering logic in the `Trigger` component
- Added a check to exclude nodes with `status === "unconfigured"`
- Improved code readability by using a more explicit loop instead of a filter function

## Test Plan
1. Create a workflow with a trigger node
2. Verify that unconfigured trigger nodes are not displayed in the header
3. Configure the trigger node and verify it appears in the header

## Additional Notes
This change improves the user experience by only showing actionable triggers in the header.