### PR TITLE
Add GitHub PR ready_for_review trigger

### DIFF
--- a/internal-packages/workflow-designer-ui/package.json
+++ b/internal-packages/workflow-designer-ui/package.json
@@ -36,7 +36,8 @@
 		"react-resizable-panels": "catalog:",
 		"rehype-raw": "^7.0.0",
 		"remark-gfm": "^4.0.1",
-		"swr": "catalog:"
+		"swr": "catalog:",
+		"zod": "catalog:"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
@@ -126,6 +126,7 @@ function Installed({
 			const formData = new FormData(e.currentTarget);
 			switch (eventId) {
 				case "github.issue.created":
+				case "github.pull_request.ready_for_review":
 					event = {
 						id: eventId,
 					};

--- a/packages/data-type/src/flow/trigger/github.ts
+++ b/packages/data-type/src/flow/trigger/github.ts
@@ -13,9 +13,14 @@ const IssueCommentCreated = z.object({
 	}),
 });
 
+const PullRequestReadyForReview = z.object({
+	id: z.literal("github.pull_request.ready_for_review"),
+});
+
 export const GitHubFlowTriggerEvent = z.discriminatedUnion("id", [
 	IssueCreated,
 	IssueCommentCreated,
+	PullRequestReadyForReview,
 ]);
 export type GitHubFlowTriggerEvent = z.infer<typeof GitHubFlowTriggerEvent>;
 

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -35,9 +35,26 @@ export const githubIssueCommentCreatedTrigger = {
 	},
 } as const satisfies GitHubTrigger;
 
+export const githubPullRequestReadyForReviewTrigger = {
+	provider,
+	event: {
+		id: "github.pull_request.ready_for_review",
+		label: "Pull Request Ready for Review",
+		payloads: z.object({
+			title: z.string(),
+			body: z.string(),
+			number: z.number(),
+			html_url: z.string(),
+			draft: z.boolean(),
+		}),
+	},
+} as const satisfies GitHubTrigger;
+
 export const triggers = {
 	[githubIssueCreatedTrigger.event.id]: githubIssueCreatedTrigger,
 	[githubIssueCommentCreatedTrigger.event.id]: githubIssueCommentCreatedTrigger,
+	[githubPullRequestReadyForReviewTrigger.event.id]:
+		githubPullRequestReadyForReviewTrigger,
 } as const;
 
 export type TriggerEventId = keyof typeof triggers;
