### PR TITLE
Add function to fetch pull request review comment

### DIFF
--- a/packages/github-tool/src/pull-requests.ts
+++ b/packages/github-tool/src/pull-requests.ts
@@ -31,3 +31,30 @@ export async function getPullRequestDiff(args: {
 	);
 	return response.data as unknown as string;
 }
+
+export async function getPullRequestReviewComment(args: {
+	repositoryNodeId: string;
+	commentId: number;
+	authConfig: GitHubAuthConfig;
+}) {
+	const client = octokit(args.authConfig);
+	const repo = await getRepositoryFullname(
+		args.repositoryNodeId,
+		args.authConfig,
+	);
+	if (repo.error || repo.data === undefined) {
+		throw new Error(`Failed to get repository information: ${repo.error}`);
+	}
+	if (repo.data.node?.__typename !== "Repository") {
+		throw new Error(`Invalid repository type: ${repo.data.node?.__typename}`);
+	}
+	const response = await client.request(
+		"GET /repos/{owner}/{repo}/pulls/comments/{comment_id}",
+		{
+			owner: repo.data.node.owner.login,
+			repo: repo.data.node.name,
+			comment_id: args.commentId,
+		},
+	);
+	return response.data;
+}


### PR DESCRIPTION
## Summary
- add `getPullRequestReviewComment` to github-tool for retrieving a pull request review comment

## Testing
- `pnpm biome check packages/github-tool/src/pull-requests.ts`
- `turbo test --cache=local:rw`


------
https://chatgpt.com/codex/tasks/task_e_683d4f844378832fb01e16e47a051ea5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve specific pull request review comments from GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->