### PR TITLE
Remove Firecrawl references

### DIFF
--- a/apps/studio.giselles.ai/.env.example
+++ b/apps/studio.giselles.ai/.env.example
@@ -13,9 +13,6 @@ DEVELOPER_FLAG="true"
 # @see https://vercel.com/docs/storage/vercel-blob/client-upload#prepare-your-local-project
 BLOB_READ_WRITE_TOKEN=
 
-# Firecrawl https://www.firecrawl.dev/
-# @see https://docs.firecrawl.dev/introduction#api-key
-FIRECRAWL_API_KEY=
 
 # @vercel/flags API Reference https://vercel.com/docs/workflow-collaboration/feature-flags/vercel-flags
 # @see https://vercel.com/docs/workflow-collaboration/feature-flags/supporting-feature-flags#flags_secret-environment-variable

--- a/apps/studio.giselles.ai/lib/opentelemetry/types.ts
+++ b/apps/studio.giselles.ai/lib/opentelemetry/types.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 
 export const ExternalServiceName = {
 	Anthropic: "anthropic",
-	Firecrawl: "firecrawl",
 	Google: "google",
 	OpenAI: "openai",
 	Tavily: "tavily",
@@ -51,10 +50,7 @@ const RequestCount = BaseMetricsSchema.extend({
 });
 
 const BasicRequestCountSchema = RequestCount.extend({
-	externalServiceName: z.enum([
-		ExternalServiceName.Tavily,
-		ExternalServiceName.Firecrawl,
-	]),
+	externalServiceName: z.enum([ExternalServiceName.Tavily]),
 });
 
 const UnstructuredRequestCountSchema = RequestCount.extend({

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ catalog:
   "@turbo/gen": 2.3.3
   next: 15.3.0
   unstorage: 1.14.4
-  "@mendable/firecrawl-js": 1.25.1
   ai: 4.3.9
   "@types/node": 22.14.0
   "@types/react": 19.1.0


### PR DESCRIPTION
## Summary
- remove `@mendable/firecrawl-js` from workspace catalog
- drop Firecrawl API key from the Studio env example
- delete Firecrawl telemetry entries

## Testing
- `pnpm biome check apps/studio.giselles.ai/lib/opentelemetry/types.ts`
- `npx turbo format --cache=local:rw` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npx turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`
- `npx turbo check-types --cache=local:rw` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `npx turbo test --cache=local:rw` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*