### PR TITLE
Enable manual triggers by default and remove state toggle UI

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/manual-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/manual-trigger-properties-panel.tsx
@@ -70,7 +70,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 					trigger: {
 						nodeId: node.id,
 						workspaceId: workspace?.id,
-						enable: false,
+						enable: true,
 						configuration: {
 							provider: "manual",
 							event: {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/manual-trigger-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/manual-trigger-configured-view.tsx
@@ -17,37 +17,6 @@ export function ManualTriggerConfiguredView({
 
 	return (
 		<div className="flex flex-col gap-[17px] p-0">
-			<div className="space-y-[4px]">
-				<p className="text-[14px] py-[1.5px] text-white-400">State</p>
-				<div className="px-[16px] py-[9px] w-full bg-transparent text-[14px]">
-					<div className="flex gap-[6px]">
-						{data.enable ? (
-							<>
-								<span>Enable</span>
-								<button
-									type="button"
-									onClick={disableFlowTrigger}
-									className="text-blue-900 cursor-pointer outline-none hover:underline"
-								>
-									→ Disable Trigger
-								</button>
-							</>
-						) : (
-							<>
-								<span>Disable</span>
-								<button
-									type="button"
-									onClick={enableFlowTrigger}
-									className="text-blue-900 cursor-pointer outline-none hover:underline"
-								>
-									→ Enable
-								</button>
-							</>
-						)}
-					</div>
-				</div>
-			</div>
-
 			{data.configuration.event.parameters.length > 0 && (
 				<div className="space-y-[4px]">
 					<p className="text-[14px] py-[1.5px] text-white-400">Parameters</p>


### PR DESCRIPTION
## Description

This PR simplifies the manual trigger UX by enabling manual triggers by default and removing the state toggle UI that was previously displayed in the configured view.

## Changes

- Change default enable state from `false` to `true` for new manual triggers
- Remove state section with enable/disable toggle from the configured view
- Simplify UI by removing redundant controls

## Testing

- Create a new workflow with a manual trigger
- Verify that the trigger is enabled by default
- Verify that the state toggle section is no longer displayed in the configured view
- Ensure that manual triggers can still be properly executed when a workflow is published

## Screenshots

*Please add any relevant screenshots showing the UI changes*

## Additional Notes

This change streamlines the user experience by making the most common configuration (enabled triggers) the default and removing unnecessary UI elements.