### PR TITLE
Remove team invitation flag

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/login/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/login/page.tsx
@@ -1,4 +1,3 @@
-import { teamInvitationViaEmailFlag } from "@/flags";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { LegalConsent } from "../../../components/legal-consent";
@@ -10,10 +9,6 @@ export default async function Page({
 	params,
 }: { params: Promise<{ token: string }> }) {
 	const { token } = await params;
-	const isTeamInvitationViaEmail = await teamInvitationViaEmailFlag();
-	if (!isTeamInvitationViaEmail) {
-		return notFound();
-	}
 
 	const tokenObj = await fetchInvitationToken(token);
 	if (!tokenObj) {

--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/page.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-import { teamInvitationViaEmailFlag } from "@/flags";
 import { getUser } from "@/lib/supabase";
 import type { User } from "@supabase/auth-js";
 import Link from "next/link";
@@ -12,10 +11,6 @@ export default async function Page({
 	params,
 }: { params: Promise<{ token: string }> }) {
 	const { token: tokenParam } = await params;
-	const isTeamInvitationViaEmail = await teamInvitationViaEmailFlag();
-	if (!isTeamInvitationViaEmail) {
-		return notFound();
-	}
 
 	const token = await fetchInvitationToken(tokenParam);
 	if (!token) {

--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/signup/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/signup/page.tsx
@@ -1,4 +1,3 @@
-import { teamInvitationViaEmailFlag } from "@/flags";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { LegalConsent } from "../../../components/legal-consent";
@@ -10,10 +9,6 @@ export default async function Page({
 	params,
 }: { params: Promise<{ token: string }> }) {
 	const { token } = await params;
-	const isTeamInvitationViaEmail = await teamInvitationViaEmailFlag();
-	if (!isTeamInvitationViaEmail) {
-		return notFound();
-	}
 
 	const tokenObj = await fetchInvitationToken(token);
 	if (!tokenObj) {

--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/signup/verify-email/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/signup/verify-email/page.tsx
@@ -1,4 +1,3 @@
-import { teamInvitationViaEmailFlag } from "@/flags";
 import { notFound, redirect } from "next/navigation";
 import { fetchInvitationToken } from "../../invitation";
 import { JoinVerifyForm } from "./form";
@@ -8,11 +7,6 @@ export default async function Page({
 }: {
 	params: Promise<{ token: string }>;
 }) {
-	const isTeamInvitationViaEmail = await teamInvitationViaEmailFlag();
-	if (!isTeamInvitationViaEmail) {
-		return notFound();
-	}
-
 	const { token } = await params;
 	const tokenObj = await fetchInvitationToken(token);
 	if (!tokenObj) {

--- a/apps/studio.giselles.ai/app/(auth)/join/success/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/success/page.tsx
@@ -1,14 +1,7 @@
 import { Button } from "@/components/ui/button";
-import { teamInvitationViaEmailFlag } from "@/flags";
 import Link from "next/link";
-import { notFound } from "next/navigation";
 
 export default async function Page() {
-	const isTeamInvitationViaEmail = await teamInvitationViaEmailFlag();
-	if (!isTeamInvitationViaEmail) {
-		return notFound();
-	}
-
 	return (
 		<div className="min-h-screen flex items-center justify-center p-4">
 			<div className="flex items-center justify-center py-12">

--- a/apps/studio.giselles.ai/app/(main)/settings/team/members/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/members/page.tsx
@@ -1,4 +1,3 @@
-import { teamInvitationViaEmailFlag } from "@/flags";
 import { fetchCurrentTeam, isProPlan } from "@/services/teams";
 import { Card } from "../../components/card";
 import { getCurrentUserRole, getTeamMembers } from "../actions";
@@ -24,12 +23,7 @@ export default async function TeamMembersPage() {
 		await getCurrentUserRole();
 	const { success: hasMembers, data: members } = await getTeamMembers();
 	const hasProPlan = isProPlan(team);
-	const teamInvitationViaEmailEnabled = await teamInvitationViaEmailFlag();
-
-	let invitations: Invitation[] = [];
-	if (teamInvitationViaEmailEnabled) {
-		invitations = await listInvitations();
-	}
+	const invitations = await listInvitations();
 
 	if (!hasMembers || !members) {
 		return (
@@ -80,7 +74,6 @@ export default async function TeamMembersPage() {
 				</h3>
 				{hasProPlan && currentUserRole === "admin" && (
 					<InviteMemberDialog
-						teamInvitationViaEmailEnabled={teamInvitationViaEmailEnabled}
 						memberEmails={members
 							.map((member) => member.email)
 							.filter((email) => email != null)}

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -40,19 +40,6 @@ export const githubToolsFlag = flag<boolean>({
 	],
 });
 
-export const teamInvitationViaEmailFlag = flag<boolean>({
-	key: "teamInvitationViaEmail",
-	async decide() {
-		return true;
-	},
-	description: "Enable team invitation via email",
-	defaultValue: false,
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const flowNodeFlag = flag<boolean>({
 	key: "flow-node",
 	async decide() {


### PR DESCRIPTION
## Summary
- delete `teamInvitationViaEmailFlag`
- drop conditional code in pages and components that used this flag

## Testing
- `npx turbo run check-types --cache=local:rw`
- `npx turbo run test --cache=local:rw`


------
https://chatgpt.com/codex/tasks/task_e_683964f98a6c8328a638c9cb07fbf225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the feature flag controlling team invitation via email, making related features always available and simplifying the invitation flow.
  - Updated team member invitation dialogs and pages to no longer check or require this feature flag.
  - Invitations are now always processed via email without fallback logic or conditional checks.
- **Chores**
  - Cleaned up code by removing unused properties, imports, and feature flag logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->