### PR TITLE
fix: Complete node deletion cleanup for issue #1098

### DIFF
--- a/packages/node-utils/src/node-reference-cleanup.ts
+++ b/packages/node-utils/src/node-reference-cleanup.ts
@@ -1,0 +1,187 @@
+import type { NodeId, OutputId } from "@giselle-sdk/data-type";
+import {
+	findNextNodeReference,
+	formatNodeReference,
+	isJsonContent,
+} from "@giselle-sdk/text-editor-utils";
+
+export function cleanupNodeReferencesInJsonContent(
+	jsonContent: unknown,
+	deletedNodeId: NodeId,
+): unknown {
+	if (!jsonContent || typeof jsonContent !== "object") {
+		return jsonContent;
+	}
+
+	const content = jsonContent as Record<string, unknown>;
+
+	// If this is a Source node with the deleted nodeId, remove it
+	if (
+		content.type === "Source" &&
+		typeof content.attrs === "object" &&
+		content.attrs !== null
+	) {
+		const attrs = content.attrs as Record<string, unknown>;
+		if (
+			attrs.node !== null &&
+			typeof attrs.node === "object" &&
+			attrs.node !== null
+		) {
+			const node = attrs.node as Record<string, unknown>;
+			if (node.id === deletedNodeId) {
+				return null;
+			}
+		}
+	}
+
+	// Recursively process content array
+	if (Array.isArray(content.content)) {
+		content.content = content.content
+			.map((child: unknown) =>
+				cleanupNodeReferencesInJsonContent(child, deletedNodeId),
+			)
+			.filter((child: unknown) => child !== null);
+	}
+
+	return content;
+}
+
+export function cleanupNodeReferencesInText(
+	text: string,
+	deletedNodeId: NodeId,
+): string {
+	// Handle JSON content (rich text from TipTap editor)
+	if (isJsonContent(text)) {
+		try {
+			const jsonContent = JSON.parse(text);
+			const cleaned = cleanupNodeReferencesInJsonContent(
+				jsonContent,
+				deletedNodeId,
+			);
+			return JSON.stringify(cleaned);
+		} catch (error) {
+			console.error("Failed to parse JSON content:", error);
+		}
+	}
+
+	// Handle plain text with {{nodeId:outputId}} references
+	let result = text;
+	let searchStart = 0;
+
+	while (true) {
+		const reference = findNextNodeReference(result, deletedNodeId, searchStart);
+		if (!reference) break;
+
+		result =
+			result.substring(0, reference.start) + result.substring(reference.end);
+		searchStart = reference.start;
+	}
+
+	return result;
+}
+
+/**
+ * Clean up specific node reference (nodeId:outputId) from JSON content
+ */
+export function cleanupSpecificNodeReferenceInJsonContent(
+	jsonContent: unknown,
+	nodeId: NodeId,
+	outputId: OutputId,
+): unknown {
+	if (!jsonContent || typeof jsonContent !== "object") {
+		return jsonContent;
+	}
+
+	const content = jsonContent as Record<string, unknown>;
+
+	// If this is a Source node with the specific nodeId and outputId, remove it
+	if (
+		content.type === "Source" &&
+		typeof content.attrs === "object" &&
+		content.attrs !== null
+	) {
+		const attrs = content.attrs as Record<string, unknown>;
+		if (
+			attrs.node !== null &&
+			typeof attrs.node === "object" &&
+			attrs.node !== null
+		) {
+			const node = attrs.node as Record<string, unknown>;
+			if (node.id === nodeId && attrs.outputId === outputId) {
+				return null;
+			}
+		}
+	}
+
+	// Recursively process content array
+	if (Array.isArray(content.content)) {
+		content.content = content.content
+			.map((child: unknown) =>
+				cleanupSpecificNodeReferenceInJsonContent(child, nodeId, outputId),
+			)
+			.filter((child: unknown) => child !== null);
+	}
+
+	// Remove empty paragraph nodes
+	if (content.type === "paragraph" && Array.isArray(content.content)) {
+		if (content.content.length === 0) {
+			return null;
+		}
+		// Check if paragraph only contains empty text nodes
+		const hasOnlyEmptyText = content.content.every((child: unknown) => {
+			if (typeof child === "object" && child !== null) {
+				const textNode = child as Record<string, unknown>;
+				return (
+					textNode.type === "text" &&
+					(textNode.text === "" || textNode.text === " ")
+				);
+			}
+			return false;
+		});
+		if (hasOnlyEmptyText) {
+			return null;
+		}
+	}
+
+	return content;
+}
+
+/**
+ * Clean up specific node reference (nodeId:outputId) from text
+ */
+export function cleanupSpecificNodeReferenceInText(
+	text: string,
+	nodeId: NodeId,
+	outputId: OutputId,
+): string {
+	// Handle JSON content (rich text from TipTap editor)
+	if (isJsonContent(text)) {
+		try {
+			const jsonContent = JSON.parse(text);
+			const cleaned = cleanupSpecificNodeReferenceInJsonContent(
+				jsonContent,
+				nodeId,
+				outputId,
+			);
+			return JSON.stringify(cleaned);
+		} catch (error) {
+			console.error("Failed to parse JSON content:", error);
+		}
+	}
+
+	// Handle plain text with specific {{nodeId:outputId}} reference
+	const targetReference = formatNodeReference(nodeId, outputId);
+	let result = text;
+	let searchStart = 0;
+
+	while (true) {
+		const startIndex = result.indexOf(targetReference, searchStart);
+		if (startIndex === -1) break;
+
+		const endIndex = startIndex + targetReference.length;
+		result = result.substring(0, startIndex) + result.substring(endIndex);
+		searchStart = startIndex;
+	}
+
+	return result;
+}

