### PR TITLE
fix: Pass inputs to update node data in GitHub action setup

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
@@ -290,6 +290,7 @@ function Installed({
 					},
 				},
 				name: action.command.label,
+				inputs,
 			});
 		},
 		[node, updateNodeData, step],


### PR DESCRIPTION
## Summary
This pull request fixes a bug in the GitHub action properties panel where input parameters weren't being saved with the node configuration. The change ensures that the `inputs` array is properly passed to the `updateNodeData` function when setting up a GitHub action.


https://github.com/user-attachments/assets/83adb7f1-cd4d-4a45-ace2-83a6ead95856



## Changes
- Added the `inputs` property to the object passed to `updateNodeData` in the GitHub action properties panel

## Testing Plan
1. Navigate to the workflow designer
2. Add a GitHub action node
3. Configure the GitHub action by selecting a repository and action
4. Verify that the input parameters are correctly saved with the node
5. Ensure the action works correctly with the configured inputs

## Related Issues
N/A