### PR TITLE
Improve GitHub flow feedback

### DIFF
--- a/packages/giselle-engine/src/core/github/event-handlers.test.ts
+++ b/packages/giselle-engine/src/core/github/event-handlers.test.ts
@@ -57,6 +57,8 @@ describe("GitHub Event Handlers", () => {
 			parseCommand: vi
 				.fn()
 				.mockReturnValue({ callsign: "giselle", content: "help me" }),
+			createIssueComment: vi.fn().mockResolvedValue({ id: 1 }),
+			updateIssueComment: vi.fn().mockResolvedValue(undefined),
 		};
 
 		// Setup base arguments
@@ -623,6 +625,7 @@ describe("GitHub Event Handlers", () => {
 				context: expect.anything(),
 				triggerId: mockFlowTriggerId,
 				payload: event,
+				onStep: expect.any(Function),
 			});
 			expect(testDeps.addReaction).toHaveBeenCalledWith({
 				id: "issue-node-id",

--- a/packages/giselle-engine/src/core/github/handle-webhook-v2.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook-v2.ts
@@ -3,8 +3,10 @@ import {
 	type WebhookEvent,
 	type WebhookEventName,
 	addReaction,
+	createIssueComment,
 	ensureWebhookEvent,
 	handleWebhook,
+	updateIssueComment,
 } from "@giselle-sdk/github-tool";
 import { runFlow } from "../flows";
 import { getFlowTrigger } from "../flows/utils";
@@ -44,6 +46,8 @@ export async function handleGitHubWebhookV2(args: {
 				ensureWebhookEvent,
 				runFlow,
 				parseCommand,
+				createIssueComment,
+				updateIssueComment,
 			},
 		});
 
@@ -143,6 +147,8 @@ async function process<TEventName extends WebhookEventName>(args: {
 					ensureWebhookEvent: args.deps.ensureWebhookEvent,
 					runFlow: args.deps.runFlow,
 					parseCommand: args.deps.parseCommand,
+					createIssueComment: args.deps.createIssueComment,
+					updateIssueComment: args.deps.updateIssueComment,
 				},
 			});
 		}),

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -227,6 +227,7 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 			triggerId: FlowTriggerId;
 			triggerInputs?: GenerationInput[];
 			payload?: unknown;
+			onStep?: Parameters<typeof runFlow>[0]["onStep"];
 		}) => runFlow({ ...args, context }),
 		handleGitHubWebhookV2: async (args: { request: Request }) =>
 			handleGitHubWebhookV2({ ...args, context }),

--- a/packages/github-tool/src/issues.ts
+++ b/packages/github-tool/src/issues.ts
@@ -85,3 +85,32 @@ export async function createPullRequestComment(args: {
 	);
 	return response.data;
 }
+
+export async function updateIssueComment(args: {
+	repositoryNodeId: string;
+	commentId: number;
+	body: string;
+	authConfig: GitHubAuthConfig;
+}) {
+	const client = octokit(args.authConfig);
+	const repo = await getRepositoryFullname(
+		args.repositoryNodeId,
+		args.authConfig,
+	);
+	if (repo.error || repo.data === undefined) {
+		throw new Error(`Failed to get repository information: ${repo.error}`);
+	}
+	if (repo.data.node?.__typename !== "Repository") {
+		throw new Error(`Invalid repository type: ${repo.data.node?.__typename}`);
+	}
+	const response = await client.request(
+		"PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}",
+		{
+			owner: repo.data.node.owner.login,
+			repo: repo.data.node.name,
+			comment_id: args.commentId,
+			body: args.body,
+		},
+	);
+	return response.data;
+}


### PR DESCRIPTION
## Summary
- add GitHub comment utilities for updating issue comments
- expose step callbacks in `runFlow`
- create and update progress comments when running flows
- wire new dependencies into webhook processing
- adjust tests for updated API

## Testing
- `turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`
- `turbo check-types --cache=local:rw`
- `turbo test --cache=local:rw`