--- a/packages/text-editor-utils/src/detect-source-changes.ts
+++ b/packages/text-editor-utils/src/detect-source-changes.ts
@@ -1,0 +1,58 @@
+import type { NodeId, OutputId } from "@giselle-sdk/data-type";
+import type { JSONContent } from "@tiptap/core";
+
+export interface SourceNode {
+	nodeId: NodeId;
+	outputId: OutputId;
+}
+
+/**
+ * Extract all Source nodes from TipTap JSONContent
+ */
+export function extractSourceNodes(content: JSONContent): SourceNode[] {
+	const sources: SourceNode[] = [];
+
+	function traverse(node: JSONContent) {
+		if (node.type === "Source") {
+			// Extract valid sources with complete attrs
+			if (node.attrs?.node?.id && node.attrs?.outputId) {
+				sources.push({
+					nodeId: node.attrs.node.id,
+					outputId: node.attrs.outputId,
+				});
+			}
+			// Log any Source nodes with incomplete attrs for debugging
+			else {
+				console.log('Found Source node with incomplete attrs:', node);
+			}
+		}
+
+		if (node.content) {
+			for (const child of node.content) {
+				traverse(child);
+			}
+		}
+	}
+
+	traverse(content);
+	return sources;
+}
+
+/**
+ * Find Source nodes that were removed between two JSON states
+ */
+export function findRemovedSources(
+	oldContent: JSONContent,
+	newContent: JSONContent,
+): SourceNode[] {
+	const oldSources = extractSourceNodes(oldContent);
+	const newSources = extractSourceNodes(newContent);
+
+	const newSourcesSet = new Set(
+		newSources.map((s) => `${s.nodeId}:${s.outputId}`),
+	);
+
+	return oldSources.filter(
+		(source) => !newSourcesSet.has(`${source.nodeId}:${source.outputId}`),
+	);
+}

--- a/packages/text-editor-utils/src/index.ts
+++ b/packages/text-editor-utils/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./extensions";
 export * from "./is-json-content";
 export * from "./json-content-to-text";
+export * from "./node-reference";
+export * from "./detect-source-changes";

--- a/packages/text-editor-utils/src/node-reference.ts
+++ b/packages/text-editor-utils/src/node-reference.ts
@@ -1,0 +1,54 @@
+import type { NodeId, OutputId } from "@giselle-sdk/data-type";
+
+/**
+ * Get node reference prefix {{nodeId:
+ */
+function getNodeReferencePrefix(nodeId: NodeId): string {
+	return `{{${nodeId}:`;
+}
+
+/**
+ * Format node reference to {{nodeId:outputId}} format
+ */
+export function formatNodeReference(
+	nodeId: NodeId,
+	outputId: OutputId,
+): string {
+	return `${getNodeReferencePrefix(nodeId)}${outputId}}}`;
+}
+
+/**
+ * Check if text contains reference to specific node
+ */
+export function containsNodeReference(text: string, nodeId: NodeId): boolean {
+	return text.includes(getNodeReferencePrefix(nodeId));
+}
+
+/**
+ * Check if text contains specific node reference (nodeId:outputId)
+ */
+export function containsSpecificNodeReference(text: string, nodeId: NodeId, outputId: OutputId): boolean {
+	return text.includes(formatNodeReference(nodeId, outputId));
+}
+
+/**
+ * Find next node reference for a specific nodeId
+ * Returns the start and end indices, or null if not found
+ */
+export function findNextNodeReference(
+	text: string,
+	nodeId: NodeId,
+	startFrom = 0,
+): { start: number; end: number } | null {
+	const prefix = getNodeReferencePrefix(nodeId);
+	const startIndex = text.indexOf(prefix, startFrom);
+	if (startIndex === -1) return null;
+
+	const endIndex = text.indexOf("}}", startIndex);
+	if (endIndex === -1) return null;
+
+	return {
+		start: startIndex,
+		end: endIndex + 2,
+	};
+}


