### PR TITLE
Add issueNumber field to GitHub issue triggers

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -75,6 +75,11 @@ type GithubEventInputMap = {
 // Define the input fields for each GitHub event type
 const githubEventInputs: GithubEventInputMap = {
 	"github.issue.created": {
+		issueNumber: {
+			label: "Issue Number",
+			type: "number",
+			required: true,
+		},
 		title: {
 			label: "Title",
 			type: "text",

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx
@@ -92,6 +92,11 @@ const githubEventInputs: GithubEventInputMap = {
 		},
 	},
 	"github.issue.closed": {
+		issueNumber: {
+			label: "Issue Number",
+			type: "number",
+			required: true,
+		},
 		title: {
 			label: "Title",
 			type: "text",

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -25,6 +25,7 @@ export const githubIssueClosedTrigger = {
 		id: "github.issue.closed",
 		label: "Issue Closed",
 		payloads: z.object({
+			issueNumber: z.number(),
 			title: z.string(),
 			body: z.string(),
 		}),

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -12,6 +12,7 @@ export const githubIssueCreatedTrigger = {
 		id: "github.issue.created",
 		label: "Issue Created",
 		payloads: z.object({
+			issueNumber: z.number(),
 			title: z.string(),
 			body: z.string(),
 		}),

--- a/packages/giselle-engine/src/core/github/trigger-utils.ts
+++ b/packages/giselle-engine/src/core/github/trigger-utils.ts
@@ -50,6 +50,12 @@ function buildIssueCreatedInputs(args: BuildTriggerInputsArgs) {
 					value: args.webhookEvent.data.payload.issue.body ?? "",
 				});
 				break;
+			case "issueNumber":
+				inputs.push({
+					name: "issueNumber",
+					value: args.webhookEvent.data.payload.issue.number.toString(),
+				});
+				break;
 			default: {
 				const _exhaustiveCheck: never = payload;
 				throw new Error(`Unhandled payload id: ${_exhaustiveCheck}`);

--- a/packages/giselle-engine/src/core/github/trigger-utils.ts
+++ b/packages/giselle-engine/src/core/github/trigger-utils.ts
@@ -88,6 +88,12 @@ function buildIssueClosedInputs(args: BuildTriggerInputsArgs) {
 					value: args.webhookEvent.data.payload.issue.body ?? "",
 				});
 				break;
+			case "issueNumber":
+				inputs.push({
+					name: "issueNumber",
+					value: args.webhookEvent.data.payload.issue.number.toString(),
+				});
+				break;
 			default: {
 				const _exhaustiveCheck: never = payload;
 				throw new Error(`Unhandled payload id: ${_exhaustiveCheck}`);


### PR DESCRIPTION
## Summary

This PR adds the `issueNumber` field to both GitHub issue created and issue closed triggers, allowing workflows to access the issue number directly.

## Changes

### GitHub Issue Created Trigger
- Added `issueNumber` field to the trigger input dialog UI
- Updated the payload schema to include `issueNumber` as a required number field
- Implemented trigger utility function to extract issue number from webhook payload

### GitHub Issue Closed Trigger
- Added `issueNumber` field to the trigger input dialog UI  
- Updated the payload schema to include `issueNumber` as a required number field
- Implemented trigger utility function to extract issue number from webhook payload

## Files Modified

- `internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog.tsx` - Added UI input fields
- `packages/flow/src/trigger/github.ts` - Updated payload schemas
- `packages/giselle-engine/src/core/github/trigger-utils.ts` - Added utility functions

## Testing

- [ ] Verified that the issue number field appears in the trigger configuration UI
- [ ] Confirmed that the issue number is correctly extracted from GitHub webhook payloads
- [ ] Validated that the schema properly validates the issueNumber field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a required "issueNumber" field to the input and payload for GitHub issue created and closed events. This field will now be visible and required when configuring these triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->