### PR TITLE
Remove unused SP import from workflow-designer-ui

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/index.tsx
@@ -15,7 +15,6 @@ import "@xyflow/react/dist/style.css";
 import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { useAnimationFrame, useSpring } from "motion/react";
-import { SP } from "next/dist/shared/lib/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	type ImperativePanelHandle,


### PR DESCRIPTION
## Description

This PR removes an unused import (`SP` from "next/dist/shared/lib/utils") from the workflow designer UI component. This is a small code cleanup that helps reduce unnecessary dependencies and improves code quality.

## Changes

- Removed unused `SP` import from workflow-designer-ui/src/editor/index.tsx

## Testing

- The application should continue to function normally as this change only removes an unused import
- Verified that the component still builds and functions correctly

## Additional Notes

- Biome formatting has been applied to ensure code consistency