### PR TITLE
feat: implement tabbed navigation in workflow designer

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/index.tsx
@@ -15,6 +15,7 @@ import "@xyflow/react/dist/style.css";
 import clsx from "clsx/lite";
 import { useFeatureFlag, useWorkflowDesigner } from "giselle-sdk/react";
 import { useAnimationFrame, useSpring } from "motion/react";
+import { Tabs } from "radix-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	type ImperativePanelHandle,
@@ -457,54 +458,58 @@ export function Editor({
 					<ReactFlowProvider>
 						<ToolbarContextProvider>
 							<MousePositionProvider>
-								<PanelGroup
-									direction="horizontal"
-									className="bg-black-900 h-full flex pr-[16px] py-[16px]"
-								>
-									<Panel defaultSize={10}>
-										<SideMenu />
-									</Panel>
-
-									<PanelResizeHandle
-										className={clsx(
-											"group pt-[16px] pb-[32px] h-full pl-[3px]",
-										)}
+								<Tabs.Root defaultValue="builder" asChild>
+									<PanelGroup
+										direction="horizontal"
+										className="bg-black-900 h-full flex pr-[16px] py-[16px]"
 									>
-										<div className="w-[2px] h-full bg-transparent group-data-[resize-handle-state=hover]:bg-black-400 group-data-[resize-handle-state=drag]:bg-black-400 transition-colors" />
-									</PanelResizeHandle>
-									<Panel className="flex-1 border border-black-400 rounded-[12px]">
-										<PanelGroup direction="horizontal">
-											<Panel>
-												<NodeCanvas />
-											</Panel>
-											<PanelResizeHandle
-												className={clsx(
-													"w-[1px] bg-black-400 cursor-col-resize",
-													"data-[resize-handle-state=hover]:bg-[#4a90e2]",
-													"opacity-0 data-[right-panel=show]:opacity-100 transition-opacity",
-												)}
-												data-right-panel={
-													selectedNodes.length === 1 ? "show" : "hide"
-												}
-											/>
-											<Panel
-												id="right-panel"
-												className="flex"
-												ref={rightPanelRef}
-												defaultSize={0}
-												data-right-panel={
-													selectedNodes.length === 1 ? "show" : "hide"
-												}
-											>
-												{selectedNodes.length === 1 && (
-													<div className="flex-1 overflow-hidden p-[16px]">
-														<PropertiesPanel />
-													</div>
-												)}
-											</Panel>
-										</PanelGroup>
-									</Panel>
-								</PanelGroup>
+										<Panel defaultSize={10}>
+											<SideMenu />
+										</Panel>
+
+										<PanelResizeHandle
+											className={clsx(
+												"group pt-[16px] pb-[32px] h-full pl-[3px]",
+											)}
+										>
+											<div className="w-[2px] h-full bg-transparent group-data-[resize-handle-state=hover]:bg-black-400 group-data-[resize-handle-state=drag]:bg-black-400 transition-colors" />
+										</PanelResizeHandle>
+										<Panel className="flex-1 border border-black-400 rounded-[12px]">
+											<Tabs.Content value="builder" className="h-full">
+												<PanelGroup direction="horizontal">
+													<Panel>
+														<NodeCanvas />
+													</Panel>
+													<PanelResizeHandle
+														className={clsx(
+															"w-[1px] bg-black-400 cursor-col-resize",
+															"data-[resize-handle-state=hover]:bg-[#4a90e2]",
+															"opacity-0 data-[right-panel=show]:opacity-100 transition-opacity",
+														)}
+														data-right-panel={
+															selectedNodes.length === 1 ? "show" : "hide"
+														}
+													/>
+													<Panel
+														id="right-panel"
+														className="flex"
+														ref={rightPanelRef}
+														defaultSize={0}
+														data-right-panel={
+															selectedNodes.length === 1 ? "show" : "hide"
+														}
+													>
+														{selectedNodes.length === 1 && (
+															<div className="flex-1 overflow-hidden p-[16px]">
+																<PropertiesPanel />
+															</div>
+														)}
+													</Panel>
+												</PanelGroup>
+											</Tabs.Content>
+										</Panel>
+									</PanelGroup>
+								</Tabs.Root>
 								<KeyboardShortcuts />
 							</MousePositionProvider>
 						</ToolbarContextProvider>

--- a/internal-packages/workflow-designer-ui/src/editor/side-menu/side-menu.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/side-menu/side-menu.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx/lite";
 import { useWorkflowDesigner } from "giselle-sdk/react";
 import { DraftingCompassIcon, FileKey2Icon, HistoryIcon } from "lucide-react";
 import Link from "next/link";
+import { Tabs } from "radix-ui";
 import { useCallback } from "react";
 import { GiselleLogo } from "../../icons";
 import { EditableText } from "../properties-panel/ui";
@@ -29,7 +30,7 @@ export function SideMenu() {
 				value={data.name}
 				size="large"
 			/>
-			<ul
+			<Tabs.List
 				className={clsx(
 					"flex flex-col w-full text-white-800 text-[14px]",
 					"**:data-list-wrapper:py-[1px] **:data-list-wrapper:cursor-pointer ",
@@ -44,25 +45,25 @@ export function SideMenu() {
 					"**:data-icon:transition-colors",
 				)}
 			>
-				<li data-state="active" className="group" data-list-wrapper>
+				<Tabs.Trigger value="builder" className="group" data-list-wrapper>
 					<div data-list>
 						<DraftingCompassIcon data-icon />
 						<p>Builder</p>
 					</div>
-				</li>
-				<li className="group" data-list-wrapper>
+				</Tabs.Trigger>
+				<Tabs.Trigger value="run-history" className="group" data-list-wrapper>
 					<div data-list>
 						<HistoryIcon data-icon />
 						<p>Run History</p>
 					</div>
-				</li>
-				<li className="group" data-list-wrapper>
+				</Tabs.Trigger>
+				<Tabs.Trigger value="credentials" className="group" data-list-wrapper>
 					<div data-list>
 						<FileKey2Icon data-icon />
 						<p>Credentials</p>
 					</div>
-				</li>
-			</ul>
+				</Tabs.Trigger>
+			</Tabs.List>
 		</div>
 	);
 }


### PR DESCRIPTION
### **User description**
## Overview
This PR implements a tabbed navigation system in the workflow designer, enhancing the UI/UX by organizing different views into separate tabs for better navigation and future extensibility.


https://github.com/user-attachments/assets/0c835ebf-1b3d-4a7d-b94a-80dc04d983ab



## Changes Made
- **Tabbed Interface**: Integrated Radix UI Tabs component to provide structured navigation
- **Side Menu Enhancement**: Converted the side menu from a simple list to a proper tabbed navigation system using `Tabs.List` and `Tabs.Trigger` components
- **Content Organization**: Wrapped the main content area in `Tabs.Content` to support view switching
- **Three Main Tabs**:
  - **Builder** (default): Existing node canvas functionality
  - **Run History**: Placeholder for workflow execution history (future implementation)
  - **Credentials**: Placeholder for authentication credential management (future implementation)

## Technical Details
- Uses Radix UI's accessible tab implementation
- Maintains existing Builder functionality as the default active tab
- Preserves all current node canvas features and properties panel behavior
- Provides foundation for implementing Run History and Credentials views

## Files Modified
- `internal-packages/workflow-designer-ui/src/editor/index.tsx`: Added Tabs.Root and Tabs.Content wrapper around main panel
- `internal-packages/workflow-designer-ui/src/editor/side-menu/side-menu.tsx`: Converted list navigation to tabbed interface

## UI/UX Impact
- Improved navigation structure for workflow designer
- Better organization of different functional areas
- Maintains current user experience while preparing for future feature additions
- Accessible tab navigation following Radix UI patterns

## Testing
- [ ] Verify Builder tab functionality remains intact
- [ ] Test tab switching behavior
- [ ] Confirm properties panel still works correctly
- [ ] Validate keyboard navigation accessibility

This change sets the foundation for expanding the workflow designer with additional views while maintaining a clean, organized interface.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced tabbed navigation using Radix UI Tabs
  - Wrapped main editor content in `Tabs.Root` and `Tabs.Content`
  - Side menu navigation converted to tabbed interface with `Tabs.List` and `Tabs.Trigger`

- Added three main tabs: Builder, Run History, Credentials

- Preserved existing Builder functionality as default tab


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add Radix UI Tabs to main editor layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/index.tsx

<li>Integrated Radix UI Tabs for main content navigation<br> <li> Wrapped editor layout in <code>Tabs.Root</code> and <code>Tabs.Content</code><br> <li> Ensured Builder tab preserves existing node canvas and properties <br>panel<br> <li> Prepared structure for future Run History and Credentials tabs


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1087/files#diff-5a0bda625c52763832cacbda314d3b4bd2c61a146636fea5b78dfa84a2878987">+52/-47</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>side-menu.tsx</strong><dd><code>Convert side menu to tabbed navigation interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/side-menu/side-menu.tsx

<li>Replaced side menu list with <code>Tabs.List</code> and <code>Tabs.Trigger</code> for tab <br>navigation<br> <li> Added triggers for Builder, Run History, and Credentials tabs<br> <li> Updated menu structure for tab-based navigation


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1087/files#diff-9886f9da7c1b99674aabefa020895b4d4db0d244a982874910e0c7fc3c34cbc0">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the side menu navigation to use a tabbed interface for improved navigation between sections such as Builder, Run History, and Credentials.
- **Style**
  - Maintained consistent styling while enhancing navigation with tabbed elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->