### PR TITLE
Set environment name and deployment ID to Langfuse trace

### DIFF
--- a/apps/studio.giselles.ai/instrumentation.ts
+++ b/apps/studio.giselles.ai/instrumentation.ts
@@ -9,6 +9,8 @@ export async function register() {
 	if (process.env.NEXT_RUNTIME === "edge") {
 		await import("./sentry.edge.config");
 	}
-}
 
+	process.env.LANGFUSE_TRACING_ENVIRONMENT =
+		process.env.VERCEL_ENV || "development";
+}
 export const onRequestError = Sentry.captureRequestError;

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -120,7 +120,15 @@ export function createLangfuseTracer({
 	const trace = langfuse.trace({
 		userId: String(settings?.metadata?.userId),
 		name: spanName,
-		metadata: settings?.metadata,
+		metadata: {
+			...settings?.metadata,
+			...(process.env.VERCEL_DEPLOYMENT_ID && {
+				deploymentId: process.env.VERCEL_DEPLOYMENT_ID.replace(
+					"dpl_",
+					"",
+				).slice(0, 9), // Convert raw deployment ID into the format shown on "Deployments" screen of vercel.com
+			}),
+		},
 		input: messages,
 		output,
 		tags,


### PR DESCRIPTION
## Summary

Set information below to Langfuse trace make their development easier:
- name of environment 
- Vercel deployment ID

## Testing

"Environment" is set to the trace arrived to Langfuse ✅ 
<img width="152" alt="image" src="https://github.com/user-attachments/assets/3c3f1ff8-55b9-43fe-9cd0-ce68b291713e" />

deployment ID is set as metadata ✅ 
<img width="224" alt="image" src="https://github.com/user-attachments/assets/1f276e26-a065-4384-b00b-0bbc2f3af56d" />


<!-- Briefly describe the testing steps or results. -->

