### PR TITLE
Group Langfuse trace by workspace

### DIFF
--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -498,6 +498,7 @@ export async function generateText(args: {
 				onConsumeAgentTime: args.context.onConsumeAgentTime,
 			});
 
+			console.log("type: ----------------", args.generation);
 			// necessary to send telemetry but not explicitly used
 			const langfuse = createLangfuseTracer({
 				sessionId:

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -500,7 +500,7 @@ export async function generateText(args: {
 
 			// necessary to send telemetry but not explicitly used
 			const langfuse = createLangfuseTracer({
-				workspaceId,
+				sessionId: workspaceId,
 				runningGeneration,
 				tags: generateTelemetryTags({
 					provider: operationNode.content.llm.provider,

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -500,7 +500,10 @@ export async function generateText(args: {
 
 			// necessary to send telemetry but not explicitly used
 			const langfuse = createLangfuseTracer({
-				sessionId: workspaceId,
+				sessionId:
+					args.generation.context.origin.type === "run"
+						? args.generation.context.origin.id
+						: null,
 				runningGeneration,
 				tags: generateTelemetryTags({
 					provider: operationNode.content.llm.provider,

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -97,7 +97,7 @@ export function createLangfuseTracer({
 	generationName,
 	settings,
 }: {
-	sessionId?: string;
+	sessionId?: string | null;
 	runningGeneration: RunningGeneration;
 	tags: string[];
 	messages: { messages: unknown[] };

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -126,6 +126,7 @@ export function createLangfuseTracer({
 				deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
 			}),
 		},
+		sessionId: workspaceId,
 		input: messages,
 		output,
 		tags,

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -97,7 +97,7 @@ export function createLangfuseTracer({
 	generationName,
 	settings,
 }: {
-	sessionId: string;
+	sessionId?: string;
 	runningGeneration: RunningGeneration;
 	tags: string[];
 	messages: { messages: unknown[] };
@@ -126,7 +126,7 @@ export function createLangfuseTracer({
 				deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
 			}),
 		},
-		sessionId,
+		...(sessionId && { sessionId }),
 		input: messages,
 		output,
 		tags,

--- a/packages/giselle-engine/src/core/generations/telemetry.ts
+++ b/packages/giselle-engine/src/core/generations/telemetry.ts
@@ -86,7 +86,7 @@ type LangfuseUnit =
 	| "REQUESTS";
 
 export function createLangfuseTracer({
-	workspaceId,
+	sessionId,
 	runningGeneration,
 	tags,
 	messages,
@@ -97,7 +97,7 @@ export function createLangfuseTracer({
 	generationName,
 	settings,
 }: {
-	workspaceId: string;
+	sessionId: string;
 	runningGeneration: RunningGeneration;
 	tags: string[];
 	messages: { messages: unknown[] };
@@ -126,7 +126,7 @@ export function createLangfuseTracer({
 				deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
 			}),
 		},
-		sessionId: workspaceId,
+		sessionId,
 		input: messages,
 		output,
 		tags,


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

Enables to view statistics of Langfuse traces by Giselle workspace

## Related Issue
<!-- Mention the related issue number if applicable. -->

- This PR will resolve #931


## Testing
<!-- Briefly describe the testing steps or results. -->

We can view the statistics of traces by workspace ✅ 
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/d6938a00-6257-4010-9d8a-39ae5ea50e6d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved telemetry data by including session identifiers for enhanced tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->