### PR TITLE
Improve node UI with setup indicators and required input styling

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -425,6 +425,7 @@ export function NodeComponent({
 											? "connected"
 											: "disconnected"
 									}
+									data-required={input.isRequired ? "true" : "false"}
 								>
 									<Handle
 										type="target"
@@ -447,6 +448,7 @@ export function NodeComponent({
 											"group-data-[state=connected]:px-[16px]",
 											"group-data-[state=disconnected]:absolute group-data-[state=disconnected]:-left-[4.5px] group-data-[state=disconnected]:whitespace-nowrap group-data-[state=disconnected]:-translate-x-[100%]",
 											"group-data-[state=connected]:text-white-900 group-data-[state=disconnected]:text-black-400",
+											"group-data-[state=disconnected]:group-data-[required=true]:text-red-900",
 										)}
 									>
 										{input.label}

--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -361,14 +361,21 @@ export function NodeComponent({
 					</div>
 				))}
 			{isActionNode(node, "github") &&
-				node.content.command.state.status === "configured" && (
+				(node.content.command.state.status === "configured" ? (
 					<div className="px-[16px] relative">
 						<GitHubRepositoryBadgeFromRepo
 							installationId={node.content.command.state.installationId}
 							repositoryNodeId={node.content.command.state.repositoryNodeId}
 						/>
 					</div>
-				)}
+				) : (
+					<div className="pl-[16px] relative pr-[32px]">
+						<div className="inline-flex items-center justify-center bg-[#342527] text-[#d7745a] rounded-full text-[12px] pl-[10px] pr-[12px] py-2 gap-[6px]">
+							<CircleAlertIcon className="size-[18px]" />
+							<span>REQUIRES SETUP</span>
+						</div>
+					</div>
+				))}
 			{isVectorStoreNode(node, "github") &&
 				node.content.source.state.status === "configured" && (
 					<div className="px-[16px] relative">


### PR DESCRIPTION
## Overview

This PR enhances the visual feedback for workflow nodes by adding clear indicators for setup requirements and improving the styling of required inputs.

<img width="357" alt="image" src="https://github.com/user-attachments/assets/15f8cd7d-a881-4f70-876a-72720ea64396" />


## Changes

### 1. Setup Indicator for Unconfigured GitHub Nodes
- Added a visual "REQUIRES SETUP" indicator for GitHub action nodes that haven't been configured yet
- The indicator uses a warning style with an alert icon and brown/orange color scheme
- Only shows when `node.content.command.state.status` is not "configured"

### 2. Red Styling for Disconnected Required Inputs
- Added red text styling for required inputs that are not connected
- Uses `data-required` attribute to identify required inputs
- Applied conditional styling: `group-data-[state=disconnected]:group-data-[required=true]:text-red-900`

## Technical Details

- Modified `/internal-packages/workflow-designer-ui/src/editor/node/node.tsx`
- Added `CircleAlertIcon` for the setup indicator
- Used conditional rendering based on node configuration status
- Implemented data attributes for better CSS targeting

## Visual Impact

- **Before**: Users had no clear indication when GitHub nodes needed setup or when required inputs were missing
- **After**: Clear visual cues help users identify what needs attention in their workflows

## Testing

- Verify setup indicator appears for unconfigured GitHub nodes
- Confirm red styling applies only to disconnected required inputs
- Check that configured nodes display the repository badge as expected

## Related

This improvement enhances the user experience by providing immediate visual feedback about workflow configuration status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible "REQUIRES SETUP" warning for GitHub action and trigger nodes when not configured.
  - Required but unconnected action node inputs are now visually highlighted for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->