### PR TITLE
Show the Web Page in the toolbar (with feature flag)

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -16,6 +16,7 @@ export default async function Layout({
 			featureFlag={{
 				flowNode: true,
 				runV2: true,
+				webPageFileNode: true,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -1,5 +1,5 @@
 import { db } from "@/drizzle";
-import { flowNodeFlag, runV2Flag } from "@/flags";
+import { flowNodeFlag, runV2Flag, webPageFileNodeFlag } from "@/flags";
 import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
 import { fetchCurrentUser } from "@/services/accounts";
@@ -35,7 +35,7 @@ export default async function Layout({
 	const usageLimits = await getUsageLimitsForTeam(currentTeam);
 	const flowNode = await flowNodeFlag();
 	const runV2 = await runV2Flag();
-
+	const webPageFileNode = await webPageFileNodeFlag();
 	return (
 		<WorkspaceProvider
 			workspaceId={workspaceId}
@@ -60,6 +60,7 @@ export default async function Layout({
 			featureFlag={{
 				flowNode,
 				runV2,
+				webPageFileNode,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -116,3 +116,16 @@ export const githubVectorStoreFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const webPageFileNodeFlag = flag<boolean>({
+	key: "web-page-file-node",
+	async decide() {
+		return takeLocalEnv("WEB_PAGE_FILE_NODE_FLAG");
+	},
+	description: "Enable Web Page File Node",
+	defaultValue: false,
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -22,6 +22,10 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 		label: "Image",
 		maxSize: 1024 * 1024,
 	},
+	webPage: {
+		accept: ["text/html", "text/markdown"],
+		label: "Web Page",
+	},
 };
 
 export function FileNodePropertiesPanel({ node }: { node: FileNode }) {

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/components/icons.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/components/icons.tsx
@@ -19,5 +19,6 @@ export {
 	UploadIcon,
 	VideoIcon,
 	WilliIcon,
+	WebPageFileIcon,
 } from "../../../../icons";
 export { ImageGenerationNodeIcon } from "../../../../icons/node";

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -52,6 +52,7 @@ import {
 	TriggerIcon,
 	UploadIcon,
 	VideoIcon,
+	WebPageFileIcon,
 	WilliIcon,
 } from "./components";
 import {
@@ -83,7 +84,7 @@ export function Toolbar() {
 	const [selectedCategory, setSelectedCategory] = useState<string>("All");
 	const { llmProviders } = useWorkflowDesigner();
 	const limits = useUsageLimits();
-	const { flowNode } = useFeatureFlag();
+	const { flowNode, webPageFileNode } = useFeatureFlag();
 	const languageModelAvailable = (languageModel: LanguageModel) => {
 		if (limits === undefined) {
 			return true;
@@ -930,6 +931,12 @@ export function Toolbar() {
 													<TextFileIcon className="w-[20px] h-[20px]" />
 													<p className="text-[14px]">Text</p>
 												</ToggleGroup.Item>
+												{webPageFileNode && (
+													<ToggleGroup.Item value="webpage" data-tool>
+														<WebPageFileIcon className="w-[20px] h-[20px]" />
+														<p className="text-[14px]">Web Page</p>
+													</ToggleGroup.Item>
+												)}
 												{/* <ToggleGroup.Item value="addGitHubNode" data-tool>
 													<GitHubIcon className="w-[20px] h-[20px]" />
 													<p className="text-[14px]">GitHub</p>

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -932,7 +932,7 @@ export function Toolbar() {
 													<p className="text-[14px]">Text</p>
 												</ToggleGroup.Item>
 												{webPageFileNode && (
-													<ToggleGroup.Item value="webpage" data-tool>
+													<ToggleGroup.Item value="webPage" data-tool>
 														<WebPageFileIcon className="w-[20px] h-[20px]" />
 														<p className="text-[14px]">Web Page</p>
 													</ToggleGroup.Item>

--- a/internal-packages/workflow-designer-ui/src/icons/content-type-icon.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/content-type-icon.tsx
@@ -18,6 +18,7 @@ import { PictureIcon } from "./picture";
 import { RecraftIcon } from "./recraft";
 import { StableDiffusionIcon } from "./stable-diffusion";
 import { TextFileIcon } from "./text-file";
+import { WebPageFileIcon } from "./web-page-file";
 
 interface TextNodeIconProps extends SVGProps<SVGSVGElement> {
 	contentType: "text";
@@ -109,6 +110,8 @@ export function ContentTypeIcon({
 					return <TextFileIcon {...props} />;
 				case "image":
 					return <PictureIcon {...props} />;
+				case "webPage":
+					return <WebPageFileIcon {...props} />;
 				default: {
 					const _exhaustiveCheck: never = fileCategory;
 					throw new Error(`Unhandled FileCategory: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/icons/index.ts
+++ b/internal-packages/workflow-designer-ui/src/icons/index.ts
@@ -44,3 +44,4 @@ export { AudioIcon } from "./audio";
 export { VideoIcon } from "./video";
 export { GenerateImageIcon } from "./generate-image";
 export * from "./trigger";
+export * from "./web-page-file";

--- a/internal-packages/workflow-designer-ui/src/icons/node/file-node.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/node/file-node.tsx
@@ -3,6 +3,7 @@ import type { SVGProps } from "react";
 import { PdfFileIcon } from "../pdf-file";
 import { PictureIcon } from "../picture";
 import { TextFileIcon } from "../text-file";
+import { WebPageFileIcon } from "../web-page-file";
 
 export function FileNodeIcon({
 	node,
@@ -17,6 +18,8 @@ export function FileNodeIcon({
 			return <TextFileIcon {...props} />;
 		case "image":
 			return <PictureIcon {...props} />;
+		case "webPage":
+			return <WebPageFileIcon {...props} />;
 		default: {
 			const _exhaustiveCheck: never = node.content.category;
 			throw new Error(`Unhandled node type: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
@@ -15,6 +15,7 @@ import { RecraftIcon } from "../recraft";
 import { StableDiffusionIcon } from "../stable-diffusion";
 import { TextFileIcon } from "../text-file";
 import { TriggerIcon } from "../trigger";
+import { WebPageFileIcon } from "../web-page-file";
 export * from "./file-node";
 export * from "./image-generation-node";
 export * from "./text-generation-node";
@@ -123,6 +124,8 @@ export function NodeIcon({
 							return <TextFileIcon {...props} data-content-type-icon />;
 						case "image":
 							return <PictureIcon {...props} data-content-type-icon />;
+						case "webPage":
+							return <WebPageFileIcon {...props} data-content-type-icon />;
 						default: {
 							const _exhaustiveCheck: never = node.content.category;
 							throw new Error(`Unhandled node type: ${_exhaustiveCheck}`);

--- a/internal-packages/workflow-designer-ui/src/icons/web-page-file.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/web-page-file.tsx
@@ -1,0 +1,23 @@
+import type { FC, SVGProps } from "react";
+
+export const WebPageFileIcon: FC<SVGProps<SVGSVGElement>> = (props) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		className="lucide lucide-panels-top-left-icon lucide-panels-top-left"
+		role="img"
+		aria-label="Web Page File"
+		{...props}
+	>
+		<rect width="18" height="18" x="3" y="3" rx="2" />
+		<path d="M3 9h18" />
+		<path d="M9 21V9" />
+	</svg>
+);

--- a/packages/data-type/src/node/variables/file.ts
+++ b/packages/data-type/src/node/variables/file.ts
@@ -76,7 +76,7 @@ export const FileData = z.union([
 ]);
 export type FileData = z.infer<typeof FileData>;
 
-export const FileCategory = z.enum(["pdf", "text", "image"]);
+export const FileCategory = z.enum(["pdf", "text", "image", "webPage"]);
 export type FileCategory = z.infer<typeof FileCategory>;
 export const FileContent = z.object({
 	type: z.literal("file"),

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -163,7 +163,8 @@ async function buildGenerationMessageForTextGeneration(
 						break;
 					}
 					case "image":
-					case "pdf": {
+					case "pdf":
+					case "webPage": {
 						const fileContents = await getFileContents(
 							contextNode.content,
 							fileResolver,
@@ -477,6 +478,7 @@ async function getFileContents(
 			switch (fileContent.category) {
 				case "pdf":
 				case "text":
+				case "webPage":
 					return {
 						type: "file",
 						data,
@@ -589,7 +591,8 @@ async function buildGenerationMessageForImageGeneration(
 				switch (contextNode.content.category) {
 					case "text":
 					case "image":
-					case "pdf": {
+					case "pdf":
+					case "webPage": {
 						const fileContents = await getFileContents(
 							contextNode.content,
 							fileResolver,

--- a/packages/workspace/src/react/feature-flag.ts
+++ b/packages/workspace/src/react/feature-flag.ts
@@ -3,6 +3,7 @@ import { createContext, useContext } from "react";
 export interface FeatureFlagContextValue {
 	flowNode: boolean;
 	runV2: boolean;
+	webPageFileNode: boolean;
 }
 export const FeatureFlagContext = createContext<
 	FeatureFlagContextValue | undefined

--- a/packages/workspace/src/react/workspace.tsx
+++ b/packages/workspace/src/react/workspace.tsx
@@ -62,6 +62,7 @@ export function WorkspaceProvider({
 									value={{
 										flowNode: featureFlag?.flowNode ?? false,
 										runV2: featureFlag?.runV2 ?? false,
+										webPageFileNode: featureFlag?.webPageFileNode ?? false,
 									}}
 								>
 									{children}


### PR DESCRIPTION
## Summary
Show the Web Page in the toolbar (with feature flag)

<img width="375" alt="image" src="https://github.com/user-attachments/assets/6f9cf8e6-0b22-46bf-abbd-553a4f170ae2" />

## Related Issue
https://github.com/giselles-ai/giselle/issues/957

## Changes
- Add webPageFileNodeFlag
- Append "webPage" to FileCategory data-type
- Add WebPageFileIcon
- Show the Web Page in the toolbar (with feature flag)

## Testing
1. Enable webPageFileNodeFlag
2. View in the app workspaces
3. Show the toolbar


## Other Information
This pr is only complete up to the point where the web page node icon appears in the toolbar.
I will create the rest of the implementation in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a feature flag to enable support for "Web Page" as a file type.
  - Integrated "Web Page" option into file node category selection in the toolbar.
  - Introduced a new icon representing web page files.
  - Rendered a dedicated icon for "Web Page" in file and node icon components.
  - Extended file content handling to recognize "webPage" category.
- **Enhancements**
  - Expanded file category options to include "Web Page" for better file organization and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->