### PR TITLE
Add tags to Langfuse trace to make model usage data analyzable

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -2,6 +2,7 @@ import { db } from "@/drizzle";
 import { flowNodeFlag, runV2Flag } from "@/flags";
 import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
+import { fetchCurrentUser } from "@/services/accounts";
 import { fetchCurrentTeam, isProPlan } from "@/services/teams";
 import { WorkspaceId } from "@giselle-sdk/data-type";
 import { WorkspaceProvider } from "giselle-sdk/react";
@@ -24,6 +25,8 @@ export default async function Layout({
 		return notFound();
 	}
 	const gitHubIntegrationState = await getGitHubIntegrationState(agent.dbId);
+
+	const currentUser = await fetchCurrentUser();
 
 	const currentTeam = await fetchCurrentTeam();
 	if (currentTeam.dbId !== agent.teamDbId) {
@@ -50,6 +53,7 @@ export default async function Layout({
 				metadata: {
 					isProPlan: isProPlan(currentTeam),
 					teamType: currentTeam.type,
+					userId: currentUser.id,
 					subscriptionId: currentTeam.activeSubscriptionId ?? "",
 				},
 			}}

--- a/packages/giselle-engine/src/core/generations/generate-image.ts
+++ b/packages/giselle-engine/src/core/generations/generate-image.ts
@@ -35,7 +35,7 @@ import type { Storage } from "unstorage";
 import { UsageLimitError } from "../error";
 import { filePath } from "../files/utils";
 import type { GiselleEngineContext } from "../types";
-import { getLangfuseInstance } from "./telemetry";
+import { generateTelemetryTags, getLangfuseInstance } from "./telemetry";
 import type { TelemetrySettings } from "./types";
 import {
 	buildMessageObject,

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -86,6 +86,7 @@ export async function generateText(args: {
 	} satisfies RunningGeneration;
 
 	const trace = langfuse.trace({
+		userId: String(args.telemetry?.metadata?.userId),
 		name: "ai.streamText",
 		metadata: args.telemetry?.metadata,
 	});

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -32,6 +32,8 @@ export function generateTelemetryTags(args: {
 }): TelemetryTag[] {
 	const tags: TelemetryTag[] = [];
 
+	tags.push(args.provider, args.LanguageModel.id);
+
 	// OpenAI Web Search
 	if (args.provider === "openai" && args.toolSet.openaiWebSearch) {
 		tags.push("web-search", "openai:web-search");

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -3,14 +3,23 @@ import type { LanguageModel } from "@giselle-sdk/language-model";
 import type { ToolSet } from "ai";
 import { Langfuse } from "langfuse";
 
-type TelemetryTag =
-	// generic name
-	| "web-search"
-	// provider-specific function name
+type BaseFunctionalityTag = "web-search";
+
+type ProviderNameTag = "openai" | "anthropic" | "google" | "perplexity" | "fal";
+
+type ProviderOptionTag =
 	| "openai:web-search"
 	| "google:search-grounding"
 	| "anthropic:reasoning"
 	| "anthropic:thinking";
+
+type ModelNameTag = string;
+
+type TelemetryTag =
+	| BaseFunctionalityTag
+	| ProviderNameTag
+	| ProviderOptionTag
+	| ModelNameTag;
 
 let langfuseInstance: Langfuse | null = null;
 
@@ -32,7 +41,7 @@ export function generateTelemetryTags(args: {
 }): TelemetryTag[] {
 	const tags: TelemetryTag[] = [];
 
-	tags.push(args.provider, args.LanguageModel.id);
+	tags.push(args.provider, args.languageModel.id);
 
 	// OpenAI Web Search
 	if (args.provider === "openai" && args.toolSet.openaiWebSearch) {

--- a/packages/giselle-engine/src/core/types.ts
+++ b/packages/giselle-engine/src/core/types.ts
@@ -22,6 +22,7 @@ export interface GiselleEngineContext {
 		waitForFlushFn?: () => Promise<unknown>;
 	};
 	vault?: Vault;
+	userId?: string;
 }
 
 interface GitHubInstalltionAppAuthResolver {


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Add tags below to Langfuse trace:
- user ID
- provider name
- model name

## Related Issue
<!-- Mention the related issue number if applicable. -->

We already tagged traces with provider tool config by #815, but we need more analytical clues to make usage data analyzable

## Testing

New tags are observed:
<img width="441" alt="image" src="https://github.com/user-attachments/assets/5f2e217c-b214-4eb0-92d3-b3eb203a4934" />


## Other Information
<!-- Add any other relevant information for the reviewer. -->
