### PR TITLE
Refactor GitHub search tools

### DIFF
--- a/packages/github-tool/src/tools.ts
+++ b/packages/github-tool/src/tools.ts
@@ -1,4 +1,4 @@
-import type { Octokit } from "@octokit/core";
+import type { Octokit } from "@octokit/rest";
 import { tool } from "ai";
 import { z } from "zod";
 
@@ -1088,7 +1088,7 @@ export function githubTools(octokit: Octokit) {
 			execute: async (params) => {
 				const { order, page, perPage, q, sort } = params;
 
-				const response = await octokit.request("GET /search/issues", {
+				const response = await octokit.search.issuesAndPullRequests({
 					q,
 					sort,
 					order,
@@ -1136,7 +1136,7 @@ export function githubTools(octokit: Octokit) {
 			execute: async (params) => {
 				const { order, page, perPage, q, sort } = params;
 
-				const response = await octokit.request("GET /search/issues", {
+				const response = await octokit.search.issuesAndPullRequests({
 					q: `${q} type:pr`,
 					sort,
 					order,


### PR DESCRIPTION
## Summary
- update GitHub tools to use `@octokit/rest`
- call `octokit.search.issuesAndPullRequests` for searching issues and PRs

## Testing
- `pnpm biome check --write packages/github-tool/src/tools.ts`
- `npx turbo run build --filter @giselle-sdk/github-tool --cache=local:rw` *(fails: cannot find module '@octokit/rest')*
- `npx turbo run check-types --filter @giselle-sdk/github-tool --cache=local:rw` *(fails: cannot find module '@octokit/rest')*

------
https://chatgpt.com/codex/tasks/task_e_6849817c0b948325a3b81e809fe6c439