### PR TITLE
remove toyamarinyon from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @shige @toyamarinyon
+* @shige


### PR DESCRIPTION
I removed myself as a Code Owner because I felt my comments as a Code Owner were not contributing to the product. I would appreciate if you could assign me as a reviewer when it seems necessary.