### PR TITLE
refactor: deprecate legacy integration settings processing for future trigger node GitHub integration

### DIFF
--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -102,6 +102,28 @@ export async function handleWebhook(args: HandleGitHubWebhookArgs) {
 		});
 
 	const command = parseCommandFromEvent(gitHubEvent);
+
+	const results = await processMatchedIntegrationSettingsDeprecated(
+		gitHubEvent,
+		args,
+		repository,
+		command,
+		workspaceGitHubIntegrationRepositorySettings,
+	);
+	return results;
+}
+
+// Extracted for legacy parallel execution.
+// @deprecated This function will be removed in the future. Please use the new webhook processing method.
+async function processMatchedIntegrationSettingsDeprecated(
+	gitHubEvent: GitHubEvent,
+	args: HandleGitHubWebhookArgs,
+	repository: { owner: string; name: string; nodeId: string },
+	command: Command | null,
+	workspaceGitHubIntegrationRepositorySettings:
+		| WorkspaceGitHubIntegrationSetting[]
+		| undefined,
+): Promise<HandleGitHubWebhookResult[]> {
 	const matchedIntegrationSettings =
 		workspaceGitHubIntegrationRepositorySettings?.filter((setting) =>
 			isMatchingIntegrationSetting(setting, gitHubEvent, command),


### PR DESCRIPTION
This pull request prepares for implementing GitHub integration via trigger nodes, while preserving the existing GitHub integration code. No new implementation is included in this PR; it only refactors and marks the legacy integration settings processing as deprecated for future removal.

- Extracted legacy integration settings processing to a separate function
- Marked as deprecated in both function name and comments (English)
- No functional changes or new features are introduced

This is a preparatory step for future enhancements.