### PR TITLE
Calculate display-only cost of Anthropic model usage

### DIFF
--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import { Capability, LanguageModelBase, Tier } from "./base";
 import {
+	BaseCostCalculator,
 	type CostCalculator,
 	type CostResultForDisplay,
-	BaseCostCalculator,
 } from "./costs/calculator";
 import { anthropicTokenPricing } from "./costs/model-prices";
 import type { ModelTokenUsage } from "./costs/usage";

--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 import { Capability, LanguageModelBase, Tier } from "./base";
+import {
+	type CostCalculator,
+	type CostResultForDisplay,
+	type ModelTokenUsage,
+	anthropicTokenPricing,
+	calculateTokenCostForDisplay,
+	getValidPricing,
+} from "./costs";
 
 const AnthropicLanguageModelConfigurations = z.object({
 	temperature: z.number(),
@@ -58,3 +66,13 @@ export const models = [claude37Sonnet, claude35Sonnet, claude35Haiku];
 
 export const LanguageModel = AnthropicLanguageModel;
 export type LanguageModel = AnthropicLanguageModel;
+
+export class AnthropicCostCalculator implements CostCalculator {
+	async calculate(
+		modelId: string,
+		usage: ModelTokenUsage,
+	): Promise<CostResultForDisplay> {
+		const validPrice = getValidPricing(modelId, anthropicTokenPricing);
+		return calculateTokenCostForDisplay(usage, validPrice.price);
+	}
+}

--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -3,11 +3,10 @@ import { Capability, LanguageModelBase, Tier } from "./base";
 import {
 	type CostCalculator,
 	type CostResultForDisplay,
-	type ModelTokenUsage,
-	anthropicTokenPricing,
-	calculateTokenCostForDisplay,
-	getValidPricing,
-} from "./costs";
+	BaseCostCalculator,
+} from "./costs/calculator";
+import { anthropicTokenPricing } from "./costs/model-prices";
+import type { ModelTokenUsage } from "./costs/usage";
 
 const AnthropicLanguageModelConfigurations = z.object({
 	temperature: z.number(),
@@ -67,12 +66,8 @@ export const models = [claude37Sonnet, claude35Sonnet, claude35Haiku];
 export const LanguageModel = AnthropicLanguageModel;
 export type LanguageModel = AnthropicLanguageModel;
 
-export class AnthropicCostCalculator implements CostCalculator {
-	async calculate(
-		modelId: string,
-		usage: ModelTokenUsage,
-	): Promise<CostResultForDisplay> {
-		const validPrice = getValidPricing(modelId, anthropicTokenPricing);
-		return calculateTokenCostForDisplay(usage, validPrice.price);
+export class AnthropicCostCalculator extends BaseCostCalculator {
+	protected getPricingTable() {
+		return anthropicTokenPricing;
 	}
 }

--- a/packages/language-model/src/costs/calculator.ts
+++ b/packages/language-model/src/costs/calculator.ts
@@ -30,8 +30,20 @@ export abstract class BaseCostCalculator implements CostCalculator {
 		modelId: string,
 		usage: ModelTokenUsage,
 	): Promise<CostResultForDisplay> {
-		const validPrice = getValidPricing(modelId, this.getPricingTable());
-		return calculateTokenCostForDisplay(usage, validPrice.price);
+		try {
+			const validPrice = getValidPricing(modelId, this.getPricingTable());
+			return calculateTokenCostForDisplay(usage, validPrice.price);
+		} catch (error) {
+			console.error(
+				`Error calculating cost for model ${modelId}:`,
+				error,
+			);
+			return {
+				input: 0,
+				output: 0,
+				total: 0,
+			};
+		}
 	}
 }
 

--- a/packages/language-model/src/costs/calculator.ts
+++ b/packages/language-model/src/costs/calculator.ts
@@ -1,6 +1,8 @@
 import type { BaseTokenPrice, Cost, TokenBasedPricing } from "./pricing";
 import { tokensToMegaTokens } from "./pricing";
-import type { ModelTokenUsage, ModelUsage } from "./usage";
+import type { ModelTokenUsage } from "./usage";
+import type { ModelPriceTable } from "./model-prices";
+import { getValidPricing } from "./model-prices";
 
 /**
  * For preliminary feedback on UI and LLM o11y platform
@@ -17,19 +19,37 @@ export interface CostResultForDisplay {
  * All provider-specific configurations should extend this interface
  * and be defined in their respective provider files.
  */
-export interface CostCalculator<TUsage extends ModelUsage = ModelTokenUsage> {
-	calculate(model: string, usage: TUsage): Promise<CostResultForDisplay>;
+export interface CostCalculator {
+	calculate(model: string, usage: ModelTokenUsage): Promise<CostResultForDisplay>;
+}
+
+export abstract class BaseCostCalculator implements CostCalculator {
+	protected abstract getPricingTable(): ModelPriceTable;
+
+	async calculate(
+		modelId: string,
+		usage: ModelTokenUsage,
+	): Promise<CostResultForDisplay> {
+		const validPrice = getValidPricing(modelId, this.getPricingTable());
+		return calculateTokenCostForDisplay(usage, validPrice.price);
+	}
 }
 
 export class DefaultCostCalculator implements CostCalculator {
-	constructor(private provider: string) {}
+	constructor(private readonly provider: string) {}
 
 	async calculate(
-		model: string,
-		usage: ModelUsage,
+		modelId: string,
+		usage: ModelTokenUsage,
 	): Promise<CostResultForDisplay> {
-		console.log(`No cost calculator found for ${this.provider}`);
-		return { input: 0, output: 0, total: 0 };
+		console.log(
+			`Cost calculation not implemented for provider: ${this.provider}, model: ${modelId}`,
+		);
+		return {
+			input: 0,
+			output: 0,
+			total: 0,
+		};
 	}
 }
 
@@ -51,9 +71,8 @@ export function calculateTokenCostForDisplay(
 		pricing.output.costPerMegaToken * dollarToCent * tokensPerMegaToken;
 
 	// Calculate costs in cents using integer arithmetic
-	const inputCostInCents = usage.promptTokens * inputCostPerMegaTokenInCents;
-	const outputCostInCents =
-		usage.completionTokens * outputCostPerMegaTokenInCents;
+	const inputCostInCents = usage.inputTokens * inputCostPerMegaTokenInCents;
+	const outputCostInCents = usage.outputTokens * outputCostPerMegaTokenInCents;
 	const totalCostInCents = inputCostInCents + outputCostInCents;
 
 	// Convert back to dollars by dividing by 1,000,000 (mega tokens) and 100 (cents)

--- a/packages/language-model/src/costs/calculator.ts
+++ b/packages/language-model/src/costs/calculator.ts
@@ -26,6 +26,10 @@ export interface CostCalculator {
 export abstract class BaseCostCalculator implements CostCalculator {
 	protected abstract getPricingTable(): ModelPriceTable;
 
+	protected getProviderName(): string {
+		return this.constructor.name.replace("CostCalculator", "");
+	}
+
 	async calculate(
 		modelId: string,
 		usage: ModelTokenUsage,
@@ -35,7 +39,7 @@ export abstract class BaseCostCalculator implements CostCalculator {
 			return calculateTokenCostForDisplay(usage, validPrice.price);
 		} catch (error) {
 			console.error(
-				`Error calculating cost for model ${modelId}:`,
+				`Error calculating cost for ${this.getProviderName()} model ${modelId}:`,
 				error,
 			);
 			return {

--- a/packages/language-model/src/costs/calculator.ts
+++ b/packages/language-model/src/costs/calculator.ts
@@ -1,8 +1,8 @@
+import type { ModelPriceTable } from "./model-prices";
+import { getValidPricing } from "./model-prices";
 import type { BaseTokenPrice, Cost, TokenBasedPricing } from "./pricing";
 import { tokensToMegaTokens } from "./pricing";
 import type { ModelTokenUsage } from "./usage";
-import type { ModelPriceTable } from "./model-prices";
-import { getValidPricing } from "./model-prices";
 
 /**
  * For preliminary feedback on UI and LLM o11y platform
@@ -20,7 +20,10 @@ export interface CostResultForDisplay {
  * and be defined in their respective provider files.
  */
 export interface CostCalculator {
-	calculate(model: string, usage: ModelTokenUsage): Promise<CostResultForDisplay>;
+	calculate(
+		model: string,
+		usage: ModelTokenUsage,
+	): Promise<CostResultForDisplay>;
 }
 
 export abstract class BaseCostCalculator implements CostCalculator {

--- a/packages/language-model/src/costs/index.ts
+++ b/packages/language-model/src/costs/index.ts
@@ -1,6 +1,7 @@
 export * from "./pricing";
 export {
 	openAiTokenPricing,
+	anthropicTokenPricing,
 	getValidPricing,
 	type ModelPriceTable,
 } from "./model-prices";

--- a/packages/language-model/src/costs/index.ts
+++ b/packages/language-model/src/costs/index.ts
@@ -9,6 +9,7 @@ export type { ModelTokenUsage } from "./usage";
 export { calculateTokenCostForDisplay } from "./calculator";
 export type { CostCalculator, CostResultForDisplay } from "./calculator";
 
+import { AnthropicCostCalculator } from "../anthropic";
 import { OpenAICostCalculator } from "../openai";
 import type { CostCalculator } from "./calculator";
 import { DefaultCostCalculator } from "./calculator";
@@ -17,6 +18,8 @@ export function createDisplayCostCalculator(provider: string): CostCalculator {
 	switch (provider) {
 		case "openai":
 			return new OpenAICostCalculator();
+		case "anthropic":
+			return new AnthropicCostCalculator();
 		default:
 			console.log(`Unimplemented provider: ${provider}`);
 			return new DefaultCostCalculator(provider);

--- a/packages/language-model/src/costs/index.ts
+++ b/packages/language-model/src/costs/index.ts
@@ -33,7 +33,8 @@ export async function calculateDisplayCost(
 ) {
 	const calculator = createDisplayCostCalculator(provider);
 	const result = await calculator.calculate(modelId, {
-		...usage,
+		inputTokens: usage.promptTokens,
+		outputTokens: usage.completionTokens,
 		totalTokens: usage.promptTokens + usage.completionTokens,
 	});
 	return {

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -111,6 +111,55 @@ export const openAiTokenPricing: ModelPriceTable = {
 	},
 };
 
+export const anthropicTokenPricing: ModelPriceTable = {
+	// https://www.anthropic.com/pricing
+	"claude-3-7-sonnet-20250219": {
+		prices: [
+			{
+				validFrom: "2025-05-19T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 3.0,
+					},
+					output: {
+						costPerMegaToken: 15.0,
+					},
+				},
+			},
+		],
+	},
+	"claude-3-5-sonnet-20241022": {
+		prices: [
+			{
+				validFrom: "2025-05-19T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 3.0,
+					},
+					output: {
+						costPerMegaToken: 15.0,
+					},
+				},
+			},
+		],
+	},
+	"claude-3-5-haiku-20241022": {
+		prices: [
+			{
+				validFrom: "2025-05-19T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.8,
+					},
+					output: {
+						costPerMegaToken: 4.0,
+					},
+				},
+			},
+		],
+	},
+};
+
 export function getValidPricing(
 	modelId: string,
 	priceTable: ModelPriceTable,

--- a/packages/language-model/src/costs/usage.ts
+++ b/packages/language-model/src/costs/usage.ts
@@ -1,7 +1,5 @@
-export type ModelTokenUsage = {
-	promptTokens: number;
-	completionTokens: number;
+export interface ModelTokenUsage {
+	inputTokens: number;
+	outputTokens: number;
 	totalTokens: number;
-};
-
-export type ModelUsage = ModelTokenUsage;
+}

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -14,6 +14,7 @@ import {
 	getValidPricing,
 	openAiTokenPricing,
 } from "./costs";
+import { BaseCostCalculator } from "./costs/calculator";
 
 const OpenAILanguageModelConfigurations = z.object({
 	temperature: z.number(),
@@ -144,12 +145,8 @@ export const models = [
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;
 
-export class OpenAICostCalculator implements CostCalculator {
-	async calculate(
-		modelId: string,
-		usage: ModelTokenUsage,
-	): Promise<CostResultForDisplay> {
-		const validPrice = getValidPricing(modelId, openAiTokenPricing);
-		return calculateTokenCostForDisplay(usage, validPrice.price);
+export class OpenAICostCalculator extends BaseCostCalculator {
+	protected getPricingTable() {
+		return openAiTokenPricing;
 	}
 }


### PR DESCRIPTION
## Summary

Calculate cost for displaying preliminary value, not for billing, of Anthropic models

## Related Issue

- part of #796 

## Testing

Cost of Anthropic models, whose cost was blank in #871, calculated and set as expected ✅ 
<img width="719" alt="image" src="https://github.com/user-attachments/assets/8f4de3a8-21ee-4633-802e-7d1a12c5fbf9" />

## Other information

The base branch is set to `telemetry-include-cost` to use changes that will be added in #871 (send calculated cost to Langfuse)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for cost calculation of Anthropic language models, including pricing for several Claude models.
  - Users can now view token cost estimates for Anthropic models in addition to existing providers.
- **Refactor**
  - Simplified and unified cost calculation logic with a new base calculator class.
  - Updated token usage terminology for clearer input/output distinction.
  - Improved cost calculation accuracy and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->