### PR TITLE
Set environment name and deployment ID to Langfuse trace

### DIFF
--- a/apps/studio.giselles.ai/instrumentation.ts
+++ b/apps/studio.giselles.ai/instrumentation.ts
@@ -9,6 +9,8 @@ export async function register() {
 	if (process.env.NEXT_RUNTIME === "edge") {
 		await import("./sentry.edge.config");
 	}
-}
 
+	process.env.LANGFUSE_TRACING_ENVIRONMENT =
+		process.env.VERCEL_ENV || "development";
+}
 export const onRequestError = Sentry.captureRequestError;

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -120,7 +120,15 @@ export function createLangfuseTracer({
 	const trace = langfuse.trace({
 		userId: String(settings?.metadata?.userId),
 		name: spanName,
-		metadata: settings?.metadata,
+		metadata: {
+			...settings?.metadata,
+			...(process.env.VERCEL_DEPLOYMENT_ID && {
+				deploymentId: process.env.VERCEL_DEPLOYMENT_ID.replace(
+					"dpl_",
+					"",
+				).slice(0, 9), // Convert raw deployment ID into the format shown on "Deployments" screen of vercel.com
+			}),
+		},
 		input: messages,
 		output,
 		tags,

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -123,10 +123,7 @@ export function createLangfuseTracer({
 		metadata: {
 			...settings?.metadata,
 			...(process.env.VERCEL_DEPLOYMENT_ID && {
-				deploymentId: process.env.VERCEL_DEPLOYMENT_ID.replace(
-					"dpl_",
-					"",
-				).slice(0, 9), // Convert raw deployment ID into the format shown on "Deployments" screen of vercel.com
+				deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
 			}),
 		},
 		input: messages,


### PR DESCRIPTION
(this PR is the updated version of #890)

## Summary

Set information below to Langfuse trace make their development easier:
- name of environment 
- Vercel deployment ID

## Testing

"Environment" is set to the trace arrived to Langfuse ✅ 
<img width="152" alt="image" src="https://github.com/user-attachments/assets/3c3f1ff8-55b9-43fe-9cd0-ce68b291713e" />

deployment ID is set as metadata ✅ 
<img width="376" alt="image" src="https://github.com/user-attachments/assets/0de65bb4-e4e6-42a8-8f1a-59476fce97c4" />



<!-- Briefly describe the testing steps or results. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployment-specific metadata is now included in tracing, allowing for improved traceability across different deployment environments.
- **Chores**
  - Updated environment variable handling to better reflect the current deployment environment in instrumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->