### PR TITLE
Fix secret encryption fallback

### DIFF
--- a/packages/giselle-engine/src/core/secrets/add-secret.ts
+++ b/packages/giselle-engine/src/core/secrets/add-secret.ts
@@ -15,8 +15,11 @@ export async function addSecret(args: {
 	value: string;
 	workspaceId: WorkspaceId;
 }) {
-	const encryptedValue =
-		(await args.context.vault?.encrypt(args.value)) ?? args.value;
+	if (!args.context.vault) {
+		throw new Error("Vault unavailable; cannot encrypt secret");
+	}
+
+	const encryptedValue = await args.context.vault.encrypt(args.value);
 
 	const secret: Secret = {
 		id: SecretId.generate(),


### PR DESCRIPTION
### **User description**
## Summary
- enforce vault requirement when adding secrets

## Testing
- `npx turbo test --cache=local:rw` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684a8ce759f483259446db06f446a8f0


___

### **PR Type**
Bug fix


___

### **Description**
• Enforce vault requirement for secret encryption
• Remove fallback to unencrypted values
• Add error handling for missing vault


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-secret.ts</strong><dd><code>Enforce mandatory vault encryption</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle-engine/src/core/secrets/add-secret.ts

• Replace optional vault encryption with mandatory requirement<br> • Add <br>error throwing when vault is unavailable<br> • Remove fallback to storing <br>unencrypted values


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1119/files#diff-5feee651ffa314ff471c6e1ca8ab7396ac757c3c6e6ed41d5e4b33f94f10410e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved security by ensuring secrets are always encrypted before storage. An error is now raised if encryption is not possible, preventing unencrypted secrets from being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->