### PR TITLE
Add workspaceId to GenerationOriginRun schema and implement data-mod

### DIFF
--- a/packages/data-mod/src/index.ts
+++ b/packages/data-mod/src/index.ts
@@ -1,6 +1,7 @@
 import type { ZodIssue, ZodSchema, z } from "zod";
 import { addAccessorToInput } from "./mods/add-accessor-to-input";
 import { addOverrideNodes } from "./mods/add-override-nodes";
+import { addWorkspaceIdToOriginRun } from "./mods/add-workspace-id-to-origin-run";
 import { fixTypoAccesorToAccessor } from "./mods/fix-typo-accesor-to-accessor";
 import { fixTypoQuquedAtToQueuedAt } from "./mods/fix-typo-ququedAt-queuedAt";
 import { renameActionToOperation } from "./mods/rename-action-to-operation";
@@ -12,6 +13,7 @@ export function dataMod(data: unknown, issue: ZodIssue) {
 	modData = fixTypoQuquedAtToQueuedAt(modData, issue);
 	modData = renameActionToOperation(modData, issue);
 	modData = addAccessorToInput(modData, issue);
+	modData = addWorkspaceIdToOriginRun(modData, issue);
 	return modData;
 }
 

--- a/packages/data-mod/src/mods/add-workspace-id-to-origin-run.test.ts
+++ b/packages/data-mod/src/mods/add-workspace-id-to-origin-run.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import type { ZodIssue } from "zod";
+import { addWorkspaceIdToOriginRun } from "./add-workspace-id-to-origin-run";
+
+describe("addWorkspaceIdToOriginRun", () => {
+	it("should add workspaceId to GenerationOriginRun when missing", () => {
+		const data = {
+			context: {
+				origin: {
+					type: "run",
+					id: "run-123456",
+				},
+			},
+		};
+
+		const issue: ZodIssue = {
+			code: "invalid_type",
+			expected: "string",
+			received: "undefined",
+			path: ["context", "origin", "workspaceId"],
+			message: "Required",
+		};
+
+		const result = addWorkspaceIdToOriginRun(data, issue);
+
+		expect(result).toEqual({
+			context: {
+				origin: {
+					type: "run",
+					id: "run-123456",
+					workspaceId: "wrks-9999999999999999",
+				},
+			},
+		});
+	});
+
+	it("should extract workspaceId from context when available", () => {
+		const data = {
+			context: {
+				origin: {
+					type: "workspace",
+					id: "wrks-abcdef",
+				},
+				someOtherField: {
+					origin: {
+						type: "run",
+						id: "run-123456",
+					},
+				},
+			},
+		};
+
+		const issue: ZodIssue = {
+			code: "invalid_type",
+			expected: "string",
+			received: "undefined",
+			path: ["context", "someOtherField", "origin", "workspaceId"],
+			message: "Required",
+		};
+
+		const result = addWorkspaceIdToOriginRun(data, issue);
+
+		expect(result).toEqual({
+			context: {
+				origin: {
+					type: "workspace",
+					id: "wrks-abcdef",
+				},
+				someOtherField: {
+					origin: {
+						type: "run",
+						id: "run-123456",
+						workspaceId: "wrks-abcdef",
+					},
+				},
+			},
+		});
+	});
+
+	it("should not modify data when issue is not related to workspaceId", () => {
+		const data = {
+			context: {
+				origin: {
+					type: "run",
+					id: "run-123456",
+				},
+			},
+		};
+
+		const issue: ZodIssue = {
+			code: "invalid_type",
+			expected: "string",
+			received: "undefined",
+			path: ["context", "origin", "someOtherField"],
+			message: "Required",
+		};
+
+		const result = addWorkspaceIdToOriginRun(data, issue);
+
+		expect(result).toBe(data);
+	});
+
+	it("should not modify data when path doesn't include origin", () => {
+		const data = {
+			context: {
+				someField: {
+					id: "run-123456",
+					type: "run",
+				},
+			},
+		};
+
+		const issue: ZodIssue = {
+			code: "invalid_type",
+			expected: "string",
+			received: "undefined",
+			path: ["context", "someField", "workspaceId"],
+			message: "Required",
+		};
+
+		const result = addWorkspaceIdToOriginRun(data, issue);
+
+		expect(result).toBe(data);
+	});
+
+	it("should not modify data when origin type is not run", () => {
+		const data = {
+			context: {
+				origin: {
+					type: "workspace",
+					id: "wrks-123456",
+				},
+			},
+		};
+
+		const issue: ZodIssue = {
+			code: "invalid_type",
+			expected: "string",
+			received: "undefined",
+			path: ["context", "origin", "workspaceId"],
+			message: "Required",
+		};
+
+		const result = addWorkspaceIdToOriginRun(data, issue);
+
+		expect(result).toBe(data);
+	});
+
+	it("should handle non-object data", () => {
+		const data = "not an object";
+
+		const issue: ZodIssue = {
+			code: "invalid_type",
+			expected: "string",
+			received: "undefined",
+			path: ["context", "origin", "workspaceId"],
+			message: "Required",
+		};
+
+		const result = addWorkspaceIdToOriginRun(data, issue);
+
+		expect(result).toBe(data);
+	});
+});

