### PR TITLE
Add action result panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/generation-panel.tsx
@@ -45,10 +45,8 @@ function Empty({ onRun }: { onRun?: () => void }) {
 
 export function GenerationPanel({
 	node,
-	onRun,
 }: {
 	node: ActionNode;
-	onRun?: () => void;
 }) {
 	const { data } = useWorkflowDesigner();
 	const { generations } = useNodeGenerations({
@@ -68,14 +66,8 @@ export function GenerationPanel({
 		}
 	}, [generations]);
 
-	const handleRun = useCallback(() => {
-		if (onRun) {
-			onRun();
-		}
-	}, [onRun]);
-
 	if (currentGeneration === undefined) {
-		return <Empty onRun={handleRun} />;
+		return null;
 	}
 
 	return (
@@ -93,7 +85,7 @@ export function GenerationPanel({
 						<p data-header-text>Running...</p>
 					)}
 					{currentGeneration.status === "completed" && (
-						<p data-header-text>Result</p>
+						<p data-header-text>Result(Beta)</p>
 					)}
 					{currentGeneration.status === "failed" && (
 						<p data-header-text>Error</p>
@@ -104,7 +96,12 @@ export function GenerationPanel({
 				</div>
 			</div>
 			<div className="flex-1 py-[4px] px-[16px] overflow-y-auto">
-				<GenerationView generation={currentGeneration} />
+				{currentGeneration.outputs?.map((output) => {
+					if (output.type !== "generated-text") {
+						return null;
+					}
+					return output.content;
+				})}
 			</div>
 		</div>
 	);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/generation-panel.tsx
@@ -1,0 +1,111 @@
+import type { ActionNode, Generation } from "@giselle-sdk/data-type";
+import clsx from "clsx/lite";
+import { useNodeGenerations, useWorkflowDesigner } from "giselle-sdk/react";
+import { useCallback, useEffect, useState } from "react";
+import { StackBlicksIcon } from "../../../icons";
+import { EmptyState } from "../../../ui/empty-state";
+import { GenerationView } from "../../../ui/generation-view";
+
+function Empty({ onRun }: { onRun?: () => void }) {
+	return (
+		<div className="bg-white-900/10 h-full rounded-[8px] flex justify-center items-center text-black-400">
+			<EmptyState
+				icon={<StackBlicksIcon />}
+				title="No action has been run yet."
+				description="Run the action to see the result."
+				className="text-black-400"
+			>
+				{onRun && (
+					<button
+						type="button"
+						onClick={onRun}
+						className="flex items-center justify-center px-[24px] py-[12px] mt-[16px] bg-[#141519] text-white rounded-[9999px] border border-white-900/15 transition-all hover:bg-[#1e1f26] hover:border-white-900/25 hover:translate-y-[-1px] cursor-pointer font-hubot font-[500] text-[14px]"
+					>
+						<span className="mr-[8px] generate-star">✦</span>
+						Run Action
+					</button>
+				)}
+				<style jsx>{`
+          .generate-star {
+            display: inline-block;
+          }
+          button:hover .generate-star {
+            animation: rotateStar 0.7s ease-in-out;
+          }
+          @keyframes rotateStar {
+            0% { transform: rotate(0deg) scale(1); }
+            50% { transform: rotate(180deg) scale(1.5); }
+            100% { transform: rotate(360deg) scale(1); }
+          }
+        `}</style>
+			</EmptyState>
+		</div>
+	);
+}
+
+export function GenerationPanel({
+	node,
+	onRun,
+}: {
+	node: ActionNode;
+	onRun?: () => void;
+}) {
+	const { data } = useWorkflowDesigner();
+	const { generations } = useNodeGenerations({
+		nodeId: node.id,
+		origin: { type: "workspace", id: data.id },
+	});
+	const [currentGeneration, setCurrentGeneration] = useState<
+		Generation | undefined
+	>();
+
+	useEffect(() => {
+		if (generations.length === 0) {
+			setCurrentGeneration(undefined);
+		} else {
+			const latestGeneration = generations[generations.length - 1];
+			setCurrentGeneration(latestGeneration);
+		}
+	}, [generations]);
+
+	const handleRun = useCallback(() => {
+		if (onRun) {
+			onRun();
+		}
+	}, [onRun]);
+
+	if (currentGeneration === undefined) {
+		return <Empty onRun={handleRun} />;
+	}
+
+	return (
+		<div className="flex flex-col bg-white-900/10 h-full rounded-[8px] py-[8px]">
+			<div
+				className={clsx(
+					"border-b border-white-400/20 py-[4px] px-[16px] flex items-center gap-[8px]",
+					"**:data-header-text:font-[700]",
+				)}
+			>
+				<div className="flex-1 flex items-center gap-[8px]">
+					{(currentGeneration.status === "created" ||
+						currentGeneration.status === "queued" ||
+						currentGeneration.status === "running") && (
+						<p data-header-text>Running...</p>
+					)}
+					{currentGeneration.status === "completed" && (
+						<p data-header-text>Result</p>
+					)}
+					{currentGeneration.status === "failed" && (
+						<p data-header-text>Error</p>
+					)}
+					{currentGeneration.status === "cancelled" && (
+						<p data-header-text>Result</p>
+					)}
+				</div>
+			</div>
+			<div className="flex-1 py-[4px] px-[16px] overflow-y-auto">
+				<GenerationView generation={currentGeneration} />
+			</div>
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
@@ -51,7 +51,7 @@ export function GitHubActionPropertiesPanel({
 				</Panel>
 				<PanelResizeHandle className="h-[1px] bg-black-700/50 data-[resize-handle-state=drag]:bg-black-600 transition-colors duration-100 ease-in-out" />
 				<Panel>
-					<GenerationPanel node={node} onRun={onRun} />
+					<GenerationPanel node={node} />
 				</Panel>
 			</PanelGroup>
 		);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/github-action-properties-panel.tsx
@@ -16,6 +16,7 @@ import {
 	useState,
 	useTransition,
 } from "react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { GitHubIcon, SpinnerIcon } from "../../../icons";
 import {
 	Select,
@@ -26,18 +27,33 @@ import {
 } from "../../../ui/select";
 import { GitHubRepositoryBlock } from "../trigger-node-properties-panel/ui";
 import { SelectRepository } from "../ui";
+import { GenerationPanel } from "./generation-panel";
 import { GitHubActionConfiguredView } from "./ui/github-action-configured-view";
 
-export function GitHubActionPropertiesPanel({ node }: { node: ActionNode }) {
+export function GitHubActionPropertiesPanel({
+	node,
+	onRun,
+}: {
+	node: ActionNode;
+	onRun?: () => void;
+}) {
 	const { value } = useIntegration();
 
 	if (node.content.command.state.status === "configured") {
 		return (
-			<GitHubActionConfiguredView
-				state={node.content.command.state}
-				nodeId={node.id}
-				inputs={node.inputs}
-			/>
+			<PanelGroup direction="vertical" className="flex-1 flex flex-col">
+				<Panel defaultSize={50} minSize={20}>
+					<GitHubActionConfiguredView
+						state={node.content.command.state}
+						nodeId={node.id}
+						inputs={node.inputs}
+					/>
+				</Panel>
+				<PanelResizeHandle className="h-[1px] bg-black-700/50 data-[resize-handle-state=drag]:bg-black-600 transition-colors duration-100 ease-in-out" />
+				<Panel>
+					<GenerationPanel node={node} onRun={onRun} />
+				</Panel>
+			</PanelGroup>
 		);
 	}
 

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/index.tsx
@@ -73,7 +73,7 @@ export function ActionNodePropertiesPanel({
 				}
 			/>
 			<PropertiesPanelContent>
-				<PropertiesPanel node={node} />
+				<PropertiesPanel node={node} onRunAction={handleClick} />
 			</PropertiesPanelContent>
 		</PropertiesPanelRoot>
 	);
@@ -81,12 +81,14 @@ export function ActionNodePropertiesPanel({
 
 function PropertiesPanel({
 	node,
+	onRunAction,
 }: {
 	node: ActionNode;
+	onRunAction: () => void;
 }) {
 	switch (node.content.command.provider) {
 		case "github":
-			return <GitHubActionPropertiesPanel node={node} />;
+			return <GitHubActionPropertiesPanel node={node} onRun={onRunAction} />;
 		default: {
 			const _exhaustiveCheck: never = node.content.command.provider;
 			throw new Error(`Unhandled action provider: ${_exhaustiveCheck}`);


### PR DESCRIPTION
## Summary
- show GitHub action results
- display results using new generation panel

> [!NOTE]
> It's displayed as-is without formatting, so it's hard to read, but we plan to improve this in the future. We also want to display the cause of errors when they occur.

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/9dff1aec-5cc3-470b-bc5d-9ebc93a24ce0" />


## Testing
- `npx turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`
- `npx turbo check-types --cache=local:rw`
- `npx turbo test --cache=local:rw`


------
https://chatgpt.com/codex/tasks/task_e_683fffc600ac832f959032b615a04181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a panel to display generation results for action nodes, including status and generated text outputs.
  - Added a vertically resizable split view when configuring GitHub action nodes, allowing users to view both configuration and generation results side by side.

- **Improvements**
  - Enhanced interaction by enabling action runs to be triggered from within the properties panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->