### PR TITLE
Fix casing for PR URL trigger property

### DIFF
--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -291,7 +291,7 @@ function buildTriggerInputs(args: {
 						break;
 					case "pullRequestUrl":
 						triggerInputs.push({
-							name: "pullRequesturl",
+							name: "pullRequestUrl",
 							value: githubEvent.payload.pull_request.html_url,
 						});
 						break;


### PR DESCRIPTION
resolves #896 

## Summary
- fix the property name in the GitHub webhook handler to match the UI definition

## Testing
- `pnpm build-sdk`
- `pnpm check-types` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `pnpm test` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a capitalization issue in the pull request URL field for improved consistency in event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->