### PR TITLE
Enhance workflow run functionality with operation flow support

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
@@ -1,4 +1,8 @@
-import { isOperationNode, isTriggerNode } from "@giselle-sdk/data-type";
+import {
+	type NodeLike,
+	isOperationNode,
+	isTriggerNode,
+} from "@giselle-sdk/data-type";
 import { defaultName } from "@giselle-sdk/node-utils";
 import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
@@ -8,6 +12,23 @@ import { useMemo, useState } from "react";
 import { NodeIcon } from "../../icons/node";
 import { TriggerInputDialog } from "../ui";
 import { Button } from "./ui/button";
+
+const menuItemClass =
+	"group relative flex items-center py-[8px] px-[12px] gap-[10px] outline-none cursor-pointer hover:bg-black-400/20 rounded-[6px] w-full";
+
+function NodeItemContent({ node }: { node: NodeLike }) {
+	return (
+		<>
+			<div className="p-[12px] bg-black-800 rounded-[8px]">
+				<NodeIcon node={node} className="size-[16px] text-white-900" />
+			</div>
+			<div className="flex flex-col gap-[0px] text-white-900 items-start">
+				<div className="text-[13px]">{node.name ?? defaultName(node)}</div>
+				<div className="text-[12px] text-white-400">{node.id}</div>
+			</div>
+		</>
+	);
+}
 
 export function RunButton() {
 	const { data } = useWorkflowDesigner();
@@ -57,23 +78,8 @@ export function RunButton() {
 										setIsDialogOpen(isOpen);
 									}}
 								>
-									<Dialog.Trigger className="group relative flex items-center py-[8px] px-[12px] gap-[10px] outline-none cursor-pointer hover:bg-black-400/20 rounded-[6px] w-full">
-										<>
-											<div className="p-[12px] bg-black-800 rounded-[8px]">
-												<NodeIcon
-													node={startingNode}
-													className="size-[16px] text-white-900"
-												/>
-											</div>
-											<div className="flex flex-col gap-[0px] text-white-900 items-start">
-												<div className="text-[13px]">
-													{startingNode.name ?? defaultName(startingNode)}
-												</div>
-												<div className="text-[12px] text-white-400">
-													{startingNode.id}
-												</div>
-											</div>
-										</>
+									<Dialog.Trigger className={menuItemClass}>
+										<NodeItemContent node={startingNode} />
 									</Dialog.Trigger>
 									<Dialog.Portal>
 										<Dialog.Overlay className="fixed inset-0 bg-black/25 z-50" />
@@ -93,24 +99,8 @@ export function RunButton() {
 									</Dialog.Portal>
 								</Dialog.Root>
 							) : (
-								<button
-									type="button"
-									className="group relative flex items-center py-[8px] px-[12px] gap-[10px] outline-none cursor-pointer hover:bg-black-400/20 rounded-[6px] w-full"
-								>
-									<div className="p-[12px] bg-black-800 rounded-[8px]">
-										<NodeIcon
-											node={startingNode}
-											className="size-[16px] text-white-900"
-										/>
-									</div>
-									<div className="flex flex-col gap-[0px] text-white-900 items-start">
-										<div className="text-[13px]">
-											{startingNode.name ?? defaultName(startingNode)}
-										</div>
-										<div className="text-[12px] text-white-400">
-											{startingNode.id}
-										</div>
-									</div>
+								<button type="button" className={menuItemClass}>
+									<NodeItemContent node={startingNode} />
 								</button>
 							)}
 						</DropdownMenu.Item>

--- a/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
@@ -8,17 +8,20 @@ import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { CirclePlayIcon } from "lucide-react";
 import { Dialog, DropdownMenu } from "radix-ui";
-import { useMemo, useState } from "react";
+import { type ButtonHTMLAttributes, useMemo, useState } from "react";
 import { NodeIcon } from "../../icons/node";
 import { TriggerInputDialog } from "../ui";
 import { Button } from "./ui/button";
 
-const menuItemClass =
-	"group relative flex items-center py-[8px] px-[12px] gap-[10px] outline-none cursor-pointer hover:bg-black-400/20 rounded-[6px] w-full";
-
-function NodeItemContent({ node }: { node: NodeLike }) {
+function NodeSelectItem({
+	node,
+	...props
+}: { node: NodeLike } & ButtonHTMLAttributes<HTMLButtonElement>) {
 	return (
-		<>
+		<button
+			className="group relative flex items-center py-[8px] px-[12px] gap-[10px] outline-none cursor-pointer hover:bg-black-400/20 rounded-[6px] w-full"
+			{...props}
+		>
 			<div className="p-[12px] bg-black-800 rounded-[8px]">
 				<NodeIcon node={node} className="size-[16px] text-white-900" />
 			</div>
@@ -26,7 +29,7 @@ function NodeItemContent({ node }: { node: NodeLike }) {
 				<div className="text-[13px]">{node.name ?? defaultName(node)}</div>
 				<div className="text-[12px] text-white-400">{node.id}</div>
 			</div>
-		</>
+		</button>
 	);
 }
 
@@ -78,8 +81,8 @@ export function RunButton() {
 										setIsDialogOpen(isOpen);
 									}}
 								>
-									<Dialog.Trigger className={menuItemClass}>
-										<NodeItemContent node={startingNode} />
+									<Dialog.Trigger asChild>
+										<NodeSelectItem node={startingNode} />
 									</Dialog.Trigger>
 									<Dialog.Portal>
 										<Dialog.Overlay className="fixed inset-0 bg-black/25 z-50" />
@@ -99,9 +102,7 @@ export function RunButton() {
 									</Dialog.Portal>
 								</Dialog.Root>
 							) : (
-								<button type="button" className={menuItemClass}>
-									<NodeItemContent node={startingNode} />
-								</button>
+								<NodeSelectItem node={startingNode} />
 							)}
 						</DropdownMenu.Item>
 					))}

