### PR TITLE
Fix html-only test in firecrawl

### DIFF
--- a/packages/web-search/src/firecrawl.test.ts
+++ b/packages/web-search/src/firecrawl.test.ts
@@ -22,6 +22,7 @@ const hasExternalApiEnv = process.env.VITEST_WITH_EXTERNAL_API === "1";
 			expect(result).toHaveProperty("html");
 			expect(result).toHaveProperty("markdown");
 			expect(typeof result.html).toBe("string");
+			expect(result.html.length).toBeGreaterThan(0);
 			expect(result.markdown).toBe("");
 		},
 		HEAVY_TEST_TIMEOUT,


### PR DESCRIPTION
## Summary
- ensure `html` results have length in `firecrawl.test`

## Testing
- `npx turbo test --cache=local:rw` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test coverage by ensuring that scraped HTML content is non-empty when using the "html" option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->