### PR TITLE
Refactor generation storage paths

### DIFF
--- a/packages/giselle-engine/src/core/generations/utils.test.ts
+++ b/packages/giselle-engine/src/core/generations/utils.test.ts
@@ -73,7 +73,7 @@ describe("getGeneration", () => {
 		});
 
 		// Set up generation data
-		const generationPath = `workspaces/${mockGenerationIndex.origin.id}/generations/${generationId}/generation.json`;
+		const generationPath = `generations/${generationId}/generation.json`;
 		await storage.setItem(generationPath, mockGeneration);
 	});
 


### PR DESCRIPTION
## Summary
- simplify generation storage structure under `generations/`
- update node generation index utilities
- adjust unit tests

## Tested items

> [!NOTE]
> This modifications effect all of generation features.

- [x] Generate Text with text generation node
- [x] Generate Text with text generation node(connected another text generation node)
- [x] Generate Image with image generation node
- [x] Execute flow with manual trigger
- [x] Execute flow with github trigger

related https://github.com/giselles-ai/giselle/issues/1019


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified and unified storage paths for generations and node generations, removing origin-based branching.
  - Updated internal handling to use consistent, origin-agnostic paths for generation data and images.

- **Tests**
  - Updated tests to reflect the new, simplified storage path structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->