### PR TITLE
Perplexity Node Now Supports Search Domain Filter Option

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
@@ -1,6 +1,9 @@
 import { PerplexityLanguageModelData } from "@giselle-sdk/data-type";
 import { perplexityLanguageModels } from "@giselle-sdk/language-model";
 import { useUsageLimits } from "giselle-sdk/react";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "../../../../ui/button";
+import { Input } from "../../../../ui/input";
 import {
 	Select,
 	SelectContent,
@@ -10,6 +13,7 @@ import {
 	SelectValue,
 } from "../../../../ui/select";
 import { Slider } from "../../../../ui/slider";
+import { Switch } from "../../../../ui/switch";
 import { languageModelAvailable } from "./utils";
 
 export function PerplexityModelPanel({
@@ -20,6 +24,78 @@ export function PerplexityModelPanel({
 	onModelChange: (changedValue: PerplexityLanguageModelData) => void;
 }) {
 	const limits = useUsageLimits();
+	const [domainInput, setDomainInput] = useState("");
+	const [includeMode, setIncludeMode] = useState(true);
+	const domains = getDomains();
+
+	// includeMode: if no domains start with '-' then include mode, if all domains start with '-' then exclude mode
+	useEffect(() => {
+		if (domains.length === 0) {
+			// Do nothing if domains is empty (allow user to toggle manually)
+			return;
+		}
+		setIncludeMode(domains.every((d) => !d.startsWith("-")));
+	}, [domains]);
+
+	function getDomains() {
+		// Always return the raw searchDomainFilter array
+		return perplexityLanguageModel.configurations.searchDomainFilter || [];
+	}
+
+	function addDomain() {
+		const value = domainInput.trim();
+		if (!value) return;
+		if (!/^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value.replace(/^\-/, "")))
+			return; // simple domain validation
+		if (domains.length >= 10) return;
+		if (domains.some((d) => d.replace(/^\-/, "") === value.replace(/^\-/, "")))
+			return;
+		// Add domain with or without '-' based on includeMode
+		const newDomain = includeMode
+			? value.replace(/^\-/, "")
+			: `-${value.replace(/^\-/, "")}`;
+		const newDomains = [...domains, newDomain];
+		onModelChange(
+			PerplexityLanguageModelData.parse({
+				...perplexityLanguageModel,
+				configurations: {
+					...perplexityLanguageModel.configurations,
+					searchDomainFilter: newDomains,
+				},
+			}),
+		);
+		setDomainInput("");
+	}
+
+	function removeDomain(idx: number) {
+		const newDomains = domains.filter((_, i) => i !== idx);
+		onModelChange(
+			PerplexityLanguageModelData.parse({
+				...perplexityLanguageModel,
+				configurations: {
+					...perplexityLanguageModel.configurations,
+					searchDomainFilter: newDomains,
+				},
+			}),
+		);
+	}
+
+	// When switching include/exclude mode, convert all domains accordingly
+	function handleModeSwitch(checked: boolean) {
+		setIncludeMode(checked);
+		const convertedDomains = checked
+			? domains.map((d) => d.replace(/^\-/, "")) // to include (remove '-')
+			: domains.map((d) => (d.startsWith("-") ? d : `-${d}`)); // to exclude (add '-')
+		onModelChange(
+			PerplexityLanguageModelData.parse({
+				...perplexityLanguageModel,
+				configurations: {
+					...perplexityLanguageModel.configurations,
+					searchDomainFilter: convertedDomains,
+				},
+			}),
+		);
+	}
 
 	return (
 		<div className="flex flex-col gap-[34px]">
@@ -127,6 +203,67 @@ export function PerplexityModelPanel({
 						}}
 					/>
 				</div>
+			</div>
+			{/* --- Search Domain Filter Section --- */}
+			<div className="flex flex-col gap-2 mt-8">
+				<span className="font-bold text-[15px]">Search Domain Filter</span>
+				<div className="flex items-center gap-4">
+					<span className="text-[13px]">Mode:</span>
+					<Switch
+						label={includeMode ? "Include" : "Exclude"}
+						name="search-domain-mode"
+						checked={includeMode}
+						onCheckedChange={handleModeSwitch}
+					/>
+				</div>
+				<div className="flex items-center gap-2 mt-2">
+					<Input
+						placeholder="Add domain (e.g. wikipedia.org)"
+						value={domainInput}
+						onChange={(e) => setDomainInput(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								addDomain();
+							}
+						}}
+						maxLength={100}
+						disabled={domains.length >= 10}
+					/>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={domains.length >= 10 || !domainInput.trim()}
+						onClick={addDomain}
+					>
+						Add
+					</Button>
+				</div>
+				{domains.length >= 10 && (
+					<p className="text-red-700 text-[12px]">
+						You can add up to 10 domains only.
+					</p>
+				)}
+				<ul className="flex flex-wrap gap-2 mt-2">
+					{domains.map((domain, idx) => (
+						<li
+							key={domain}
+							className="flex items-center bg-white-900/10 rounded px-2 py-1 text-[13px]"
+						>
+							{/* Display domain without '-' in exclude mode for clarity */}
+							{includeMode
+								? domain.replace(/^\-/, "")
+								: domain.replace(/^\-/, "")}
+							<Button
+								variant="ghost"
+								size="sm"
+								className="ml-1 px-1"
+								onClick={() => removeDomain(idx)}
+							>
+								×
+							</Button>
+						</li>
+					))}
+				</ul>
 			</div>
 		</div>
 	);

--- a/internal-packages/workflow-designer-ui/src/ui/input.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/input.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+export interface InputProps
+	extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+	({ className, type = "text", ...props }, ref) => {
+		return (
+			<input
+				type={type}
+				className={`flex w-full rounded-md bg-[hsla(207,43%,91%,0.2)] border border-transparent p-[12px] text-[14px] shadow-xs transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-black--50 disabled:cursor-not-allowed disabled:opacity-50${className ? ` ${className}` : ""}`}
+				ref={ref}
+				{...props}
+			/>
+		);
+	},
+);
+Input.displayName = "Input";

--- a/packages/language-model/src/perplexity.ts
+++ b/packages/language-model/src/perplexity.ts
@@ -6,6 +6,7 @@ const PerplexityLanguageModelConfigurations = z.object({
 	topP: z.number(),
 	presencePenalty: z.number(),
 	frequencyPenalty: z.number(),
+	searchDomainFilter: z.array(z.string()).optional(),
 });
 type PerplexityLanguageModelConfigurations = z.infer<
 	typeof PerplexityLanguageModelConfigurations


### PR DESCRIPTION
## Summary
Perplexity Node Now Supports Search Domain Filter Option.

- [Search Domain Filter Guide \- Perplexity](https://docs.perplexity.ai/guides/search-domain-filters)

### Mode: Include

https://github.com/user-attachments/assets/46838189-b5b7-4b3f-ad15-587706990f93

### Mode: Exclude

https://github.com/user-attachments/assets/9e77399a-ac3f-4571-8472-a9c10ef02caa

## Related Issue
None.

## Changes
- SSIA

## Testing
1. Visit app workspaces
2. Place `sonar` or `sonar-pro` node
3. Please check the operation of Search Domain Filter in the following cases:
   - Do not specify anything
   - Include domain
   - Exclude domain

## Other Information
- In this PR, we have made the function available.
- UX improvements will be requested separately.