### PR TITLE
Add getDiscussion function to GitHub tools

### DIFF
--- a/packages/github-tool/src/discussions.ts
+++ b/packages/github-tool/src/discussions.ts
@@ -1,0 +1,50 @@
+import { graphql } from "./client";
+import { graphql as gql } from "./graphql";
+import type { GitHubAuthConfig } from "./types";
+
+const DiscussionQuery = gql(/* GraphQL */ `
+    query DiscussionQuery($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+            discussion(number: $number) {
+                id
+                number
+                title
+                comments(first: 100) {
+                    totalCount
+                    nodes {
+                        body
+                        author {
+                            avatarUrl
+                            login
+                        }
+                        replies(first: 100) {
+                            nodes {
+                                body
+                                author {
+                                    avatarUrl
+                                    login
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`);
+
+export async function getDiscussion({
+	owner,
+	name,
+	number,
+	authConfig,
+}: {
+	owner: string;
+	name: string;
+	number: number;
+	authConfig: GitHubAuthConfig;
+}) {
+	const client = await graphql(authConfig);
+
+	return await client.query(DiscussionQuery, { owner, name, number });
+}

--- a/packages/github-tool/src/index.ts
+++ b/packages/github-tool/src/index.ts
@@ -9,6 +9,7 @@ export * from "./reactions";
 export * from "./webhooks";
 export * from "./errors";
 export * from "./pull-requests";
+export * from "./discussions";
 
 export const IssueNodeIdQuery = gql(/* GraphQL */ `
   query IssueNodeIdQuery($name: String!, $owner: String!, $issueNumber: Int!) {


### PR DESCRIPTION
## Summary
- add `getDiscussion` GraphQL helper for GitHub discussions
- export the new helper from package index

## Testing
- `turbo build --filter @giselle-sdk/github-tool --cache=local:rw`
- `turbo check-types --filter @giselle-sdk/github-tool --cache=local:rw`
- `turbo format --filter @giselle-sdk/github-tool --cache=local:rw`
- `turbo test --filter @giselle-sdk/github-tool --cache=local:rw` *(fails: Could not find task `test` in project)*

------
https://chatgpt.com/codex/tasks/task_e_683fdc1a2e1c832f96a37e9523a9d57b