### PR TITLE
Add Zed editor test runner configuration

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,9 @@
+[
+	{
+		"label": "test with symbol",
+		"command": "pnpm vitest watch",
+		"cwd": "$ZED_DIRNAME",
+		"args": ["$ZED_FILENAME", "--testNamePattern", "$ZED_SYMBOL"],
+		"tags": ["js-test", "ts-test", "tsx-test"]
+	}
+]


### PR DESCRIPTION
## Description
This PR adds configuration for the Zed editor to run Vitest tests with symbol support. This enhances the developer experience by allowing tests to be run more efficiently directly from the editor.


https://github.com/user-attachments/assets/72203943-5336-48b3-b495-00ad7c5beaf1



## Changes
- Added `.zed/tasks.json` with configuration for running Vitest tests
- Configuration includes support for running tests with current symbol

## Testing
- Verified that the configuration works correctly with Zed editor
- Ran Biome check to ensure the configuration file follows project standards

## Additional Notes
This configuration is specific to users of the Zed editor and doesn't affect functionality for users of other editors.