### PR TITLE
Calculate display-only cost of Google model usage

### DIFF
--- a/packages/language-model/src/costs/index.ts
+++ b/packages/language-model/src/costs/index.ts
@@ -10,6 +10,7 @@ export { calculateTokenCostForDisplay } from "./calculator";
 export type { CostCalculator, CostResultForDisplay } from "./calculator";
 
 import { AnthropicCostCalculator } from "../anthropic";
+import { GoogleCostCalculator } from "../google";
 import { OpenAICostCalculator } from "../openai";
 import type { CostCalculator } from "./calculator";
 import { DefaultCostCalculator } from "./calculator";
@@ -20,6 +21,8 @@ export function createDisplayCostCalculator(provider: string): CostCalculator {
 			return new OpenAICostCalculator();
 		case "anthropic":
 			return new AnthropicCostCalculator();
+		case "google":
+			return new GoogleCostCalculator();
 		default:
 			console.log(`Unimplemented provider: ${provider}`);
 			return new DefaultCostCalculator(provider);

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -201,7 +201,7 @@ export const googleTokenPricing: ModelPriceTable = {
 						costPerMegaToken: 0.15,
 					},
 					output: {
-						costPerMegaToken: 0.60, // will be 3.50 if "thinking" enabled
+						costPerMegaToken: 0.6, // will be 3.50 if "thinking" enabled
 						// thinking option can be controlled using "thinkingBudget" option
 						// refs:
 						// - https://ai.google.dev/gemini-api/docs/thinking#javascript
@@ -217,10 +217,10 @@ export const googleTokenPricing: ModelPriceTable = {
 				validFrom: "2025-05-20T00:00:00Z",
 				price: {
 					input: {
-						costPerMegaToken: 0.10,
+						costPerMegaToken: 0.1,
 					},
 					output: {
-						costPerMegaToken: 0.40,
+						costPerMegaToken: 0.4,
 					},
 				},
 			},
@@ -235,7 +235,7 @@ export const googleTokenPricing: ModelPriceTable = {
 						costPerMegaToken: 0.075,
 					},
 					output: {
-						costPerMegaToken: 0.30,
+						costPerMegaToken: 0.3,
 					},
 				},
 			},

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -160,6 +160,119 @@ export const anthropicTokenPricing: ModelPriceTable = {
 	},
 };
 
+export const googleTokenPricing: ModelPriceTable = {
+	// https://ai.google.dev/gemini-api/docs/pricing
+	"gemini-2.5-pro-exp-03-25": {
+		prices: [
+			{
+				validFrom: "2025-05-20T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.0,
+					},
+					output: {
+						costPerMegaToken: 0.0,
+					},
+				},
+			},
+		],
+	},
+	"gemini-2.5-pro-preview-03-25": {
+		prices: [
+			{
+				validFrom: "2025-05-20T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 1.25,
+					},
+					output: {
+						costPerMegaToken: 10.0,
+					},
+				},
+			},
+		],
+	},
+	"gemini-2.5-flash-preview-04-17": {
+		prices: [
+			{
+				validFrom: "2025-05-20T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.15,
+					},
+					output: {
+						costPerMegaToken: 0.60, // will be 3.50 if "thinking" enabled
+						// thinking option can be controlled using "thinkingBudget" option
+						// refs:
+						// - https://ai.google.dev/gemini-api/docs/thinking#javascript
+						// - https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
+					},
+				},
+			},
+		],
+	},
+	"gemini-2.0-flash": {
+		prices: [
+			{
+				validFrom: "2025-05-20T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.10,
+					},
+					output: {
+						costPerMegaToken: 0.40,
+					},
+				},
+			},
+		],
+	},
+	"gemini-2.0-flash-lite-preview-02-05": {
+		prices: [
+			{
+				validFrom: "2025-05-20T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.075,
+					},
+					output: {
+						costPerMegaToken: 0.30,
+					},
+				},
+			},
+		],
+	},
+	"gemini-2.0-flash-thinking-exp-01-21": {
+		prices: [
+			{
+				validFrom: "2025-05-20T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.0,
+					},
+					output: {
+						costPerMegaToken: 0.0,
+					},
+				},
+			},
+		],
+	},
+	"gemini-2.0-pro-exp-02-05": {
+		prices: [
+			{
+				validFrom: "2025-05-20T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.0,
+					},
+					output: {
+						costPerMegaToken: 0.0,
+					},
+				},
+			},
+		],
+	},
+};
+
 export function getValidPricing(
 	modelId: string,
 	priceTable: ModelPriceTable,

--- a/packages/language-model/src/google.ts
+++ b/packages/language-model/src/google.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 import { Capability, LanguageModelBase, Tier } from "./base";
+import {
+	BaseCostCalculator,
+	type CostCalculator,
+	type CostResultForDisplay,
+} from "./costs/calculator";
+import { googleTokenPricing } from "./costs/model-prices";
+import type { ModelTokenUsage } from "./costs/usage";
 
 const GoogleLanguageModelConfigurations = z.object({
 	temperature: z.number(),
@@ -107,3 +114,9 @@ export const models = [
 
 export const LanguageModel = GoogleLanguageModel;
 export type LanguageModel = GoogleLanguageModel;
+
+export class GoogleCostCalculator extends BaseCostCalculator {
+	protected getPricingTable() {
+		return googleTokenPricing;
+	}
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Calculate cost for displaying preliminary value, not for billing, of Google models

## Related Issue

- part of https://github.com/giselles-ai/giselle/issues/796
  - we already merged similar functionality for Anthropic models by https://github.com/giselles-ai/giselle/pull/872

## Testing

Cost of Google models are calculated using pricing info in `cost/model-prices.ts` (not the pricing info on Langfuse) ✅ 

<img width="865" alt="image" src="https://github.com/user-attachments/assets/879b039f-5fa5-4a40-b784-33c5e7aac4dd" />

The costs in the screenshot are calculated from a cost table set up in the local environment as follows:
```ts
-						costPerMegaToken: 0.10,
+						costPerMegaToken: 123456,
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for cost calculation of Google Gemini language models.
  - Introduced detailed pricing information for various Google Gemini model variants, including token usage costs.
- **Enhancements**
  - Users can now view and estimate costs for Google Gemini models alongside other supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->