### PR TITLE
Refactor web-search API

### DIFF
--- a/packages/web-search/README.md
+++ b/packages/web-search/README.md
@@ -24,10 +24,10 @@ pnpm install
 Create a web search tool by specifying the provider. Firecrawl requires an API key.
 
 ```ts
-import { websearch } from "@giselle-sdk/web-search";
+import { webSearch } from "@giselle-sdk/web-search";
 
-const firecrawlTool = websearch({ provider: "firecrawl", apiKey: "fc-..." });
-const selfMadeTool = websearch({ provider: "self-made" });
+const firecrawlTool = webSearch({ provider: "firecrawl", apiKey: "fc-..." });
+const selfMadeTool = webSearch({ provider: "self-made" });
 
 const result = await firecrawlTool.fetchUrl("https://example.com", ["html"]);
 console.log(result.html); // HTML content

--- a/packages/web-search/src/index.ts
+++ b/packages/web-search/src/index.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { FirecrawlWebSearchProvider, firecrawlProviderName } from "./firecrawl";
 import { SelfMadeWebSearchProvider, selfMadeProviderName } from "./self-made";
-export { websearch } from "./websearch";
+export { webSearch } from "./web-search";
 
 export { scrapeUrl as firecrawlScrapeUrl } from "./firecrawl";
 export { scrapeUrl as selfMadeScrapeUrl } from "./self-made";

--- a/packages/web-search/src/web-search.test.ts
+++ b/packages/web-search/src/web-search.test.ts
@@ -1,21 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { websearch } from "./index";
+import { webSearch } from "./index";
 
 const TEST_URL = "https://example.com/";
 
 const hasExternalApiEnv = process.env.VITEST_WITH_EXTERNAL_API === "1";
 
-describe("websearch (invalid URL)", () => {
-	const tool = websearch({ provider: "self-made" });
+describe("webSearch (invalid URL)", () => {
+	const tool = webSearch({ provider: "self-made" });
 	it("should throw on invalid URL", async () => {
 		await expect(tool.fetchUrl("not-a-url")).rejects.toThrow();
 	});
 });
 
 (hasExternalApiEnv ? describe : describe.skip)(
-	"websearch self-made (valid URL)",
+	"webSearch self-made (valid URL)",
 	() => {
-		const tool = websearch({ provider: "self-made" });
+		const tool = webSearch({ provider: "self-made" });
 		it("should fetch a valid URL", async () => {
 			const result = await tool.fetchUrl(TEST_URL, ["html"]);
 			expect(result).toHaveProperty("html");

--- a/packages/web-search/src/web-search.ts
+++ b/packages/web-search/src/web-search.ts
@@ -9,18 +9,18 @@ import {
 
 export type AllowedFormats = "html" | "markdown";
 
-export interface WebsearchConfigFirecrawl {
+export interface WebSearchConfigFirecrawl {
 	provider: typeof firecrawlProviderName;
 	apiKey?: string;
 }
 
-export interface WebsearchConfigSelfMade {
+export interface WebSearchConfigSelfMade {
 	provider: typeof selfMadeProviderName;
 }
 
-export type WebsearchConfig =
-	| WebsearchConfigFirecrawl
-	| WebsearchConfigSelfMade;
+export type WebSearchConfig =
+	| WebSearchConfigFirecrawl
+	| WebSearchConfigSelfMade;
 
 export type WebSearchResult = {
 	url: string;
@@ -29,14 +29,14 @@ export type WebSearchResult = {
 	markdown: string;
 };
 
-export interface WebsearchTool {
+export interface WebSearchTool {
 	fetchUrl: (
 		url: string,
 		formats?: AllowedFormats[],
 	) => Promise<WebSearchResult>;
 }
 
-export function websearch(config: WebsearchConfig): WebsearchTool {
+export function webSearch(config: WebSearchConfig): WebSearchTool {
 	if (config.provider === firecrawlProviderName) {
 		return {
 			fetchUrl: (url: string, formats?: AllowedFormats[]) =>


### PR DESCRIPTION
## Summary
- rename `websearch` source and test files to `web-search`
- update API names from `websearch`/`Websearch` to `webSearch`/`WebSearch`
- adjust README examples

## Testing
- `pnpm -F @giselle-sdk/web-search build`
- `pnpm -F @giselle-sdk/web-search test`
- `pnpm -F @giselle-sdk/web-search check-types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated naming conventions for web search-related functions, types, and interfaces to use consistent camel case formatting.

- **Documentation**
  - Revised usage examples in the README to reflect updated function and type names.

- **Tests**
  - Updated test references to match the new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->