### PR TITLE
feat: implement action node duplication with settings preservation

### DIFF
--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -328,6 +328,8 @@ const actionFactoryImpl = {
 		}) satisfies ActionNode,
 	clone: (orig: ActionNode): NodeFactoryCloneResult<ActionNode> => {
 		const clonedContent = structuredClone(orig.content);
+		// Reset action state to unconfigured - actual configuration duplication
+		// is handled at higher level in handleActionNodeCopy
 		clonedContent.command.state = { status: "unconfigured" };
 
 		const { newIo: newInputs, idMap: inputIdMap } =

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+	type ActionNode,
 	type ConnectionId,
 	type FailedFileData,
 	type FileContent,
@@ -16,6 +17,7 @@ import {
 	createFailedFileData,
 	createUploadedFileData,
 	createUploadingFileData,
+	isActionNode,
 	isFileNode,
 	isTriggerNode,
 } from "@giselle-sdk/data-type";
@@ -256,6 +258,30 @@ export function WorkflowDesignerProvider({
 		[client, setAndSaveWorkspace],
 	);
 
+	const handleActionNodeCopy = useCallback(
+		(sourceNode: Node, newNode: Node): void => {
+			if (
+				!isActionNode(sourceNode) ||
+				!isActionNode(newNode) ||
+				sourceNode.content.command.state.status !== "configured"
+			) {
+				return;
+			}
+
+			workflowDesignerRef.current.updateNodeData(newNode, {
+				content: {
+					...newNode.content,
+					command: {
+						...newNode.content.command,
+						state: sourceNode.content.command.state,
+					},
+				},
+			});
+			setAndSaveWorkspace();
+		},
+		[setAndSaveWorkspace],
+	);
+
 	const copyNode = useCallback(
 		async (
 			sourceNode: Node,
@@ -275,10 +301,16 @@ export function WorkflowDesignerProvider({
 
 			await handleFileNodeCopy(sourceNode, newNodeDefinition);
 			await handleTriggerNodeCopy(sourceNode, newNodeDefinition);
+			handleActionNodeCopy(sourceNode, newNodeDefinition);
 
 			return newNodeDefinition;
 		},
-		[setAndSaveWorkspace, handleFileNodeCopy, handleTriggerNodeCopy],
+		[
+			setAndSaveWorkspace,
+			handleFileNodeCopy,
+			handleTriggerNodeCopy,
+			handleActionNodeCopy,
+		],
 	);
 
 	const updateNodeData = useCallback(


### PR DESCRIPTION
## Summary
- Add support for duplicating GitHub Action nodes with their configuration settings preserved
- Implement handleActionNodeCopy function that copies the action command state during node duplication
- Follow the same pattern as trigger and file node duplication for consistency

## Changes
- Add ActionNode type import and isActionNode function to workflow-designer-context.tsx
- Implement handleActionNodeCopy function to preserve action command state
- Integrate action duplication into the existing copyNode workflow
- Add clarifying comment in node-factories.ts about state reset behavior

## Test Plan
- [ ] Duplicate a configured GitHub Action node
- [ ] Verify that the action settings (command state) are preserved in the duplicated node
- [ ] Ensure unconfigured action nodes duplicate without errors
- [ ] Test that other node types (trigger, file, vector store) still duplicate correctly

Related to #1037