### PR TITLE
fix: add workaround for Tailwind CSS IntelliSense issue in workflow-designer-ui

### DIFF
--- a/internal-packages/workflow-designer-ui/src/app/workaround.css
+++ b/internal-packages/workflow-designer-ui/src/app/workaround.css
@@ -1,0 +1,2 @@
+/* globals.css をappで読み込むとworkflow-designer-uiでtailwind-language-serverが動かなくなるので、workaroundとしてこのファイルで読み込んでいます。 */
+@import "globals.css";

--- a/internal-packages/workflow-designer-ui/src/app/workaround.css
+++ b/internal-packages/workflow-designer-ui/src/app/workaround.css
@@ -1,2 +1,5 @@
-/* globals.css をappで読み込むとworkflow-designer-uiでtailwind-language-serverが動かなくなるので、workaroundとしてこのファイルで読み込んでいます。 */
+/*
+ * When globals.css is imported in the app, tailwind-language-server stops working in workflow-designer-ui, so as a workaround we're importing it in this file.
+ * Related issue: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1377
+ */
 @import "globals.css";


### PR DESCRIPTION
### **User description**
## Summary
This PR adds a workaround file to fix Tailwind CSS IntelliSense not working properly in the workflow-designer-ui package.

## Problem
When `globals.css` is directly imported in the app, the tailwind-language-server stops working in the workflow-designer-ui package, causing IntelliSense to fail.

## Solution
Created a `workaround.css` file that imports `globals.css` to resolve the Tailwind CSS IntelliSense issue.

## Related Issue
This addresses a known issue documented in the Tailwind CSS IntelliSense repository:
https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1377

## Test Plan
1. Open the workflow-designer-ui package in VS Code
2. Verify that Tailwind CSS IntelliSense is now working properly
3. Check that class name autocompletion and hover information are functional
4. Ensure no regression in styling or functionality

## Files Changed
- `internal-packages/workflow-designer-ui/src/app/workaround.css` - New workaround file to enable Tailwind IntelliSense

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


___

### **PR Type**
Bug fix


___

### **Description**
• Add workaround CSS file to fix Tailwind IntelliSense
• Import globals.css indirectly to resolve language server issue
• Address known Tailwind CSS IntelliSense compatibility problem


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workaround.css</strong><dd><code>Add Tailwind IntelliSense workaround CSS file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/app/workaround.css

• Create new CSS file with Japanese comment explaining the workaround<br> <br>• Import globals.css to fix Tailwind language server issue


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1100/files#diff-6dded2ad79a0cc2ea1249c42e69a1a914d309c33b451e488c70dc052ee2bd3c9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a workaround to ensure global styles are applied without disrupting Tailwind support in the workflow designer UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->