### PR TITLE
Add pull request comment trigger

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
@@ -144,6 +144,19 @@ function Installed({
 					};
 					break;
 				}
+				case "github.pull_request_comment.created": {
+					const callsign = formData.get("callsign");
+					if (typeof callsign !== "string" || callsign.length === 0) {
+						throw new Error("unexpected request");
+					}
+					event = {
+						id: "github.pull_request_comment.created",
+						conditions: {
+							callsign,
+						},
+					};
+					break;
+				}
 				default: {
 					const _exhaustiveCheck: never = eventId;
 					throw new Error(`Unhandled eventId: ${_exhaustiveCheck}`);
@@ -251,7 +264,8 @@ function Installed({
 							</SelectContent>
 						</Select>
 					</fieldset>
-					{eventId === "github.issue_comment.created" && (
+					{(eventId === "github.issue_comment.created" ||
+						eventId === "github.pull_request_comment.created") && (
 						<fieldset className="flex flex-col gap-[4px]">
 							<div className="flex items-center gap-[4px]">
 								<p className="text-[16px]">Callsign</p>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/configured-views/github-trigger-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/ui/configured-views/github-trigger-configured-view.tsx
@@ -66,8 +66,10 @@ export function GitHubTriggerConfiguredView({
 					{githubTriggerIdToLabel(data.trigger.configuration.event.id)}
 				</div>
 			</div>
-			{data.trigger.configuration.event.id ===
-				"github.issue_comment.created" && (
+			{(data.trigger.configuration.event.id ===
+				"github.issue_comment.created" ||
+				data.trigger.configuration.event.id ===
+					"github.pull_request_comment.created") && (
 				<div>
 					<div className="space-y-[4px]">
 						<p className="text-[14px] py-[1.5px] text-white-400">Call sign</p>

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -108,6 +108,28 @@ const githubEventInputs: GithubEventInputMap = {
 			required: true,
 		},
 	},
+	"github.pull_request_comment.created": {
+		issueNumber: {
+			label: "Pull Request Number",
+			type: "number",
+			required: true,
+		},
+		issueTitle: {
+			label: "Pull Request Title",
+			type: "text",
+			required: true,
+		},
+		issueBody: {
+			label: "Pull Request Body",
+			type: "multiline-text",
+			required: true,
+		},
+		body: {
+			label: "Pull Request Comment",
+			type: "multiline-text",
+			required: true,
+		},
+	},
 	"github.pull_request.ready_for_review": {
 		title: {
 			label: "Title",

--- a/packages/data-type/src/flow/trigger/github.ts
+++ b/packages/data-type/src/flow/trigger/github.ts
@@ -13,6 +13,13 @@ const IssueCommentCreated = z.object({
 	}),
 });
 
+const PullRequestCommentCreated = z.object({
+	id: z.literal("github.pull_request_comment.created"),
+	conditions: z.object({
+		callsign: z.string(),
+	}),
+});
+
 const PullRequestReadyForReview = z.object({
 	id: z.literal("github.pull_request.ready_for_review"),
 });
@@ -20,6 +27,7 @@ const PullRequestReadyForReview = z.object({
 export const GitHubFlowTriggerEvent = z.discriminatedUnion("id", [
 	IssueCreated,
 	IssueCommentCreated,
+	PullRequestCommentCreated,
 	PullRequestReadyForReview,
 ]);
 export type GitHubFlowTriggerEvent = z.infer<typeof GitHubFlowTriggerEvent>;

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -35,6 +35,23 @@ export const githubIssueCommentCreatedTrigger = {
 	},
 } as const satisfies GitHubTrigger;
 
+export const githubPullRequestCommentCreatedTrigger = {
+	provider,
+	event: {
+		id: "github.pull_request_comment.created",
+		label: "Pull Request Comment Created",
+		payloads: z.object({
+			body: z.string(),
+			issueNumber: z.number(),
+			issueTitle: z.string(),
+			issueBody: z.string(),
+		}),
+		conditions: z.object({
+			callsign: z.string(),
+		}),
+	},
+} as const satisfies GitHubTrigger;
+
 export const githubPullRequestReadyForReviewTrigger = {
 	provider,
 	event: {
@@ -52,6 +69,8 @@ export const githubPullRequestReadyForReviewTrigger = {
 export const triggers = {
 	[githubIssueCreatedTrigger.event.id]: githubIssueCreatedTrigger,
 	[githubIssueCommentCreatedTrigger.event.id]: githubIssueCommentCreatedTrigger,
+	[githubPullRequestCommentCreatedTrigger.event.id]:
+		githubPullRequestCommentCreatedTrigger,
 	[githubPullRequestReadyForReviewTrigger.event.id]:
 		githubPullRequestReadyForReviewTrigger,
 } as const;
@@ -64,6 +83,8 @@ export function triggerIdToLabel(triggerId: TriggerEventId) {
 			return githubIssueCreatedTrigger.event.label;
 		case "github.issue_comment.created":
 			return githubIssueCommentCreatedTrigger.event.label;
+		case "github.pull_request_comment.created":
+			return githubPullRequestCommentCreatedTrigger.event.label;
 		case "github.pull_request.ready_for_review":
 			return githubPullRequestReadyForReviewTrigger.event.label;
 		default: {

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -62,7 +62,7 @@ export const githubPullRequestCommentCreatedTrigger = {
 			callsign: z.string(),
 		}),
 	},
-};
+} as const satisfies GitHubTrigger;
 
 export const githubPullRequestOpenedTrigger = {
 	provider,

--- a/packages/giselle-engine/src/core/github/handle-webhook.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook.ts
@@ -265,6 +265,17 @@ function buildTriggerInputs(args: {
 				githubTrigger.event.payloads.keyof().options,
 				trigger.configuration.event.conditions.callsign,
 			);
+		case "github.pull_request_comment.created":
+			if (
+				trigger.configuration.event.id !== "github.pull_request_comment.created"
+			) {
+				return null;
+			}
+			return buildIssueCommentInputs(
+				githubEvent,
+				githubTrigger.event.payloads.keyof().options,
+				trigger.configuration.event.conditions.callsign,
+			);
 		case "github.pull_request.ready_for_review": {
 			if (githubEvent.type !== GitHubEventType.PULL_REQUEST_READY_FOR_REVIEW) {
 				return null;


### PR DESCRIPTION
## Summary
- support GitHub pull_request_comment.created event
- expose new trigger in Flow SDK
- handle webhook for pull request comment trigger
- update workflow designer to configure and display the new trigger

## Testing
- `pnpm build-sdk`
- `pnpm check-types` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the GitHub "Pull Request Comment Created" event as a trigger, allowing users to configure workflows based on new comments on pull requests.
  - Users can now specify a callsign condition when setting up this trigger, similar to the existing issue comment event.
  - The UI now displays relevant input fields and examples for this new trigger event.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->