### PR TITLE
Add model prices of Claude 4 series

### DIFF
--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -128,6 +128,36 @@ export const openAiTokenPricing: ModelPriceTable = {
 
 export const anthropicTokenPricing: ModelPriceTable = {
 	// https://www.anthropic.com/pricing
+	"claude-4-opus-20250514": {
+		prices: [
+			{
+				validFrom: "2025-05-23T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 15.0,
+					},
+					output: {
+						costPerMegaToken: 75.0,
+					},
+				},
+			},
+		],
+	},
+	"claude-4-sonnet-20250514": {
+		prices: [
+			{
+				validFrom: "2025-05-23T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 3.0,
+					},
+					output: {
+						costPerMegaToken: 15.0,
+					},
+				},
+			},
+		],
+	},
 	"claude-3-7-sonnet-20250219": {
 		prices: [
 			{


### PR DESCRIPTION
## Summary

Enables display-only cost calculation of Claude 4 series
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue

- https://github.com/giselles-ai/giselle/pull/934

## Testing

### Before

Cost is not calculated for Claude 4 series in manually instrumented traces 👎 
<img width="565" alt="image" src="https://github.com/user-attachments/assets/9fc385fc-df52-4376-8dd1-2f32c1cdbcd6" />

### After

Costs are properly calculated ✅ 
<img width="593" alt="image" src="https://github.com/user-attachments/assets/afbb3a42-4fc4-4e6e-94ce-aa5c32aba17e" />


<!-- Briefly describe the testing steps or results. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pricing information for the "claude-4-opus-20250514" and "claude-4-sonnet-20250514" models, effective from May 23, 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->