### PR TITLE
refactor: consolidate ID generator to Zod v4 and remove legacy v3 implementation

### DIFF
--- a/packages/data-type/src/connection.ts
+++ b/packages/data-type/src/connection.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 import { InputId, NodeReference, OutputId } from "./node";
 

--- a/packages/data-type/src/flow/trigger/index.ts
+++ b/packages/data-type/src/flow/trigger/index.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import type { z } from "zod/v4";
 export { GitHubFlowTrigger, GitHubFlowTriggerEvent } from "./github";
 export {

--- a/packages/data-type/src/flow/trigger/manual.ts
+++ b/packages/data-type/src/flow/trigger/manual.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 
 export const Provider = z.literal("manual");

--- a/packages/data-type/src/generation/index.ts
+++ b/packages/data-type/src/generation/index.ts
@@ -1,6 +1,6 @@
 import type { Message as AISdkMessage } from "@ai-sdk/react";
 export type { Message as AISdkMessage } from "@ai-sdk/react";
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 import { NodeId } from "../node";
 import { GenerationContextLike, GenerationOrigin } from "./context";

--- a/packages/data-type/src/generation/output.ts
+++ b/packages/data-type/src/generation/output.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import type { ProviderMetadata } from "ai";
 import { z } from "zod/v4";
 import { OutputId } from "../node";

--- a/packages/data-type/src/node/base.ts
+++ b/packages/data-type/src/node/base.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 
 export const InputId = createIdGenerator("inp");

--- a/packages/data-type/src/node/variables/file.ts
+++ b/packages/data-type/src/node/variables/file.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 
 export const FileId = createIdGenerator("fl");

--- a/packages/data-type/src/run/index.ts
+++ b/packages/data-type/src/run/index.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 import { OverrideNode } from "../node";
 import { Workflow } from "../workflow";

--- a/packages/data-type/src/workflow/index.ts
+++ b/packages/data-type/src/workflow/index.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 import { GenerationTemplate } from "../generation/template";
 import { NodeLike } from "../node";

--- a/packages/data-type/src/workspace/index.ts
+++ b/packages/data-type/src/workspace/index.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 import { Connection } from "../connection";
 import { NodeId, NodeLike, NodeUIState } from "../node";

--- a/packages/data-type/src/workspace/integrations/github.ts
+++ b/packages/data-type/src/workspace/integrations/github.ts
@@ -1,4 +1,4 @@
-import { createIdGeneratorV4 as createIdGenerator } from "@giselle-sdk/utils";
+import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 import { WorkspaceId } from "..";
 import { NodeId } from "../../node";

--- a/packages/utils/src/generate-id.ts
+++ b/packages/utils/src/generate-id.ts
@@ -1,9 +1,8 @@
 import { customAlphabet } from "nanoid/non-secure";
-import { z as z3 } from "zod";
 import { z as z4 } from "zod/v4";
 
 /**
- * Creates an ID generator with built-in validation using Zod v3.
+ * Creates an ID generator with built-in validation using Zod v4.
  *
  * @param prefix - The prefix for the generated IDs (e.g., 'user', 'message')
  * @returns An object containing ID generation and validation utilities
@@ -19,46 +18,6 @@ import { z as z4 } from "zod/v4";
  * userIds.parse("invalid"); // ❌ Throws error
  */
 export const createIdGenerator = <T extends string>(prefix: T) => {
-	const schema = z3
-		.string()
-		.regex(
-			new RegExp(`^${prefix}-[0-9A-Za-z]{16}$`),
-			`ID must start with "${prefix}-" followed by 16 alphanumeric characters`,
-		)
-		.transform((id): `${T}-${string}` => id as `${T}-${string}`);
-
-	const generator = customAlphabet(
-		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
-		16,
-	);
-
-	const generate = () => `${prefix}-${generator()}` as `${T}-${string}`;
-
-	return {
-		schema,
-		generate,
-		parse: (input: unknown) => schema.parse(input),
-		safeParse: (input: unknown) => schema.safeParse(input),
-	} as const;
-};
-
-/**
- * Creates an ID generator with built-in validation using Zod v4.
- *
- * @param prefix - The prefix for the generated IDs (e.g., 'user', 'message')
- * @returns An object containing ID generation and validation utilities
- *
- * @example
- * const userIds = createIdGeneratorV4('user');
- *
- * // Generate a new ID
- * const newId = userIds.generate(); // "user-1234567890abcdef"
- *
- * // Validate an ID
- * userIds.parse(newId); // ✅ OK
- * userIds.parse("invalid"); // ❌ Throws error
- */
-export const createIdGeneratorV4 = <T extends string>(prefix: T) => {
 	const schema = z4
 		.string()
 		.regex(


### PR DESCRIPTION
## Summary

This PR consolidates the ID generation utilities by removing the obsolete Zod v3 implementation and promoting the Zod v4 version as the default. This simplifies the API and eliminates legacy code dependencies.

## Changes Made

### Utils Package
- **Removed**: `createIdGenerator` function that used Zod v3
- **Renamed**: `createIdGeneratorV4` → `createIdGenerator` (now the default)
- **Updated**: Function documentation to reflect Zod v4 usage
- **Removed**: Zod v3 import dependency

### Data-Type Package  
- **Updated**: Import statements across 11 files to use the simplified `createIdGenerator` import
- **Affected modules**: connection, flow triggers, generation, nodes, runs, workflows, workspace, and GitHub integrations

## Benefits

- **Simplified API**: Single `createIdGenerator` function instead of two variants
- **Reduced complexity**: Eliminates the need for import aliasing (`createIdGeneratorV4 as createIdGenerator`)
- **Cleaner codebase**: Removes legacy Zod v3 dependencies and dead code
- **Future-ready**: All ID generation now consistently uses Zod v4

## Testing

Verified with the following commands:
- `turbo build --filter "@giselle-sdk/utils" --filter "@giselle-sdk/data-type" --cache=local:rw`
- `turbo check-types --filter "@giselle-sdk/utils" --filter "@giselle-sdk/data-type" --cache=local:rw`  
- `turbo test --filter "@giselle-sdk/utils" --filter "@giselle-sdk/data-type" --cache=local:rw`

## Impact

This is a **breaking change** for any external consumers of `createIdGeneratorV4`, but since this appears to be internal tooling, the impact should be minimal. All existing functionality remains the same, just with a cleaner API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined and unified the ID generator to use an updated validation library, simplifying its usage and removing legacy support.
- **Chores**
  - Updated internal references to the ID generator to use the new, consolidated implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->