--- a/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
@@ -1,5 +1,4 @@
 import {
-	type Node,
 	type NodeLike,
 	type OperationNode,
 	isOperationNode,

--- a/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
+++ b/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
@@ -1,0 +1,88 @@
+import type { Generation, Workflow } from "@giselle-sdk/data-type";
+import { useGenerationRunnerSystem } from "@giselle-sdk/giselle-engine/react";
+import { useWorkflowDesigner } from "giselle-sdk/react";
+import { useCallback, useRef } from "react";
+import {
+	type FormInput,
+	createGenerationsForFlow,
+} from "../header/ui/trigger-input-dialog/helpers";
+import { useToasts } from "../ui/toast";
+
+export function useFlowController() {
+	const { createGeneration, startGeneration, stopGeneration } =
+		useGenerationRunnerSystem();
+	const { data } = useWorkflowDesigner();
+	const { info } = useToasts();
+
+	const activeGenerationsRef = useRef<Generation[]>([]);
+	const cancelRef = useRef(false);
+
+	const stopFlow = useCallback(async () => {
+		cancelRef.current = true;
+		await Promise.all(
+			activeGenerationsRef.current.map((generation) =>
+				stopGeneration(generation.id),
+			),
+		);
+	}, [stopGeneration]);
+
+	const startFlow = useCallback(
+		async (
+			flow: Workflow | null,
+			inputs: FormInput[],
+			values: Record<string, string | number>,
+			onComplete?: () => void,
+		) => {
+			if (flow === null) {
+				return;
+			}
+			const generations = createGenerationsForFlow(
+				flow,
+				inputs,
+				values,
+				createGeneration,
+				data.id,
+			);
+			activeGenerationsRef.current = generations;
+
+			cancelRef.current = false;
+			info("Workflow submitted successfully", {
+				action: (
+					<button
+						type="button"
+						className="bg-white rounded-[4px] text-black-850 px-[8px] text-[14px] py-[2px] cursor-pointer"
+						onClick={async () => {
+							await stopFlow();
+						}}
+					>
+						Cancel
+					</button>
+				),
+			});
+
+			for (const [jobIndex, job] of flow.jobs.entries()) {
+				await Promise.all(
+					job.operations.map(async (operation) => {
+						const generation = generations.find(
+							(g) => g.context.operationNode.id === operation.node.id,
+						);
+						if (generation === undefined) {
+							return;
+						}
+						if (cancelRef.current) {
+							return;
+						}
+						await startGeneration(generation.id);
+					}),
+				);
+
+				if (jobIndex === 0 && onComplete) {
+					onComplete();
+				}
+			}
+		},
+		[createGeneration, data.id, info, startGeneration, stopFlow],
+	);
+
+	return { startFlow };
+}


### PR DESCRIPTION
## Overview

This PR enhances the workflow execution capabilities in the workflow designer UI by adding support for starting operation flows directly and improving the overall code organization around workflow execution.

## Key Changes

### 🚀 New Features
- **Operation Flow Execution**: Added ability to start workflows directly from operation nodes via the run button dropdown
- **Enhanced Run Button**: Users can now select and run workflows from both trigger nodes and operation nodes

### 🔧 Code Organization Improvements
- **Flow Controller Hook**: Extracted workflow execution logic into a reusable `useFlowController` hook
- **Component Refactoring**: 
  - Extracted `NodeItemContent` component for better code reuse
  - Refactored to `NodeSelectItem` component for improved structure
- **Separation of Concerns**: Moved workflow execution logic out of UI components into dedicated hooks

### 🧹 Code Quality
- Removed unused imports and type definitions
- Improved component structure and maintainability
- Better TypeScript typing throughout

## Technical Details

### New Hook: `useFlowController`
- Centralizes workflow execution logic
- Handles generation management and flow control
- Provides consistent interface for starting workflows from different contexts

### Enhanced Run Button Functionality
- Supports both trigger nodes (with input dialog) and operation nodes (direct execution)
- Uses dropdown menu for node selection
- Maintains existing trigger workflow functionality while adding operation support

### Refactored Components
- `NodeSelectItem`: Reusable component for node selection UI
- Cleaner separation between UI and business logic
- Improved code maintainability

## Files Changed
- `internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx`
- `internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx`
- `internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx` (new)

## Testing
- [x] Run button dropdown displays both trigger and operation nodes
- [x] Trigger nodes still open input dialog as expected
- [x] Operation nodes can be executed directly
- [x] Workflow execution works for both node types
- [x] No unused imports or type errors

## Breaking Changes
None - all existing functionality is preserved while adding new capabilities.