### PR TITLE
Update price of OpenAI o3

### DIFF
--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -95,6 +95,17 @@ export const openAiTokenPricing: ModelPriceTable = {
 					},
 				},
 			},
+			{
+				validFrom: "2025-06-11T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 2.0,
+					},
+					output: {
+						costPerMegaToken: 8.0,
+					},
+				},
+			},
 		],
 	},
 	"o3-mini": {


### PR DESCRIPTION
### **User description**
## Related Issue

- https://github.com/giselles-ai/giselle/issues/1093
<!-- Mention the related issue number if applicable. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

cost of manual-instrumented trace is calculated correctly ✅ 
<img width="594" alt="image" src="https://github.com/user-attachments/assets/b91fb6fc-1f87-4375-b0ec-587ae513afbc" />


___

### **PR Type**
Enhancement


___

### **Description**
• Update OpenAI o3 model pricing to reflect new rates
• Add new pricing tier with reduced input/output costs
• Implement cost changes effective from June 11, 2025


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Add reduced o3 model pricing tier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

• Add new pricing tier for o3 model with reduced costs<br> • Set input <br>cost to $2/1M tokens (from $10/1M tokens)<br> • Set output cost to $8/1M <br>tokens (from $40/1M tokens)<br> • Configure effective date as June 11, <br>2025


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1097/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the OpenAI "o3" model pricing to include new rates effective from June 11, 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->