### PR DESCRIPTION
### **User description**
## Summary
Fixes #1098: Node references (`{{nodeId:outputId}}`) remain in text fields after node deletion, causing "empty app deletion" errors.

## Problem
When a node is deleted from the workflow, its references in text fields (prompt, query, etc.) were not being cleaned up. This caused issues when trying to delete an empty app, as the system still detected references to non-existent nodes.

## Solution
- Added `handleDeleteNodeCleanup` function that:
  - Scans all nodes for references to the deleted node
  - Cleans up both plain text references (`{{nodeId:outputId}}`) and JSON content references
  - Updates affected nodes to remove orphaned references
- Integrated cleanup into the `deleteNode` function
- Also extracts and properly handles trigger deletion for configured trigger nodes

## Dependencies
This PR depends on #1127 (node reference utilities) for the `containsNodeReference` utility function.

## Testing
1. Create a workflow with nodes that reference each other
2. Delete a referenced node
3. Check that all `{{nodeId:outputId}}` references are removed from text fields
4. Verify you can delete an empty app without errors


___

### **PR Type**
Bug fix


___

### **Description**
• Fix node deletion cleanup to prevent orphaned references
• Add comprehensive text and JSON content cleanup utilities
• Resolve app deletion errors after clearing all nodes
• Implement proper trigger cleanup for configured nodes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-reference-cleanup.ts</strong><dd><code>Add comprehensive node reference cleanup utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-utils/src/node-reference-cleanup.ts

• Add functions to clean up node references in text and JSON content<br> • <br>Support both general node cleanup and specific nodeId:outputId cleanup<br> <br>• Handle TipTap JSON content with Source node removal<br> • Remove empty <br>paragraph nodes after cleanup


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1128/files#diff-6e990e5c46d1805426a944dc867c3406b984e1a1bb3e0998e1780e3d6f0600e1">+187/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflow-designer-context.tsx</strong><dd><code>Implement complete node deletion with reference cleanup</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/workflow-designer/src/react/workflow-designer-context.tsx

• Add <code>handleDeleteNodeCleanup</code> to clean up all node references<br> • Add <br><code>handleDeleteTriggerCleanup</code> for proper trigger deletion<br> • Update <br><code>deleteNode</code> to perform comprehensive cleanup before deletion<br> • Import <br>new cleanup utilities from node-utils and text-editor-utils


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1128/files#diff-40ba84286ab0edff82fb048cae4fe6cf25db8efd787058a13e06d29cfbadc6cd">+70/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>detect-source-changes.ts</strong><dd><code>Add Source node change detection utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/text-editor-utils/src/detect-source-changes.ts

• Add functions to extract Source nodes from TipTap JSONContent<br> • <br>Implement detection of removed Source nodes between states<br> • Support <br>debugging of incomplete Source node attributes


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1128/files#diff-7bc663d1615482722347d12fb022bd575de197a6869f45c069e9384b3041c4a7">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-reference.ts</strong><dd><code>Add node reference formatting and detection utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/text-editor-utils/src/node-reference.ts

• Add functions to format and find node references<br> • Support checking <br>for specific nodeId:outputId references<br> • Provide utilities for node <br>reference manipulation


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1128/files#diff-d03ae591650248c193575af9dd61ed89916846c56a8eca437c5b61932f4e1b2e">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export new utility modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/text-editor-utils/src/index.ts

• Export new node-reference and detect-source-changes modules


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1128/files#diff-e4ec26d065bb72c4b09d8b2bc3ea516f5b7d443019bc91d9b2b1458b0dda1687">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added utilities to clean up references to deleted nodes within text and JSON content, ensuring that removed nodes are no longer referenced elsewhere.
  - Introduced tools to detect and identify removed "Source" nodes in editor content.
  - Provided functions to generate and locate node references in text.
- **Refactor**
  - Improved node deletion workflow to automatically clean up references and associated triggers when a node is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->