### PR TITLE
Make PR Body Field Optional When Marking Ready for Review

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -117,7 +117,7 @@ const githubEventInputs: GithubEventInputMap = {
 		body: {
 			label: "Body",
 			type: "multiline-text",
-			required: true,
+			required: false,
 		},
 		number: {
 			label: "Number",


### PR DESCRIPTION
fix: https://github.com/giselles-ai/giselle/pull/894#discussion_r2099305657

## Summary
I fix the follwing feedback.

> 
> **Make the Pull Request body field optional**
> 
> The GitHub PR body isn’t mandatory when marking a PR as ready for review, so the `body` field in this dialog should not be marked as required.
> 
> • File: `internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx`  
>   Lines ~114–118: update the `body` field’s `required` flag
> 
> Suggested diff:
> ```diff
>    "github.pull_request.ready_for_review": {
>      title: {
>        label: "Title",
>        type: "text",
>        required: true,
>      },
>      body: {
>        label: "Body",
>        type: "multiline-text",
> -      required: true,
> +      required: false,
>      },
>      number: {
>        label: "Number",
>        type: "number",
>        required: true,
>      },
>      pullRequestUrl: {
>        label: "Pull request URL",
>        type: "text",
>        required: true,
>      },
>    },
> ```
> 


## Related Issue
https://github.com/giselles-ai/giselle/pull/894#discussion_r2099305657


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - The "Body" field is now optional when configuring the "Pull Request Ready for Review" GitHub event in the trigger input dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->