### PR TITLE
feat: Web Page File Node 

### DIFF
--- a/internal-packages/workflow-designer-ui/package.json
+++ b/internal-packages/workflow-designer-ui/package.json
@@ -20,6 +20,7 @@
 		"@giselle-sdk/text-editor": "workspace:^",
 		"@giselle-sdk/text-editor-utils": "workspace:^",
 		"@giselle-sdk/usage-limits": "workspace:^",
+		"@giselle-sdk/web-search": "workspace:^",
 		"@giselle-sdk/workflow-utils": "workspace:^",
 		"@giselle/giselle-sdk-tsconfig": "workspace:*",
 		"@xyflow/react": "catalog:",

--- a/internal-packages/workflow-designer-ui/package.json
+++ b/internal-packages/workflow-designer-ui/package.json
@@ -20,7 +20,6 @@
 		"@giselle-sdk/text-editor": "workspace:^",
 		"@giselle-sdk/text-editor-utils": "workspace:^",
 		"@giselle-sdk/usage-limits": "workspace:^",
-		"@giselle-sdk/web-search": "workspace:^",
 		"@giselle-sdk/workflow-utils": "workspace:^",
 		"@giselle/giselle-sdk-tsconfig": "workspace:*",
 		"@xyflow/react": "catalog:",

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-web-page-file-node.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-web-page-file-node.ts
@@ -1,70 +1,128 @@
-import type { FileData, FileNode } from "@giselle-sdk/data-type";
-import { useState } from "react";
+import type {
+	FileData,
+	FileNode,
+	WebPageContent,
+} from "@giselle-sdk/data-type";
+import { FileId } from "@giselle-sdk/data-type";
+import { type WebSearchResult, webSearch } from "@giselle-sdk/web-search";
+import { useWorkflowDesigner } from "giselle-sdk/react";
+import { useCallback, useState } from "react";
 
