### PR TITLE
Log trigger info when processEvent fails

### DIFF
--- a/packages/giselle-engine/src/core/github/handle-webhook-v2.ts
+++ b/packages/giselle-engine/src/core/github/handle-webhook-v2.ts
@@ -133,18 +133,25 @@ async function process<TEventName extends WebhookEventName>(args: {
 				installationId,
 			});
 
-			await processEvent({
-				event: args.event,
-				context: args.context,
-				trigger,
-				createAuthConfig,
-				deps: {
-					addReaction: args.deps.addReaction,
-					ensureWebhookEvent: args.deps.ensureWebhookEvent,
-					runFlow: args.deps.runFlow,
-					parseCommand: args.deps.parseCommand,
-				},
-			});
+			try {
+				await processEvent({
+					event: args.event,
+					context: args.context,
+					trigger,
+					createAuthConfig,
+					deps: {
+						addReaction: args.deps.addReaction,
+						ensureWebhookEvent: args.deps.ensureWebhookEvent,
+						runFlow: args.deps.runFlow,
+						parseCommand: args.deps.parseCommand,
+					},
+				});
+			} catch (error) {
+				console.error(
+					`processEvent failed for workspaceId=${trigger.workspaceId} nodeId=${trigger.nodeId}:`,
+					error,
+				);
+			}
 		}),
 	);
 }


### PR DESCRIPTION
## Summary
- log trigger workspaceId and nodeId when `processEvent` throws in webhook handler

## Testing
- `turbo test --cache=local:rw`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent interruptions when processing events. Errors are now logged, allowing other processes to continue without disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->