### PR TITLE
Add model price of OpenAI o4-mini

### DIFF
--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -94,7 +94,7 @@ export const openAiTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"o4-mini": {
+	"o3-mini": {
 		prices: [
 			{
 				validFrom: "2025-05-12T00:00:00Z",
@@ -109,7 +109,7 @@ export const openAiTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"o3-mini": {
+	"o4-mini": {
 		prices: [
 			{
 				validFrom: "2025-05-12T00:00:00Z",

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -94,6 +94,21 @@ export const openAiTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
+	"o4-mini": {
+		prices: [
+			{
+				validFrom: "2025-05-12T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 1.1,
+					},
+					output: {
+						costPerMegaToken: 4.4,
+					},
+				},
+			},
+		],
+	},
 	"o3-mini": {
 		prices: [
 			{


### PR DESCRIPTION
## Summary

Add [price](https://platform.openai.com/docs/pricing#other-models:~:text=o4%2Dmini,%244.40) of OpenAI o4-mini

## Related Issue

This should have been included in #834


## Testing
<!-- Briefly describe the testing steps or results. -->

### Before

Cost of o4-mini is not calculated on manually instrumented trace 👎 
<img width="619" alt="image" src="https://github.com/user-attachments/assets/658fce78-b8af-4ba0-baf1-381353cb651a" />


### After
Cost of o4-mini is calculated on manually instrumented trace ✅ 
<img width="627" alt="image" src="https://github.com/user-attachments/assets/52a46db1-e49d-45cf-b2f9-b99886084470" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pricing information for the "o4-mini" model, effective from May 12, 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->