### PR TITLE
Add GitHub pull request opened trigger

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
@@ -127,6 +127,7 @@ function Installed({
 			switch (eventId) {
 				case "github.issue.created":
 				case "github.pull_request.ready_for_review":
+				case "github.pull_request.opened":
 					event = {
 						id: eventId,
 					};

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -130,6 +130,28 @@ const githubEventInputs: GithubEventInputMap = {
 			required: true,
 		},
 	},
+	"github.pull_request.opened": {
+		title: {
+			label: "Title",
+			type: "text",
+			required: true,
+		},
+		body: {
+			label: "Body",
+			type: "multiline-text",
+			required: false,
+		},
+		number: {
+			label: "Number",
+			type: "number",
+			required: true,
+		},
+		pullRequestUrl: {
+			label: "Pull request URL",
+			type: "text",
+			required: true,
+		},
+	},
 };
 
 export function TriggerInputDialog({

--- a/packages/data-type/src/flow/trigger/github.ts
+++ b/packages/data-type/src/flow/trigger/github.ts
@@ -13,6 +13,10 @@ const IssueCommentCreated = z.object({
 	}),
 });
 
+const PullRequestOpened = z.object({
+	id: z.literal("github.pull_request.opened"),
+});
+
 const PullRequestReadyForReview = z.object({
 	id: z.literal("github.pull_request.ready_for_review"),
 });
@@ -20,6 +24,7 @@ const PullRequestReadyForReview = z.object({
 export const GitHubFlowTriggerEvent = z.discriminatedUnion("id", [
 	IssueCreated,
 	IssueCommentCreated,
+	PullRequestOpened,
 	PullRequestReadyForReview,
 ]);
 export type GitHubFlowTriggerEvent = z.infer<typeof GitHubFlowTriggerEvent>;

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -35,6 +35,20 @@ export const githubIssueCommentCreatedTrigger = {
 	},
 } as const satisfies GitHubTrigger;
 
+export const githubPullRequestOpenedTrigger = {
+	provider,
+	event: {
+		id: "github.pull_request.opened",
+		label: "Pull Request Opened",
+		payloads: z.object({
+			title: z.string(),
+			body: z.string(),
+			number: z.number(),
+			pullRequestUrl: z.string(),
+		}),
+	},
+} as const satisfies GitHubTrigger;
+
 export const githubPullRequestReadyForReviewTrigger = {
 	provider,
 	event: {
@@ -52,6 +66,7 @@ export const githubPullRequestReadyForReviewTrigger = {
 export const triggers = {
 	[githubIssueCreatedTrigger.event.id]: githubIssueCreatedTrigger,
 	[githubIssueCommentCreatedTrigger.event.id]: githubIssueCommentCreatedTrigger,
+	[githubPullRequestOpenedTrigger.event.id]: githubPullRequestOpenedTrigger,
 	[githubPullRequestReadyForReviewTrigger.event.id]:
 		githubPullRequestReadyForReviewTrigger,
 } as const;
@@ -64,6 +79,8 @@ export function triggerIdToLabel(triggerId: TriggerEventId) {
 			return githubIssueCreatedTrigger.event.label;
 		case "github.issue_comment.created":
 			return githubIssueCommentCreatedTrigger.event.label;
+		case "github.pull_request.opened":
+			return githubPullRequestOpenedTrigger.event.label;
 		case "github.pull_request.ready_for_review":
 			return githubPullRequestReadyForReviewTrigger.event.label;
 		default: {

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -264,6 +264,45 @@ function buildTriggerInputs(args: {
 				githubTrigger.event.payloads.keyof().options,
 				trigger.configuration.event.conditions.callsign,
 			);
+		case "github.pull_request.opened": {
+			if (githubEvent.type !== GitHubEventType.PULL_REQUEST_OPENED) {
+				return null;
+			}
+			const triggerInputs: GenerationInput[] = [];
+			for (const payload of githubTrigger.event.payloads.keyof().options) {
+				switch (payload) {
+					case "title":
+						triggerInputs.push({
+							name: "title",
+							value: githubEvent.payload.pull_request.title,
+						});
+						break;
+					case "body":
+						triggerInputs.push({
+							name: "body",
+							value: githubEvent.payload.pull_request.body ?? "",
+						});
+						break;
+					case "number":
+						triggerInputs.push({
+							name: "number",
+							value: githubEvent.payload.pull_request.number.toString(),
+						});
+						break;
+					case "pullRequestUrl":
+						triggerInputs.push({
+							name: "pullRequesturl",
+							value: githubEvent.payload.pull_request.html_url,
+						});
+						break;
+					default: {
+						const _exhaustiveCheck: never = payload;
+						throw new Error(`Unhandled payload id: ${_exhaustiveCheck}`);
+					}
+				}
+			}
+			return triggerInputs;
+		}
 		case "github.pull_request.ready_for_review": {
 			if (githubEvent.type !== GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW) {
 				return null;


### PR DESCRIPTION
resolves #882 

## Summary by CodeRabbit

- **New Features**
  - Added support for the "Pull Request Opened" event from GitHub, allowing workflows to be triggered when a pull request is opened.
  - The trigger input dialog now supports entering details for pull requests, including title, body, number, and URL.
- **Bug Fixes**
  - None.
- **Documentation**
  - None.
- **Refactor**
  - None.
- **Style**
  - None.
- **Tests**
  - None.
- **Chores**
  - None.
- **Revert**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->