### PR TITLE
Add GitHub pull request closed event

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
@@ -127,6 +127,7 @@ function Installed({
 			switch (eventId) {
 				case "github.issue.created":
 				case "github.pull_request.ready_for_review":
+				case "github.pull_request.closed":
 					event = {
 						id: eventId,
 					};

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -130,6 +130,28 @@ const githubEventInputs: GithubEventInputMap = {
 			required: true,
 		},
 	},
+	"github.pull_request.closed": {
+		title: {
+			label: "Title",
+			type: "text",
+			required: true,
+		},
+		body: {
+			label: "Body",
+			type: "multiline-text",
+			required: false,
+		},
+		number: {
+			label: "Number",
+			type: "number",
+			required: true,
+		},
+		pullRequestUrl: {
+			label: "Pull request URL",
+			type: "text",
+			required: true,
+		},
+	},
 };
 
 export function TriggerInputDialog({

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -131,7 +131,7 @@ const githubEventInputs: GithubEventInputMap = {
 		},
 	},
 	"github.pull_request.closed": {
-      title: {
+		title: {
 			label: "Title",
 			type: "text",
 			required: true,
@@ -151,7 +151,7 @@ const githubEventInputs: GithubEventInputMap = {
 			type: "text",
 			required: true,
 		},
-  },
+	},
 	"github.pull_request.opened": {
 		title: {
 			label: "Title",

--- a/packages/data-type/src/flow/trigger/github.ts
+++ b/packages/data-type/src/flow/trigger/github.ts
@@ -17,10 +17,15 @@ const PullRequestReadyForReview = z.object({
 	id: z.literal("github.pull_request.ready_for_review"),
 });
 
+const PullRequestClosed = z.object({
+	id: z.literal("github.pull_request.closed"),
+});
+
 export const GitHubFlowTriggerEvent = z.discriminatedUnion("id", [
 	IssueCreated,
 	IssueCommentCreated,
 	PullRequestReadyForReview,
+	PullRequestClosed,
 ]);
 export type GitHubFlowTriggerEvent = z.infer<typeof GitHubFlowTriggerEvent>;
 

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -49,11 +49,26 @@ export const githubPullRequestReadyForReviewTrigger = {
 	},
 } as const satisfies GitHubTrigger;
 
+export const githubPullRequestClosedTrigger = {
+	provider,
+	event: {
+		id: "github.pull_request.closed",
+		label: "Pull Request Closed",
+		payloads: z.object({
+			title: z.string(),
+			body: z.string(),
+			number: z.number(),
+			pullRequestUrl: z.string(),
+		}),
+	},
+} as const satisfies GitHubTrigger;
+
 export const triggers = {
 	[githubIssueCreatedTrigger.event.id]: githubIssueCreatedTrigger,
 	[githubIssueCommentCreatedTrigger.event.id]: githubIssueCommentCreatedTrigger,
 	[githubPullRequestReadyForReviewTrigger.event.id]:
 		githubPullRequestReadyForReviewTrigger,
+	[githubPullRequestClosedTrigger.event.id]: githubPullRequestClosedTrigger,
 } as const;
 
 export type TriggerEventId = keyof typeof triggers;
@@ -66,6 +81,8 @@ export function triggerIdToLabel(triggerId: TriggerEventId) {
 			return githubIssueCommentCreatedTrigger.event.label;
 		case "github.pull_request.ready_for_review":
 			return githubPullRequestReadyForReviewTrigger.event.label;
+		case "github.pull_request.closed":
+			return githubPullRequestClosedTrigger.event.label;
 		default: {
 			const exhaustiveCheck: never = triggerId;
 			throw new Error(`Unknown trigger ID: ${exhaustiveCheck}`);

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -303,6 +303,45 @@ function buildTriggerInputs(args: {
 			}
 			return triggerInputs;
 		}
+		case "github.pull_request.closed": {
+			if (githubEvent.type !== GitHubEventType.PULL_REQUEST_CLOSED) {
+				return null;
+			}
+			const triggerInputs: GenerationInput[] = [];
+			for (const payload of githubTrigger.event.payloads.keyof().options) {
+				switch (payload) {
+					case "title":
+						triggerInputs.push({
+							name: "title",
+							value: githubEvent.payload.pull_request.title,
+						});
+						break;
+					case "body":
+						triggerInputs.push({
+							name: "body",
+							value: githubEvent.payload.pull_request.body ?? "",
+						});
+						break;
+					case "number":
+						triggerInputs.push({
+							name: "number",
+							value: githubEvent.payload.pull_request.number.toString(),
+						});
+						break;
+					case "pullRequestUrl":
+						triggerInputs.push({
+							name: "pullRequestUrl",
+							value: githubEvent.payload.pull_request.html_url,
+						});
+						break;
+					default: {
+						const _exhaustiveCheck: never = payload;
+						throw new Error(`Unhandled payload id: ${_exhaustiveCheck}`);
+					}
+				}
+			}
+			return triggerInputs;
+		}
 		default: {
 			const _exhaustiveCheck: never = githubTrigger.event;
 			throw new Error(`Unhandled event id: ${_exhaustiveCheck}`);


### PR DESCRIPTION
## Summary by CodeRabbit

- **New Features**
  - Added support for the "Pull Request Closed" event from GitHub, allowing workflows to be triggered when a pull request is closed.
  - Introduced new input fields for this event, including title, body, number, and pull request URL, for enhanced workflow customization.
- **Bug Fixes**
  - None.
- **Documentation**
  - None.
- **Refactor**
  - None.
- **Style**
  - None.
- **Tests**
  - None.
- **Chores**
  - None.
- **Revert**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "Pull Request Closed" GitHub event trigger, allowing workflows to respond when a pull request is closed.
  - Introduced new input fields for the "Pull Request Closed" event, including title, body, number, and pull request URL.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

- **Refactor**
  - None.

- **Style**
  - None.

- **Tests**
  - None.

- **Chores**
  - None.

- **Revert**
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->