### PR TITLE
Refactor GitHub badge rendering

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -32,11 +32,7 @@ import { useEffect, useMemo, useState, useTransition } from "react";
 import { NodeIcon } from "../../icons/node";
 import { EditableText } from "../../ui/editable-text";
 import { Tooltip } from "../../ui/tooltip";
-import {
-	GitHubRepositoryBadge,
-	GitHubRepositoryBadgeFromRepo,
-	GitHubRepositoryBadgeFromTrigger,
-} from "./ui";
+import { GitHubNodeInfo } from "./ui";
 import { GitHubTriggerStatusBadge } from "./ui/github-trigger/status-badge";
 
 type GiselleWorkflowDesignerTextGenerationNode = XYFlowNode<
@@ -345,46 +341,7 @@ export function NodeComponent({
 					</div>
 				</div>
 			</div>
-			{isTriggerNode(node, "github") &&
-				(node.content.state.status === "configured" ? (
-					<div className="px-[16px] relative">
-						<GitHubRepositoryBadgeFromTrigger
-							flowTriggerId={node.content.state.flowTriggerId}
-						/>
-					</div>
-				) : (
-					<div className="pl-[16px] relative pr-[32px]">
-						<div className="inline-flex items-center justify-center bg-[#342527] text-[#d7745a] rounded-full text-[12px] pl-[10px] pr-[12px] py-2 gap-[6px]">
-							<CircleAlertIcon className="size-[18px]" />
-							<span>REQUIRES SETUP</span>
-						</div>
-					</div>
-				))}
-			{isActionNode(node, "github") &&
-				(node.content.command.state.status === "configured" ? (
-					<div className="px-[16px] relative">
-						<GitHubRepositoryBadgeFromRepo
-							installationId={node.content.command.state.installationId}
-							repositoryNodeId={node.content.command.state.repositoryNodeId}
-						/>
-					</div>
-				) : (
-					<div className="pl-[16px] relative pr-[32px]">
-						<div className="inline-flex items-center justify-center bg-[#342527] text-[#d7745a] rounded-full text-[12px] pl-[10px] pr-[12px] py-2 gap-[6px]">
-							<CircleAlertIcon className="size-[18px]" />
-							<span>REQUIRES SETUP</span>
-						</div>
-					</div>
-				))}
-			{isVectorStoreNode(node, "github") &&
-				node.content.source.state.status === "configured" && (
-					<div className="px-[16px] relative">
-						<GitHubRepositoryBadge
-							owner={node.content.source.state.owner}
-							repo={node.content.source.state.repo}
-						/>
-					</div>
-				)}
+			<GitHubNodeInfo node={node} />
 			{!preview && (
 				<div className="flex justify-between">
 					<div className="grid">

--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx
@@ -1,0 +1,67 @@
+import type { Node } from "@giselle-sdk/data-type";
+import {
+	isActionNode,
+	isTriggerNode,
+	isVectorStoreNode,
+} from "@giselle-sdk/data-type";
+import { CircleAlertIcon } from "lucide-react";
+import type { ReactElement } from "react";
+import {
+	GitHubRepositoryBadge,
+	GitHubRepositoryBadgeFromRepo,
+	GitHubRepositoryBadgeFromTrigger,
+} from "./";
+
+function RequiresSetupBadge(): ReactElement {
+	return (
+		<div className="pl-[16px] relative pr-[32px]">
+			<div className="inline-flex items-center justify-center bg-[#342527] text-[#d7745a] rounded-full text-[12px] pl-[10px] pr-[12px] py-2 gap-[6px]">
+				<CircleAlertIcon className="size-[18px]" />
+				<span>REQUIRES SETUP</span>
+			</div>
+		</div>
+	);
+}
+
+export function GitHubNodeInfo({ node }: { node: Node }): ReactElement | null {
+	if (isTriggerNode(node, "github")) {
+		return node.content.state.status === "configured" ? (
+			<div className="px-[16px] relative">
+				<GitHubRepositoryBadgeFromTrigger
+					flowTriggerId={node.content.state.flowTriggerId}
+				/>
+			</div>
+		) : (
+			<RequiresSetupBadge />
+		);
+	}
+
+	if (isActionNode(node, "github")) {
+		return node.content.command.state.status === "configured" ? (
+			<div className="px-[16px] relative">
+				<GitHubRepositoryBadgeFromRepo
+					installationId={node.content.command.state.installationId}
+					repositoryNodeId={node.content.command.state.repositoryNodeId}
+				/>
+			</div>
+		) : (
+			<RequiresSetupBadge />
+		);
+	}
+
+	if (
+		isVectorStoreNode(node, "github") &&
+		node.content.source.state.status === "configured"
+	) {
+		return (
+			<div className="px-[16px] relative">
+				<GitHubRepositoryBadge
+					owner={node.content.source.state.owner}
+					repo={node.content.source.state.repo}
+				/>
+			</div>
+		);
+	}
+
+	return null;
+}

--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/index.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/index.ts
@@ -1,3 +1,4 @@
 export * from "./github-repository-badge";
 export * from "./github-repository-badge-from-repo";
 export * from "./github-repository-badge-from-trigger";
+export * from "./github-node-info";


### PR DESCRIPTION
## Summary
- centralize GitHub node status logic in `GitHubNodeInfo`
- update node component to use the new helper

## Testing
- `turbo test --cache=local:rw`
- `turbo check-types --cache=local:rw`
