### PR TITLE
Add GitHub issue closed trigger

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
@@ -126,6 +126,7 @@ function Installed({
 			const formData = new FormData(e.currentTarget);
 			switch (eventId) {
 				case "github.issue.created":
+				case "github.issue.closed":
 				case "github.pull_request.ready_for_review":
 					event = {
 						id: eventId,

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -86,6 +86,18 @@ const githubEventInputs: GithubEventInputMap = {
 			required: false,
 		},
 	},
+	"github.issue.closed": {
+		title: {
+			label: "Title",
+			type: "text",
+			required: true,
+		},
+		body: {
+			label: "Body",
+			type: "multiline-text",
+			required: false,
+		},
+	},
 	"github.issue_comment.created": {
 		issueNumber: {
 			label: "Issue Number",

--- a/packages/data-type/src/flow/trigger/github.ts
+++ b/packages/data-type/src/flow/trigger/github.ts
@@ -6,6 +6,10 @@ const IssueCreated = z.object({
 	id: z.literal("github.issue.created"),
 });
 
+const IssueClosed = z.object({
+	id: z.literal("github.issue.closed"),
+});
+
 const IssueCommentCreated = z.object({
 	id: z.literal("github.issue_comment.created"),
 	conditions: z.object({
@@ -19,6 +23,7 @@ const PullRequestReadyForReview = z.object({
 
 export const GitHubFlowTriggerEvent = z.discriminatedUnion("id", [
 	IssueCreated,
+	IssueClosed,
 	IssueCommentCreated,
 	PullRequestReadyForReview,
 ]);

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -18,6 +18,18 @@ export const githubIssueCreatedTrigger = {
 	},
 } as const satisfies GitHubTrigger;
 
+export const githubIssueClosedTrigger = {
+	provider,
+	event: {
+		id: "github.issue.closed",
+		label: "Issue Closed",
+		payloads: z.object({
+			title: z.string(),
+			body: z.string(),
+		}),
+	},
+} as const satisfies GitHubTrigger;
+
 export const githubIssueCommentCreatedTrigger = {
 	provider,
 	event: {
@@ -51,6 +63,7 @@ export const githubPullRequestReadyForReviewTrigger = {
 
 export const triggers = {
 	[githubIssueCreatedTrigger.event.id]: githubIssueCreatedTrigger,
+	[githubIssueClosedTrigger.event.id]: githubIssueClosedTrigger,
 	[githubIssueCommentCreatedTrigger.event.id]: githubIssueCommentCreatedTrigger,
 	[githubPullRequestReadyForReviewTrigger.event.id]:
 		githubPullRequestReadyForReviewTrigger,
@@ -62,6 +75,8 @@ export function triggerIdToLabel(triggerId: TriggerEventId) {
 	switch (triggerId) {
 		case "github.issue.created":
 			return githubIssueCreatedTrigger.event.label;
+		case "github.issue.closed":
+			return githubIssueClosedTrigger.event.label;
 		case "github.issue_comment.created":
 			return githubIssueCommentCreatedTrigger.event.label;
 		case "github.pull_request.ready_for_review":

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -256,6 +256,11 @@ function buildTriggerInputs(args: {
 				githubEvent,
 				githubTrigger.event.payloads.keyof().options,
 			);
+		case "github.issue.closed":
+			return buildIssueClosedInputs(
+				githubEvent,
+				githubTrigger.event.payloads.keyof().options,
+			);
 		case "github.issue_comment.created":
 			if (trigger.configuration.event.id !== "github.issue_comment.created") {
 				return null;
@@ -316,6 +321,35 @@ function buildIssueCreatedInputs(
 	payloads: readonly ("title" | "body")[],
 ): GenerationInput[] | null {
 	if (githubEvent.type !== GitHubEventType.ISSUES_OPENED) {
+		return null;
+	}
+
+	const inputs: GenerationInput[] = [];
+	for (const payload of payloads) {
+		switch (payload) {
+			case "title":
+				inputs.push({ name: "title", value: githubEvent.payload.issue.title });
+				break;
+			case "body":
+				inputs.push({
+					name: "body",
+					value: githubEvent.payload.issue.body ?? "",
+				});
+				break;
+			default: {
+				const _exhaustiveCheck: never = payload;
+				throw new Error(`Unhandled payload id: ${_exhaustiveCheck}`);
+			}
+		}
+	}
+	return inputs;
+}
+
+function buildIssueClosedInputs(
+	githubEvent: GitHubEvent,
+	payloads: readonly ("title" | "body")[],
+): GenerationInput[] | null {
+	if (githubEvent.type !== GitHubEventType.ISSUES_CLOSED) {
 		return null;
 	}
 


### PR DESCRIPTION
## Summary
- support `github.issue.closed` event in trigger schema
- expose `github.issue.closed` trigger in flow package
- handle issue closed webhook
- allow choosing issue closed trigger in UI

## Testing
- `pnpm build-sdk`
- `pnpm check-types` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `pnpm test` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "GitHub Issue Closed" event, allowing workflows to be triggered when a GitHub issue is closed.
  - Introduced input fields for the "Issue Closed" event, including required "title" and optional "body" fields.
  - Updated event labels and trigger options to include "Issue Closed" for consistent selection and display.

- **Bug Fixes**
  - Ensured proper handling and input extraction for the "Issue Closed" event in webhook processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->