### PR TITLE
Refactor properties panel utilities

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/common/filter-node-items.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/common/filter-node-items.ts
@@ -1,0 +1,18 @@
+import type { NodeBase } from "@giselle-sdk/data-type";
+
+export function filterNodeItems<
+	T extends NodeBase,
+	I extends { node: NodeBase },
+>(
+	items: I[],
+	guardFn: (value: unknown) => value is T,
+): (Omit<I, "node"> & { node: T })[] {
+	const filtered: (Omit<I, "node"> & { node: T })[] = [];
+	for (const item of items) {
+		if (!guardFn(item.node)) {
+			continue;
+		}
+		filtered.push({ ...(item as I), node: item.node });
+	}
+	return filtered;
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/common/index.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./filter-node-items";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
@@ -15,7 +15,7 @@ import {
 } from "@giselle-sdk/text-editor-utils";
 import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
-import { CheckIcon, TrashIcon } from "lucide-react";
+import { CheckIcon } from "lucide-react";
 import pluralize from "pluralize";
 import { Popover, ToggleGroup } from "radix-ui";
 import {
@@ -27,6 +27,7 @@ import {
 } from "react";
 import { GeneratedContentIcon, PdfFileIcon, PromptIcon } from "../../../icons";
 import { EmptyState } from "../../../ui/empty-state";
+import { ConnectionListItem, ConnectionListRoot } from "../ui";
 import {
 	type Source,
 	useConnectedSources,
@@ -241,63 +242,6 @@ function SourceSelect({
 	);
 }
 
-function SourceListRoot({
-	title,
-	children,
-}: {
-	title: string;
-	children: ReactNode;
-}) {
-	return (
-		<div className="flex flex-col gap-[8px]">
-			<p className="text-[14px]">{title}</p>
-			{children}
-		</div>
-	);
-}
-function SourceListItem({
-	icon,
-	title,
-	subtitle,
-	onRemove,
-}: {
-	icon: ReactNode;
-	title: string;
-	subtitle: string;
-	onRemove: () => void;
-}) {
-	return (
-		<div
-			className={clsx(
-				"group flex items-center",
-				"border border-white-900/20 rounded-[8px] h-[60px]",
-			)}
-		>
-			<div className="w-[60px] flex items-center justify-center">{icon}</div>
-			<div className="w-[1px] h-full border-l border-white-900/20" />
-			<div className="px-[16px] flex-1 flex items-center justify-between">
-				<div className="flex flex-col gap-[4px]">
-					<p className="text=[16px]">{title}</p>
-					<div className="text-[10px] text-black-400">
-						<p className="line-clamp-1">{subtitle}</p>
-					</div>
-				</div>
-				<button
-					type="button"
-					className={clsx(
-						"hidden group-hover:block",
-						"p-[4px] rounded-[4px]",
-						"bg-transparent hover:bg-black-300/50 transition-colors",
-					)}
-					onClick={onRemove}
-				>
-					<TrashIcon className="w-[18px] h-[18px] text-white-900" />
-				</button>
-			</div>
-		</div>
-	);
-}
-
 export function InputPanel({
 	node: imageGenerationNode,
 }: {
@@ -444,9 +388,9 @@ export function InputPanel({
 			</div>
 			<div className="flex flex-col gap-[32px]">
 				{connectedSources.generation.length > 0 && (
-					<SourceListRoot title="Generated Sources">
+					<ConnectionListRoot title="Generated Sources">
 						{connectedSources.generation.map((source) => (
-							<SourceListItem
+							<ConnectionListItem
 								icon={
 									<GeneratedContentIcon className="size-[24px] text-white-900" />
 								}
@@ -456,10 +400,10 @@ export function InputPanel({
 								onRemove={() => handleRemove(source.connection)}
 							/>
 						))}
-					</SourceListRoot>
+					</ConnectionListRoot>
 				)}
 				{connectedSources.variable.length > 0 && (
-					<SourceListRoot title="Static Contents">
+					<ConnectionListRoot title="Static Contents">
 						{connectedSources.variable.map((source) => {
 							switch (source.node.content.type) {
 								case "text": {
@@ -479,7 +423,7 @@ export function InputPanel({
 									}
 
 									return (
-										<SourceListItem
+										<ConnectionListItem
 											icon={
 												<PromptIcon className="size-[24px] text-white-900" />
 											}
@@ -497,7 +441,7 @@ export function InputPanel({
 										);
 									}
 									return (
-										<SourceListItem
+										<ConnectionListItem
 											icon={
 												<PdfFileIcon className="size-[24px] text-white-900" />
 											}
@@ -519,7 +463,7 @@ export function InputPanel({
 								}
 							}
 						})}
-					</SourceListRoot>
+					</ConnectionListRoot>
 				)}
 			</div>
 		</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/sources/utils.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/sources/utils.ts
@@ -1,19 +1,10 @@
 import type { NodeBase } from "@giselle-sdk/data-type";
+import { filterNodeItems } from "../../common/filter-node-items";
 import type { Source } from "./types";
 
 export function filterSources<T extends NodeBase>(
 	sources: Source[],
 	guardFn: (args: unknown) => args is T,
 ): Source<T>[] {
-	const tmpSources: Source<T>[] = [];
-	for (const source of sources) {
-		if (!guardFn(source.node)) {
-			continue;
-		}
-		tmpSources.push({
-			...source,
-			node: source.node,
-		});
-	}
-	return tmpSources;
+	return filterNodeItems(sources, guardFn);
 }

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
@@ -20,9 +20,8 @@ import {
 	PromptIcon,
 } from "../../../icons";
 import { EmptyState } from "../../../ui/empty-state";
+import { ConnectionListItem, ConnectionListRoot } from "../ui";
 import {
-	ConnectedOutputListItem,
-	ConnectedOutputListRoot,
 	type OutputWithDetails,
 	SelectOutputPopover,
 	useConnectedOutputs,
@@ -174,9 +173,9 @@ export function InputPanel({
 			</div>
 			<div className="flex flex-col gap-[32px]">
 				{connectedOutputs.trigger.length > 0 && (
-					<ConnectedOutputListRoot title="Generated Sources">
+					<ConnectionListRoot title="Generated Sources">
 						{connectedOutputs.trigger.map((source) => (
-							<ConnectedOutputListItem
+							<ConnectionListItem
 								icon={
 									<GeneratedContentIcon className="size-[24px] text-white-900" />
 								}
@@ -186,12 +185,12 @@ export function InputPanel({
 								onRemove={() => handleRemove(source.connection)}
 							/>
 						))}
-					</ConnectedOutputListRoot>
+					</ConnectionListRoot>
 				)}
 				{connectedOutputs.generation.length > 0 && (
-					<ConnectedOutputListRoot title="Generated Sources">
+					<ConnectionListRoot title="Generated Sources">
 						{connectedOutputs.generation.map((source) => (
-							<ConnectedOutputListItem
+							<ConnectionListItem
 								icon={
 									<GeneratedContentIcon className="size-[24px] text-white-900" />
 								}
@@ -201,12 +200,12 @@ export function InputPanel({
 								onRemove={() => handleRemove(source.connection)}
 							/>
 						))}
-					</ConnectedOutputListRoot>
+					</ConnectionListRoot>
 				)}
 				{connectedOutputs.action.length > 0 && (
-					<ConnectedOutputListRoot title="Generated Sources">
+					<ConnectionListRoot title="Generated Sources">
 						{connectedOutputs.action.map((source) => (
-							<ConnectedOutputListItem
+							<ConnectionListItem
 								icon={<GitHubIcon className="size-[24px] text-white-900" />}
 								key={source.connection.id}
 								title={source.node.name ?? defaultName(source.node)}
@@ -214,10 +213,10 @@ export function InputPanel({
 								onRemove={() => handleRemove(source.connection)}
 							/>
 						))}
-					</ConnectedOutputListRoot>
+					</ConnectionListRoot>
 				)}
 				{connectedOutputs.variable.length > 0 && (
-					<ConnectedOutputListRoot title="Static Contents">
+					<ConnectionListRoot title="Static Contents">
 						{connectedOutputs.variable.map((source) => {
 							switch (source.node.content.type) {
 								case "text": {
@@ -232,7 +231,7 @@ export function InputPanel({
 									}
 
 									return (
-										<ConnectedOutputListItem
+										<ConnectionListItem
 											icon={
 												<PromptIcon className="size-[24px] text-white-900" />
 											}
@@ -245,7 +244,7 @@ export function InputPanel({
 								}
 								case "file":
 									return (
-										<ConnectedOutputListItem
+										<ConnectionListItem
 											icon={
 												<PdfFileIcon className="size-[24px] text-white-900" />
 											}
@@ -257,7 +256,7 @@ export function InputPanel({
 									);
 								case "github":
 									return (
-										<ConnectedOutputListItem
+										<ConnectionListItem
 											icon={
 												<GitHubIcon className="size-[24px] text-white-900" />
 											}
@@ -277,7 +276,7 @@ export function InputPanel({
 								}
 							}
 						})}
-					</ConnectedOutputListRoot>
+					</ConnectionListRoot>
 				)}
 			</div>
 		</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/outputs/components.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/outputs/components.tsx
@@ -14,6 +14,7 @@ import {
 	useCallback,
 	useState,
 } from "react";
+import { ConnectionListItem, ConnectionListRoot } from "../../ui";
 import type { OutputWithDetails } from "./types";
 import { useCategoriedOutputs } from "./use-categoried-outputs";
 
@@ -253,62 +254,5 @@ export function SelectOutputPopover({
 				</Popover.Content>
 			</Popover.Portal>
 		</Popover.Root>
-	);
-}
-
-export function ConnectedOutputListRoot({
-	title,
-	children,
-}: {
-	title: string;
-	children: ReactNode;
-}) {
-	return (
-		<div className="flex flex-col gap-[8px]">
-			<p className="text-[14px]">{title}</p>
-			{children}
-		</div>
-	);
-}
-export function ConnectedOutputListItem({
-	icon,
-	title,
-	subtitle,
-	onRemove,
-}: {
-	icon: ReactNode;
-	title: string;
-	subtitle: string;
-	onRemove: () => void;
-}) {
-	return (
-		<div
-			className={clsx(
-				"group flex items-center",
-				"border border-white-900/20 rounded-[8px] h-[60px]",
-			)}
-		>
-			<div className="w-[60px] flex items-center justify-center">{icon}</div>
-			<div className="w-[1px] h-full border-l border-white-900/20" />
-			<div className="px-[16px] flex-1 flex items-center justify-between">
-				<div className="flex flex-col gap-[4px]">
-					<p className="text-[16px]">{title}</p>
-					<div className="text-[10px] text-black-400">
-						<p className="line-clamp-1">{subtitle}</p>
-					</div>
-				</div>
-				<button
-					type="button"
-					className={clsx(
-						"hidden group-hover:block",
-						"p-[4px] rounded-[4px]",
-						"bg-transparent hover:bg-black-300/50 transition-colors",
-					)}
-					onClick={onRemove}
-				>
-					<TrashIcon className="w-[18px] h-[18px] text-white-900" />
-				</button>
-			</div>
-		</div>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/outputs/utils.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/outputs/utils.ts
@@ -1,19 +1,10 @@
 import type { NodeBase } from "@giselle-sdk/data-type";
+import { filterNodeItems } from "../../common/filter-node-items";
 import type { OutputWithDetails } from "./types";
 
 export function filterInputs<T extends NodeBase>(
 	inputs: OutputWithDetails[],
 	guardFn: (args: unknown) => args is T,
 ): OutputWithDetails<T>[] {
-	const tmpInputs: OutputWithDetails<T>[] = [];
-	for (const input of inputs) {
-		if (!guardFn(input.node)) {
-			continue;
-		}
-		tmpInputs.push({
-			...input,
-			node: input.node,
-		});
-	}
-	return tmpInputs;
+	return filterNodeItems(inputs, guardFn);
 }

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/connection-list.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/connection-list.tsx
@@ -1,0 +1,61 @@
+import clsx from "clsx/lite";
+import { TrashIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function ConnectionListRoot({
+	title,
+	children,
+}: {
+	title: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="flex flex-col gap-[8px]">
+			<p className="text-[14px]">{title}</p>
+			{children}
+		</div>
+	);
+}
+
+export function ConnectionListItem({
+	icon,
+	title,
+	subtitle,
+	onRemove,
+}: {
+	icon: ReactNode;
+	title: string;
+	subtitle: string;
+	onRemove: () => void;
+}) {
+	return (
+		<div
+			className={clsx(
+				"group flex items-center",
+				"border border-white-900/20 rounded-[8px] h-[60px]",
+			)}
+		>
+			<div className="w-[60px] flex items-center justify-center">{icon}</div>
+			<div className="w-[1px] h-full border-l border-white-900/20" />
+			<div className="px-[16px] flex-1 flex items-center justify-between">
+				<div className="flex flex-col gap-[4px]">
+					<p className="text-[16px]">{title}</p>
+					<div className="text-[10px] text-black-400">
+						<p className="line-clamp-1">{subtitle}</p>
+					</div>
+				</div>
+				<button
+					type="button"
+					className={clsx(
+						"hidden group-hover:block",
+						"p-[4px] rounded-[4px]",
+						"bg-transparent hover:bg-black-300/50 transition-colors",
+					)}
+					onClick={onRemove}
+				>
+					<TrashIcon className="w-[18px] h-[18px] text-white-900" />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/index.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/index.ts
@@ -3,3 +3,4 @@ export * from "./node-dropdown";
 export * from "./editable-text";
 export * from "./select-repository";
 export { RemoveButton } from "./remove-button";
+export * from "./connection-list";


### PR DESCRIPTION
## Summary
- add `filterNodeItems` helper to dedupe node filtering logic
- create reusable `ConnectionListRoot` and `ConnectionListItem`
- update input panels to use new list components
- export new components in `ui/index.ts`
- use common filter helper in existing utilities

## Testing
- `npx turbo run check-types --filter=@giselle-internal/workflow-designer-ui --cache=local:rw`
- `npx turbo run test --filter=@giselle-internal/workflow-designer-ui --cache=local:rw` *(fails: Missing tasks in project)*