### PR TITLE
Implement GitHub reactions with GraphQL API

### DIFF
--- a/packages/github-tool/src/index.ts
+++ b/packages/github-tool/src/index.ts
@@ -5,6 +5,7 @@ export * from "./octokit";
 export * from "./repository";
 export * from "./tools";
 export * from "./types";
+export * from "./reactions";
 
 export const IssueNodeIdQuery = gql(/* GraphQL */ `
   query IssueNodeIdQuery($name: String!, $owner: String!, $issueNumber: Int!) {

--- a/packages/github-tool/src/reactions.ts
+++ b/packages/github-tool/src/reactions.ts
@@ -1,0 +1,26 @@
+import type { VariablesOf } from "gql.tada";
+import { graphql } from "./client";
+import { graphql as gql } from "./graphql";
+import type { GitHubAuthConfig } from "./types";
+
+const AddReactionMutation = gql(/* GraphQL */ `
+    mutation addReaction($id: ID!, $content: ReactionContent!) {
+        addReaction(input: {subjectId: $id, content: $content}) {
+            reaction {
+                content
+            }
+        }
+    }
+`);
+type AddReactionContentMutationVariables = VariablesOf<
+	typeof AddReactionMutation
+>;
+
+export async function addReaction({
+	id,
+	content,
+	authConfig,
+}: AddReactionContentMutationVariables & { authConfig: GitHubAuthConfig }) {
+	const client = await graphql(authConfig);
+	await client.mutation(AddReactionMutation, { id, content });
+}


### PR DESCRIPTION
## Overview

This PR implements GitHub reactions for issues, pull requests, and comments using the GitHub GraphQL API.

## Changes

- Added GraphQL-based reaction implementation to simplify the code
- Implemented reaction support for issues, pull requests, and comments
- Uses the 👀 (eyes) reaction to indicate that Giselle has seen and is processing an event

## Why GraphQL?

The previous implementation relied on REST API calls, but moving to GraphQL has simplified the implementation by:

1. Reducing the number of API calls needed
2. Simplifying the authentication and request flow
3. Making the code more maintainable and readable
4. Providing better type safety through GraphQL schema

## Testing

Verified that reactions are properly added to:
- New issues
- Issue comments

Tested with GitHub app installation authentication.

resolves #889 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically adds an "EYES" reaction emoji to GitHub issues, pull requests, and comments when relevant events occur.
- **Improvements**
  - Enhanced GitHub integration to provide immediate visual feedback on supported events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->