### PR TITLE
Update run button styling and hide when no start nodes

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
@@ -27,7 +27,7 @@ function NodeSelectItem({
 }: { node: NodeLike } & ButtonHTMLAttributes<HTMLButtonElement>) {
 	return (
 		<button
-			className="group relative flex items-center py-[8px] px-[12px] gap-[10px] outline-none cursor-pointer hover:bg-black-400/20 rounded-[6px] w-full"
+			className="group relative flex items-center py-[8px] px-[12px] gap-[10px] outline-none cursor-pointer hover:bg-black-400/30 rounded-[6px] w-full"
 			{...props}
 		>
 			<div className="p-[12px] bg-black-800 rounded-[8px]">
@@ -77,6 +77,10 @@ export function RunButton() {
 		[startFlow, data.nodes, data.connections],
 	);
 
+	if (startingNodes.length === 0) {
+		return null;
+	}
+
 	return (
 		<DropdownMenu.Root open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
 			<DropdownMenu.Trigger asChild>
@@ -88,7 +92,7 @@ export function RunButton() {
 				<DropdownMenu.Content
 					className={clsx(
 						"relative rounded-[8px] px-[8px] py-[8px] min-w-[200px]",
-						"bg-[hsla(255,_40%,_98%,_0.04)] text-white-900",
+						"bg-[rgba(0,0,0,_0.8)] text-white-900",
 						"backdrop-blur-[4px]",
 					)}
 					sideOffset={5}


### PR DESCRIPTION
### **User description**
https://github.com/user-attachments/assets/de526d39-6c35-4dd0-a9d1-e0fe8128feae


___

### **PR Type**
Enhancement


___

### **Description**
- Hide the Run button when no start nodes are present

- Update Run button and dropdown styling for improved UI


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-button.tsx</strong><dd><code>Hide Run button conditionally and update UI styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx

<li>Hide the Run button if there are no starting nodes<br> <li> Adjust hover background color for node select items<br> <li> Change dropdown menu background to a darker color


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1058/files#diff-266610d1f8234683d924ae8072e15de57a249d65e1d8f6ca45b5a2c61678abb3">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The Run button dropdown menu no longer appears when there are no starting nodes.
- **Style**
	- Improved hover effect on selection items for better visibility.
	- Updated dropdown menu background to a darker shade for enhanced contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->