### PR TITLE
fix: Update gemini-2.5-pro-preview name for latest

### DIFF
--- a/packages/language-model/src/google.test.ts
+++ b/packages/language-model/src/google.test.ts
@@ -4,8 +4,8 @@ import { GoogleLanguageModelId } from "./google";
 describe("google llm", () => {
 	describe("GoogleLanguageModelId", () => {
 		it("should parse valid enum values successfully", () => {
-			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-05-20")).toBe(
-				"gemini-2.5-pro-preview-05-20",
+			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-05-06")).toBe(
+				"gemini-2.5-pro-preview-05-06",
 			);
 			expect(
 				GoogleLanguageModelId.parse("gemini-2.5-flash-preview-05-20"),
@@ -18,18 +18,18 @@ describe("google llm", () => {
 			);
 		});
 
-		it("should fallback gemini-2.5-pro-preview variants to gemini-2.5-pro-preview-05-20", () => {
+		it("should fallback gemini-2.5-pro-preview variants to gemini-2.5-pro-preview-05-06", () => {
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-03-25")).toBe(
-				"gemini-2.5-pro-preview-05-20",
+				"gemini-2.5-pro-preview-05-06",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-01-01")).toBe(
-				"gemini-2.5-pro-preview-05-20",
+				"gemini-2.5-pro-preview-05-06",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-12-31")).toBe(
-				"gemini-2.5-pro-preview-05-20",
+				"gemini-2.5-pro-preview-05-06",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-")).toBe(
-				"gemini-2.5-pro-preview-05-20",
+				"gemini-2.5-pro-preview-05-06",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-1.5-flash")).toBe(
 				"gemini-2.0-flash",

--- a/packages/language-model/src/google.ts
+++ b/packages/language-model/src/google.ts
@@ -20,7 +20,7 @@ const defaultConfigurations: GoogleLanguageModelConfigurations = {
 
 export const GoogleLanguageModelId = z
 	.enum([
-		"gemini-2.5-pro-preview-05-20",
+		"gemini-2.5-pro-preview-05-06",
 		"gemini-2.5-flash-preview-05-20",
 		"gemini-2.0-flash",
 		"gemini-2.0-flash-lite",
@@ -30,7 +30,7 @@ export const GoogleLanguageModelId = z
 			return "gemini-2.0-flash";
 		}
 		if (ctx.value.startsWith("gemini-2.5-pro-preview-")) {
-			return "gemini-2.5-pro-preview-05-20";
+			return "gemini-2.5-pro-preview-05-06";
 		}
 		if (ctx.value.startsWith("gemini-2.5-flash-preview-")) {
 			return "gemini-2.5-flash-preview-05-20";
@@ -47,7 +47,7 @@ type GoogleLanguageModel = z.infer<typeof GoogleLanguageModel>;
 
 const gemini25ProPreview: GoogleLanguageModel = {
 	provider: "google",
-	id: "gemini-2.5-pro-preview-05-20",
+	id: "gemini-2.5-pro-preview-05-06",
 	capabilities:
 		Capability.TextGeneration |
 		Capability.GenericFileInput |


### PR DESCRIPTION
## Summary
I update gemini-2.5-pro-preview name for latest

## Related Issue
ref: https://github.com/giselles-ai/giselle/pull/1010

## Changes
Fixed the following error:

> models/gemini-2.5-pro-preview-05-20 is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.

## Testing
Please use `gemini-2.5-pro-preview-05-06`

## Other Information
docs: https://ai.google.dev/gemini-api/docs/models?hl=en

<img width="766" alt="image" src="https://github.com/user-attachments/assets/de725035-ef51-4c2c-8c73-0ef36ff7b9ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the identifier for the "gemini-2.5-pro-preview" language model to "gemini-2.5-pro-preview-05-06" to ensure correct model selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->