### PR TITLE
Fix typo in GitHubActionCommandConfiguredState type name

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
@@ -1,6 +1,6 @@
 import {
 	type ConnectionId,
-	type GitHubActionCommandCofiguredState,
+	type GitHubActionCommandConfiguredState,
 	type Input,
 	type Node,
 	type NodeId,
@@ -27,7 +27,7 @@ export function GitHubActionConfiguredView({
 }: {
 	nodeId: NodeId;
 	inputs: Input[];
-	state: GitHubActionCommandCofiguredState;
+	state: GitHubActionCommandConfiguredState;
 }) {
 	const client = useGiselleEngine();
 	const {

--- a/packages/data-type/src/node/operations/action.ts
+++ b/packages/data-type/src/node/operations/action.ts
@@ -8,21 +8,21 @@ export type GitHubActionCommandUnconfiguredState = z.infer<
 	typeof GitHubActionCommandUnconfiguredState
 >;
 
-const GitHubActionCommandCofiguredState = z.object({
+const GitHubActionCommandConfiguredState = z.object({
 	status: z.literal("configured"),
 	commandId: z.custom<GitHubActionCommandId>(),
 	installationId: z.number(),
 	repositoryNodeId: z.string(),
 });
-export type GitHubActionCommandCofiguredState = z.infer<
-	typeof GitHubActionCommandCofiguredState
+export type GitHubActionCommandConfiguredState = z.infer<
+	typeof GitHubActionCommandConfiguredState
 >;
 
 const GitHubActionCommandData = z.object({
 	provider: z.literal("github"),
 	state: z.discriminatedUnion("status", [
 		GitHubActionCommandUnconfiguredState,
-		GitHubActionCommandCofiguredState,
+		GitHubActionCommandConfiguredState,
 	]),
 });
 export type GitHubActionCommandData = z.infer<typeof GitHubActionCommandData>;

--- a/packages/giselle-engine/src/core/operations/execute-action.ts
+++ b/packages/giselle-engine/src/core/operations/execute-action.ts
@@ -1,7 +1,7 @@
 import {
 	type CompletedGeneration,
 	GenerationContext,
-	type GitHubActionCommandCofiguredState,
+	type GitHubActionCommandConfiguredState,
 	type QueuedGeneration,
 	isActionNode,
 } from "@giselle-sdk/data-type";
@@ -69,7 +69,7 @@ export async function executeAction(args: {
 }
 
 async function executeGitHubActionCommand(args: {
-	state: GitHubActionCommandCofiguredState;
+	state: GitHubActionCommandConfiguredState;
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
 }) {


### PR DESCRIPTION
This PR fixes a typo in the type name GitHubActionCommandCofiguredState, renaming it to GitHubActionCommandConfiguredState across multiple files. This ensures consistent type naming and prevents potential type errors.

## Test Plan
1. Build the project with 'pnpm build'
2. Verify there are no type errors related to GitHub action components
3. Verify the GitHub Action functionality works as expected