### PR TITLE
Add copyItem method to blob-storage

### DIFF
--- a/packages/blob-storage/package.json
+++ b/packages/blob-storage/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@giselle-sdk/blob-storage",
+	"version": "0.0.0",
+	"private": true,
+	"main": "./dist/index.js",
+	"module": "./dist/index.mjs",
+	"types": "./dist/index.d.ts",
+	"files": ["dist/**"],
+	"scripts": {
+		"build": "tsup",
+		"check-types": "tsc --noEmit",
+		"format": "biome check --write ."
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js"
+		}
+	},
+	"devDependencies": {
+		"@giselle/giselle-sdk-tsconfig": "workspace:*",
+		"tsup": "catalog:"
+	},
+	"dependencies": {
+		"@supabase/supabase-js": "catalog:"
+	}
+}

--- a/packages/blob-storage/src/drivers/filesystem.ts
+++ b/packages/blob-storage/src/drivers/filesystem.ts
@@ -55,14 +55,12 @@ export function filesystemDriver(
 		async copyItem(from, to) {
 			const srcFile = toPath(base, from);
 			const dstFile = toPath(base, to);
-			const data = await fs.readFile(srcFile);
-			await ensureDir(dirname(dstFile));
-			await fs.writeFile(dstFile, data);
+			fs.copyFile(from, to);
 		},
 		async setItemRaw(key, value) {
 			const file = toPath(base, key);
 			await ensureDir(dirname(file));
-			await fs.writeFile(file, Buffer.from(value));
+			await fs.writeFile(file, value);
 		},
 		async getItemRaw(key) {
 			return await fs.readFile(toPath(base, key));

--- a/packages/blob-storage/src/drivers/filesystem.ts
+++ b/packages/blob-storage/src/drivers/filesystem.ts
@@ -1,6 +1,6 @@
 import { promises as fs, existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import type { BlobStorageDriver, GetKeysOptions, WatchCallback } from "..";
+import type { BlobStorageDriver, GetKeysOptions } from "..";
 
 export interface FilesystemDriverOptions {
 	base: string;
@@ -79,10 +79,6 @@ export function filesystemDriver(
 		async clear(prefix = "") {
 			const dir = toPath(base, prefix);
 			await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
-		},
-		async dispose() {},
-		async watch(_cb: WatchCallback) {
-			return async () => {};
 		},
 	};
 }

--- a/packages/blob-storage/src/drivers/filesystem.ts
+++ b/packages/blob-storage/src/drivers/filesystem.ts
@@ -1,0 +1,88 @@
+import { promises as fs, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import type { BlobStorageDriver, GetKeysOptions, WatchCallback } from "..";
+
+export interface FilesystemDriverOptions {
+	base: string;
+}
+
+function toPath(base: string, key: string) {
+	const normalized = key.replace(/:/g, "/");
+	return join(base, normalized);
+}
+
+async function ensureDir(dir: string) {
+	await fs.mkdir(dir, { recursive: true });
+}
+
+async function list(dir: string, base: string, files: string[]) {
+	const entries = await fs
+		.readdir(dir, { withFileTypes: true })
+		.catch(() => []);
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		const rel = full.slice(base.length + 1).replace(/\\/g, "/");
+		if (entry.isDirectory()) {
+			await list(full, base, files);
+		} else {
+			files.push(rel.replace(/\//g, ":"));
+		}
+	}
+	return files;
+}
+
+export function filesystemDriver(
+	options: FilesystemDriverOptions,
+): BlobStorageDriver {
+	const base = resolve(options.base);
+
+	return {
+		async hasItem(key) {
+			return existsSync(toPath(base, key));
+		},
+		async getItem(key) {
+			try {
+				return await fs.readFile(toPath(base, key), "utf8");
+			} catch {
+				return null;
+			}
+		},
+		async setItem(key, value) {
+			const file = toPath(base, key);
+			await ensureDir(dirname(file));
+			await fs.writeFile(file, value, "utf8");
+		},
+		async copyItem(from, to) {
+			const srcFile = toPath(base, from);
+			const dstFile = toPath(base, to);
+			const data = await fs.readFile(srcFile);
+			await ensureDir(dirname(dstFile));
+			await fs.writeFile(dstFile, data);
+		},
+		async setItemRaw(key, value) {
+			const file = toPath(base, key);
+			await ensureDir(dirname(file));
+			await fs.writeFile(file, Buffer.from(value));
+		},
+		async getItemRaw(key) {
+			return await fs.readFile(toPath(base, key));
+		},
+		async removeItem(key) {
+			try {
+				await fs.unlink(toPath(base, key));
+			} catch {}
+		},
+		async getKeys(prefix = "", _opts?: GetKeysOptions) {
+			const dir = toPath(base, prefix);
+			return list(dir, base, []);
+		},
+		async clear(prefix = "") {
+			const dir = toPath(base, prefix);
+			await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+		},
+		async dispose() {},
+		async watch(_cb: WatchCallback) {
+			return async () => {};
+		},
+	};
+}

--- a/packages/blob-storage/src/drivers/supabase.ts
+++ b/packages/blob-storage/src/drivers/supabase.ts
@@ -63,7 +63,6 @@ export function supabaseStorageDriver(
 	}
 
 	return {
-		name: "supabase-storage-driver",
 		async hasItem(key) {
 			const path = r(key);
 			const dirPath = path.split("/").slice(0, -1).join("/");
@@ -160,10 +159,6 @@ export function supabaseStorageDriver(
 				prefix ? joinKeys(prefix, item.name) : item.name,
 			);
 			await supabase.storage.from(bucket).remove(filePaths);
-		},
-		async dispose() {},
-		async watch() {
-			return async () => {};
 		},
 	};
 }

--- a/packages/blob-storage/src/drivers/supabase.ts
+++ b/packages/blob-storage/src/drivers/supabase.ts
@@ -1,0 +1,169 @@
+import { createClient } from "@supabase/supabase-js";
+import type {
+	BlobStorageDriver,
+	GetItemOptions,
+	GetKeysOptions,
+	SetItemOptions,
+	SetItemRawOptions,
+} from "..";
+import { joinKeys } from "..";
+
+export interface SupabaseStorageDriverOptions {
+	supabaseUrl: string;
+	supabaseServiceKey: string;
+	bucket: string;
+}
+
+const r = (key: string) => {
+	const path = key.startsWith("/") ? key.slice(1) : key;
+	return path.replace(/:/g, "/");
+};
+
+export function supabaseStorageDriver(
+	options: SupabaseStorageDriverOptions,
+): BlobStorageDriver {
+	const supabase = createClient(
+		options.supabaseUrl,
+		options.supabaseServiceKey,
+		{},
+	);
+	const bucket = options.bucket;
+
+	async function getNestedList(
+		prefix: string,
+		maxLevel = 4,
+		currentLevel = 0,
+	): Promise<string[]> {
+		if (currentLevel > maxLevel) {
+			return [];
+		}
+
+		const { data, error } = await supabase.storage.from(bucket).list(r(prefix));
+		if (error || !data) {
+			return [];
+		}
+
+		const results: string[] = [];
+		for (const item of data) {
+			const itemPath = joinKeys(prefix, item.name);
+			if (!item.id) {
+				if (currentLevel < maxLevel) {
+					const nestedFiles = await getNestedList(
+						itemPath,
+						maxLevel,
+						currentLevel + 1,
+					);
+					results.push(...nestedFiles);
+				}
+			} else {
+				results.push(itemPath);
+			}
+		}
+		return results;
+	}
+
+	return {
+		name: "supabase-storage-driver",
+		async hasItem(key) {
+			const path = r(key);
+			const dirPath = path.split("/").slice(0, -1).join("/");
+			const fileName = path.split("/").pop() || "";
+			const { data, error } = await supabase.storage
+				.from(bucket)
+				.list(dirPath, { search: fileName });
+			if (error) {
+				return false;
+			}
+			return !!data && data.length > 0;
+		},
+		async getItem(key, opts?: GetItemOptions) {
+			if (opts?.publicURL) {
+				const path = r(key);
+				const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+				return data.publicUrl || null;
+			}
+			let path = r(key);
+			if (opts?.bypassingCache) {
+				path = `${path}?timestamp=${Date.now()}`;
+			}
+			const { data, error } = await supabase.storage
+				.from(bucket)
+				.download(path);
+			if (error) {
+				return null;
+			}
+			return await data.text();
+		},
+		async setItem(key, value, opts?: SetItemOptions) {
+			const { cacheControlMaxAge, contentType } = opts || {};
+			const { error } = await supabase.storage
+				.from(bucket)
+				.upload(r(key), value, {
+					upsert: true,
+					cacheControl: cacheControlMaxAge,
+					contentType,
+				});
+			if (error) {
+				throw new Error(`Failed to set item at ${key}: ${error.message}`);
+			}
+		},
+		async copyItem(from, to) {
+			const { error } = await supabase.storage
+				.from(bucket)
+				.copy(r(from), r(to));
+			if (error) {
+				throw new Error(
+					`Failed to copy item from ${from} to ${to}: ${error.message}`,
+				);
+			}
+		},
+		async setItemRaw(key, value, opts?: SetItemRawOptions) {
+			const { contentType } = opts || {};
+			const { error } = await supabase.storage
+				.from(bucket)
+				.upload(r(key), value, {
+					upsert: true,
+					contentType,
+				});
+			if (error) {
+				throw new Error(`Failed to set item at ${key}: ${error.message}`);
+			}
+		},
+		async getItemRaw(key) {
+			const { data, error } = await supabase.storage
+				.from(bucket)
+				.download(r(key));
+			if (error || !data) {
+				throw new Error(
+					`Failed to get item at ${key}: ${error?.message || "Unknown error"}`,
+				);
+			}
+			return await data.arrayBuffer();
+		},
+		async removeItem(key) {
+			const { error } = await supabase.storage.from(bucket).remove([r(key)]);
+			if (error) {
+				throw new Error(`Failed to remove item at ${key}: ${error.message}`);
+			}
+		},
+		async getKeys(base, opts?: GetKeysOptions) {
+			const level = opts?.level || 2;
+			return getNestedList(base, level);
+		},
+		async clear(base) {
+			const prefix = base ? r(base) : "";
+			const { data, error } = await supabase.storage.from(bucket).list(prefix);
+			if (error || !data || data.length === 0) {
+				return;
+			}
+			const filePaths = data.map((item) =>
+				prefix ? joinKeys(prefix, item.name) : item.name,
+			);
+			await supabase.storage.from(bucket).remove(filePaths);
+		},
+		async dispose() {},
+		async watch() {
+			return async () => {};
+		},
+	};
+}

--- a/packages/blob-storage/src/index.ts
+++ b/packages/blob-storage/src/index.ts
@@ -16,9 +16,6 @@ export interface GetKeysOptions {
 	level?: number;
 }
 
-export type WatchEvent = "update" | "remove";
-export type WatchCallback = (event: WatchEvent, key: string) => void;
-
 export interface BlobStorageDriver {
 	hasItem(key: string, opts?: Record<string, unknown>): Promise<boolean>;
 	getItem(key: string, opts?: GetItemOptions): Promise<unknown>;
@@ -40,8 +37,6 @@ export interface BlobStorageDriver {
 	removeItem?(key: string, opts?: Record<string, unknown>): Promise<void>;
 	getKeys?(base: string, opts?: GetKeysOptions): Promise<string[]>;
 	clear?(base: string, opts?: Record<string, unknown>): Promise<void>;
-	dispose?(): Promise<void>;
-	watch?(callback: WatchCallback): Promise<() => void>;
 }
 
 export function defineDriver<O>(factory: (opts: O) => BlobStorageDriver) {

--- a/packages/blob-storage/src/index.ts
+++ b/packages/blob-storage/src/index.ts
@@ -1,0 +1,62 @@
+export interface GetItemOptions {
+	bypassingCache?: boolean;
+	publicURL?: boolean;
+}
+
+export interface SetItemOptions {
+	cacheControlMaxAge?: number;
+	contentType?: string;
+}
+
+export interface SetItemRawOptions {
+	contentType?: string;
+}
+
+export interface GetKeysOptions {
+	level?: number;
+}
+
+export type WatchEvent = "update" | "remove";
+export type WatchCallback = (event: WatchEvent, key: string) => void;
+
+export interface BlobStorageDriver {
+	hasItem(key: string, opts?: Record<string, unknown>): Promise<boolean>;
+	getItem(key: string, opts?: GetItemOptions): Promise<unknown>;
+	setItem(key: string, value: string, opts?: SetItemOptions): Promise<void>;
+	copyItem?(
+		from: string,
+		to: string,
+		opts?: Record<string, unknown>,
+	): Promise<void>;
+	setItemRaw?(
+		key: string,
+		value: ArrayBuffer | Uint8Array | Buffer,
+		opts?: SetItemRawOptions,
+	): Promise<void>;
+	getItemRaw?(
+		key: string,
+		opts?: Record<string, unknown>,
+	): Promise<ArrayBuffer | Uint8Array | Buffer | null>;
+	removeItem?(key: string, opts?: Record<string, unknown>): Promise<void>;
+	getKeys?(base: string, opts?: GetKeysOptions): Promise<string[]>;
+	clear?(base: string, opts?: Record<string, unknown>): Promise<void>;
+	dispose?(): Promise<void>;
+	watch?(callback: WatchCallback): Promise<() => void>;
+}
+
+export function defineDriver<O>(factory: (opts: O) => BlobStorageDriver) {
+	return factory;
+}
+
+export function createStorage(options: {
+	driver: BlobStorageDriver;
+}): BlobStorageDriver {
+	return options.driver;
+}
+
+export function joinKeys(...keys: string[]): string {
+	return keys
+		.map((k) => k.replace(/^:+|:+$/g, ""))
+		.filter(Boolean)
+		.join(":");
+}

--- a/packages/blob-storage/tsconfig.json
+++ b/packages/blob-storage/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": "@giselle/giselle-sdk-tsconfig/react-library.json",
+	"include": ["."],
+	"exclude": ["node_modules"]
+}

--- a/packages/blob-storage/tsup.config.ts
+++ b/packages/blob-storage/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: ["cjs", "esm"],
+	dts: true,
+	sourcemap: true,
+});

--- a/packages/blob-storage/turbo.json
+++ b/packages/blob-storage/turbo.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["**/dist/**"]
+		},
+		"test": {}
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,6 +1108,19 @@ importers:
         specifier: 'catalog:'
         version: 8.3.5(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
 
+  packages/blob-storage:
+    dependencies:
+      '@supabase/supabase-js':
+        specifier: 'catalog:'
+        version: 2.45.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+    devDependencies:
+      '@giselle/giselle-sdk-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: 'catalog:'
+        version: 8.3.5(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
+
   packages/telemetry:
     dependencies:
       ai:


### PR DESCRIPTION
## Summary
- extend `BlobStorageDriver` interface with optional `copyItem`
- implement `copyItem` for filesystem and Supabase drivers

## Testing
- `npx biome check packages/blob-storage --write`
- `pnpm test` *(fails: corepack cannot download pnpm during studio.giselles.ai tests)*