### PR TITLE
Fix trigger node duplication to preserve settings configuration

### DIFF
--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -289,6 +289,9 @@ const triggerFactoryImpl = {
 		console.log("[DEBUG] Cloning Trigger Node");
 		console.log("[DEBUG] Original state:", orig.content.state);
 		const clonedContent = structuredClone(orig.content);
+		// Reset trigger state to unconfigured - actual configuration duplication 
+		// is handled at higher level in useDuplicateNode
+		clonedContent.state = { status: "unconfigured" };
 		console.log("[DEBUG] Cloned state:", clonedContent.state);
 
 		const { newIo: newInputs, idMap: inputIdMap } =

--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -286,8 +286,10 @@ const triggerFactoryImpl = {
 			outputs: [],
 		}) satisfies TriggerNode,
 	clone: (orig: TriggerNode): NodeFactoryCloneResult<TriggerNode> => {
+		console.log("[DEBUG] Cloning Trigger Node");
+		console.log("[DEBUG] Original state:", orig.content.state);
 		const clonedContent = structuredClone(orig.content);
-		clonedContent.state = { status: "unconfigured" };
+		console.log("[DEBUG] Cloned state:", clonedContent.state);
 
 		const { newIo: newInputs, idMap: inputIdMap } =
 			cloneAndRenewInputIdsWithMap(orig.inputs);

--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -526,8 +526,10 @@ const vectorStoreFactoryImpl = {
 		],
 	}),
 	clone: (orig: VectorStoreNode): NodeFactoryCloneResult<VectorStoreNode> => {
+		console.log("[DEBUG] Cloning VectorStore Node");
+		console.log("[DEBUG] Original state:", orig.content.source.state);
 		const clonedContent = structuredClone(orig.content);
-		clonedContent.source.state = { status: "unconfigured" };
+		console.log("[DEBUG] Cloned state:", clonedContent.source.state);
 
 		const { newIo: newInputs, idMap: inputIdMap } =
 			cloneAndRenewInputIdsWithMap(orig.inputs);

--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -286,13 +286,10 @@ const triggerFactoryImpl = {
 			outputs: [],
 		}) satisfies TriggerNode,
 	clone: (orig: TriggerNode): NodeFactoryCloneResult<TriggerNode> => {
-		console.log("[DEBUG] Cloning Trigger Node");
-		console.log("[DEBUG] Original state:", orig.content.state);
 		const clonedContent = structuredClone(orig.content);
 		// Reset trigger state to unconfigured - actual configuration duplication
-		// is handled at higher level in useDuplicateNode
+		// is handled at higher level in handleTriggerNodeCopy
 		clonedContent.state = { status: "unconfigured" };
-		console.log("[DEBUG] Cloned state:", clonedContent.state);
 
 		const { newIo: newInputs, idMap: inputIdMap } =
 			cloneAndRenewInputIdsWithMap(orig.inputs);

--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -289,7 +289,7 @@ const triggerFactoryImpl = {
 		console.log("[DEBUG] Cloning Trigger Node");
 		console.log("[DEBUG] Original state:", orig.content.state);
 		const clonedContent = structuredClone(orig.content);
-		// Reset trigger state to unconfigured - actual configuration duplication 
+		// Reset trigger state to unconfigured - actual configuration duplication
 		// is handled at higher level in useDuplicateNode
 		clonedContent.state = { status: "unconfigured" };
 		console.log("[DEBUG] Cloned state:", clonedContent.state);
@@ -330,10 +330,8 @@ const actionFactoryImpl = {
 			outputs: [],
 		}) satisfies ActionNode,
 	clone: (orig: ActionNode): NodeFactoryCloneResult<ActionNode> => {
-		console.log("[DEBUG] Cloning Action Node");
-		console.log("[DEBUG] Original state:", orig.content.command.state);
 		const clonedContent = structuredClone(orig.content);
-		console.log("[DEBUG] Cloned state:", clonedContent.command.state);
+		clonedContent.command.state = { status: "unconfigured" };
 
 		const { newIo: newInputs, idMap: inputIdMap } =
 			cloneAndRenewInputIdsWithMap(orig.inputs);
@@ -529,10 +527,8 @@ const vectorStoreFactoryImpl = {
 		],
 	}),
 	clone: (orig: VectorStoreNode): NodeFactoryCloneResult<VectorStoreNode> => {
-		console.log("[DEBUG] Cloning VectorStore Node");
-		console.log("[DEBUG] Original state:", orig.content.source.state);
 		const clonedContent = structuredClone(orig.content);
-		console.log("[DEBUG] Cloned state:", clonedContent.source.state);
+		clonedContent.source.state = { status: "unconfigured" };
 
 		const { newIo: newInputs, idMap: inputIdMap } =
 			cloneAndRenewInputIdsWithMap(orig.inputs);

--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -327,8 +327,10 @@ const actionFactoryImpl = {
 			outputs: [],
 		}) satisfies ActionNode,
 	clone: (orig: ActionNode): NodeFactoryCloneResult<ActionNode> => {
+		console.log("[DEBUG] Cloning Action Node");
+		console.log("[DEBUG] Original state:", orig.content.command.state);
 		const clonedContent = structuredClone(orig.content);
-		clonedContent.command.state = { status: "unconfigured" };
+		console.log("[DEBUG] Cloned state:", clonedContent.command.state);
 
 		const { newIo: newInputs, idMap: inputIdMap } =
 			cloneAndRenewInputIdsWithMap(orig.inputs);

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -9,6 +9,7 @@ import {
 	type NodeBase,
 	type NodeId,
 	type NodeUIState,
+	type TriggerNode,
 	type UploadedFileData,
 	type Viewport,
 	type Workspace,
@@ -239,41 +240,15 @@ export function WorkflowDesignerProvider({
 					});
 
 					if (result?.triggerId) {
-						const provider = newNode.content.provider;
-
-						switch (provider) {
-							case "github": {
-								workflowDesignerRef.current.updateNodeData(newNode, {
-									content: {
-										type: "trigger",
-										provider: "github",
-										state: {
-											status: "configured",
-											flowTriggerId: result.triggerId,
-										},
-									},
-								});
-								break;
-							}
-							case "manual": {
-								workflowDesignerRef.current.updateNodeData(newNode, {
-									content: {
-										type: "trigger",
-										provider: "manual",
-										state: {
-											status: "configured",
-											flowTriggerId: result.triggerId,
-										},
-									},
-								});
-								break;
-							}
-							default: {
-								const _exhaustiveCheck: never = provider;
-								console.error(`Unsupported provider: ${String(provider)}`);
-								return;
-							}
-						}
+						workflowDesignerRef.current.updateNodeData(newNode, {
+							content: {
+								...newNode.content,
+								state: {
+									status: "configured",
+									flowTriggerId: result.triggerId,
+								},
+							},
+						} as Partial<TriggerNode>);
 
 						console.log(
 							"[DEBUG] Trigger configuration duplicated successfully",

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -218,7 +218,6 @@ export function WorkflowDesignerProvider({
 			}
 
 			try {
-				console.log("[DEBUG] Duplicating trigger configuration");
 				const originalTriggerId = sourceNode.content.state.flowTriggerId;
 
 				const originalTriggerResult = await client.getTrigger({
@@ -226,9 +225,6 @@ export function WorkflowDesignerProvider({
 				});
 
 				if (originalTriggerResult?.trigger) {
-					console.log(
-						"[DEBUG] Original trigger found, creating new configuration",
-					);
 					const originalTrigger = originalTriggerResult.trigger;
 					const result = await client.configureTrigger({
 						trigger: {
@@ -250,9 +246,6 @@ export function WorkflowDesignerProvider({
 							},
 						} as Partial<TriggerNode>);
 
-						console.log(
-							"[DEBUG] Trigger configuration duplicated successfully",
-						);
 						setAndSaveWorkspace();
 					}
 				}
@@ -280,7 +273,6 @@ export function WorkflowDesignerProvider({
 			}
 			setAndSaveWorkspace();
 
-			// Handle different node types - following existing pattern
 			await handleFileNodeCopy(sourceNode, newNodeDefinition);
 			await handleTriggerNodeCopy(sourceNode, newNodeDefinition);
 

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -279,16 +279,14 @@ export function WorkflowDesignerProvider({
 				return undefined;
 			}
 			setAndSaveWorkspace();
+
+			// Handle different node types - following existing pattern
 			await handleFileNodeCopy(sourceNode, newNodeDefinition);
 			await handleTriggerNodeCopy(sourceNode, newNodeDefinition);
+
 			return newNodeDefinition;
 		},
-		[setAndSaveWorkspace, handleFileNodeCopy],
-		[
-			setAndSaveWorkspace,
-			handleFileNodeCopy,
-			handleTriggerNodeCopy,
-		],
+		[setAndSaveWorkspace, handleFileNodeCopy, handleTriggerNodeCopy],
 	);
 
 	const updateNodeData = useCallback(


### PR DESCRIPTION
### **User description**
## Summary
This PR implements trigger node duplication functionality that preserves the configured settings for Manual Trigger and GitHub Trigger nodes. When duplicating a configured trigger node, the new node will maintain the same trigger configuration as the original.

## Related Issue
ref #1037 - Node Duplication: Settings Values Not Copied for Manual Trigger, GitHub Trigger, GitHub Action, and GitHub Vector Store

## Changes
- Added `handleTriggerNodeCopy` function in `workflow-designer-context.tsx` to handle trigger node duplication with settings preservation
- Updated trigger node factory to reset state to "unconfigured" during cloning, with actual configuration handled at higher level
- Implemented API calls to duplicate trigger configuration using `getTrigger` and `configureTrigger` methods
- Added proper type handling for both manual and GitHub trigger providers
- Updated `copyNode` function to call the new trigger node copy handler

## Testing
- Verified that duplicating configured Manual Trigger nodes preserves settings
- Verified that duplicating configured GitHub Trigger nodes preserves settings and configurations
- Confirmed that unconfigured trigger nodes are duplicated without attempting configuration copy

## Other Information
This PR addresses the trigger node portion of issue #1037. GitHub Action and GitHub Vector Store node duplication will be handled in separate PRs as mentioned in the original issue.


___

### **PR Type**
Enhancement


___

### **Description**
- Preserve trigger node settings during duplication
  - Manual Trigger and GitHub Trigger nodes retain configurations
  - Uses new `handleTriggerNodeCopy` logic for settings copy

- Refactor trigger node cloning to reset state at factory level

- Integrate trigger duplication into main node copy workflow


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow-designer-context.tsx</strong><dd><code>Add trigger configuration preservation to node duplication</code></dd></summary>
<hr>

packages/workflow-designer/src/react/workflow-designer-context.tsx

<li>Add <code>handleTriggerNodeCopy</code> to duplicate trigger configurations<br> <li> Update <code>copyNode</code> to invoke trigger duplication logic<br> <li> Ensure trigger nodes retain settings after duplication<br> <li> Enhance type handling for trigger nodes


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1051/files#diff-40ba84286ab0edff82fb048cae4fe6cf25db8efd787058a13e06d29cfbadc6cd">+54/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-factories.ts</strong><dd><code>Reset trigger node state on clone for duplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-utils/src/node-factories.ts

<li>Update trigger node factory to reset state to unconfigured on clone<br> <li> Add comment clarifying configuration duplication responsibility


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1051/files#diff-fad6e773473d49bcbeba4cee8f28db6878f20226b6d3743e6b462afb04985fa2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When duplicating trigger nodes, their configuration is now automatically copied, ensuring the new node retains the same setup as the original.
- **Documentation**
  - Added clarifying comments regarding trigger state reset during node cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->