### PR TITLE
Include cost (for display not billing) to Langfuse

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -507,11 +507,11 @@ export async function generateText(args: {
 					inputCost: costInfo?.inputCostForDisplay ?? 0,
 					outputCost: costInfo?.outputCostForDisplay ?? 0,
 					totalCost: costInfo?.totalCostForDisplay ?? 0,
+					unit: "TOKENS",
 				},
 				completedGeneration,
 				spanName: "ai.streamText",
 				generationName: "ai.streamText.doStream",
-				unit: "TOKENS",
 				settings: args.telemetry,
 			});
 			await Promise.all(

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -148,11 +148,7 @@ export function createLangfuseTracer({
 		modelParameters:
 			runningGeneration.context.operationNode.content.llm.configurations,
 		input: messages,
-		usage: {
-			input: usage.input,
-			output: usage.output,
-			unit,
-		},
+		usage,
 		startTime: new Date(runningGeneration.createdAt),
 		completionStartTime: new Date(runningGeneration.startedAt),
 		metadata: settings?.metadata,

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -95,7 +95,6 @@ export function createLangfuseTracer({
 	completedGeneration,
 	spanName,
 	generationName,
-	unit,
 	settings,
 }: {
 	workspaceId: string;
@@ -110,11 +109,11 @@ export function createLangfuseTracer({
 		inputCost: number; // these cost values are for preliminary analysis on Langfuse, not for billing purpose
 		outputCost: number;
 		totalCost: number;
+		unit: LangfuseUnit;
 	};
 	completedGeneration: CompletedGeneration;
 	spanName: string;
 	generationName: string;
-	unit: LangfuseUnit;
 	settings?: TelemetrySettings;
 }): {
 	langfuse: Langfuse;


### PR DESCRIPTION
## Summary

Fix construction of telemetry data to send cost info to Langfuse correctly
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue

- #834 calculated the cost info but failed to include them in telemetry

## Testing
<!-- Briefly describe the testing steps or results. -->

Cost info of OpenAI model arrived ✅
<img width="722" alt="image" src="https://github.com/user-attachments/assets/9cd2dd29-61ad-481e-b0aa-18296236b1fe" />

Cost info of Anthropic model is blank as expected ✅ 
- Because their unit price is not implemented yet (will be added by #872)

<img width="793" alt="image" src="https://github.com/user-attachments/assets/3a1ed519-9fa5-4f5c-9fa6-6aea74c4b520" />

But in auto-instrumented telemetry, cost is ["inferred" by usage](https://langfuse.com/docs/model-usage-and-cost#infer)