### PR TITLE
Refactor GitHub event reactions

### DIFF
--- a/packages/giselle-engine/src/core/github/event-handlers.test.ts
+++ b/packages/giselle-engine/src/core/github/event-handlers.test.ts
@@ -128,12 +128,11 @@ describe("GitHub Event Handlers", () => {
 			const result = await handleIssueOpened(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(true);
-			expect(args.deps.addReaction).toHaveBeenCalledWith({
-				id: "issue-node-id",
-				content: "EYES",
-				authConfig: args.authConfig,
+			expect(result).toEqual({
+				shouldRun: true,
+				reactionNodeId: "issue-node-id",
 			});
+			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
 		it("should not run if event type doesn't match", async () => {
@@ -159,7 +158,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handleIssueOpened(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
@@ -183,7 +182,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handleIssueOpened(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 	});
@@ -213,13 +212,12 @@ describe("GitHub Event Handlers", () => {
 			const result = await handleIssueCommentCreated(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(true);
-			expect(args.deps.parseCommand).toHaveBeenCalledWith("@giselle help me");
-			expect(args.deps.addReaction).toHaveBeenCalledWith({
-				id: "comment-node-id",
-				content: "EYES",
-				authConfig: args.authConfig,
+			expect(result).toEqual({
+				shouldRun: true,
+				reactionNodeId: "comment-node-id",
 			});
+			expect(args.deps.parseCommand).toHaveBeenCalledWith("@giselle help me");
+			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
 		it("should not run if callsign doesn't match", async () => {
@@ -253,7 +251,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handleIssueCommentCreated(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 	});
@@ -280,12 +278,11 @@ describe("GitHub Event Handlers", () => {
 			const result = await handleIssueClosed(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(true);
-			expect(args.deps.addReaction).toHaveBeenCalledWith({
-				id: "issue-node-id",
-				content: "EYES",
-				authConfig: args.authConfig,
+			expect(result).toEqual({
+				shouldRun: true,
+				reactionNodeId: "issue-node-id",
 			});
+			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
 		it("should not run if trigger event ID doesn't match", async () => {
@@ -309,7 +306,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handleIssueClosed(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 	});
@@ -336,12 +333,11 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestOpened(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(true);
-			expect(args.deps.addReaction).toHaveBeenCalledWith({
-				id: "pr-node-id",
-				content: "EYES",
-				authConfig: args.authConfig,
+			expect(result).toEqual({
+				shouldRun: true,
+				reactionNodeId: "pr-node-id",
 			});
+			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
 		it("should not run if trigger event ID doesn't match", async () => {
@@ -365,7 +361,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestOpened(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 	});
@@ -392,12 +388,11 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestClosed(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(true);
-			expect(args.deps.addReaction).toHaveBeenCalledWith({
-				id: "pr-node-id",
-				content: "EYES",
-				authConfig: args.authConfig,
+			expect(result).toEqual({
+				shouldRun: true,
+				reactionNodeId: "pr-node-id",
 			});
+			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
 		it("should not run if trigger event ID doesn't match", async () => {
@@ -421,7 +416,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestClosed(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 	});
@@ -455,13 +450,12 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestCommentCreated(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(true);
-			expect(args.deps.parseCommand).toHaveBeenCalledWith("@giselle help me");
-			expect(args.deps.addReaction).toHaveBeenCalledWith({
-				id: "comment-node-id",
-				content: "EYES",
-				authConfig: args.authConfig,
+			expect(result).toEqual({
+				shouldRun: true,
+				reactionNodeId: "comment-node-id",
 			});
+			expect(args.deps.parseCommand).toHaveBeenCalledWith("@giselle help me");
+			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
 		it("should not run if callsign doesn't match", async () => {
@@ -499,7 +493,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestCommentCreated(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 	});
@@ -527,12 +521,11 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestReadyForReview(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(true);
-			expect(args.deps.addReaction).toHaveBeenCalledWith({
-				id: "pr-node-id",
-				content: "EYES",
-				authConfig: args.authConfig,
+			expect(result).toEqual({
+				shouldRun: true,
+				reactionNodeId: "pr-node-id",
 			});
+			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 
 		it("should not run if trigger event ID doesn't match", async () => {
@@ -556,7 +549,7 @@ describe("GitHub Event Handlers", () => {
 			const result = await handlePullRequestReadyForReview(args);
 
 			// Assert
-			expect(result.shouldRun).toBe(false);
+			expect(result).toEqual({ shouldRun: false });
 			expect(args.deps.addReaction).not.toHaveBeenCalled();
 		});
 	});
@@ -631,6 +624,11 @@ describe("GitHub Event Handlers", () => {
 				triggerId: mockFlowTriggerId,
 				payload: event,
 			});
+			expect(testDeps.addReaction).toHaveBeenCalledWith({
+				id: "issue-node-id",
+				content: "EYES",
+				authConfig: expect.anything(),
+			});
 		});
 
 		it("should return false when trigger is disabled", async () => {
@@ -690,6 +688,7 @@ describe("GitHub Event Handlers", () => {
 			// Assert
 			expect(result).toBe(false);
 			expect(testDeps.runFlow).not.toHaveBeenCalled();
+			expect(testDeps.addReaction).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/giselle-engine/src/core/github/event-handlers.ts
+++ b/packages/giselle-engine/src/core/github/event-handlers.ts
@@ -27,6 +27,7 @@ export type EventHandlerArgs<TEventName extends WebhookEventName> = {
 
 export type EventHandlerResult = {
 	shouldRun: boolean;
+	reactionNodeId?: string;
 };
 
 export async function handleIssueOpened<TEventName extends WebhookEventName>(
@@ -44,13 +45,7 @@ export async function handleIssueOpened<TEventName extends WebhookEventName>(
 		return { shouldRun: false };
 	}
 
-	await args.deps.addReaction({
-		id: issue.node_id,
-		content: "EYES",
-		authConfig: args.authConfig,
-	});
-
-	return { shouldRun: true };
+	return { shouldRun: true, reactionNodeId: issue.node_id };
 }
 
 export async function handleIssueClosed<TEventName extends WebhookEventName>(
@@ -68,13 +63,7 @@ export async function handleIssueClosed<TEventName extends WebhookEventName>(
 		return { shouldRun: false };
 	}
 
-	await args.deps.addReaction({
-		id: issue.node_id,
-		content: "EYES",
-		authConfig: args.authConfig,
-	});
-
-	return { shouldRun: true };
+	return { shouldRun: true, reactionNodeId: issue.node_id };
 }
 
 export async function handleIssueCommentCreated<
@@ -102,13 +91,7 @@ export async function handleIssueCommentCreated<
 		return { shouldRun: false };
 	}
 
-	await args.deps.addReaction({
-		id: comment.node_id,
-		content: "EYES",
-		authConfig: args.authConfig,
-	});
-
-	return { shouldRun: true };
+	return { shouldRun: true, reactionNodeId: comment.node_id };
 }
 
 export async function handlePullRequestCommentCreated<
@@ -136,13 +119,10 @@ export async function handlePullRequestCommentCreated<
 		return { shouldRun: false };
 	}
 
-	await args.deps.addReaction({
-		id: args.event.data.payload.comment.node_id,
-		content: "EYES",
-		authConfig: args.authConfig,
-	});
-
-	return { shouldRun: true };
+	return {
+		shouldRun: true,
+		reactionNodeId: args.event.data.payload.comment.node_id,
+	};
 }
 
 export async function handlePullRequestOpened<
@@ -160,13 +140,7 @@ export async function handlePullRequestOpened<
 		return { shouldRun: false };
 	}
 
-	await args.deps.addReaction({
-		id: pullRequest.node_id,
-		content: "EYES",
-		authConfig: args.authConfig,
-	});
-
-	return { shouldRun: true };
+	return { shouldRun: true, reactionNodeId: pullRequest.node_id };
 }
 
 export async function handlePullRequestReadyForReview<
@@ -188,13 +162,7 @@ export async function handlePullRequestReadyForReview<
 		return { shouldRun: false };
 	}
 
-	await args.deps.addReaction({
-		id: pullRequest.node_id,
-		content: "EYES",
-		authConfig: args.authConfig,
-	});
-
-	return { shouldRun: true };
+	return { shouldRun: true, reactionNodeId: pullRequest.node_id };
 }
 
 export async function handlePullRequestClosed<
@@ -212,13 +180,7 @@ export async function handlePullRequestClosed<
 		return { shouldRun: false };
 	}
 
-	await args.deps.addReaction({
-		id: pullRequest.node_id,
-		content: "EYES",
-		authConfig: args.authConfig,
-	});
-
-	return { shouldRun: true };
+	return { shouldRun: true, reactionNodeId: pullRequest.node_id };
 }
 
 export const eventHandlers = [
@@ -260,6 +222,14 @@ export async function processEvent<TEventName extends WebhookEventName>(
 			authConfig,
 			deps,
 		});
+
+		if (result.reactionNodeId) {
+			await deps.addReaction({
+				id: result.reactionNodeId,
+				content: "EYES",
+				authConfig,
+			});
+		}
 
 		if (result.shouldRun) {
 			await deps.runFlow({


### PR DESCRIPTION
## Summary
- refactor GitHub event handlers to return a node ID for reactions instead of calling `addReaction`
- invoke `addReaction` from `processEvent`
- update tests for new behaviour

## Testing
- `pnpm -F @giselle-sdk/giselle-engine test`