### PR TITLE
feat: add setup indicator for unconfigured GitHub trigger nodes

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -25,7 +25,7 @@ import {
 } from "@xyflow/react";
 import clsx from "clsx/lite";
 import { useNodeGenerations, useWorkflowDesigner } from "giselle-sdk/react";
-import { CheckIcon, SquareIcon } from "lucide-react";
+import { CheckIcon, CircleAlertIcon, SquareIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { NodeIcon } from "../../icons/node";
@@ -337,13 +337,20 @@ export function NodeComponent({
 				</div>
 			</div>
 			{isTriggerNode(node, "github") &&
-				node.content.state.status === "configured" && (
+				(node.content.state.status === "configured" ? (
 					<div className="px-[16px] relative">
 						<GitHubRepositoryBadgeFromTrigger
 							flowTriggerId={node.content.state.flowTriggerId}
 						/>
 					</div>
-				)}
+				) : (
+					<div className="pl-[16px] relative pr-[32px]">
+						<div className="inline-flex items-center justify-center bg-[#342527] text-[#d7745a] rounded-full text-[12px] pl-[10px] pr-[12px] py-2 gap-[6px]">
+							<CircleAlertIcon className="size-[18px]" />
+							<span>REQUIRES SETUP</span>
+						</div>
+					</div>
+				))}
 			{isActionNode(node, "github") &&
 				node.content.command.state.status === "configured" && (
 					<div className="px-[16px] relative">

--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/github-repository-badge.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/github-repository-badge.tsx
@@ -13,7 +13,7 @@ export function GitHubRepositoryBadge({
 	repo,
 }: GitHubRepositoryBadgeProps) {
 	return (
-		<div className="flex items-center gap-[6px] rounded-full bg-black-900 pl-[10px] pr-[12px] py-2 text-sm text-white-200 transition-colors text-[12px]">
+		<div className="flex items-center gap-[6px] rounded-full bg-black-900 pl-[10px] pr-[12px] py-2 text-white-200 transition-colors text-[12px]">
 			<GitHubIcon className="size-[18px]" />
 			<div className="space-x-[2px]">
 				<span>{owner}</span>


### PR DESCRIPTION
## Summary

This PR improves the user experience for GitHub trigger nodes in the workflow designer by adding a visual indicator when the node requires setup.


https://github.com/user-attachments/assets/c6343f4e-5532-4660-806c-33450b290ff5



## Changes

- **GitHub Trigger Node Enhancement**: Added a "REQUIRES SETUP" badge for GitHub trigger nodes that are not configured
- **Visual Feedback**: Implemented an alert icon with appropriate styling (orange/red color scheme) to clearly indicate unconfigured nodes
- **Code Cleanup**: Removed duplicate `text-sm` class in `GitHubRepositoryBadge` component

## Technical Details

- Added `CircleAlertIcon` import from lucide-react
- Conditional rendering logic to show either the repository badge (configured) or setup indicator (unconfigured)
- Used consistent styling with proper spacing and colors that match the design system
