### PR TITLE
Perplexity Node Supports Search Domain Filter Option with Combine Approaches

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
@@ -16,6 +16,8 @@ import { Slider } from "../../../../ui/slider";
 import { Switch } from "../../../../ui/switch";
 import { languageModelAvailable } from "./utils";
 
+const DOMAIN_VALIDATION_REGEX = /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
 export function PerplexityModelPanel({
 	perplexityLanguageModel,
 	onModelChange,
@@ -58,7 +60,7 @@ export function PerplexityModelPanel({
 	function addAllowDomain() {
 		const value = allowlistInput.trim();
 		if (!value) return;
-		if (!/^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value)) return;
+		if (!DOMAIN_VALIDATION_REGEX.test(value)) return;
 		if (allowlist.length + denylist.length >= 10) return;
 		if (allowlist.includes(value) || denylist.some((d) => d.slice(1) === value))
 			return;
@@ -69,7 +71,7 @@ export function PerplexityModelPanel({
 	function addDenyDomain() {
 		const value = denylistInput.trim();
 		if (!value) return;
-		if (!/^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value)) return;
+		if (!DOMAIN_VALIDATION_REGEX.test(value)) return;
 		if (allowlist.length + denylist.length >= 10) return;
 		if (denylist.includes(`-${value}`) || allowlist.includes(value)) return;
 		updateDomainFilter(allowlist, [...denylist, `-${value}`]);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
@@ -1,7 +1,7 @@
 import { PerplexityLanguageModelData } from "@giselle-sdk/data-type";
 import { perplexityLanguageModels } from "@giselle-sdk/language-model";
 import { useUsageLimits } from "giselle-sdk/react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "../../../../ui/button";
 import { Input } from "../../../../ui/input";
 import {
@@ -13,7 +13,6 @@ import {
 	SelectValue,
 } from "../../../../ui/select";
 import { Slider } from "../../../../ui/slider";
-import { Switch } from "../../../../ui/switch";
 import { languageModelAvailable } from "./utils";
 
 const DOMAIN_VALIDATION_REGEX = /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/perplexity.tsx
@@ -25,16 +25,16 @@ export function PerplexityModelPanel({
 }) {
 	const limits = useUsageLimits();
 	const [domainInput, setDomainInput] = useState("");
-	const [includeMode, setIncludeMode] = useState(true);
+	const [listMode, setListMode] = useState(true);
 	const domains = getDomains();
 
-	// includeMode: if no domains start with '-' then include mode, if all domains start with '-' then exclude mode
+	// listMode: if no domains start with '-' then allowlist, if all domains start with '-' then denylist
 	useEffect(() => {
 		if (domains.length === 0) {
 			// Do nothing if domains is empty (allow user to toggle manually)
 			return;
 		}
-		setIncludeMode(domains.every((d) => !d.startsWith("-")));
+		setListMode(domains.every((d) => !d.startsWith("-")));
 	}, [domains]);
 
 	function getDomains() {
@@ -50,8 +50,8 @@ export function PerplexityModelPanel({
 		if (domains.length >= 10) return;
 		if (domains.some((d) => d.replace(/^\-/, "") === value.replace(/^\-/, "")))
 			return;
-		// Add domain with or without '-' based on includeMode
-		const newDomain = includeMode
+		// Add domain with or without '-' based on listMode
+		const newDomain = listMode
 			? value.replace(/^\-/, "")
 			: `-${value.replace(/^\-/, "")}`;
 		const newDomains = [...domains, newDomain];
@@ -80,12 +80,12 @@ export function PerplexityModelPanel({
 		);
 	}
 
-	// When switching include/exclude mode, convert all domains accordingly
+	// When switching allowlist/denylist mode, convert all domains accordingly
 	function handleModeSwitch(checked: boolean) {
-		setIncludeMode(checked);
+		setListMode(checked);
 		const convertedDomains = checked
-			? domains.map((d) => d.replace(/^\-/, "")) // to include (remove '-')
-			: domains.map((d) => (d.startsWith("-") ? d : `-${d}`)); // to exclude (add '-')
+			? domains.map((d) => d.replace(/^\-/, "")) // to allowlist (remove '-')
+			: domains.map((d) => (d.startsWith("-") ? d : `-${d}`)); // to denylist (add '-')
 		onModelChange(
 			PerplexityLanguageModelData.parse({
 				...perplexityLanguageModel,
@@ -210,9 +210,9 @@ export function PerplexityModelPanel({
 				<div className="flex items-center gap-4">
 					<span className="text-[13px]">Mode:</span>
 					<Switch
-						label={includeMode ? "Include" : "Exclude"}
+						label={listMode ? "Allowlist" : "Denylist"}
 						name="search-domain-mode"
-						checked={includeMode}
+						checked={listMode}
 						onCheckedChange={handleModeSwitch}
 					/>
 				</div>
@@ -249,10 +249,8 @@ export function PerplexityModelPanel({
 							key={domain}
 							className="flex items-center bg-white-900/10 rounded px-2 py-1 text-[13px]"
 						>
-							{/* Display domain without '-' in exclude mode for clarity */}
-							{includeMode
-								? domain.replace(/^\-/, "")
-								: domain.replace(/^\-/, "")}
+							{/* Display domain without '-' in denylist mode for clarity */}
+							{domain.replace(/^\-/, "")}
 							<Button
 								variant="ghost"
 								size="sm"


### PR DESCRIPTION
## Summary
Perplexity Node Supports Search Domain Filter Option with Combine Approaches.


https://github.com/user-attachments/assets/b7362fc6-f436-4cfc-a1bc-44173133f8ac


## Related Issue
previous pr: https://github.com/giselles-ai/giselle/pull/833

## Changes
- Match wording to official documentation
- I have improved the UX to allow the following usage that mixes Allowlist and Denylist.
    > Combine approaches: You can mix inclusion and exclusion in the same request (e.g., ["wikipedia.org", "-pinterest.com"]).
    >
    > via: https://docs.perplexity.ai/guides/search-domain-filters#filter-optimization


## Testing
1. Visit app workspaces
2. Place `sonar` or `sonar-pro` node
3. Please check the operation of Search Domain Filter in the following cases:
   - Do not specify anything
   - Add or Remove domains to Allowlist
   - Add or Remove domains to Denylist
   - Combine the domains with Allowlist and Denylist

## Other Information
<!-- Add any other relevant information for the reviewer. -->
