### PR TITLE
Tag Langfuse trace with Perplexity option

### DIFF
--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -9,7 +9,8 @@ type TelemetryTag =
 	| "openai:web-search"
 	| "google:search-grounding"
 	| "anthropic:reasoning"
-	| "anthropic:thinking";
+	| "anthropic:thinking"
+	| "perplexity:search-domain-filter";
 
 export function generateTelemetryTags(args: {
 	provider: string;
@@ -41,6 +42,18 @@ export function generateTelemetryTags(args: {
 			// treat as an independent tag because extended thinking is available only on specific models
 			// ref: https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
 			tags.push("anthropic:thinking");
+		}
+	}
+
+	// Perplexity Search Domain Filter
+	if (args.provider === "perplexity") {
+		tags.push("web-search");
+
+		if (
+			Array.isArray(args.configurations.searchDomainFilter) &&
+			args.configurations.searchDomainFilter.length > 0
+		) {
+			tags.push("perplexity:search-domain-filter");
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR enables tagging Langfuse trace with Perplexity "Search Domain Filter" option
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue

- https://github.com/giselles-ai/giselle/pull/833

## Testing

### Trace is tagged when using filter ✅ 
<img width="332" alt="image" src="https://github.com/user-attachments/assets/f9b80f47-23b2-49f5-a18a-228deb9c4c6b" />

### without filter ✅ 

<img width="180" alt="image" src="https://github.com/user-attachments/assets/8baf14af-ba91-44b4-87bd-acdf5131c857" />
