### PR TITLE
Add edge config support for flow-node flag

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -1,3 +1,4 @@
+import { get } from "@vercel/edge-config";
 import { flag } from "flags/next";
 
 function takeLocalEnv(localEnvironmentKey: string) {
@@ -81,10 +82,16 @@ export const teamInvitationViaEmailFlag = flag<boolean>({
 export const flowNodeFlag = flag<boolean>({
 	key: "flow-node",
 	async decide() {
-		return takeLocalEnv("FLOW_NODE_FLAG");
+		if (process.env.NODE_ENV !== "development") {
+			return takeLocalEnv("FLOW_NODE_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return Boolean(edgeConfig);
 	},
 	description: "Enable Flow Node",
-	defaultValue: false,
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },
@@ -97,7 +104,7 @@ export const runV2Flag = flag<boolean>({
 		return takeLocalEnv("RUN_V2_FLAG");
 	},
 	description: "Enable Run v2",
-	defaultValue: false,
+	defaultValue: true,
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -101,10 +101,16 @@ export const flowNodeFlag = flag<boolean>({
 export const runV2Flag = flag<boolean>({
 	key: "run-v2",
 	async decide() {
-		return takeLocalEnv("RUN_V2_FLAG");
+		if (process.env.NODE_ENV !== "development") {
+			return takeLocalEnv("FLOW_NODE_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return Boolean(edgeConfig);
 	},
 	description: "Enable Run v2",
-	defaultValue: true,
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -82,7 +82,7 @@ export const teamInvitationViaEmailFlag = flag<boolean>({
 export const flowNodeFlag = flag<boolean>({
 	key: "flow-node",
 	async decide() {
-		if (process.env.NODE_ENV !== "development") {
+		if (process.env.NODE_ENV === "development") {
 			return takeLocalEnv("FLOW_NODE_FLAG");
 		}
 		const edgeConfig = await get(`flag__${this.key}`);
@@ -101,7 +101,7 @@ export const flowNodeFlag = flag<boolean>({
 export const runV2Flag = flag<boolean>({
 	key: "run-v2",
 	async decide() {
-		if (process.env.NODE_ENV !== "development") {
+		if (process.env.NODE_ENV === "development") {
 			return takeLocalEnv("FLOW_NODE_FLAG");
 		}
 		const edgeConfig = await get(`flag__${this.key}`);

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -89,7 +89,7 @@ export const flowNodeFlag = flag<boolean>({
 		if (edgeConfig === undefined) {
 			return false;
 		}
-		return Boolean(edgeConfig);
+		return edgeConfig === true || edgeConfig === "true";
 	},
 	description: "Enable Flow Node",
 	options: [
@@ -102,13 +102,13 @@ export const runV2Flag = flag<boolean>({
 	key: "run-v2",
 	async decide() {
 		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("FLOW_NODE_FLAG");
+			return takeLocalEnv("RUN_V2_FLAG");
 		}
 		const edgeConfig = await get(`flag__${this.key}`);
 		if (edgeConfig === undefined) {
 			return false;
 		}
-		return Boolean(edgeConfig);
+		return edgeConfig === true || edgeConfig === "true";
 	},
 	description: "Enable Run v2",
 	options: [


### PR DESCRIPTION
Also enable `run v2`, `flow node` flag by default

I've set up edge config to manage flag default values using the rule `flag__[KEY OF FLAG]`. Currently, I'm only managing `run-v2` and `flow-node`.

With the following Edge config, RunV2 and FlowNode are disabled (same as current state):
```json
{
  "flag__flow-node": false,
  "flag__run-v2": false
}
```

By doing the following, FlowNode and RunV2 become enabled:
```json
{
  "flag__flow-node": true,
  "flag__run-v2": true
}
```

> [!NOTE]
> If edge config is not set, the default value is `false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feature flags now dynamically fetch their values from a remote configuration in production environments.
- **Bug Fixes**
  - Improved fallback behavior to ensure feature flags return a default value if configuration is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->