### PR TITLE
Fix: disable shortcuts when inputs are focused

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/keyboard-shortcuts.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/keyboard-shortcuts.tsx
@@ -17,18 +17,19 @@ export function KeyboardShortcuts() {
 
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if ((event.metaKey || event.ctrlKey) && event.key === "d") {
-				event.preventDefault();
-				duplicateNode();
+			const activeElement = document.activeElement as HTMLElement | null;
+
+			if (
+				activeElement &&
+				(ignoredTags.includes(activeElement.tagName) ||
+					activeElement.isContentEditable)
+			) {
 				return;
 			}
 
-			const activeElement = document.activeElement;
-
-			if (
-				ignoredTags.includes(activeElement?.tagName ?? "") ||
-				activeElement?.getAttribute("contenteditable") === "true"
-			) {
+			if ((event.metaKey || event.ctrlKey) && event.key === "d") {
+				event.preventDefault();
+				duplicateNode();
 				return;
 			}
 			switch (event.key) {


### PR DESCRIPTION
## Summary
- disable editor shortcuts when an input element is focused

## Testing
- `npx turbo test --cache=local:rw`
- `npx turbo check-types --filter @giselle-internal/workflow-designer-ui --cache=local:rw`
- `npx turbo build --filter @giselle-internal/workflow-designer-ui --cache=local:rw`
- `npx turbo format --cache=local:rw`


------
https://chatgpt.com/codex/tasks/task_e_683ea94b2aa8832f87eb8cf46ffafb56