-export function useWebPageFileNode(_node: FileNode) {
+function createFileDataFromWebPage(
+	result: WebSearchResult,
+	format: "html" | "markdown",
+): FileData {
+	const content = format === "markdown" ? result.markdown : result.html;
+	const now = Date.now();
+	return {
+		id: FileId.generate(),
+		name: result.url,
+		type: format === "markdown" ? "text/markdown" : "text/html",
+		size: new Blob([content]).size,
+		status: "uploaded",
+		uploadedAt: now,
+	};
+}
+
+function createWebPageContentFromResult(
+	result: WebSearchResult,
+	format: "html" | "markdown",
+): WebPageContent {
+	return {
+		type: "webPage",
+		url: result.url,
+		format,
+		file: createFileDataFromWebPage(result, format),
+		status: "completed",
+	};
+}
+
+function createFileFromWebSearchResult(
+	url: string,
+	result: WebSearchResult,
+	format: "html" | "markdown",
+): File {
+	const content = format === "markdown" ? result.markdown : result.html;
+	const mimeType = format === "markdown" ? "text/markdown" : "text/html";
+	const fileName = `${url} (Format: ${format === "markdown" ? "Markdown" : "HTML"})`;
+	return new File([content], fileName, { type: mimeType });
+}
+
+export function useWebPageFileNode(node: FileNode) {
+	const { isLoading, updateNodeDataContent, uploadFile } =
+		useWorkflowDesigner();
 	const [urls, setUrls] = useState("");
 	const [format, setFormat] = useState<"html" | "markdown">("markdown");
-	const [isFetching, setIsFetching] = useState(false);
-	const [fetchStatuses, setFetchStatuses] = useState<
-		Record<string, "fetching" | "success" | "error">
-	>({});
-	const [files, setFiles] = useState<FileData[]>([]);
 	const [urlError, setUrlError] = useState("");
 
-	const onFetch = async () => {
+	// onFetch now uploads web page content as files using uploadFile, and updates webPages metadata for display
+	const onFetch = useCallback(async () => {
 		const urlList = urls
 			.split("\n")
 			.map((u) => u.trim())
-			.filter(Boolean);
+			.filter((u: string) => Boolean(u));
 		if (urlList.length === 0) return;
-		setIsFetching(true);
 		setUrlError("");
-		setFetchStatuses(
-			Object.fromEntries(urlList.map((url) => [url, "fetching"])),
-		);
-		// Simulate async fetch for each URL
-		await Promise.all(
-			urlList.map(
-				(url, i) =>
-					new Promise<void>((resolve) => {
-						setTimeout(
-							() => {
-								setFetchStatuses((prev) => ({ ...prev, [url]: "success" }));
-								setFiles((prev) => [
-									...prev,
-									{
-										id: `fl-${url.replace(/[^a-zA-Z0-9]/g, "")}-${Date.now()}`,
-										name: url,
-										type: format === "markdown" ? "text/markdown" : "text/html",
-										size: 0,
-										status: "uploaded",
-										uploadedAt: Date.now(),
-									},
-								]);
-								resolve();
-							},
-							800 + i * 400,
-						); // staggered for effect
-					}),
-			),
-		);
-		setIsFetching(false);
-	};
 
-	const onRemoveFile = (file: FileData) => {
-		setFiles((prev) => prev.filter((f) => f.id !== file.id));
-	};
+		try {
+			const selfMadeWebSearch = webSearch({ provider: "self-made" });
+			const newWebPages: WebPageContent[] = [];
+			const filesToUpload: File[] = [];
+			for (const url of urlList) {
+				try {
+					const result = await selfMadeWebSearch.fetchUrl(url, [format]);
+					const file = createFileFromWebSearchResult(url, result, format);
+					filesToUpload.push(file);
+					const webPageContent = createWebPageContentFromResult(result, format);
+					newWebPages.push(webPageContent);
+				} catch (e) {
+					setUrlError("Failed to fetch one or more URLs.");
+				}
+			}
+			// Upload files using uploadFile
+			if (filesToUpload.length > 0) {
+				await uploadFile(filesToUpload, node, {
+					onError: (errorMessage) => {
+						setUrlError(errorMessage);
+					},
+				});
+			}
+
+			// Update node content for all file statuses
+			updateNodeDataContent(node, {
+				type: "file",
+				category: "webPage",
+				files: newWebPages.map((wp) => wp.file),
+			});
+		} catch (error) {
+			setUrlError("Failed to fetch one or more URLs.");
+		}
+	}, [urls, format, node, updateNodeDataContent, uploadFile]);
+
+	const onRemoveFile = useCallback(
+		(file: FileData) => {
+			if (!node.content || !Array.isArray(node.content.files)) return;
+			updateNodeDataContent(node, {
+				type: "file",
+				category: "webPage",
+				files: node.content.files.filter((f: FileData) => f.id !== file.id),
+			});
+		},
+		[node, updateNodeDataContent],
+	);
 
 	return {
 		urls,
 		setUrls,
 		format,
 		setFormat,
-		isFetching,
-		fetchStatuses,
-		files,
+		isLoading,
 		onFetch,
 		onRemoveFile,
+		files:
+			node.content && Array.isArray(node.content.files)
+				? node.content.files
+				: [],
 		urlError,
 	};
 }

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-web-page-file-node.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-web-page-file-node.ts
@@ -1,55 +1,9 @@
-import type {
-	FileData,
-	FileNode,
-	WebPageContent,
-} from "@giselle-sdk/data-type";
-import { FileId } from "@giselle-sdk/data-type";
-import { type WebSearchResult, webSearch } from "@giselle-sdk/web-search";
+import type { FileData, FileNode } from "@giselle-sdk/data-type";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { useCallback, useState } from "react";
 
-function createFileDataFromWebPage(
-	result: WebSearchResult,
-	format: "html" | "markdown",
-): FileData {
-	const content = format === "markdown" ? result.markdown : result.html;
-	const now = Date.now();
-	return {
-		id: FileId.generate(),
-		name: result.url,
-		type: format === "markdown" ? "text/markdown" : "text/html",
-		size: new Blob([content]).size,
-		status: "uploaded",
-		uploadedAt: now,
-	};
-}
-
-function createWebPageContentFromResult(
-	result: WebSearchResult,
-	format: "html" | "markdown",
-): WebPageContent {
-	return {
-		type: "webPage",
-		url: result.url,
-		format,
-		file: createFileDataFromWebPage(result, format),
-		status: "completed",
-	};
-}
-
-function createFileFromWebSearchResult(
-	url: string,
-	result: WebSearchResult,
-	format: "html" | "markdown",
-): File {
-	const content = format === "markdown" ? result.markdown : result.html;
-	const mimeType = format === "markdown" ? "text/markdown" : "text/html";
-	const fileName = `${url} (Format: ${format === "markdown" ? "Markdown" : "HTML"})`;
-	return new File([content], fileName, { type: mimeType });
-}
-
 export function useWebPageFileNode(node: FileNode) {
-	const { isLoading, updateNodeDataContent, uploadFile } =
+	const { isLoading, updateNodeDataContent, uploadFile, fetchWebPageFiles } =
 		useWorkflowDesigner();
 	const [urls, setUrls] = useState("");
 	const [format, setFormat] = useState<"html" | "markdown">("markdown");
@@ -65,21 +19,18 @@ export function useWebPageFileNode(node: FileNode) {
 		setUrlError("");
 
 		try {
-			const selfMadeWebSearch = webSearch({ provider: "self-made" });
-			const newWebPages: WebPageContent[] = [];
-			const filesToUpload: File[] = [];
-			for (const url of urlList) {
-				try {
-					const result = await selfMadeWebSearch.fetchUrl(url, [format]);
-					const file = createFileFromWebSearchResult(url, result, format);
-					filesToUpload.push(file);
-					const webPageContent = createWebPageContentFromResult(result, format);
-					newWebPages.push(webPageContent);
-				} catch (e) {
-					setUrlError("Failed to fetch one or more URLs.");
-				}
-			}
-			// Upload files using uploadFile
+			const webPageFileResults = await fetchWebPageFiles({
+				urls: urlList,
+				format,
+			});
+
+			// Convert content string to File for browser upload
+			const filesToUpload = webPageFileResults.map((r) => {
+				const blob = new Blob([r.content], { type: r.mimeType });
+				return new File([blob], r.fileName, { type: r.mimeType });
+			});
+			const fileDataList = webPageFileResults.map((r) => r.fileData);
+
 			if (filesToUpload.length > 0) {
 				await uploadFile(filesToUpload, node, {
 					onError: (errorMessage) => {
@@ -90,21 +41,29 @@ export function useWebPageFileNode(node: FileNode) {
 
 			// Update node content for all file statuses
 			updateNodeDataContent(node, {
-				type: "file",
-				category: "webPage",
-				files: newWebPages.map((wp) => wp.file),
+				files: fileDataList,
 			});
+
+			// Remove only successfully fetched URLs from urls, keep failed URLs
+			const fetchedUrls = new Set(webPageFileResults.map((r) => r.url));
+			const failedUrls = urlList.filter((url) => !fetchedUrls.has(url));
+			setUrls(failedUrls.join("\n"));
 		} catch (error) {
 			setUrlError("Failed to fetch one or more URLs.");
 		}
-	}, [urls, format, node, updateNodeDataContent, uploadFile]);
+	}, [
+		urls,
+		format,
+		node,
+		updateNodeDataContent,
+		uploadFile,
+		fetchWebPageFiles,
+	]);
 
 	const onRemoveFile = useCallback(
 		(file: FileData) => {
 			if (!node.content || !Array.isArray(node.content.files)) return;
 			updateNodeDataContent(node, {
-				type: "file",
-				category: "webPage",
 				files: node.content.files.filter((f: FileData) => f.id !== file.id),
 			});
 		},

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/web-page-file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/web-page-file-panel.tsx
@@ -12,11 +12,11 @@ export function WebPageFilePanel({ node, config }: FilePanelProps) {
 		setUrls,
 		format,
 		setFormat,
-		files,
 		onFetch,
 		onRemoveFile,
+		isLoading,
+		files,
 		urlError,
-		isFetching,
 	} = useWebPageFileNode(node);
 
 	return (
@@ -25,7 +25,7 @@ export function WebPageFilePanel({ node, config }: FilePanelProps) {
 				{/* Fetched Files List */}
 				{files.length > 0 && (
 					<div className="pb-[16px] flex flex-col gap-[8px]">
-						{files.map((file) => (
+						{files.map((file: FileData) => (
 							<WebPageFileListItem
 								key={file.id}
 								fileData={file}
@@ -97,9 +97,9 @@ export function WebPageFilePanel({ node, config }: FilePanelProps) {
 						type="button"
 						className="w-fit px-[16px] py-[8px] rounded-[8px] bg-blue-700 text-white-800 font-semibold hover:bg-blue-800 disabled:bg-black-400"
 						onClick={onFetch}
-						disabled={isFetching || !urls.trim()}
+						disabled={isLoading || !urls.trim()}
 					>
-						{isFetching ? "Fetching..." : "Fetch Web Pages"}
+						{isLoading ? "Fetching..." : "Fetch Web Pages"}
 					</button>
 				</div>
 			</div>

--- a/packages/data-type/src/node/variables/index.ts
+++ b/packages/data-type/src/node/variables/index.ts
@@ -15,6 +15,7 @@ export * from "./file";
 export * from "./github";
 export * from "./text";
 export * from "./vector-store";
+export * from "./web-page";
 
 const VariableNodeContent = z.discriminatedUnion("type", [
 	TextContent,

--- a/packages/data-type/src/node/variables/web-page.ts
+++ b/packages/data-type/src/node/variables/web-page.ts
@@ -1,0 +1,11 @@
+import { z } from "zod/v4";
+import { FileData } from "./file";
+
+export const WebPageContent = z.object({
+	type: z.literal("webPage"),
+	url: z.url().min(1),
+	format: z.enum(["html", "markdown"]).default("html"),
+	file: FileData,
+	status: z.enum(["idle", "fetching", "completed", "failed"]).default("idle"),
+});
+export type WebPageContent = z.infer<typeof WebPageContent>;

--- a/packages/data-type/src/node/variables/web-page.ts
+++ b/packages/data-type/src/node/variables/web-page.ts
@@ -9,3 +9,12 @@ export const WebPageContent = z.object({
 	status: z.enum(["idle", "fetching", "completed", "failed"]).default("idle"),
 });
 export type WebPageContent = z.infer<typeof WebPageContent>;
+
+export const WebPageFileResult = z.object({
+	url: z.string(),
+	content: z.string(),
+	fileName: z.string(),
+	mimeType: z.string(),
+	fileData: FileData,
+});
+export type WebPageFileResult = z.infer<typeof WebPageFileResult>;

--- a/packages/giselle-engine/package.json
+++ b/packages/giselle-engine/package.json
@@ -43,6 +43,7 @@
 	"devDependencies": {
 		"@giselle-sdk/data-type": "workspace:*",
 		"@giselle-sdk/utils": "workspace:*",
+		"@giselle-sdk/web-search": "workspace:*",
 		"@giselle/giselle-sdk-tsconfig": "workspace:*",
 		"@octokit/webhooks-types": "7.6.1",
 		"@types/pg": "catalog:",

--- a/packages/giselle-engine/src/core/files/index.ts
+++ b/packages/giselle-engine/src/core/files/index.ts
@@ -1,3 +1,4 @@
 export * from "./copy-file";
 export * from "./remove-file";
 export * from "./upload-file";
+export * from "./web-page-file";

--- a/packages/giselle-engine/src/core/files/web-page-file.ts
+++ b/packages/giselle-engine/src/core/files/web-page-file.ts
@@ -1,0 +1,35 @@
+import type { FileData, WebPageFileResult } from "@giselle-sdk/data-type";
+import { FileId as FileIdGenerator } from "@giselle-sdk/data-type";
+import { webSearch } from "@giselle-sdk/web-search";
+
+export async function fetchWebPageFiles(args: {
+	urls: string[];
+	format: "markdown" | "html";
+	provider?: "self-made";
+}): Promise<WebPageFileResult[]> {
+	const { urls, format, provider = "self-made" } = args;
+	const search = webSearch({ provider });
+	const results: WebPageFileResult[] = [];
+	for (const url of urls) {
+		const result = await search.fetchUrl(url, [format]);
+
+		const content = format === "markdown" ? result.markdown : result.html;
+		const mimeType = format === "markdown" ? "text/markdown" : "text/html";
+		const fileName = result.url;
+		const fileData: FileData = {
+			id: FileIdGenerator.generate(),
+			name: fileName,
+			type: mimeType,
+			size: content.length, // size in characters (not bytes)
+			status: "uploading",
+		};
+		results.push({
+			url: result.url,
+			content,
+			fileName,
+			mimeType,
+			fileData,
+		});
+	}
+	return results;
+}

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -17,7 +17,7 @@ import type {
 	WorkspaceId,
 } from "@giselle-sdk/data-type";
 import { getLanguageModelProviders } from "./configurations/get-language-model-providers";
-import { copyFile, removeFile, uploadFile } from "./files";
+import { copyFile, fetchWebPageFiles, removeFile, uploadFile } from "./files";
 import {
 	type ConfigureTriggerInput,
 	configureTrigger,
@@ -140,6 +140,13 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		},
 		removeFile: async (workspaceId: WorkspaceId, fileId: FileId) => {
 			return await removeFile({ context, fileId, workspaceId });
+		},
+		fetchWebPageFiles: async (args: {
+			urls: string[];
+			format: "html" | "markdown";
+			provider?: "self-made";
+		}) => {
+			return await fetchWebPageFiles(args);
 		},
 		upsertGithubIntegrationSetting: async (
 			workspaceGitHubIntegrationSetting: WorkspaceGitHubIntegrationSetting,

--- a/packages/giselle-engine/src/http/router.ts
+++ b/packages/giselle-engine/src/http/router.ts
@@ -164,6 +164,19 @@ export const createJsonRouters = {
 				return new Response(null, { status: 204 });
 			},
 		}),
+	fetchWebPageFiles: (giselleEngine: GiselleEngine) =>
+		createHandler({
+			input: z.object({
+				urls: z.array(z.string()),
+				format: z.enum(["html", "markdown"]),
+				provider: z.literal("self-made").optional(),
+			}),
+			handler: async ({ input }) => {
+				return JsonResponse.json({
+					webPageFiles: await giselleEngine.fetchWebPageFiles(input),
+				});
+			},
+		}),
 	upsertWorkspaceGitHubIntegrationSetting: (giselleEngine: GiselleEngine) =>
 		createHandler({
 			input: z.object({

--- a/packages/web-search/src/index.ts
+++ b/packages/web-search/src/index.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { SelfMadeWebSearchProvider, selfMadeProviderName } from "./self-made";
-export { webSearch } from "./web-search";
+export { type WebSearchResult, webSearch } from "./web-search";
 export { scrapeUrl as selfMadeScrapeUrl } from "./self-made";
 
 export const WebSearchProviderSchema = SelfMadeWebSearchProvider;

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -9,6 +9,7 @@ import {
 	type NodeUIState,
 	type UploadedFileData,
 	type Viewport,
+	type WebPageFileResult,
 	type Workspace,
 	createFailedFileData,
 	createUploadedFileData,
@@ -57,6 +58,11 @@ export interface WorkflowDesignerContextValue
 	) => void;
 	uploadFile: UploadFileFn;
 	removeFile: (uploadedFile: UploadedFileData) => Promise<void>;
+	fetchWebPageFiles: (args: {
+		urls: string[];
+		format: "markdown" | "html";
+		provider?: "self-made";
+	}) => Promise<WebPageFileResult[]>;
 	deleteNode: (nodeId: NodeId | string) => void;
 	llmProviders: LanguageModelProvider[];
 	isLoading: boolean;
@@ -301,6 +307,18 @@ export function WorkflowDesignerProvider({
 		[setAndSaveWorkspace, client, data.id],
 	);
 
+	const fetchWebPageFiles = useCallback(
+		async (args: {
+			urls: string[];
+			format: "markdown" | "html";
+			provider?: "self-made";
+		}): Promise<WebPageFileResult[]> => {
+			const result = await client.fetchWebPageFiles(args);
+			return result.webPageFiles;
+		},
+		[client],
+	);
+
 	const usePropertiesPanelHelper = usePropertiesPanel();
 	const useViewHelper = useView();
 
@@ -318,6 +336,7 @@ export function WorkflowDesignerProvider({
 				deleteConnection,
 				uploadFile,
 				removeFile,
+				fetchWebPageFiles,
 				llmProviders,
 				isLoading,
 				setUiViewport,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -924,6 +924,9 @@ importers:
       '@giselle-sdk/utils':
         specifier: workspace:*
         version: link:../utils
+      '@giselle-sdk/web-search':
+        specifier: workspace:*
+        version: link:../web-search
       '@giselle/giselle-sdk-tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,6 +685,9 @@ importers:
       '@giselle-sdk/usage-limits':
         specifier: workspace:^
         version: link:../../packages/usage-limits
+      '@giselle-sdk/web-search':
+        specifier: workspace:^
+        version: link:../../packages/web-search
       '@giselle-sdk/workflow-utils':
         specifier: workspace:^
         version: link:../../packages/workflow-utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,9 +685,6 @@ importers:
       '@giselle-sdk/usage-limits':
         specifier: workspace:^
         version: link:../../packages/usage-limits
-      '@giselle-sdk/web-search':
-        specifier: workspace:^
-        version: link:../../packages/web-search
       '@giselle-sdk/workflow-utils':
         specifier: workspace:^
         version: link:../../packages/workflow-utils


### PR DESCRIPTION
## Summary
This PR implements the Web Page File Node feature, which allows users to fetch and process web page content within the workflow designer. The implementation includes both frontend and backend components, with proper integration between the workflow designer UI and the Giselle engine.

## Related Issue
https://github.com/giselles-ai/giselle/issues/957

## Changes
- Added Web Page File Node frontend implementation
- Defined necessary types and interfaces:
  - `WebPageContent` in data-type package
  - `WebPageFileResult` in giselle-engine
  - Exported `WebSearchResult` from web-search package
- Implemented backend functionality:
  - Added `fetchWebPageFiles` in giselle-engine
  - Integrated web search functionality in the engine
  - Implemented file fetching in workflow-designer
- Integrated the backend logic with the file-node-properties-panel

## Testing
1. Visit app workspace
2. Place Web page file node 
3. Input your URLs and select output format (Markdown or HTML)
4. Hit the "Fetch Web Pages" button
5. After fetched web pages, connect the generation model and summary by AI

## Other Information
The following are ToDo items not included in this PR:

* We plan to request UI/UX improvements from a designer before removing the feature flag.
* Detailed error handling is planned for future implementation.
* Since we are currently using only a self-made web search, we are considering using an API such as [https://exa.ai/exa-api](https://exa.ai/exa-api) as a fallback.