### PR TITLE
GitHub Action Integration UI

### DIFF
--- a/apps/studio.giselles.ai/app/globals.css
+++ b/apps/studio.giselles.ai/app/globals.css
@@ -251,6 +251,9 @@
 	--color-trigger-node-1: var(--color-black-400);
 	--color-trigger-node-2: var(--color-black-400);
 
+	--color-action-node-1: var(--color-deep-purple-900);
+	--color-action-node-2: hsl(275, 91%, 26%);
+
 	--color-github-node-1: var(--color-deep-purple-900);
 	--color-github-node-2: hsl(275, 91%, 26%);
 

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
@@ -1,0 +1,350 @@
+import { type ActionNode, type Input, InputId } from "@giselle-sdk/data-type";
+import { actions, githubActions } from "@giselle-sdk/flow";
+import type { GitHubIntegrationInstallation } from "@giselle-sdk/integration";
+import { useIntegration } from "@giselle-sdk/integration/react";
+import { useWorkflowDesigner } from "giselle-sdk/react";
+import {
+	type FormEventHandler,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	useTransition,
+} from "react";
+import { GitHubIcon, SpinnerIcon } from "../../../icons";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../../../ui/select";
+import { GitHubRepositoryBlock, SelectRepository } from "./ui";
+
+export function GitHubActionPropertiesPanel({ node }: { node: ActionNode }) {
+	const { value } = useIntegration();
+
+	if (node.content.command.state.status === "configured") {
+		return "todo";
+	}
+
+	if (value?.github === undefined) {
+		return "unset";
+	}
+	switch (value.github.status) {
+		case "unset":
+			return "unset";
+		case "unauthorized":
+			return <Unauthorized authUrl={value.github.authUrl} />;
+		case "not-installed":
+			return (
+				<InstallGitHubApplication
+					installationUrl={value.github.installationUrl}
+				/>
+			);
+		case "invalid-credential":
+			return "invalid-credential";
+		case "installed":
+			return (
+				<Installed
+					installations={value.github.installations}
+					node={node}
+					installationUrl={value.github.installationUrl}
+				/>
+			);
+		default: {
+			const _exhaustiveCheck: never = value.github;
+			throw new Error(`Unhandled status: ${_exhaustiveCheck}`);
+		}
+	}
+}
+
+function Unauthorized({
+	authUrl,
+}: {
+	authUrl: string;
+}) {
+	const { refresh } = useIntegration();
+	const [isPending, startTransition] = useTransition();
+	const popupRef = useRef<Window | null>(null);
+
+	// Handler for installation message from popup window
+	const handleInstallationMessage = useCallback(
+		(event: MessageEvent) => {
+			if (event.data?.type === "github-app-installed") {
+				startTransition(() => {
+					refresh();
+				});
+			}
+		},
+		[refresh],
+	);
+
+	// Listen for visibility changes to refresh data when user returns to the page
+	useEffect(() => {
+		// Add event listener for installation message from popup
+		window.addEventListener("message", handleInstallationMessage);
+
+		return () => {
+			window.removeEventListener("message", handleInstallationMessage);
+
+			// Close popup if component unmounts
+			if (popupRef.current && !popupRef.current.closed) {
+				popupRef.current.close();
+			}
+		};
+	}, [handleInstallationMessage]);
+
+	const handleClick = useCallback(() => {
+		const width = 800;
+		const height = 800;
+		const left = window.screenX + (window.outerWidth - width) / 2;
+		const top = window.screenY + (window.outerHeight - height) / 2;
+
+		popupRef.current = window.open(
+			authUrl,
+			"Configure GitHub App",
+			`width=${width},height=${height},top=${top},left=${left},popup=1`,
+		);
+
+		if (!popupRef.current) {
+			console.warn("Failed to open popup window");
+			return;
+		}
+	}, [authUrl]);
+
+	return (
+		<div className="bg-white-900/10 h-[300px] rounded-[8px] flex items-center justify-center">
+			<div className="flex flex-col gap-[8px]">
+				<p>To get started you have to sign into your GitHub account</p>
+				<button
+					type="button"
+					className="group cursor-pointer bg-black-900 rounded-[4px] py-[4px] flex items-center justify-center gap-[8px] disabled:opacity-50 disabled:cursor-wait"
+					onClick={handleClick}
+					disabled={isPending}
+				>
+					<GitHubIcon className="size-[18px]" />
+					Continue with GitHub
+					<SpinnerIcon className="hidden group-disabled:block animate-follow-through-overlap-spin" />
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function InstallGitHubApplication({
+	installationUrl,
+}: {
+	installationUrl: string;
+}) {
+	const [isPending, startTransition] = useTransition();
+	const { refresh } = useIntegration();
+	const popupRef = useRef<Window | null>(null);
+	const handleClick = useCallback(() => {
+		const width = 800;
+		const height = 800;
+		const left = window.screenX + (window.outerWidth - width) / 2;
+		const top = window.screenY + (window.outerHeight - height) / 2;
+
+		popupRef.current = window.open(
+			installationUrl,
+			"Configure GitHub App",
+			`width=${width},height=${height},top=${top},left=${left},popup=1`,
+		);
+
+		if (!popupRef.current) {
+			console.warn("Failed to open popup window");
+			return;
+		}
+	}, [installationUrl]);
+
+	// Handler for installation message from popup window
+	const handleInstallationMessage = useCallback(
+		(event: MessageEvent) => {
+			if (event.data?.type === "github-app-installed") {
+				startTransition(() => {
+					refresh();
+				});
+			}
+		},
+		[refresh],
+	);
+
+	// Listen for visibility changes to refresh data when user returns to the page
+	useEffect(() => {
+		// Add event listener for installation message from popup
+		window.addEventListener("message", handleInstallationMessage);
+
+		return () => {
+			window.removeEventListener("message", handleInstallationMessage);
+
+			// Close popup if component unmounts
+			if (popupRef.current && !popupRef.current.closed) {
+				popupRef.current.close();
+			}
+		};
+	}, [handleInstallationMessage]);
+	return (
+		<div className="bg-white-900/10 h-[300px] rounded-[8px] flex items-center justify-center">
+			<div className="flex flex-col gap-[8px]">
+				<p>
+					Install the GitHub application for the accounts you wish to perform
+					actions with
+				</p>
+				<button
+					type="button"
+					className="group cursor-pointer bg-black-900 rounded-[4px] py-[4px] flex items-center justify-center gap-[8px] disabled:opacity-50 disabled:cursor-wait"
+					onClick={handleClick}
+					disabled={isPending}
+				>
+					<GitHubIcon className="size-[18px]" />
+					Install
+					<SpinnerIcon className="hidden group-disabled:block animate-follow-through-overlap-spin" />
+				</button>
+			</div>
+		</div>
+	);
+}
+
+interface SelectRepositoryStep {
+	state: "select-repository";
+}
+interface SelectActionStep {
+	state: "select-action";
+	owner: string;
+	repo: string;
+	repoNodeId: string;
+	installationId: number;
+}
+interface ConfigureActionStep {
+	state: "configure-action";
+	owner: string;
+	repo: string;
+	repoNodeId: string;
+	installationId: number;
+	actionId: string;
+}
+export type GitHubActionSetupStep =
+	| SelectRepositoryStep
+	| SelectActionStep
+	| ConfigureActionStep;
+
+function Installed({
+	installations,
+	node,
+	installationUrl,
+}: {
+	installations: GitHubIntegrationInstallation[];
+	node: ActionNode;
+	installationUrl: string;
+}) {
+	const [step, setStep] = useState<GitHubActionSetupStep>({
+		state: "select-repository",
+	});
+	const { updateNodeData } = useWorkflowDesigner();
+	const handleSubmit = useCallback<FormEventHandler<HTMLFormElement>>(
+		async (e) => {
+			e.preventDefault();
+			if (step.state !== "select-action") {
+				throw new Error("Unexpected state");
+			}
+			const formData = new FormData(e.currentTarget);
+
+			const commandId = formData.get("commandId");
+			if (typeof commandId !== "string" || commandId.length === 0) {
+				throw new Error("unexpected request");
+			}
+
+			const action = actions.find(
+				(action) =>
+					action.provider === "github" && action.command.id === commandId,
+			);
+
+			if (action === undefined) {
+				return;
+			}
+
+			// Setup inputs and outputs for the action
+			const inputs: Input[] = [];
+
+			// Add inputs based on the action type
+			for (const key of action.command.parameters.keyof().options) {
+				inputs.push({
+					id: InputId.generate(),
+					label: key,
+				});
+			}
+
+			updateNodeData(node, {
+				content: {
+					...node.content,
+					command: {
+						...node.content.command,
+						provider: "github",
+						state: {
+							status: "configured",
+							commandId: action.command.id,
+							repositoryNodeId: step.repoNodeId,
+							installationId: step.installationId,
+						},
+					},
+				},
+			});
+		},
+		[node, updateNodeData, step],
+	);
+
+	return (
+		<div className="flex flex-col gap-[16px] px-[16px]">
+			<p className="text-[18px]">Setup GitHub Action</p>
+			{step.state === "select-repository" && (
+				<SelectRepository
+					installations={installations}
+					installationUrl={installationUrl}
+					onSelectRepository={(value) => {
+						setStep({
+							state: "select-action",
+							installationId: value.installationId,
+							owner: value.owner,
+							repo: value.repo,
+							repoNodeId: value.repoNodeId,
+						});
+					}}
+				/>
+			)}
+			{step.state === "select-action" && (
+				<form
+					className="w-full flex flex-col gap-[16px]"
+					onSubmit={handleSubmit}
+				>
+					<GitHubRepositoryBlock owner={step.owner} repo={step.repo} />
+					<p className="text-[14px]">Choose what action you want to perform.</p>
+					<fieldset className="flex flex-col gap-[4px]">
+						<Select name="commandId">
+							<SelectTrigger>
+								<SelectValue placeholder="Select an command" />
+							</SelectTrigger>
+							<SelectContent>
+								{githubActions.map((githubAction) => (
+									<SelectItem
+										key={githubAction.command.id}
+										value={githubAction.command.id}
+									>
+										{githubAction.command.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</fieldset>
+
+					<button
+						type="submit"
+						className="h-[28px] rounded-[8px] bg-white-800 text-[14px] cursor-pointer text-black-800 font-[700] px-[16px] font-accent disabled:opacity-50"
+					>
+						Setup Action
+					</button>
+				</form>
+			)}
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/index.tsx
@@ -1,0 +1,46 @@
+import type { ActionNode } from "@giselle-sdk/data-type";
+import { useWorkflowDesigner } from "giselle-sdk/react";
+import { NodeIcon } from "../../../icons/node";
+import {
+	PropertiesPanelContent,
+	PropertiesPanelHeader,
+	PropertiesPanelRoot,
+} from "../ui";
+import { GitHubActionPropertiesPanel } from "./github-action-properties-panel";
+
+export function ActionNodePropertiesPanel({
+	node,
+}: {
+	node: ActionNode;
+}) {
+	const { updateNodeData } = useWorkflowDesigner();
+	return (
+		<PropertiesPanelRoot>
+			<PropertiesPanelHeader
+				icon={<NodeIcon node={node} className="size-[20px] text-black-900" />}
+				node={node}
+				onChangeName={(name) => {
+					updateNodeData(node, { name });
+				}}
+			/>
+			<PropertiesPanelContent>
+				<PropertiesPanel node={node} />
+			</PropertiesPanelContent>
+		</PropertiesPanelRoot>
+	);
+}
+
+function PropertiesPanel({
+	node,
+}: {
+	node: ActionNode;
+}) {
+	switch (node.content.command.provider) {
+		case "github":
+			return <GitHubActionPropertiesPanel node={node} />;
+		default: {
+			const _exhaustiveCheck: never = node.content.command.provider;
+			throw new Error(`Unhandled action provider: ${_exhaustiveCheck}`);
+		}
+	}
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-repository-block.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-repository-block.tsx
@@ -1,0 +1,20 @@
+import { GitHubIcon } from "../../../../icons";
+
+export function GitHubRepositoryBlock({
+	owner,
+	repo,
+}: {
+	owner: string;
+	repo: string;
+}) {
+	return (
+		<div className="flex items-center gap-[8px] bg-black-800 px-[14px] py-[10px] rounded-[4px]">
+			<GitHubIcon className="size-[20px]" />
+			<p className="space-x-[2px]">
+				<span>{owner}</span>
+				<span>/</span>
+				<span>{repo}</span>
+			</p>
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/index.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/index.ts
@@ -1,0 +1,2 @@
+export * from "./select-repository";
+export * from "./github-repository-block";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/select-repository.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/select-repository.tsx
@@ -1,0 +1,219 @@
+import type { GitHubIntegrationInstalledState } from "@giselle-sdk/integration";
+import { useIntegration } from "@giselle-sdk/integration/react";
+import {
+	type FormEventHandler,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	useTransition,
+} from "react";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../../../../ui/select";
+
+interface SelectRepository {
+	installationId: number;
+	owner: string;
+	repo: string;
+	repoNodeId: string;
+}
+export function SelectRepository({
+	installations,
+	installationUrl,
+	onSelectRepository,
+}: Pick<
+	GitHubIntegrationInstalledState,
+	"installations" | "installationUrl"
+> & {
+	onSelectRepository: (value: SelectRepository) => void;
+}) {
+	const [installationId, setInstalltionId] = useState<string>(
+		`${installations[0].id}`,
+	);
+	const repositories = useMemo(() => {
+		if (installationId === undefined) {
+			return undefined;
+		}
+		const installation = installations.find(
+			(installation) => installation.id === Number.parseInt(installationId),
+		);
+		if (installation === undefined) {
+			return undefined;
+		}
+		return installation.repositories;
+	}, [installationId, installations]);
+
+	const { refresh } = useIntegration();
+	const [isPending, startTransition] = useTransition();
+	const popupRef = useRef<Window | null>(null);
+
+	// Handler for installation message from popup window
+	const handleInstallationMessage = useCallback(
+		(event: MessageEvent) => {
+			if (event.data?.type === "github-app-installed") {
+				startTransition(() => {
+					refresh();
+				});
+			}
+		},
+		[refresh],
+	);
+
+	// Listen for visibility changes to refresh data when user returns to the page
+	useEffect(() => {
+		// Add event listener for installation message from popup
+		window.addEventListener("message", handleInstallationMessage);
+
+		return () => {
+			window.removeEventListener("message", handleInstallationMessage);
+
+			// Close popup if component unmounts
+			if (popupRef.current && !popupRef.current.closed) {
+				popupRef.current.close();
+			}
+		};
+	}, [handleInstallationMessage]);
+
+	const handleClick = useCallback(() => {
+		const width = 800;
+		const height = 800;
+		const left = window.screenX + (window.outerWidth - width) / 2;
+		const top = window.screenY + (window.outerHeight - height) / 2;
+
+		popupRef.current = window.open(
+			installationUrl,
+			"Configure GitHub App",
+			`width=${width},height=${height},top=${top},left=${left},popup=1`,
+		);
+
+		if (!popupRef.current) {
+			console.warn("Failed to open popup window");
+			return;
+		}
+	}, [installationUrl]);
+	const handleSubmit = useCallback<FormEventHandler<HTMLFormElement>>(
+		(e) => {
+			e.preventDefault();
+			const formData = new FormData(e?.currentTarget);
+			const installationId = formData.get("installationId");
+			const owner = formData.get("owner");
+			const repo = formData.get("repo");
+			const repoNodeId = formData.get("repoNodeId");
+			if (
+				typeof installationId !== "string" ||
+				typeof owner !== "string" ||
+				typeof repo !== "string" ||
+				typeof repoNodeId !== "string"
+			) {
+				throw new Error(
+					"Invalid form data: 'installationId', 'owner', 'repo', and 'repoNodeId' must all be strings.",
+				);
+			}
+
+			onSelectRepository({
+				installationId: Number.parseInt(installationId),
+				owner,
+				repo,
+				repoNodeId,
+			});
+		},
+		[onSelectRepository],
+	);
+	return (
+		<div className="w-full flex flex-col gap-[16px]">
+			<fieldset className="flex flex-col gap-[8px]">
+				<Select
+					name="repositoryNodeId"
+					value={installationId}
+					onValueChange={(value) => setInstalltionId(value)}
+				>
+					<SelectTrigger>
+						<SelectValue placeholder="Select a repository" />
+					</SelectTrigger>
+					<SelectContent>
+						{installations.map((installation) => (
+							<SelectItem key={installation.id} value={`${installation.id}`}>
+								{installation.account &&
+									"login" in installation.account &&
+									installation.account.login}
+								{installation.account &&
+									"slug" in installation.account &&
+									installation.account.slug}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<p className="text-black-400 text-[14px]">
+					Missing GitHub account?
+					<button
+						type="button"
+						className="text-blue-900 px-[4px] cursor-pointer hover:underline"
+						onClick={handleClick}
+					>
+						Adjust GitHub App Permissions →
+					</button>
+				</p>
+			</fieldset>
+			{installationId && repositories && (
+				<div className="flex flex-col gap-[8px]">
+					<ul className="flex flex-col border rounded-[8px] divide-y">
+						{isPending ? (
+							<li className="flex items-center justify-center h-[64px]">
+								Loading...
+							</li>
+						) : (
+							repositories.map((repo) => (
+								<li
+									key={repo.node_id}
+									className="px-[12px] py-[12px] flex items-center justify-between"
+								>
+									{repo.name}
+									<form onSubmit={handleSubmit}>
+										<input
+											type="hidden"
+											name="installationId"
+											value={installationId}
+										/>
+										<input
+											type="hidden"
+											name="owner"
+											value={repo.owner.login}
+										/>
+										<input type="hidden" name="repo" value={repo.name} />
+										<input
+											type="hidden"
+											name="repoNodeId"
+											value={repo.node_id}
+										/>
+										<button
+											type="submit"
+											className="rounded-[4px] px-[12px] h-[30px] bg-white-900 text-black-900 cursor-pointer"
+										>
+											Set up
+										</button>
+									</form>
+								</li>
+							))
+						)}
+					</ul>
+					<p className="text-black-400 text-[14px]">
+						Missing Git repository?
+						<button
+							type="button"
+							className="text-blue-900 px-[4px] cursor-pointer hover:underline"
+							onClick={handleClick}
+						>
+							Adjust GitHub App Permissions →
+						</button>
+					</p>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/index.tsx
@@ -1,4 +1,5 @@
 import {
+	isActionNode,
 	isFileNode,
 	isImageGenerationNode,
 	isTextGenerationNode,
@@ -8,6 +9,7 @@ import {
 import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { useMemo } from "react";
+import { ActionNodePropertiesPanel } from "./action-node-properties-panel";
 import { FileNodePropertiesPanel } from "./file-node-properties-panel";
 import { ImageGenerationNodePropertiesPanel } from "./image-generation-node-properties-panel";
 import { TextGenerationNodePropertiesPanel } from "./text-generation-node-properties-panel";
@@ -53,6 +55,12 @@ export function PropertiesPanel() {
 				)}
 				{isTriggerNode(selectedNodes[0]) && (
 					<TriggerNodePropertiesPanel
+						node={selectedNodes[0]}
+						key={selectedNodes[0].id}
+					/>
+				)}
+				{isActionNode(selectedNodes[0]) && (
+					<ActionNodePropertiesPanel
 						node={selectedNodes[0]}
 						key={selectedNodes[0].id}
 					/>

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/component.tsx
@@ -6,7 +6,9 @@ import {
 	isTextGenerationLanguageModelData,
 } from "@giselle-sdk/data-type";
 import {
+	type ActionProvider,
 	type TriggerProvider,
+	actionProviders,
 	githubActions,
 	triggerProviders,
 } from "@giselle-sdk/flow";
@@ -47,7 +49,7 @@ import {
 } from "../../../icons";
 import { ImageGenerationNodeIcon } from "../../../icons/node";
 import { Tooltip } from "../../../ui/tooltip";
-import { triggerNodeDefaultName } from "../../../utils";
+import { actionNodeDefaultName, triggerNodeDefaultName } from "../../../utils";
 import { isToolAction } from "../types";
 import {
 	actionNode,
@@ -298,19 +300,25 @@ export function Toolbar() {
 															"**:data-tool:data-[state=on]:bg-primary-900 **:data-tool:focus:outline-none",
 														)}
 														onValueChange={(value) => {
-															setSelectedTool(addNodeTool(actionNode(value)));
+															setSelectedTool(
+																addNodeTool(
+																	actionNode(value as ActionProvider),
+																),
+															);
 														}}
 													>
-														{githubActions.map((githubAction) => (
+														{actionProviders.map((actionProvider) => (
 															<ToggleGroup.Item
-																key={githubAction.id}
-																value={githubAction.id}
+																key={actionProvider}
+																value={actionProvider}
 																data-tool
 															>
-																<GitHubIcon className="w-[20px] h-[20px] shrink-0" />
+																{actionProvider === "github" && (
+																	<GitHubIcon className="size-[20px] shrink-0" />
+																)}
 																<p className="text-[14px]">
-																	{githubAction.label}
-																</p>
+																	{actionNodeDefaultName(actionProvider)}
+																</p>{" "}
 															</ToggleGroup.Item>
 														))}
 													</ToggleGroup.Root>

--- a/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
@@ -89,7 +89,7 @@ export function NodeIcon({
 						case "manual":
 							return <TriggerIcon {...props} data-content-type-icon />;
 						default: {
-							const _exhaustiveCheck: never = node.content;
+							const _exhaustiveCheck: never = node.content.provider;
 							throw new Error(
 								`Unhandled TriggerProviderType: ${_exhaustiveCheck}`,
 							);
@@ -97,13 +97,11 @@ export function NodeIcon({
 					}
 				}
 				case "action": {
-					switch (node.content.provider.type) {
+					switch (node.content.command.provider) {
 						case "github":
 							return <GitHubIcon {...props} data-content-type-icon />;
 						default: {
-							throw new Error(
-								`Unhandled TriggerProviderType: ${node.content.provider.type}`,
-							);
+							throw new Error(`Unhandled TriggerProviderType: ${node.content}`);
 						}
 					}
 				}

--- a/internal-packages/workflow-designer-ui/src/utils.ts
+++ b/internal-packages/workflow-designer-ui/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Node } from "@giselle-sdk/data-type";
-import type { TriggerProvider } from "@giselle-sdk/flow";
+import type { ActionProvider, TriggerProvider } from "@giselle-sdk/flow";
 
 export const triggerProviderLabel: Record<TriggerProvider, string> = {
 	github: "GitHub",
@@ -8,6 +8,14 @@ export const triggerProviderLabel: Record<TriggerProvider, string> = {
 
 export function triggerNodeDefaultName(triggerProvider: TriggerProvider) {
 	return `${triggerProviderLabel[triggerProvider]} Trigger`;
+}
+
+export const actionProviderLabel: Record<ActionProvider, string> = {
+	github: "GitHub",
+};
+
+export function actionNodeDefaultName(triggerProvider: ActionProvider) {
+	return `${triggerProviderLabel[triggerProvider]} Action`;
 }
 
 export function defaultName(node: Node) {
@@ -20,7 +28,9 @@ export function defaultName(node: Node) {
 				case "trigger":
 					return node.name ?? triggerNodeDefaultName(node.content.provider);
 				case "action":
-					return node.name ?? node.content.provider.type;
+					return (
+						node.name ?? actionNodeDefaultName(node.content.command.provider)
+					);
 				default: {
 					const _exhaustiveCheck: never = node.content;
 					throw new Error(`Unhandled action content type: ${_exhaustiveCheck}`);

--- a/packages/data-type/src/flow/action/github.ts
+++ b/packages/data-type/src/flow/action/github.ts
@@ -1,11 +1,11 @@
-import type { GitHubActionComandId } from "@giselle-sdk/flow";
+import type { GitHubActionCommandId } from "@giselle-sdk/flow";
 import { z } from "zod";
 
 export const Provider = z.literal("github");
 
 export const GitHubFlowAction = z.object({
 	provider: Provider,
-	commandId: z.custom<GitHubActionComandId>(),
+	commandId: z.custom<GitHubActionCommandId>(),
 	installationId: z.number(),
 	repositoryNodeId: z.string(),
 });

--- a/packages/data-type/src/flow/action/github.ts
+++ b/packages/data-type/src/flow/action/github.ts
@@ -1,0 +1,12 @@
+import type { GitHubActionComandId } from "@giselle-sdk/flow";
+import { z } from "zod";
+
+export const Provider = z.literal("github");
+
+export const GitHubFlowAction = z.object({
+	provider: Provider,
+	commandId: z.custom<GitHubActionComandId>(),
+	installationId: z.number(),
+	repositoryNodeId: z.string(),
+});
+export type GitHubFlowAction = z.infer<typeof GitHubFlowAction>;

--- a/packages/data-type/src/flow/action/index.ts
+++ b/packages/data-type/src/flow/action/index.ts
@@ -1,0 +1,6 @@
+import { createIdGenerator } from "@giselle-sdk/utils";
+import type { z } from "zod";
+export { GitHubFlowAction } from "./github";
+
+export const FlowActionId = createIdGenerator("flac");
+export type FlowActionId = z.infer<typeof FlowActionId.schema>;

--- a/packages/data-type/src/node/operations/action.ts
+++ b/packages/data-type/src/node/operations/action.ts
@@ -1,42 +1,31 @@
+import type { GitHubActionComandId } from "@giselle-sdk/flow";
 import { z } from "zod";
 
-const GitHubActionProviderAuthUnauthenticated = z.object({
-	state: z.literal("unauthenticated"),
+const GitHubActionCommandUnconfiguredState = z.object({
+	status: z.literal("unconfigured"),
 });
-const GitHubActionProviderAuthAuthenticated = z.object({
-	state: z.literal("authenticated"),
-	installtionId: z.number(),
+const GitHubActionCommandCofiguredState = z.object({
+	status: z.literal("configured"),
+	commandId: z.custom<GitHubActionComandId>(),
+	installationId: z.number(),
+	repositoryNodeId: z.string(),
 });
-const GitHubActionProviderAuth = z.discriminatedUnion("state", [
-	GitHubActionProviderAuthUnauthenticated,
-	GitHubActionProviderAuthAuthenticated,
-]);
 
-export const GitHubActionProvider = z.object({
-	type: z.literal("github"),
-	actionId: z.string(),
-	auth: GitHubActionProviderAuth,
+const GitHubActionCommandData = z.object({
+	provider: z.literal("github"),
+	state: z.discriminatedUnion("status", [
+		GitHubActionCommandUnconfiguredState,
+		GitHubActionCommandCofiguredState,
+	]),
 });
-export type GitHubActionProvider = z.infer<typeof GitHubActionProvider>;
-
-export const ActionProvider = z.discriminatedUnion("type", [
-	GitHubActionProvider,
-]);
-export type ActionProvider = z.infer<typeof ActionProvider>;
-
-export const ActionProviderLike = z.object({
-	type: z.string(),
-	actionId: z.string(),
-});
-export type ActionProviderLike = z.infer<typeof ActionProviderLike>;
 
 export const ActionContent = z.object({
 	type: z.literal("action"),
-	provider: ActionProviderLike,
+	command: GitHubActionCommandData,
 });
 export type ActionContent = z.infer<typeof ActionContent>;
 
 export const ActionContentReference = z.object({
-	type: z.literal("action"),
+	type: ActionContent.shape.type,
 });
 export type ActionContentReference = z.infer<typeof ActionContentReference>;

--- a/packages/data-type/src/node/operations/action.ts
+++ b/packages/data-type/src/node/operations/action.ts
@@ -4,7 +4,9 @@ import { z } from "zod";
 const GitHubActionCommandUnconfiguredState = z.object({
 	status: z.literal("unconfigured"),
 });
-export type GitHubActionCommandUnconfiguredState = z.infer<typeof GitHubActionCommandUnconfiguredState>;
+export type GitHubActionCommandUnconfiguredState = z.infer<
+	typeof GitHubActionCommandUnconfiguredState
+>;
 
 const GitHubActionCommandCofiguredState = z.object({
 	status: z.literal("configured"),
@@ -12,7 +14,9 @@ const GitHubActionCommandCofiguredState = z.object({
 	installationId: z.number(),
 	repositoryNodeId: z.string(),
 });
-export type GitHubActionCommandCofiguredState = z.infer<typeof GitHubActionCommandUnconfiguredState> | z.infer<typeof GitHubActionCommandCofiguredState>;
+export type GitHubActionCommandCofiguredState =
+	| z.infer<typeof GitHubActionCommandUnconfiguredState>
+	| z.infer<typeof GitHubActionCommandCofiguredState>;
 
 const GitHubActionCommandData = z.object({
 	provider: z.literal("github"),

--- a/packages/data-type/src/node/operations/action.ts
+++ b/packages/data-type/src/node/operations/action.ts
@@ -1,15 +1,18 @@
-import type { GitHubActionComandId } from "@giselle-sdk/flow";
+import type { GitHubActionCommandId } from "@giselle-sdk/flow";
 import { z } from "zod";
 
 const GitHubActionCommandUnconfiguredState = z.object({
 	status: z.literal("unconfigured"),
 });
+export type GitHubActionCommandUnconfiguredState = z.infer<typeof GitHubActionCommandUnconfiguredState>;
+
 const GitHubActionCommandCofiguredState = z.object({
 	status: z.literal("configured"),
-	commandId: z.custom<GitHubActionComandId>(),
+	commandId: z.custom<GitHubActionCommandId>(),
 	installationId: z.number(),
 	repositoryNodeId: z.string(),
 });
+export type GitHubActionCommandCofiguredState = z.infer<typeof GitHubActionCommandUnconfiguredState> | z.infer<typeof GitHubActionCommandCofiguredState>;
 
 const GitHubActionCommandData = z.object({
 	provider: z.literal("github"),
@@ -18,6 +21,7 @@ const GitHubActionCommandData = z.object({
 		GitHubActionCommandCofiguredState,
 	]),
 });
+export type GitHubActionCommandData = z.infer<typeof GitHubActionCommandData>;
 
 export const ActionContent = z.object({
 	type: z.literal("action"),

--- a/packages/data-type/src/node/operations/index.ts
+++ b/packages/data-type/src/node/operations/index.ts
@@ -73,6 +73,10 @@ export const ActionNode = OperationNode.extend({
 	content: ActionContent,
 });
 export type ActionNode = z.infer<typeof ActionNode>;
+export function isActionNode(args?: unknown): args is ActionNode {
+	const result = ActionNode.safeParse(args);
+	return result.success;
+}
 
 const OverrideOperationNodeContent = z.discriminatedUnion("type", [
 	OverrideTextGenerationContent,

--- a/packages/flow/src/action/github.ts
+++ b/packages/flow/src/action/github.ts
@@ -1,37 +1,43 @@
 import { z } from "zod";
 import type { ActionBase } from "../base";
 
-const provider = "github" as const;
+export const provider = "github" as const;
 
 export interface GitHubAction extends ActionBase {
-	parameters: z.AnyZodObject;
+	provider: typeof provider;
 }
 
 export const githubCreateIssueAction = {
 	provider,
-	id: "github.create.issue",
-	label: "Create Issue",
-	parameters: z.object({
-		title: z.string(),
-		body: z.string(),
-		repositoryOwner: z.string(),
-		repositoryName: z.string(),
-	}),
+	command: {
+		id: "github.create.issue",
+		label: "Create Issue",
+		parameters: z.object({
+			repositoryOwner: z.string(),
+			repositoryName: z.string(),
+			title: z.string(),
+			body: z.string(),
+		}),
+	},
 } as const satisfies GitHubAction;
 
 export const githubCreateIssueCommentAction = {
 	provider,
-	id: "github.create.issue.comment",
-	label: "Create Issue Comment",
-	parameters: z.object({
-		issueNumber: z.number(),
-		body: z.string(),
-		repositoryOwner: z.string(),
-		repositoryName: z.string(),
-	}),
+	command: {
+		id: "github.create.issueComment",
+		label: "Create Issue Comment",
+		parameters: z.object({
+			issueNumber: z.number(),
+			body: z.string(),
+			repositoryOwner: z.string(),
+			repositoryName: z.string(),
+		}),
+	},
 } as const satisfies GitHubAction;
 
 export const actions = [
 	githubCreateIssueAction,
 	githubCreateIssueCommentAction,
 ] as const;
+
+export type ActionCommandId = (typeof actions)[number]["command"]["id"];

--- a/packages/flow/src/action/index.ts
+++ b/packages/flow/src/action/index.ts
@@ -3,7 +3,7 @@ import { actions as githubActions, provider as githubProvider } from "./github";
 export {
 	actions as githubActions,
 	provider as githubProvider,
-	type ActionCommandId as GitHubActionComandId,
+	type ActionCommandId as GitHubActionCommandId,
 } from "./github";
 
 export const actions = [...githubActions];

--- a/packages/flow/src/action/index.ts
+++ b/packages/flow/src/action/index.ts
@@ -1,5 +1,11 @@
-import { actions as githubActions } from "./github";
+import { actions as githubActions, provider as githubProvider } from "./github";
 
-export { actions as githubActions } from "./github";
+export {
+	actions as githubActions,
+	provider as githubProvider,
+	type ActionCommandId as GitHubActionComandId,
+} from "./github";
 
 export const actions = [...githubActions];
+export type ActionProvider = typeof githubProvider;
+export const actionProviders = [githubProvider];

--- a/packages/flow/src/base.ts
+++ b/packages/flow/src/base.ts
@@ -1,6 +1,6 @@
 import type { z } from "zod";
 
-export interface TriggerEventBase {
+export interface TriggerEvent {
 	id: string;
 	label: string;
 	description?: string;
@@ -9,13 +9,17 @@ export interface TriggerEventBase {
 }
 export interface TriggerBase {
 	provider: string;
-	event: TriggerEventBase;
+	event: TriggerEvent;
 }
 
-export interface ActionBase {
-	provider: string;
+export interface ActionCommand {
 	id: string;
 	label: string;
 	description?: string;
 	parameters?: z.AnyZodObject;
+}
+
+export interface ActionBase {
+	provider: string;
+	command: ActionCommand;
 }

--- a/packages/text-editor/src/react/source-extension-react.tsx
+++ b/packages/text-editor/src/react/source-extension-react.tsx
@@ -15,7 +15,7 @@ function defaultName(node: GiselleNode) {
 				case "trigger":
 					return node.name ?? node.content.provider;
 				case "action":
-					return node.name ?? node.content.provider.type;
+					return node.name ?? node.content.command.provider;
 				default: {
 					const _exhaustiveCheck: never = node.content;
 					throw new Error(`Unhandled action content type: ${_exhaustiveCheck}`);


### PR DESCRIPTION
## Description

This PR adds GitHub action integration UI to the workflow designer, allowing users to configure GitHub actions directly in the workflow designer UI.

### Changes

- Added action node styling with dedicated colors
- Implemented GitHub action configuration UI with repository selection
- Added properties panel for action nodes
- Fixed action node naming to use the provider name correctly
- Formatted all code with Biome

## Test Plan

1. Open the workflow designer
2. Add an action node to the canvas
3. Verify the action node has the correct styling
4. Open the properties panel for the action node
5. Verify you can select a GitHub repository
6. Verify you can select a GitHub action
7. Verify the configuration UI works correctly

## Screenshots

https://github.com/user-attachments/assets/cf86bc75-39cf-4568-a1e9-2576ba2f0621


