### PR TITLE
Add Dark Theme Support for Tooltips

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -302,13 +302,15 @@ export function NodeComponent({
 						/>
 						<div className="flex items-center gap-[2px] pl-[4px] text-[10px] text-white-300 font-mono [&>*:not(:last-child)]:after:content-['/'] [&>*:not(:last-child)]:after:ml-[2px] [&>*:not(:last-child)]:after:text-white-300">
 							{metadataTexts.map((item, index) => (
-								<Tooltip
-									key={item.label}
-									className="text-[10px] text-white-400"
-									text={item.tooltip}
-								>
-									<button type="button">{item.label}</button>
-								</Tooltip>
+								<div key={item.label} className="text-[10px] text-white-400">
+									{selected ? (
+										<Tooltip text={item.tooltip} variant="dark">
+											<button type="button">{item.label}</button>
+										</Tooltip>
+									) : (
+										item.label
+									)}
+								</div>
 							))}
 						</div>
 					</div>

--- a/internal-packages/workflow-designer-ui/src/ui/tooltip.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/tooltip.tsx
@@ -11,6 +11,7 @@ export type TooltipProps = Omit<
 	sideOffset?: number;
 	delayDuration?: number;
 	className?: string;
+	variant?: "light" | "dark";
 };
 
 export function Tooltip({
@@ -18,6 +19,7 @@ export function Tooltip({
 	sideOffset = 8,
 	delayDuration = 300,
 	className,
+	variant = "light",
 	...props
 }: TooltipProps) {
 	return (
@@ -26,15 +28,22 @@ export function Tooltip({
 				<TooltipPrimitive.Trigger asChild {...props} />
 				<TooltipPrimitive.Portal>
 					<TooltipPrimitive.Content
+						data-variant={variant}
 						className={clsx(
-							"z-50 overflow-hidden rounded-md bg-[#97A2BE] px-2 py-1 text-xs text-black-850 shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+							"group z-50 overflow-hidden rounded-md px-2 py-1 text-xs shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+							"data-[variant=light]:bg-[#97A2BE] data-[variant=light]:text-black-850",
+							"data-[variant=dark]:bg-black-850 data-[variant=dark]:text-white",
 							className,
 						)}
 						sideOffset={sideOffset}
 					>
 						{text}
 						<TooltipPrimitive.Arrow
-							className="fill-[#97A2BE] border-[hsla(232,36%,72%,0.2)]"
+							className={clsx(
+								"border-[hsla(232,36%,72%,0.2)]",
+								"group-data-[variant=light]:fill-[#97A2BE]",
+								"group-data-[variant=dark]:fill-black-850",
+							)}
 							width={12}
 							height={6}
 						/>


### PR DESCRIPTION
## Description
This PR enhances tooltip functionality in the workflow designer UI by adding a dark variant and improving tooltip behavior in node components.

### Changes
- Added a dark variant to the Tooltip component with appropriate styling
- Modified node component to conditionally display metadata tooltips only when a node is selected
- Ensured all code follows Biome formatting guidelines

## Why
This improves UI consistency in dark-themed interfaces and reduces visual clutter by showing tooltips only when relevant (node is selected).

## Test Plan
1. Open the workflow designer
2. Select a node to verify that metadata tooltips display correctly with the dark theme
3. Deselect the node to confirm tooltips are hidden
4. Verify tooltip styling is appropriate for dark interfaces

## Screenshots

Variant|Capture
------|-----
Light(Default)|<img width="128" alt="image" src="https://github.com/user-attachments/assets/b5dcd73f-a2b9-48db-9294-3f14abb67276" />
🆕 Dark|<img width="291" alt="image" src="https://github.com/user-attachments/assets/cd0c5f08-29d3-45d2-a597-8d0950d1fbf6" />
