### PR TITLE
Fix crash when GitHub is returning 5xx error

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/account/github-authentication.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/github-authentication.tsx
@@ -25,6 +25,14 @@ export async function GitHubAuthentication() {
 		);
 	}
 
+	if (identityState.status === "error") {
+		return (
+			<GitHubAuthenticationPresentation
+				alert={`GitHub integration error: ${identityState.error.message}`}
+			/>
+		);
+	}
+
 	return (
 		<GitHubAuthenticationPresentation
 			gitHubUser={identityState.gitHubUser}

--- a/apps/studio.giselles.ai/app/(main)/settings/account/github-authentication.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/github-authentication.tsx
@@ -28,7 +28,7 @@ export async function GitHubAuthentication() {
 	if (identityState.status === "error") {
 		return (
 			<GitHubAuthenticationPresentation
-				alert={`GitHub integration error: ${identityState.error.message}`}
+				alert={`GitHub integration error: ${identityState.errorMessage}`}
 			/>
 		);
 	}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/integrations/github-integration.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/integrations/github-integration.tsx
@@ -1,8 +1,10 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { GitHubAppInstallButton } from "@/packages/components/github-app-install-button";
 import { getGitHubIdentityState } from "@/services/accounts";
 import { gitHubAppInstallURL } from "@/services/external/github";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import type { components } from "@octokit/openapi-types";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { Button } from "../../components/button";
 
@@ -14,6 +16,9 @@ export async function GitHubIntegration() {
 		identityState.status === "invalid-credential"
 	) {
 		return <GitHubIntegrationPresentation installationUrl={installUrl} />;
+	}
+	if (identityState.status === "error") {
+		return <GitHubError message={identityState.error.message} />;
 	}
 
 	const gitHubUserClient = identityState.gitHubUserClient;
@@ -35,6 +40,23 @@ export async function GitHubIntegration() {
 			installations={installationsWithRepos}
 			installationUrl={installUrl}
 		/>
+	);
+}
+
+type GitHubErrorProps = {
+	message: string;
+};
+
+function GitHubError({ message }: GitHubErrorProps) {
+	return (
+		<Alert variant="destructive" className="max-w-2xl">
+			<ExclamationTriangleIcon className="h-4 w-4" />
+			<AlertTitle>GitHub Integration Error</AlertTitle>
+			<AlertDescription className="mt-2">
+				<p className="mb-2">{message}</p>
+				<p className="text-sm">Try refreshing the page later.</p>
+			</AlertDescription>
+		</Alert>
 	);
 }
 

--- a/apps/studio.giselles.ai/app/(main)/settings/team/integrations/github-integration.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/integrations/github-integration.tsx
@@ -9,16 +9,20 @@ import Link from "next/link";
 import { Button } from "../../components/button";
 
 export async function GitHubIntegration() {
-	const installUrl = await gitHubAppInstallURL();
 	const identityState = await getGitHubIdentityState();
+	if (identityState.status === "error") {
+		return <GitHubError message={identityState.errorMessage} />;
+	}
+
+	const installUrl = await gitHubAppInstallURL();
+	if (installUrl == null) {
+		return <GitHubError message="Failed to get GitHub App installation URL." />;
+	}
 	if (
 		identityState.status === "unauthorized" ||
 		identityState.status === "invalid-credential"
 	) {
 		return <GitHubIntegrationPresentation installationUrl={installUrl} />;
-	}
-	if (identityState.status === "error") {
-		return <GitHubError message={identityState.errorMessage} />;
 	}
 
 	const gitHubUserClient = identityState.gitHubUserClient;

--- a/apps/studio.giselles.ai/app/(main)/settings/team/integrations/github-integration.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/integrations/github-integration.tsx
@@ -4,7 +4,7 @@ import { getGitHubIdentityState } from "@/services/accounts";
 import { gitHubAppInstallURL } from "@/services/external/github";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import type { components } from "@octokit/openapi-types";
-import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { TriangleAlertIcon } from "lucide-react";
 import Link from "next/link";
 import { Button } from "../../components/button";
 
@@ -18,7 +18,7 @@ export async function GitHubIntegration() {
 		return <GitHubIntegrationPresentation installationUrl={installUrl} />;
 	}
 	if (identityState.status === "error") {
-		return <GitHubError message={identityState.error.message} />;
+		return <GitHubError message={identityState.errorMessage} />;
 	}
 
 	const gitHubUserClient = identityState.gitHubUserClient;
@@ -49,12 +49,13 @@ type GitHubErrorProps = {
 
 function GitHubError({ message }: GitHubErrorProps) {
 	return (
-		<Alert variant="destructive" className="max-w-2xl">
-			<ExclamationTriangleIcon className="h-4 w-4" />
-			<AlertTitle>GitHub Integration Error</AlertTitle>
-			<AlertDescription className="mt-2">
-				<p className="mb-2">{message}</p>
-				<p className="text-sm">Try refreshing the page later.</p>
+		<Alert variant="destructive" className="p-4">
+			<TriangleAlertIcon className="w-[18px] h-[18px] text-error-900/80" />
+			<AlertTitle className="mb-0 text-error-900 font-bold text-[12px] leading-[20.4px] font-geist">
+				Authentication Error
+			</AlertTitle>
+			<AlertDescription className="text-error-900/70 font-medium text-[12px] leading-[20.4px] font-geist">
+				{message}
 			</AlertDescription>
 		</Alert>
 	);

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
@@ -4,7 +4,7 @@ import { githubVectorStoreFlag } from "@/flags";
 import { getGitHubIdentityState } from "@/services/accounts";
 import { fetchCurrentTeam } from "@/services/teams";
 import { desc, eq } from "drizzle-orm";
-import { ExternalLink } from "lucide-react";
+import { AlertCircle, ExternalLink } from "lucide-react";
 import { notFound } from "next/navigation";
 import { deleteRepositoryIndex, registerRepositoryIndex } from "./actions";
 import { RepositoryItem } from "./repository-item";
@@ -22,6 +22,12 @@ export default async function TeamVectorStorePage() {
 		githubIdentityState.status === "invalid-credential"
 	) {
 		return <GitHubAuthRequiredCard />;
+	}
+
+	if (githubIdentityState.status === "error") {
+		return (
+			<GitHubAuthErrorCard errorMessage={githubIdentityState.errorMessage} />
+		);
 	}
 
 	const userClient = githubIdentityState.gitHubUserClient;
@@ -117,6 +123,32 @@ function GitHubAuthRequiredCard() {
 					>
 						Open Authentication Settings
 					</a>
+				</div>
+			</Card>
+		</div>
+	);
+}
+
+function GitHubAuthErrorCard({ errorMessage }: { errorMessage: string }) {
+	return (
+		<div className="flex flex-col gap-[24px]">
+			<h3
+				className="text-primary-100 font-semibold text-[28px] leading-[28px] tracking-[-0.011em] font-hubot"
+				style={{ textShadow: "0px 0px 20px hsla(207, 100%, 48%, 1)" }}
+			>
+				Vector Store
+			</h3>
+			<Card className="border-[0.5px] border-red-500/50 rounded-[8px] bg-red-500/5 p-6">
+				<div className="flex flex-col items-center justify-center py-8">
+					<div className="flex items-center gap-2 mb-4">
+						<AlertCircle className="text-red-400" size={24} />
+						<h4 className="text-red-200 font-medium text-[18px] leading-[21.6px] font-hubot">
+							GitHub authentication error occurred.
+						</h4>
+					</div>
+					<p className="text-red-300 text-[14px] leading-[20.4px] font-geist text-center mb-4">
+						{errorMessage}
+					</p>
 				</div>
 			</Card>
 		</div>

--- a/apps/studio.giselles.ai/packages/lib/github.ts
+++ b/apps/studio.giselles.ai/packages/lib/github.ts
@@ -38,6 +38,12 @@ export async function getGitHubIntegrationState(
 		gitHubUserClient.getInstallations(),
 		gitHubAppInstallURL(),
 	]);
+	if (installationUrl == null) {
+		return {
+			status: "error",
+			errorMessage: "Failed to get GitHub App installation URL.",
+		};
+	}
 	if (installations.length === 0) {
 		return {
 			status: "not-installed",

--- a/apps/studio.giselles.ai/packages/lib/github.ts
+++ b/apps/studio.giselles.ai/packages/lib/github.ts
@@ -29,7 +29,7 @@ export async function getGitHubIntegrationState(
 	if (identityState.status === "error") {
 		return {
 			status: "error",
-			error: identityState.error.message,
+			errorMessage: identityState.errorMessage,
 		};
 	}
 

--- a/apps/studio.giselles.ai/packages/lib/github.ts
+++ b/apps/studio.giselles.ai/packages/lib/github.ts
@@ -4,6 +4,7 @@ import { db, type githubIntegrationSettings } from "@/drizzle";
 import { getGitHubIdentityState } from "@/services/accounts";
 import { gitHubAppInstallURL } from "@/services/external/github";
 import type {
+	GitHubIntegrationErrorState,
 	GitHubIntegrationInstalledState,
 	GitHubIntegrationInvalidCredentialState,
 	GitHubIntegrationNotInstalledState,
@@ -23,6 +24,12 @@ export async function getGitHubIntegrationState(
 	if (identityState.status === "invalid-credential") {
 		return {
 			status: identityState.status,
+		};
+	}
+	if (identityState.status === "error") {
+		return {
+			status: "error",
+			error: identityState.error.message,
 		};
 	}
 
@@ -76,6 +83,7 @@ export type GitHubIntegrationState = (
 	| GitHubIntegrationInvalidCredentialState
 	| GitHubIntegrationNotInstalledState
 	| GitHubIntegrationInstalledState
+	| GitHubIntegrationErrorState
 ) &
 	GitHubIntegrationSettingState;
 

--- a/apps/studio.giselles.ai/services/accounts/github-identity-state.ts
+++ b/apps/studio.giselles.ai/services/accounts/github-identity-state.ts
@@ -29,7 +29,7 @@ type GitHubIdentityStateAuthorized = {
 
 type GitHubIdentityStateError = {
 	status: "error";
-	error: Error;
+	errorMessage: string;
 };
 
 export async function getGitHubIdentityState(): Promise<GitHubIdentityState> {
@@ -51,9 +51,9 @@ export async function getGitHubIdentityState(): Promise<GitHubIdentityState> {
 			return { status: "invalid-credential" };
 		}
 		if (error instanceof Error) {
-			return { status: "error", error };
+			return { status: "error", errorMessage: error.message };
 		}
 
-		return { status: "error", error: new Error(String(error)) };
+		return { status: "error", errorMessage: String(error) };
 	}
 }

--- a/apps/studio.giselles.ai/services/accounts/github-identity-state.ts
+++ b/apps/studio.giselles.ai/services/accounts/github-identity-state.ts
@@ -50,10 +50,11 @@ export async function getGitHubIdentityState(): Promise<GitHubIdentityState> {
 		if (needsAuthorization(error)) {
 			return { status: "invalid-credential" };
 		}
-		if (error instanceof Error) {
-			return { status: "error", errorMessage: error.message };
-		}
 
-		return { status: "error", errorMessage: String(error) };
+		console.error("Error getting GitHub identity state:", error);
+		return {
+			status: "error",
+			errorMessage: "The GitHub API returned an error. Please try again later.",
+		};
 	}
 }

--- a/apps/studio.giselles.ai/services/external/github/app.ts
+++ b/apps/studio.giselles.ai/services/external/github/app.ts
@@ -11,15 +11,20 @@ import { RequestError } from "@octokit/request-error";
  * @returns {Promise<string>} The URL for installing the GitHub App.
  * @throws {Error} If the request to get app information fails.
  */
-export async function gitHubAppInstallURL(): Promise<string> {
+export async function gitHubAppInstallURL(): Promise<string | undefined> {
 	const auth = appAuth();
 	const app = await auth({ type: "app" });
 	const octokit = new Octokit({ auth: app.token });
-	const res = await octokit.request("GET /app");
-	if (res.status !== 200 || !res.data) {
-		throw new Error("Failed to get app information");
+	try {
+		const res = await octokit.request("GET /app");
+		if (res.status !== 200 || !res.data) {
+			throw new Error("Failed to get app information");
+		}
+		return `https://github.com/apps/${res.data.slug}/installations/new`;
+	} catch (error: unknown) {
+		console.error("Error getting GitHub App information:", error);
+		return;
 	}
-	return `https://github.com/apps/${res.data.slug}/installations/new`;
 }
 
 /**

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
@@ -66,7 +66,7 @@ export function GitHubActionPropertiesPanel({ node }: { node: ActionNode }) {
 				/>
 			);
 		case "error":
-			return `GitHub integration error: ${value.github.error}`;
+			return `GitHub integration error: ${value.github.errorMessage}`;
 		default: {
 			const _exhaustiveCheck: never = value.github;
 			throw new Error(`Unhandled status: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
@@ -65,6 +65,8 @@ export function GitHubActionPropertiesPanel({ node }: { node: ActionNode }) {
 					installationUrl={value.github.installationUrl}
 				/>
 			);
+		case "error":
+			return `GitHub integration error: ${value.github.error}`;
 		default: {
 			const _exhaustiveCheck: never = value.github;
 			throw new Error(`Unhandled status: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
@@ -65,7 +65,7 @@ export function GitHubTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 				/>
 			);
 		case "error":
-			return `GitHub integration error: ${value.github.error}`;
+			return `GitHub integration error: ${value.github.errorMessage}`;
 		default: {
 			const _exhaustiveCheck: never = value.github;
 			throw new Error(`Unhandled status: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/github-trigger-properties-panel.tsx
@@ -13,12 +13,9 @@ import { InfoIcon } from "lucide-react";
 import {
 	type FormEventHandler,
 	useCallback,
-	useEffect,
-	useRef,
 	useState,
 	useTransition,
 } from "react";
-import { GitHubIcon, SpinnerIcon } from "../../../../../icons";
 import {
 	Select,
 	SelectContent,
@@ -28,8 +25,7 @@ import {
 } from "../../../../../ui/select";
 import { Tooltip } from "../../../../../ui/tooltip";
 import { SelectRepository } from "../../../ui";
-import { GitHubRepositoryBlock } from "../../ui";
-import { GitHubTriggerConfiguredView } from "../../ui";
+import { GitHubRepositoryBlock, GitHubTriggerConfiguredView } from "../../ui";
 import { InstallGitHubApplication } from "./components/install-application";
 import { Unauthorized } from "./components/unauthorized";
 
@@ -68,6 +64,8 @@ export function GitHubTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 					installationUrl={value.github.installationUrl}
 				/>
 			);
+		case "error":
+			return `GitHub integration error: ${value.github.error}`;
 		default: {
 			const _exhaustiveCheck: never = value.github;
 			throw new Error(`Unhandled status: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -250,6 +250,8 @@ export function GitHubIntegrationSettingForm() {
 			return "invalid-credential";
 		case "installed":
 			return <Installed repositories={github.repositories} />;
+		case "error":
+			return `GitHub integration error: ${github.error}`;
 		default: {
 			const _exhaustiveCheck: never = github;
 			throw new Error(`Unhandled status: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
+++ b/internal-packages/workflow-designer-ui/src/settings/github-integration/github-integration-setting-form.tsx
@@ -251,7 +251,7 @@ export function GitHubIntegrationSettingForm() {
 		case "installed":
 			return <Installed repositories={github.repositories} />;
 		case "error":
-			return `GitHub integration error: ${github.error}`;
+			return `GitHub integration error: ${github.errorMessage}`;
 		default: {
 			const _exhaustiveCheck: never = github;
 			throw new Error(`Unhandled status: ${_exhaustiveCheck}`);

--- a/packages/integration/src/github/index.ts
+++ b/packages/integration/src/github/index.ts
@@ -41,7 +41,7 @@ export type GitHubIntegrationInstalledState = z.infer<
 
 export const GitHubIntegrationErrorState = z.object({
 	status: z.literal("error"),
-	error: z.string(),
+	errorMessage: z.string(),
 });
 export type GitHubIntegrationErrorState = z.infer<
 	typeof GitHubIntegrationErrorState

--- a/packages/integration/src/github/index.ts
+++ b/packages/integration/src/github/index.ts
@@ -38,11 +38,20 @@ export const GitHubIntegrationInstalledState = z.object({
 export type GitHubIntegrationInstalledState = z.infer<
 	typeof GitHubIntegrationInstalledState
 >;
+
+export const GitHubIntegrationErrorState = z.object({
+	status: z.literal("error"),
+	error: z.string(),
+});
+export type GitHubIntegrationErrorState = z.infer<
+	typeof GitHubIntegrationErrorState
+>;
 export const GitHubIntegrationState = z.discriminatedUnion("status", [
 	GitHubIntegrationUnsetState,
 	GitHubIntegrationUnauthorizedState,
 	GitHubIntegrationInvalidCredentialState,
 	GitHubIntegrationNotInstalledState,
 	GitHubIntegrationInstalledState,
+	GitHubIntegrationErrorState,
 ]);
 export type GitHubIntegration = z.infer<typeof GitHubIntegrationState>;


### PR DESCRIPTION
## Summary
When GitHub returns 5xx error, Giselle also crashes.
This PR adds a minimum error handling for this case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced explicit error handling with user-visible messages for GitHub integration errors across multiple components and settings.
- **Bug Fixes**
	- Improved error management to prevent unhandled exceptions and provide clearer feedback during GitHub-related issues.
- **Style**
	- Streamlined import statements by removing unused React hooks for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->