### PR TITLE
Enhance GitHub Trigger UI with usage example

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/github-trigger-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/github-trigger-configured-view.tsx
@@ -19,7 +19,7 @@ export function GitHubTriggerConfiguredView({
 	}
 
 	return (
-		<div className="flex flex-col gap-[17px] p-0">
+		<div className="flex flex-col gap-[16px] p-0 overflow-y-auto">
 			<div className="space-y-[4px]">
 				<p className="text-[14px] py-[1.5px] text-white-400">State</p>
 				<div className="px-[16px] py-[9px] w-full bg-transparent text-[14px]">

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/github-trigger-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/github-trigger-configured-view.tsx
@@ -75,7 +75,7 @@ export function GitHubTriggerConfiguredView({
 							/{data.trigger.configuration.event.conditions.callsign}
 						</div>
 					</div>
-					<div className="border border-black-800 rounded-[4px] overflow-hidden">
+					<div className="border border-black-800 rounded-[4px] overflow-hidden ml-[16px] pointer-events-none">
 						<div className="bg-black-850 p-[8px] border-b border-black-800">
 							<h3 className="text-[14px] text-black-300">
 								GitHub Usage Example
@@ -107,7 +107,7 @@ export function GitHubTriggerConfiguredView({
 										[enter your request...]
 									</div>
 
-									<div className="flex items-center justify-end p-3 bg-[#161b22]">
+									<div className="flex items-center justify-end p-[6px] bg-[#161b22]">
 										<div className="px-3 py-1.5 bg-[#238636] text-white text-sm rounded-md">
 											Comment
 										</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/github-trigger-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/github-trigger-configured-view.tsx
@@ -1,5 +1,6 @@
 import type { FlowTriggerId } from "@giselle-sdk/data-type";
 import { githubTriggerIdToLabel } from "@giselle-sdk/flow";
+import { UserIcon } from "lucide-react";
 import { useGitHubTrigger } from "../../../lib/use-github-trigger";
 import { GitHubRepositoryBlock } from "../../ui";
 
@@ -67,10 +68,53 @@ export function GitHubTriggerConfiguredView({
 			</div>
 			{data.trigger.configuration.event.id ===
 				"github.issue_comment.created" && (
-				<div className="space-y-[4px]">
-					<p className="text-[14px] py-[1.5px] text-white-400">Call sign</p>
-					<div className="px-[16px] py-[9px] w-full bg-transparent text-[14px]">
-						{data.trigger.configuration.event.conditions.callsign}
+				<div>
+					<div className="space-y-[4px]">
+						<p className="text-[14px] py-[1.5px] text-white-400">Call sign</p>
+						<div className="px-[16px] py-[9px] w-full bg-transparent text-[14px]">
+							/{data.trigger.configuration.event.conditions.callsign}
+						</div>
+					</div>
+					<div className="border border-black-800 rounded-[4px] overflow-hidden">
+						<div className="bg-black-850 p-[8px] border-b border-black-800">
+							<h3 className="text-[14px] text-black-300">
+								GitHub Usage Example
+							</h3>
+						</div>
+						<div className="p-4 bg-[#0d1117] flex gap-[8px]">
+							<div>
+								<div className="rounded-full bg-black-800 p-[6px]">
+									<UserIcon className="size-[18px]" />
+								</div>
+							</div>
+							<div className="flex-1">
+								<div className="flex items-start gap-3 mb-2">
+									<h2 className="text-[16px]">Add a comment</h2>
+								</div>
+								<div className="border border-[#30363d] rounded-md overflow-hidden">
+									{/* Tab Navigation */}
+									<div className="border-b border-[#30363d] bg-[#161b22] flex">
+										<div className="border-b-2 border-[#f78166] px-4 py-2 text-sm">
+											Write
+										</div>
+										<div className="px-4 py-2 text-sm text-gray-400">
+											Preview
+										</div>
+									</div>
+
+									<div className="min-h-[150px] p-4 bg-[#0d1117] text-gray-400 border-b border-[#30363d]">
+										/{data.trigger.configuration.event.conditions.callsign}{" "}
+										[enter your request...]
+									</div>
+
+									<div className="flex items-center justify-end p-3 bg-[#161b22]">
+										<div className="px-3 py-1.5 bg-[#238636] text-white text-sm rounded-md">
+											Comment
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
 					</div>
 				</div>
 			)}


### PR DESCRIPTION
## Summary

This PR improves the GitHub trigger configuration panel by adding a visual example of how to use GitHub comment triggers. The enhancement provides users with a clear representation of how to use call signs in GitHub issues.

<img width="735" alt="image" src="https://github.com/user-attachments/assets/92107d84-cff4-45b4-aa0b-3ac46266f692" />


## Changes

- Added a visual GitHub comment UI example in the GitHub trigger panel
- Improved the display of call signs by adding a slash prefix for better clarity
- Implemented a mock GitHub interface to help users understand the context

## Test Plan

1. Open the workflow editor
2. Add a GitHub trigger with the 'Issue comment created' event
3. Configure the trigger with a call sign
4. Verify the visual example appears with the correct call sign
5. Confirm the UI accurately represents the GitHub comment interface