--- a/packages/data-mod/src/mods/add-workspace-id-to-origin-run.ts
+++ b/packages/data-mod/src/mods/add-workspace-id-to-origin-run.ts
@@ -1,0 +1,66 @@
+import type { ZodIssue } from "zod";
+import { getValueAtPath, isObject, setValueAtPath } from "../utils";
+
+/**
+ * Adds workspaceId to GenerationOriginRun objects when missing
+ * This handles the schema change where workspaceId was added to GenerationOriginRun
+ * When adding workspaceId via this mod, we use a fixed value "wrks-9999999999999999"
+ * to make it clear the ID was automatically added by the data-mod system
+ */
+export function addWorkspaceIdToOriginRun(data: unknown, issue: ZodIssue) {
+	// Check if this is an issue with a missing required workspaceId field in an origin object
+	const pathLen = issue.path.length;
+	if (
+		pathLen < 2 ||
+		issue.path[pathLen - 1] !== "workspaceId" ||
+		issue.path[pathLen - 2] !== "origin"
+	) {
+		return data;
+	}
+
+	if (!isObject(data)) {
+		return data;
+	}
+
+	// Get the origin object
+	const originPath = issue.path.slice(0, -1);
+	const origin = getValueAtPath(data, originPath);
+
+	// Verify this is a run type origin
+	if (!origin || typeof origin !== "object" || origin.type !== "run") {
+		return data;
+	}
+
+	// Clone the data to avoid mutating the original
+	const newData = { ...data };
+
+	// Get workspace ID from context if available
+	let workspaceId: string | undefined;
+	const contextPath = issue.path.slice(0, issue.path.indexOf("origin") - 1);
+	const context = getValueAtPath(data, contextPath);
+
+	if (context && typeof context === "object") {
+		// Try to find workspaceId in other parts of the context
+		if (
+			context.origin &&
+			typeof context.origin === "object" &&
+			context.origin.id
+		) {
+			// If origin.type is "workspace", use that ID
+			if (context.origin.type === "workspace") {
+				workspaceId = context.origin.id;
+			}
+		}
+	}
+
+	// If we couldn't find the workspaceId, use a fixed placeholder value
+	// This makes it clear the ID was automatically added by the data-mod system
+	if (!workspaceId) {
+		workspaceId = "wrks-9999999999999999";
+	}
+
+	// Set the workspaceId in the origin
+	setValueAtPath(newData, [...originPath, "workspaceId"], workspaceId);
+
+	return newData;
+}

--- a/packages/data-type/src/generation/context.ts
+++ b/packages/data-type/src/generation/context.ts
@@ -28,6 +28,7 @@ export type GenerationOriginWorkspace = z.infer<
 
 export const GenerationOriginRun = z.object({
 	id: RunId.schema,
+	workspaceId: WorkspaceId.schema,
 	type: GenerationOriginTypeRun,
 });
 export type GenerationOriginRun = z.infer<typeof GenerationOriginRun>;

--- a/packages/giselle-engine/src/core/runs/add-run.ts
+++ b/packages/giselle-engine/src/core/runs/add-run.ts
@@ -86,6 +86,7 @@ async function copyFiles({
 				fileId,
 				type: "run",
 				id: queuedRun.id,
+				workspaceId: queuedRun.workspaceId,
 			});
 			await storage.setItemRaw(runFilePath, fileContent);
 		}),

--- a/packages/giselle-engine/src/react/run/contexts/run-system.tsx
+++ b/packages/giselle-engine/src/react/run/contexts/run-system.tsx
@@ -130,7 +130,7 @@ export function RunSystemContextProvider({
 						}
 						await startGeneration(
 							{
-								origin: { type: "run", id: runId },
+								origin: { type: "run", id: runId, workspaceId },
 								...operation.generationTemplate,
 							},
 							{


### PR DESCRIPTION
## Description

This PR adds the `workspaceId` field to the `GenerationOriginRun` schema and implements a data-mod to maintain backward compatibility with existing data.

### Motivation

This change simplifies the workspaceId extraction process in `generate-text.ts`. Currently, when processing generations with origins of type "run", we need to extract the workspaceId using a separate function call. By adding workspaceId directly to the GenerationOriginRun schema, we can access it directly without the extra extraction step.

### Changes

- Added `workspaceId: WorkspaceId.schema` to the `GenerationOriginRun` schema in `data-type`
- Created a new data-mod `addWorkspaceIdToOriginRun` that automatically adds the workspaceId field with a placeholder value when missing
- Added comprehensive tests for the data-mod
- Integrated the new data-mod into the main processing pipeline

### Impact

- Improved code clarity and reduced complexity in generation processing
- Maintained backward compatibility with existing data through the data-mod
- Used a clearly identifiable placeholder value (`wrks-9999999999999999`) when automatically adding workspaceId to make these cases easy to identify

## Testing

All tests for the data-mod pass successfully, verifying that the transformation works as expected in all relevant scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a required workspace ID in run origin objects, enhancing linkage between runs and workspaces.
- **Bug Fixes**
  - Improved data handling to automatically add missing workspace IDs to run origins when needed.
- **Tests**
  - Introduced comprehensive tests to verify correct addition of workspace IDs in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->