### PR TITLE
feat: add GitHub get discussion action

### DIFF
--- a/packages/flow/src/action/github.ts
+++ b/packages/flow/src/action/github.ts
@@ -56,6 +56,17 @@ export const githubReplyPullRequestReviewCommentAction = {
 	},
 } as const satisfies GitHubActionBase;
 
+export const githubGetDiscussionAction = {
+	provider,
+	command: {
+		id: "github.get.discussion",
+		label: "Get Discussion",
+		parameters: z.object({
+			discussionNumber: z.coerce.number(),
+		}),
+	},
+} as const satisfies GitHubActionBase;
+
 export const actions = {
 	[githubCreateIssueAction.command.id]: githubCreateIssueAction,
 	[githubCreateIssueCommentAction.command.id]: githubCreateIssueCommentAction,
@@ -63,13 +74,15 @@ export const actions = {
 		githubCreatePullRequestCommentAction,
 	[githubReplyPullRequestReviewCommentAction.command.id]:
 		githubReplyPullRequestReviewCommentAction,
+	[githubGetDiscussionAction.command.id]: githubGetDiscussionAction,
 } as const;
 
 export type GitHubAction =
 	| typeof githubCreateIssueAction
 	| typeof githubCreateIssueCommentAction
 	| typeof githubCreatePullRequestCommentAction
-	| typeof githubReplyPullRequestReviewCommentAction;
+	| typeof githubReplyPullRequestReviewCommentAction
+	| typeof githubGetDiscussionAction;
 
 export type ActionCommandId = keyof typeof actions;
 
@@ -83,6 +96,8 @@ export function actionIdToLabel(triggerId: ActionCommandId) {
 			return githubCreatePullRequestCommentAction.command.label;
 		case "github.reply.pullRequestReviewComment":
 			return githubReplyPullRequestReviewCommentAction.command.label;
+		case "github.get.discussion":
+			return githubGetDiscussionAction.command.label;
 		default: {
 			const exhaustiveCheck: never = triggerId;
 			throw new Error(`Unknown trigger ID: ${exhaustiveCheck}`);

--- a/packages/giselle-engine/src/core/operations/execute-action.ts
+++ b/packages/giselle-engine/src/core/operations/execute-action.ts
@@ -13,6 +13,8 @@ import {
 	createIssue,
 	createIssueComment,
 	createPullRequestComment,
+	getDiscussion,
+	getRepositoryFullname,
 	replyPullRequestReviewComment,
 } from "@giselle-sdk/github-tool";
 import {
@@ -222,6 +224,29 @@ async function executeGitHubActionCommand(args: {
 				authConfig: commonAuthConfig,
 			});
 			return createActionOutput(result, args.generationContext);
+		}
+		case "github.get.discussion": {
+			const { discussionNumber } =
+				githubActions["github.get.discussion"].command.parameters.parse(inputs);
+			const repo = await getRepositoryFullname(
+				args.state.repositoryNodeId,
+				commonAuthConfig,
+			);
+			if (repo.error || repo.data === undefined) {
+				throw new Error(`Failed to get repository information: ${repo.error}`);
+			}
+			if (repo.data.node?.__typename !== "Repository") {
+				throw new Error(
+					`Invalid repository type: ${repo.data.node?.__typename}`,
+				);
+			}
+			const result = await getDiscussion({
+				owner: repo.data.node.owner.login,
+				name: repo.data.node.name,
+				number: discussionNumber,
+				authConfig: commonAuthConfig,
+			});
+			return createActionOutput(result.data, args.generationContext);
 		}
 		default: {
 			const _exhaustiveCheck: never = args.state.commandId;


### PR DESCRIPTION
## Summary

This PR adds support for retrieving GitHub discussions through a new action, enabling workflows to fetch and process GitHub discussion content.

## Changes

### Flow Package (`packages/flow/src/action/github.ts`)
- Added `githubGetDiscussionAction` with `discussionNumber` parameter
- Updated action exports and type definitions to include the new action
- Added action label mapping for UI display

### Giselle Engine Package (`packages/giselle-engine/src/core/operations/execute-action.ts`)
- Implemented execution logic for `github.get.discussion` command
- Added repository retrieval and discussion fetching functionality
- Integrated with existing GitHub tool SDK methods

## Test Plan

- [x] Code compiles without TypeScript errors
- [x] All modified files pass Biome formatting checks
- [x] Type checking passes for both modified packages
- [ ] Manual testing: Create a workflow that uses the new GitHub get discussion action
- [ ] Verify discussion data is correctly retrieved and returned
- [ ] Test error handling for invalid discussion numbers or repository access issues

## Breaking Changes

None. This is a pure feature addition that doesn't modify existing functionality.

## Dependencies

This change relies on the existing `getDiscussion` and `getRepositoryFullname` functions from `@giselle-sdk/github-tool`, which should already be available in the codebase.