### PR TITLE
feat: implement vector store node duplication with settings preservation

### DIFF
--- a/packages/node-utils/src/node-factories.ts
+++ b/packages/node-utils/src/node-factories.ts
@@ -527,6 +527,8 @@ const vectorStoreFactoryImpl = {
 	}),
 	clone: (orig: VectorStoreNode): NodeFactoryCloneResult<VectorStoreNode> => {
 		const clonedContent = structuredClone(orig.content);
+		// Reset vector store state to unconfigured - actual configuration duplication
+		// is handled at higher level in handleVectorStoreNodeCopy
 		clonedContent.source.state = { status: "unconfigured" };
 
 		const { newIo: newInputs, idMap: inputIdMap } =

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -12,6 +12,7 @@ import {
 	type NodeUIState,
 	type TriggerNode,
 	type UploadedFileData,
+	type VectorStoreNode,
 	type Viewport,
 	type Workspace,
 	createFailedFileData,
@@ -20,6 +21,7 @@ import {
 	isActionNode,
 	isFileNode,
 	isTriggerNode,
+	isVectorStoreNode,
 } from "@giselle-sdk/data-type";
 import { GenerationRunnerSystemProvider } from "@giselle-sdk/giselle-engine/react";
 import {
@@ -282,6 +284,30 @@ export function WorkflowDesignerProvider({
 		[setAndSaveWorkspace],
 	);
 
+	const handleVectorStoreNodeCopy = useCallback(
+		(sourceNode: Node, newNode: Node): void => {
+			if (
+				!isVectorStoreNode(sourceNode) ||
+				!isVectorStoreNode(newNode) ||
+				sourceNode.content.source.state.status !== "configured"
+			) {
+				return;
+			}
+
+			workflowDesignerRef.current.updateNodeData(newNode, {
+				content: {
+					...newNode.content,
+					source: {
+						...newNode.content.source,
+						state: structuredClone(sourceNode.content.source.state),
+					},
+				},
+			});
+			setAndSaveWorkspace();
+		},
+		[setAndSaveWorkspace],
+	);
+
 	const copyNode = useCallback(
 		async (
 			sourceNode: Node,
@@ -299,9 +325,11 @@ export function WorkflowDesignerProvider({
 			}
 			setAndSaveWorkspace();
 
+			// Handle different node types - following existing pattern
 			await handleFileNodeCopy(sourceNode, newNodeDefinition);
 			await handleTriggerNodeCopy(sourceNode, newNodeDefinition);
 			handleActionNodeCopy(sourceNode, newNodeDefinition);
+			handleVectorStoreNodeCopy(sourceNode, newNodeDefinition);
 
 			return newNodeDefinition;
 		},
@@ -310,6 +338,7 @@ export function WorkflowDesignerProvider({
 			handleFileNodeCopy,
 			handleTriggerNodeCopy,
 			handleActionNodeCopy,
+			handleVectorStoreNodeCopy,
 		],
 	);
 


### PR DESCRIPTION
### **User description**
## Summary
Add support for duplicating GitHub Vector Store nodes with their configuration settings preserved.

## Changes
- Add VectorStoreNode type import and isVectorStoreNode function to workflow-designer-context.tsx
- Implement handleVectorStoreNodeCopy function to preserve vector store source state during duplication
- Use structuredClone to prevent shared mutable state issues between duplicated nodes
- Integrate vector store duplication into the existing copyNode workflow
- Add clarifying comment in node-factories.ts about state reset behavior

## Implementation Details
- Only duplicates configuration for nodes with \configured\ status
- Uses deep cloning to ensure each duplicated node has independent state
- Follows the same pattern as trigger and action node duplication for consistency

## Test Plan
- [ ] Duplicate a configured GitHub Vector Store node
- [ ] Verify that the vector store settings (source state) are preserved in the duplicated node
- [ ] Ensure unconfigured vector store nodes duplicate without errors
- [ ] Test that other node types (trigger, action, file) still duplicate correctly

## Notes
- Vector store ingestion may not work in localhost environment due to dependency on background services
- The duplication logic focuses on preserving the configuration state, not triggering new ingestion processes

Related to #1037


___

### **PR Type**
Enhancement


___

### **Description**
- Preserve configuration when duplicating GitHub Vector Store nodes

- Add `handleVectorStoreNodeCopy` to copy vector store state

- Integrate vector store duplication into main copyNode workflow

- Clarify state reset behavior in vector store node factory


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow-designer-context.tsx</strong><dd><code>Add vector store node duplication with settings preservation</code></dd></summary>
<hr>

packages/workflow-designer/src/react/workflow-designer-context.tsx

<li>Import <code>VectorStoreNode</code> type and <code>isVectorStoreNode</code> function<br> <li> Add <code>handleVectorStoreNodeCopy</code> to duplicate vector store configuration <br>state<br> <li> Call <code>handleVectorStoreNodeCopy</code> in the main <code>copyNode</code> workflow<br> <li> Update dependencies and callbacks to include new handler


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1085/files#diff-40ba84286ab0edff82fb048cae4fe6cf25db8efd787058a13e06d29cfbadc6cd">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-factories.ts</strong><dd><code>Clarify vector store node state reset on clone</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-utils/src/node-factories.ts

<li>Add comment clarifying state reset in vector store node cloning<br> <li> Note that configuration duplication is now handled at a higher level


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1085/files#diff-fad6e773473d49bcbeba4cee8f28db6878f20226b6d3743e6b462afb04985fa2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for copying VectorStore nodes within the workflow designer, ensuring their state is duplicated when duplicated.
- **Documentation**
  - Clarified internal behavior with an explanatory comment regarding vector store state resetting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->