### PR TITLE
Remove flowNode and runV2 feature flags

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -14,8 +14,6 @@ export default async function Layout({
 		<WorkspaceProvider
 			workspaceId={workspaceId}
 			featureFlag={{
-				flowNode: true,
-				runV2: true,
 				githubVectorStore: true,
 				webPageFileNode: true,
 			}}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -1,11 +1,6 @@
 import { getGitHubVectorStores } from "@/app/services/vector-store";
 import { db } from "@/drizzle";
-import {
-	flowNodeFlag,
-	githubVectorStoreFlag,
-	runV2Flag,
-	webPageFileNodeFlag,
-} from "@/flags";
+import { githubVectorStoreFlag, webPageFileNodeFlag } from "@/flags";
 import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
 import { fetchCurrentUser } from "@/services/accounts";
@@ -39,8 +34,6 @@ export default async function Layout({
 		return notFound();
 	}
 	const usageLimits = await getUsageLimitsForTeam(currentTeam);
-	const flowNode = await flowNodeFlag();
-	const runV2 = await runV2Flag();
 	const githubVectorStore = await githubVectorStoreFlag();
 	const gitHubVectorStores = await getGitHubVectorStores(currentTeam.dbId);
 	const webPageFileNode = await webPageFileNodeFlag();
@@ -70,8 +63,6 @@ export default async function Layout({
 				},
 			}}
 			featureFlag={{
-				flowNode,
-				runV2,
 				githubVectorStore,
 				webPageFileNode,
 			}}

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -1,4 +1,3 @@
-import { get } from "@vercel/edge-config";
 import { flag } from "flags/next";
 
 function takeLocalEnv(localEnvironmentKey: string) {
@@ -34,44 +33,6 @@ export const githubToolsFlag = flag<boolean>({
 	},
 	description: "Enable GitHub Tools",
 	defaultValue: false,
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
-export const flowNodeFlag = flag<boolean>({
-	key: "flow-node",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("FLOW_NODE_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return false;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable Flow Node",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
-export const runV2Flag = flag<boolean>({
-	key: "run-v2",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("RUN_V2_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return false;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable Run v2",
 	options: [
 		{ value: false, label: "disable" },
 		{ value: true, label: "Enable" },

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -91,7 +91,7 @@ export function Toolbar() {
 	const [selectedCategory, setSelectedCategory] = useState<string>("All");
 	const { llmProviders } = useWorkflowDesigner();
 	const limits = useUsageLimits();
-	const { flowNode, webPageFileNode, githubVectorStore } = useFeatureFlag();
+	const { webPageFileNode, githubVectorStore } = useFeatureFlag();
 
 	const modelsFilteredBySearchOnly = languageModels
 		.filter((model) => llmProviders.includes(model.provider))
@@ -248,133 +248,131 @@ export function Toolbar() {
 						}
 					}}
 				>
-					{flowNode && (
-						<>
-							<ToggleGroup.Item
-								value="selectTrigger"
-								data-tool
-								className="relative"
-							>
-								<Tooltip text={<TooltipAndHotkey text="Trigger" hotkey="t" />}>
-									<TriggerIcon data-icon />
-								</Tooltip>
-								{selectedTool?.action === "selectTrigger" && (
-									<Popover.Root open={true}>
-										<Popover.Anchor />
-										<Popover.Portal>
-											<Popover.Content
-												className={clsx(
-													"relative rounded-[8px] px-[8px] py-[8px] min-w-[200px]",
-													"bg-[hsla(255,_40%,_98%,_0.04)] text-white-900",
-													"backdrop-blur-[4px]",
-												)}
-												sideOffset={42}
-											>
-												<div className="absolute z-0 rounded-[8px] inset-0 border mask-fill bg-gradient-to-br from-[hsla(232,37%,72%,0.2)] to-[hsla(218,58%,21%,0.9)] bg-origin-border bg-clip-border border-transparent" />
-												<div className="relative flex flex-col gap-[8px]">
-													<ToggleGroup.Root
-														type="single"
-														className={clsx(
-															"flex flex-col gap-[8px]",
-															"**:data-tool:flex **:data-tool:rounded-[8px] **:data-tool:items-center **:data-tool:w-full",
-															"**:data-tool:select-none **:data-tool:outline-none **:data-tool:px-[8px] **:data-tool:py-[4px] **:data-tool:gap-[8px] **:data-tool:hover:bg-white-900/10",
-															"**:data-tool:data-[state=on]:bg-primary-900 **:data-tool:focus:outline-none",
-														)}
-														onValueChange={(value) => {
-															setSelectedTool(
-																addNodeTool(
-																	createTriggerNode(value as TriggerProvider),
-																),
-															);
-														}}
-													>
-														{triggerProviders.map((triggerProvider) => (
-															<ToggleGroup.Item
-																key={triggerProvider}
-																value={triggerProvider}
-																data-tool
-															>
-																{triggerProvider === "manual" && (
-																	<TriggerIcon className="size-[20px] shrink-0" />
-																)}
-																{triggerProvider === "github" && (
-																	<GitHubIcon className="size-[20px] shrink-0" />
-																)}
+					<>
+						<ToggleGroup.Item
+							value="selectTrigger"
+							data-tool
+							className="relative"
+						>
+							<Tooltip text={<TooltipAndHotkey text="Trigger" hotkey="t" />}>
+								<TriggerIcon data-icon />
+							</Tooltip>
+							{selectedTool?.action === "selectTrigger" && (
+								<Popover.Root open={true}>
+									<Popover.Anchor />
+									<Popover.Portal>
+										<Popover.Content
+											className={clsx(
+												"relative rounded-[8px] px-[8px] py-[8px] min-w-[200px]",
+												"bg-[hsla(255,_40%,_98%,_0.04)] text-white-900",
+												"backdrop-blur-[4px]",
+											)}
+											sideOffset={42}
+										>
+											<div className="absolute z-0 rounded-[8px] inset-0 border mask-fill bg-gradient-to-br from-[hsla(232,37%,72%,0.2)] to-[hsla(218,58%,21%,0.9)] bg-origin-border bg-clip-border border-transparent" />
+											<div className="relative flex flex-col gap-[8px]">
+												<ToggleGroup.Root
+													type="single"
+													className={clsx(
+														"flex flex-col gap-[8px]",
+														"**:data-tool:flex **:data-tool:rounded-[8px] **:data-tool:items-center **:data-tool:w-full",
+														"**:data-tool:select-none **:data-tool:outline-none **:data-tool:px-[8px] **:data-tool:py-[4px] **:data-tool:gap-[8px] **:data-tool:hover:bg-white-900/10",
+														"**:data-tool:data-[state=on]:bg-primary-900 **:data-tool:focus:outline-none",
+													)}
+													onValueChange={(value) => {
+														setSelectedTool(
+															addNodeTool(
+																createTriggerNode(value as TriggerProvider),
+															),
+														);
+													}}
+												>
+													{triggerProviders.map((triggerProvider) => (
+														<ToggleGroup.Item
+															key={triggerProvider}
+															value={triggerProvider}
+															data-tool
+														>
+															{triggerProvider === "manual" && (
+																<TriggerIcon className="size-[20px] shrink-0" />
+															)}
+															{triggerProvider === "github" && (
+																<GitHubIcon className="size-[20px] shrink-0" />
+															)}
 
-																<p className="text-[14px]">
-																	{triggerNodeDefaultName(triggerProvider)}
-																</p>
-															</ToggleGroup.Item>
-														))}
-													</ToggleGroup.Root>
-												</div>
-											</Popover.Content>
-										</Popover.Portal>
-									</Popover.Root>
-								)}
-							</ToggleGroup.Item>
+															<p className="text-[14px]">
+																{triggerNodeDefaultName(triggerProvider)}
+															</p>
+														</ToggleGroup.Item>
+													))}
+												</ToggleGroup.Root>
+											</div>
+										</Popover.Content>
+									</Popover.Portal>
+								</Popover.Root>
+							)}
+						</ToggleGroup.Item>
 
-							<ToggleGroup.Item
-								value="selectAction"
-								data-tool
-								className="relative"
-							>
-								<Tooltip text={<TooltipAndHotkey text="Action" hotkey="a" />}>
-									<WorkflowIcon data-icon />
-								</Tooltip>
-								{selectedTool?.action === "selectAction" && (
-									<Popover.Root open={true}>
-										<Popover.Anchor />
-										<Popover.Portal>
-											<Popover.Content
-												className={clsx(
-													"relative rounded-[8px] px-[8px] py-[8px]",
-													"bg-[hsla(255,_40%,_98%,_0.04)] text-white-900",
-													"backdrop-blur-[4px]",
-												)}
-												sideOffset={42}
-											>
-												<div className="absolute z-0 rounded-[8px] inset-0 border mask-fill bg-gradient-to-br from-[hsla(232,37%,72%,0.2)] to-[hsla(218,58%,21%,0.9)] bg-origin-border bg-clip-border border-transparent" />
-												<div className="relative flex flex-col gap-[8px]">
-													<ToggleGroup.Root
-														type="single"
-														className={clsx(
-															"flex flex-col gap-[8px]",
-															"**:data-tool:flex **:data-tool:rounded-[8px] **:data-tool:items-center **:data-tool:w-full",
-															"**:data-tool:select-none **:data-tool:outline-none **:data-tool:px-[8px] **:data-tool:py-[4px] **:data-tool:gap-[8px] **:data-tool:hover:bg-white-900/10",
-															"**:data-tool:data-[state=on]:bg-primary-900 **:data-tool:focus:outline-none",
-														)}
-														onValueChange={(value) => {
-															setSelectedTool(
-																addNodeTool(
-																	createActionNode(value as ActionProvider),
-																),
-															);
-														}}
-													>
-														{actionProviders.map((actionProvider) => (
-															<ToggleGroup.Item
-																key={actionProvider}
-																value={actionProvider}
-																data-tool
-															>
-																{actionProvider === "github" && (
-																	<GitHubIcon className="size-[20px] shrink-0" />
-																)}
-																<p className="text-[14px]">
-																	{actionNodeDefaultName(actionProvider)}
-																</p>{" "}
-															</ToggleGroup.Item>
-														))}
-													</ToggleGroup.Root>
-												</div>
-											</Popover.Content>
-										</Popover.Portal>
-									</Popover.Root>
-								)}
-							</ToggleGroup.Item>
-						</>
-					)}
+						<ToggleGroup.Item
+							value="selectAction"
+							data-tool
+							className="relative"
+						>
+							<Tooltip text={<TooltipAndHotkey text="Action" hotkey="a" />}>
+								<WorkflowIcon data-icon />
+							</Tooltip>
+							{selectedTool?.action === "selectAction" && (
+								<Popover.Root open={true}>
+									<Popover.Anchor />
+									<Popover.Portal>
+										<Popover.Content
+											className={clsx(
+												"relative rounded-[8px] px-[8px] py-[8px]",
+												"bg-[hsla(255,_40%,_98%,_0.04)] text-white-900",
+												"backdrop-blur-[4px]",
+											)}
+											sideOffset={42}
+										>
+											<div className="absolute z-0 rounded-[8px] inset-0 border mask-fill bg-gradient-to-br from-[hsla(232,37%,72%,0.2)] to-[hsla(218,58%,21%,0.9)] bg-origin-border bg-clip-border border-transparent" />
+											<div className="relative flex flex-col gap-[8px]">
+												<ToggleGroup.Root
+													type="single"
+													className={clsx(
+														"flex flex-col gap-[8px]",
+														"**:data-tool:flex **:data-tool:rounded-[8px] **:data-tool:items-center **:data-tool:w-full",
+														"**:data-tool:select-none **:data-tool:outline-none **:data-tool:px-[8px] **:data-tool:py-[4px] **:data-tool:gap-[8px] **:data-tool:hover:bg-white-900/10",
+														"**:data-tool:data-[state=on]:bg-primary-900 **:data-tool:focus:outline-none",
+													)}
+													onValueChange={(value) => {
+														setSelectedTool(
+															addNodeTool(
+																createActionNode(value as ActionProvider),
+															),
+														);
+													}}
+												>
+													{actionProviders.map((actionProvider) => (
+														<ToggleGroup.Item
+															key={actionProvider}
+															value={actionProvider}
+															data-tool
+														>
+															{actionProvider === "github" && (
+																<GitHubIcon className="size-[20px] shrink-0" />
+															)}
+															<p className="text-[14px]">
+																{actionNodeDefaultName(actionProvider)}
+															</p>{" "}
+														</ToggleGroup.Item>
+													))}
+												</ToggleGroup.Root>
+											</div>
+										</Popover.Content>
+									</Popover.Portal>
+								</Popover.Root>
+							)}
+						</ToggleGroup.Item>
+					</>
 
 					<ToggleGroup.Item
 						value="selectLanguageModel"

--- a/packages/workspace/src/react/feature-flag.ts
+++ b/packages/workspace/src/react/feature-flag.ts
@@ -1,8 +1,6 @@
 import { createContext, useContext } from "react";
 
 export interface FeatureFlagContextValue {
-	flowNode: boolean;
-	runV2: boolean;
 	githubVectorStore: boolean;
 	webPageFileNode: boolean;
 }

--- a/packages/workspace/src/react/workspace.tsx
+++ b/packages/workspace/src/react/workspace.tsx
@@ -65,8 +65,6 @@ export function WorkspaceProvider({
 							<GenerationRunnerSystemProvider>
 								<FeatureFlagContext
 									value={{
-										flowNode: featureFlag?.flowNode ?? false,
-										runV2: featureFlag?.runV2 ?? false,
 										githubVectorStore: featureFlag?.githubVectorStore ?? false,
 										webPageFileNode: featureFlag?.webPageFileNode ?? false,
 									}}


### PR DESCRIPTION
## Summary
- delete `flowNode` and `runV2` feature flag code
- update workspace provider and layouts to remove those flags
- stop gating toolbar trigger actions on `flowNode`

## Testing
- `npx turbo test --cache=local:rw` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683f9e91b3648325970f2386aeea5bd5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Trigger" and "Action" toggle options in the workflow designer toolbar are now always visible to all users.

- **Chores**
  - Removed support for the "flowNode" and "runV2" feature flags across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->