### PR TITLE
Add component names to GitHub actions and triggers

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
@@ -289,6 +289,7 @@ function Installed({
 						},
 					},
 				},
+				name: action.command.label,
 			});
 		},
 		[node, updateNodeData, step],

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
@@ -31,6 +31,7 @@ import {
 	SelectValue,
 } from "../../../ui/select";
 import { Tooltip } from "../../../ui/tooltip";
+import { triggerNodeDefaultName } from "../../../utils";
 import { GitHubRepositoryBlock, SelectRepository } from "../ui";
 import { ConfiguredView } from "./ui";
 
@@ -305,7 +306,6 @@ function Installed({
 					accessor: key,
 				});
 			}
-
 			startTransition(async () => {
 				const { triggerId } = await client.configureTrigger({
 					trigger: {
@@ -329,6 +329,7 @@ function Installed({
 						},
 					},
 					outputs: [...node.outputs, ...outputs],
+					name: trigger.event.label,
 				});
 			});
 		},

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
@@ -305,6 +305,7 @@ function Installed({
 					accessor: key,
 				});
 			}
+
 			startTransition(async () => {
 				const { triggerId } = await client.configureTrigger({
 					trigger: {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
@@ -31,7 +31,6 @@ import {
 	SelectValue,
 } from "../../../ui/select";
 import { Tooltip } from "../../../ui/tooltip";
-import { triggerNodeDefaultName } from "../../../utils";
 import { GitHubRepositoryBlock, SelectRepository } from "../ui";
 import { ConfiguredView } from "./ui";
 


### PR DESCRIPTION
## Description
This PR adds proper component naming to GitHub actions and triggers in the workflow designer. Each action and trigger will now have a `name` field based on its label, ensuring that components are properly identified in the workflow view.

https://github.com/user-attachments/assets/63ef32b8-74d6-4200-a589-b77a4d616aeb


## Changes
- Added the `name` field to GitHub action configurations using the action's label
- Added the `name` field to GitHub trigger configurations using the trigger's event label
- All formatting follows Biome standards

## Test Plan
1. Create a new workflow with GitHub triggers and actions
2. Verify the components are properly named in the workflow view
3. Check that the names correctly reflect their respective labels

## Related Issues
This is part of the ongoing GitHub UI components refactoring.