### PR TITLE
Bug Fix: “Start Manual Flow” dialog always shows the same Node

### DIFF
--- a/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/run-button/run-button.tsx
@@ -45,7 +45,7 @@ export function RunButton() {
 	const { data } = useWorkflowDesigner();
 	const { startFlow } = useFlowController();
 
-	const [isDialogOpen, setIsDialogOpen] = useState(false);
+	const [openDialogNodeId, setOpenDialogNodeId] = useState<string | null>(null);
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 	const startingNodes = useMemo(() => {
 		const triggerNodes = data.nodes.filter((node) => isTriggerNode(node));
@@ -111,9 +111,9 @@ export function RunButton() {
 						>
 							{isTriggerNode(startingNode) ? (
 								<Dialog.Root
-									open={isDialogOpen}
+									open={openDialogNodeId === startingNode.id}
 									onOpenChange={(isOpen) => {
-										setIsDialogOpen(isOpen);
+										setOpenDialogNodeId(isOpen ? startingNode.id : null);
 									}}
 								>
 									<Dialog.Trigger asChild>
@@ -130,7 +130,7 @@ export function RunButton() {
 												node={startingNode}
 												onClose={() => {
 													setIsDropdownOpen(false);
-													setIsDialogOpen(false);
+													setOpenDialogNodeId(null);
 												}}
 											/>
 										</Dialog.Content>


### PR DESCRIPTION
This PR fixes an issue where clicking the “Run” button and selecting a trigger node would always open the “Start Manual Flow” dialog for the same node, regardless of which node was selected.

**Cause:**
The bug was due to a single dialog open state (`isDialogOpen`) being shared across all trigger nodes in the dropdown. As a result, opening the dialog for any node would always show the same node.

**Fix:**
The dialog open state is now tracked per node using the node’s ID. This ensures that only the dialog for the selected node is open, and the correct node is shown in the dialog.

**How to test:**
- Click the “Run” button.
- Select different trigger nodes from the dropdown.
- The “Start Manual Flow” dialog should now display the correct node each time.

## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
