### PR TITLE
Remove unused flags

### DIFF
--- a/apps/studio.giselles.ai/.env.example
+++ b/apps/studio.giselles.ai/.env.example
@@ -5,8 +5,6 @@ COOKIE_SECRET=
 CRON_SECRET=
 
 ## Enable @vercel/flags at all times in the development environment
-DEBUG_FLAG="true"
-VIEW_FLAG="true"
 DEVELOPER_FLAG="true"
 
 # @vercel/blob https://vercel.com/docs/storage/vercel-blob/using-blob-sdk

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -14,32 +14,6 @@ function takeLocalEnv(localEnvironmentKey: string) {
 	return true;
 }
 
-export const debugFlag = flag<boolean>({
-	key: "debug",
-	async decide() {
-		return takeLocalEnv("DEBUG_FLAG");
-	},
-	description: "Enable debug mode",
-	defaultValue: false,
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
-export const viewFlag = flag<boolean>({
-	key: "view",
-	async decide() {
-		return takeLocalEnv("VIEW_FLAG");
-	},
-	description: "Enable view mode",
-	defaultValue: false,
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const developerFlag = flag<boolean>({
 	key: "developer",
 	async decide() {


### PR DESCRIPTION
## Summary
Remove unused flags

## Related Issue
None

## Changes
Remove unused flags:
- DEBUG_FLAG
- VIEW_FLAG

## Testing
Please do your OATs in app workspace.

## Other Information
Due to too many flags causing scrolling in the Vercel Flags Explorer and reducing review productivity in the Vercel preview environment, I/we have deleted them.

