### PR TITLE
Ensure telemetry being flushed before function ends

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -486,7 +486,7 @@ export async function generateText(args: {
 			});
 
 			// necessary to send telemetry but not explicitly used
-			const _langfuseTracer = createLangfuseTracer({
+			const { langfuse } = createLangfuseTracer({
 				workspaceId,
 				runningGeneration,
 				tags: generateTelemetryTags({
@@ -514,11 +514,12 @@ export async function generateText(args: {
 				generationName: "ai.streamText.doStream",
 				settings: args.telemetry,
 			});
-			await Promise.all(
+			await Promise.all([
+				langfuse.shutdownAsync(),
 				preparedToolSet.cleanupFunctions.map((cleanupFunction) =>
 					cleanupFunction(),
 				),
-			);
+			]);
 		},
 		experimental_telemetry: {
 			isEnabled: args.context.telemetry?.isEnabled,


### PR DESCRIPTION
## Summary

Manually flush Langfuse trace to ensure them being sent before Vercel function ends

## Related Issue

- This PR fixes #877
<!-- Mention the related issue number if applicable. -->

## Testing

Confirmed telemetry arrives when I use node with "single click" and do nothing after
<img width="868" alt="image" src="https://github.com/user-attachments/assets/a6bc125c-b2c9-4526-8586-340fddc98565" />


## Other Information
<!-- Add any other relevant information for the reviewer. -->
