### PR TITLE
Fix: Improve GitHub webhook error handling

### DIFF
--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -100,7 +100,8 @@ export async function handleWebhook(args: HandleGitHubWebhookArgs) {
 		args.github.payload,
 	);
 	if (!gitHubEvent) {
-		throw new Error("Unsupported event");
+		console.log(`Unsupport event: ${JSON.stringify(args.github, null, 2)}`);
+		return [];
 	}
 
 	const repository = getRepositoryInfo(gitHubEvent);


### PR DESCRIPTION
## Description
This PR improves the error handling for unsupported GitHub webhook events. Instead of throwing an error, it now logs the event details and returns an empty array. This prevents unnecessary crashes while maintaining visibility of unexpected events through logs.

## Changes
- Modified error handling in `packages/giselle-engine/src/core/github/handle-webhook.ts`
- Added detailed logging of unsupported events
- Changed from throwing an error to returning empty array

## Test Plan
1. Verify that unsupported GitHub webhook events are properly logged
2. Confirm that the application continues to function instead of crashing
3. Ensure that supported events are still processed correctly

## Related Issues
N/A