### PR TITLE
Add type checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           cache: "pnpm"
       - name: Run Biome
         run: biome ci .
+      - name: Check types
+        run: pnpm check-types
       - name: Build SDK
         run: pnpm build-sdk
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           cache: "pnpm"
       - name: Run Biome
         run: biome ci .
-      - name: Check types
-        run: pnpm check-types
       - name: Build SDK
         run: pnpm build-sdk
+      - name: Check types
+        run: pnpm check-types
       - name: Test
         run: pnpm test


### PR DESCRIPTION
## Summary
- Add `pnpm check-types` to CI workflow to ensure type safety
- This PR addresses the issue described in #876

## Related Issue
This PR resolves #876: "Fix giselle-engine type checking in CI pipeline"

## Implementation Details
- Added a dedicated type checking step in CI that runs `pnpm check-types` against all packages
- This change ensures that type errors in any package (including giselle-engine) will fail the CI build consistently
- Type checking will now be enforced uniformly across all packages and applications

## Expected Impact
- Prevents type errors from being merged into production
- Ensures consistent type safety across all parts of our application
- Reduces debugging time by catching type-related issues earlier
- Improves overall code quality

## Testing
- `pnpm check-types` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `pnpm test` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a type-checking step to the continuous integration workflow to improve code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->