@@ -48,6 +65,8 @@ export function triggerIdToLabel(triggerId: TriggerEventId) {
 			return githubIssueCreatedTrigger.event.label;
 		case "github.issue_comment.created":
 			return githubIssueCommentCreatedTrigger.event.label;
+		case "github.pull_request.ready_for_review":
+			return githubPullRequestReadyForReviewTrigger.event.label;
 		default: {
 			const exhaustiveCheck: never = triggerId;
 			throw new Error(`Unknown trigger ID: ${exhaustiveCheck}`);

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -44,7 +44,7 @@ export const githubPullRequestReadyForReviewTrigger = {
 			title: z.string(),
 			body: z.string(),
 			number: z.number(),
-			pullRequesturl: z.string(),
+			pullRequestUrl: z.string(),
 		}),
 	},
 } as const satisfies GitHubTrigger;

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -44,8 +44,7 @@ export const githubPullRequestReadyForReviewTrigger = {
 			title: z.string(),
 			body: z.string(),
 			number: z.number(),
-			html_url: z.string(),
-			draft: z.boolean(),
+			pullRequesturl: z.string(),
 		}),
 	},
 } as const satisfies GitHubTrigger;

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -209,6 +209,51 @@ function buildTriggerInputs(args: {
 				githubTrigger.event.payloads.keyof().options,
 				trigger.configuration.event.conditions.callsign,
 			);
+		case "github.pull_request.ready_for_review": {
+			if (githubEvent.type !== GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW) {
+				return null;
+			}
+			const triggerInputs: GenerationInput[] = [];
+			for (const payload of githubTrigger.event.payloads.keyof().options) {
+				switch (payload) {
+					case "title":
+						triggerInputs.push({
+							name: "title",
+							value: githubEvent.payload.pull_request.title,
+						});
+						break;
+					case "body":
+						triggerInputs.push({
+							name: "body",
+							value: githubEvent.payload.pull_request.body ?? "",
+						});
+						break;
+					case "number":
+						triggerInputs.push({
+							name: "number",
+							value: githubEvent.payload.pull_request.number.toString(),
+						});
+						break;
+					case "html_url":
+						triggerInputs.push({
+							name: "html_url",
+							value: githubEvent.payload.pull_request.html_url,
+						});
+						break;
+					case "draft":
+						triggerInputs.push({
+							name: "draft",
+							value: githubEvent.payload.pull_request.draft.toString(),
+						});
+						break;
+					default: {
+						const _exhaustiveCheck: never = payload;
+						throw new Error(`Unhandled payload id: ${_exhaustiveCheck}`);
+					}
+				}
+			}
+			return triggerInputs;
+		}
 		default: {
 			const _exhaustiveCheck: never = githubTrigger.event;
 			throw new Error(`Unhandled event id: ${_exhaustiveCheck}`);

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -234,7 +234,7 @@ function buildTriggerInputs(args: {
 							value: githubEvent.payload.pull_request.number.toString(),
 						});
 						break;
-					case "pullRequesturl":
+					case "pullRequestUrl":
 						triggerInputs.push({
 							name: "pullRequesturl",
 							value: githubEvent.payload.pull_request.html_url,

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -234,16 +234,10 @@ function buildTriggerInputs(args: {
 							value: githubEvent.payload.pull_request.number.toString(),
 						});
 						break;
-					case "html_url":
+					case "pullRequesturl":
 						triggerInputs.push({
-							name: "html_url",
+							name: "pullRequesturl",
 							value: githubEvent.payload.pull_request.html_url,
-						});
-						break;
-					case "draft":
-						triggerInputs.push({
-							name: "draft",
-							value: githubEvent.payload.pull_request.draft.toString(),
 						});
 						break;
 					default: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,7 +283,7 @@ importers:
         version: 12.4.1(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       geist:
         specifier: 1.3.1
-        version: 1.3.1(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.3.1(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       giselle-sdk:
         specifier: workspace:^
         version: link:../../packages/giselle-sdk
@@ -536,7 +536,7 @@ importers:
         version: 6.7.1
       geist:
         specifier: 1.3.1
-        version: 1.3.1(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.3.1(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       giselle-sdk:
         specifier: workspace:*
         version: link:../../packages/giselle-sdk
@@ -769,6 +769,9 @@ importers:
       swr:
         specifier: 'catalog:'
         version: 2.2.5(react@19.1.0)
+      zod:
+        specifier: 'catalog:'
+        version: 3.24.1
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -14844,7 +14847,7 @@ snapshots:
       - encoding
       - supports-color
 
-  geist@1.3.1(next@15.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  geist@1.3.1(next@15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
       next: 15.3.0(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 


### PR DESCRIPTION
## Summary
- support `github.pull_request.ready_for_review` trigger
- expose new label for trigger id
- extract payload from PR ready-for-review webhook

<img width="708" alt="image" src="https://github.com/user-attachments/assets/1c5b682e-fc24-4152-a177-24881c10ebb1" />

> [!NOTE]
> The retrieval of code diffs will be handled in a separate pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "Pull Request Ready for Review" GitHub event trigger, allowing workflows to respond to this event.
  - Input fields for GitHub triggers are now generated dynamically, improving consistency and scalability for future events.

- **Bug Fixes**
  - None.

- **Chores**
  - Updated dependencies to include the `zod` library for enhanced schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->