### PR TITLE
Improve GitHub trigger node naming for better readability

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/github-trigger-properties-panel.tsx
@@ -333,7 +333,7 @@ function Installed({
 						},
 					},
 					outputs: [...node.outputs, ...outputs],
-					name: trigger.event.label,
+					name: `On ${trigger.event.label}`,
 				});
 			});
 		},


### PR DESCRIPTION
## Summary
This PR improves the naming of GitHub trigger nodes in the workflow designer UI by prefixing trigger names with "On". For example, "Issue Created" becomes "On Issue Created". This change makes workflow diagrams more intuitive and readable.


https://github.com/user-attachments/assets/8a11ed1c-2037-45c2-a90f-b17c72b14538



## Changes
- Updated the node name format in the GitHub trigger properties panel to prefix event labels with "On"

## Test Plan
1. Create a new workflow
2. Add a GitHub trigger
3. Configure the trigger with any event
4. Verify that the node is named "On [Event Name]" in the workflow designer

## Screenshots
Before: Trigger nodes displayed only the event name
After: Trigger nodes display "On [Event Name]" for better readability