### PR TITLE
Refactor: Remove unused providerOptions parameter from generateImage function

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-image.ts
+++ b/packages/giselle-engine/src/core/generations/generate-image.ts
@@ -46,14 +46,9 @@ import {
 	setNodeGenerationIndex,
 } from "./utils";
 
-type ProviderOptions = Parameters<
-	typeof generateImageAiSdk
->[0]["providerOptions"];
-
 export async function generateImage(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
-	providerOptions?: ProviderOptions;
 	telemetry?: TelemetrySettings;
 }) {
 	const operationNode = args.generation.context.operationNode;


### PR DESCRIPTION
## Summary

This PR removes an unused parameter from the generateImage function signature in the giselle-engine package. The providerOptions parameter was not being used in the main function as provider-specific options are handled directly in the provider-specific functions.

## Changes

- Removed the providerOptions parameter from the generateImage function signature
- Removed the associated type definition that was only used for this parameter

## Test Plan

- All existing tests should continue to pass
- The functionality remains unchanged as the parameter was unused

## Additional Information

Cleanup of unused code to improve maintainability and readability.