### PR TITLE
fix: UI connection delete cleanup for issue #1099

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/input-panel.tsx
@@ -322,7 +322,7 @@ export function InputPanel({
 }: {
 	node: ImageGenerationNode;
 }) {
-	const { data, addConnection, deleteConnection, updateNodeData } =
+	const { data, addConnection, deleteConnectionWithCleanup, updateNodeData } =
 		useWorkflowDesigner();
 	const sources = useMemo<Source[]>(() => {
 		const tmpSources: Source[] = [];
@@ -401,7 +401,7 @@ export function InputPanel({
 				if (connection === undefined) {
 					continue;
 				}
-				deleteConnection(connection.id);
+				deleteConnectionWithCleanup(connection.id);
 
 				mutableInputs = mutableInputs.filter(
 					(input) => input.id !== connection.inputId,
@@ -416,21 +416,21 @@ export function InputPanel({
 			data.nodes,
 			data.connections,
 			addConnection,
-			deleteConnection,
+			deleteConnectionWithCleanup,
 			updateNodeData,
 		],
 	);
 
 	const handleRemove = useCallback(
 		(connection: Connection) => {
-			deleteConnection(connection.id);
+			deleteConnectionWithCleanup(connection.id);
 			updateNodeData(imageGenerationNode, {
 				inputs: imageGenerationNode.inputs.filter(
 					(input) => input.id !== connection.inputId,
 				),
 			});
 		},
-		[imageGenerationNode, deleteConnection, updateNodeData],
+		[imageGenerationNode, deleteConnectionWithCleanup, updateNodeData],
 	);
 
 	if (imageGenerationNode.inputs.length === 0) {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
@@ -25,7 +25,7 @@ export function PromptPanel({
 }: {
 	node: ImageGenerationNode;
 }) {
-	const { updateNodeDataContent } = useWorkflowDesigner();
+	const { updateNodeDataContent, handleSourceRemoved } = useWorkflowDesigner();
 	const { all: connectedSources } = useConnectedSources(node);
 	const nodes = useMemo(
 		() =>
@@ -42,6 +42,7 @@ export function PromptPanel({
 			onValueChange={(value) => {
 				updateNodeDataContent(node, { prompt: value });
 			}}
+			onSourceRemoved={handleSourceRemoved}
 			nodes={nodes}
 			tools={(editor) => (
 				<DropdownMenu.Root>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/input-panel.tsx
@@ -329,7 +329,7 @@ export function InputPanel({
 }: {
 	node: QueryNode;
 }) {
-	const { data, addConnection, deleteConnection, updateNodeData } =
+	const { data, addConnection, deleteConnectionWithCleanup, updateNodeData } =
 		useWorkflowDesigner();
 	const sources = useMemo<Source[]>(() => {
 		const tmpSources: Source[] = [];
@@ -406,7 +406,7 @@ export function InputPanel({
 				if (connection === undefined) {
 					continue;
 				}
-				deleteConnection(connection.id);
+				deleteConnectionWithCleanup(connection.id);
 
 				mutableInputs = mutableInputs.filter(
 					(input) => input.id !== connection.inputId,
@@ -421,21 +421,21 @@ export function InputPanel({
 			data.nodes,
 			data.connections,
 			addConnection,
-			deleteConnection,
+			deleteConnectionWithCleanup,
 			updateNodeData,
 		],
 	);
 
 	const handleRemove = useCallback(
 		(connection: Connection) => {
-			deleteConnection(connection.id);
+			deleteConnectionWithCleanup(connection.id);
 			updateNodeData(queryNode, {
 				inputs: queryNode.inputs.filter(
 					(input) => input.id !== connection.inputId,
 				),
 			});
 		},
-		[queryNode, deleteConnection, updateNodeData],
+		[queryNode, deleteConnectionWithCleanup, updateNodeData],
 	);
 
 	if (queryNode.inputs.length === 0) {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -113,7 +113,7 @@ function DataSourceDisplayBar({
 }
 
 export function QueryPanel({ node }: { node: QueryNode }) {
-	const { updateNodeDataContent } = useWorkflowDesigner();
+	const { updateNodeDataContent, handleSourceRemoved } = useWorkflowDesigner();
 	const { all: connectedInputs } = useConnectedSources(node);
 	const connectedDatasourceInputs = useMemo(
 		() =>
@@ -138,6 +138,7 @@ export function QueryPanel({ node }: { node: QueryNode }) {
 					onValueChange={(value) => {
 						updateNodeDataContent(node, { query: value });
 					}}
+					onSourceRemoved={handleSourceRemoved}
 					nodes={connectedInputsWithoutDatasource.map((input) => input.node)}
 					tools={(editor) => (
 						<DropdownMenu.Root>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/input-panel.tsx
@@ -35,7 +35,7 @@ export function InputPanel({
 }: {
 	node: TextGenerationNode;
 }) {
-	const { data, addConnection, deleteConnection, updateNodeData } =
+	const { data, addConnection, deleteConnectionWithCleanup, updateNodeData } =
 		useWorkflowDesigner();
 	const outputs = useMemo<OutputWithDetails[]>(() => {
 		const tmp: OutputWithDetails[] = [];
@@ -114,7 +114,7 @@ export function InputPanel({
 				if (connection === undefined) {
 					continue;
 				}
-				deleteConnection(connection.id);
+				deleteConnectionWithCleanup(connection.id);
 
 				mutableInputs = mutableInputs.filter(
 					(input) => input.id !== connection.inputId,
@@ -129,21 +129,21 @@ export function InputPanel({
 			data.nodes,
 			data.connections,
 			addConnection,
-			deleteConnection,
+			deleteConnectionWithCleanup,
 			updateNodeData,
 		],
 	);
 
 	const handleRemove = useCallback(
 		(connection: Connection) => {
-			deleteConnection(connection.id);
+			deleteConnectionWithCleanup(connection.id);
 			updateNodeData(textGenerationNode, {
 				inputs: textGenerationNode.inputs.filter(
 					(input) => input.id !== connection.inputId,
 				),
 			});
 		},
-		[textGenerationNode, deleteConnection, updateNodeData],
+		[textGenerationNode, deleteConnectionWithCleanup, updateNodeData],
 	);
 
 	if (textGenerationNode.inputs.length === 0) {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -23,7 +23,7 @@ export function PromptPanel({
 }: {
 	node: TextGenerationNode;
 }) {
-	const { updateNodeDataContent } = useWorkflowDesigner();
+	const { updateNodeDataContent, handleSourceRemoved } = useWorkflowDesigner();
 	const { all: connectedSources } = useConnectedOutputs(node);
 	return (
 		<TextEditor
@@ -31,6 +31,7 @@ export function PromptPanel({
 			onValueChange={(value) => {
 				updateNodeDataContent(node, { prompt: value });
 			}}
+			onSourceRemoved={handleSourceRemoved}
 			nodes={connectedSources.map((source) => source.node)}
 			tools={(editor) => (
 				<DropdownMenu.Root>

--- a/packages/node-utils/src/node-reference-cleanup.ts
+++ b/packages/node-utils/src/node-reference-cleanup.ts
@@ -1,0 +1,187 @@
+import type { NodeId, OutputId } from "@giselle-sdk/data-type";
+import {
+	findNextNodeReference,
+	formatNodeReference,
+	isJsonContent,
+} from "@giselle-sdk/text-editor-utils";
+
+export function cleanupNodeReferencesInJsonContent(
+	jsonContent: unknown,
+	deletedNodeId: NodeId,
+): unknown {
+	if (!jsonContent || typeof jsonContent !== "object") {
+		return jsonContent;
+	}
+
+	const content = jsonContent as Record<string, unknown>;
+
+	// If this is a Source node with the deleted nodeId, remove it
+	if (
+		content.type === "Source" &&
+		typeof content.attrs === "object" &&
+		content.attrs !== null
+	) {
+		const attrs = content.attrs as Record<string, unknown>;
+		if (
+			attrs.node !== null &&
+			typeof attrs.node === "object" &&
+			attrs.node !== null
+		) {
+			const node = attrs.node as Record<string, unknown>;
+			if (node.id === deletedNodeId) {
+				return null;
+			}
+		}
+	}
+
+	// Recursively process content array
+	if (Array.isArray(content.content)) {
+		content.content = content.content
+			.map((child: unknown) =>
+				cleanupNodeReferencesInJsonContent(child, deletedNodeId),
+			)
+			.filter((child: unknown) => child !== null);
+	}
+
+	return content;
+}
+
+export function cleanupNodeReferencesInText(
+	text: string,
+	deletedNodeId: NodeId,
+): string {
+	// Handle JSON content (rich text from TipTap editor)
+	if (isJsonContent(text)) {
+		try {
+			const jsonContent = JSON.parse(text);
+			const cleaned = cleanupNodeReferencesInJsonContent(
+				jsonContent,
+				deletedNodeId,
+			);
+			return JSON.stringify(cleaned);
+		} catch (error) {
+			console.error("Failed to parse JSON content:", error);
+		}
+	}
+
+	// Handle plain text with {{nodeId:outputId}} references
+	let result = text;
+	let searchStart = 0;
+
+	while (true) {
+		const reference = findNextNodeReference(result, deletedNodeId, searchStart);
+		if (!reference) break;
+
+		result =
+			result.substring(0, reference.start) + result.substring(reference.end);
+		searchStart = reference.start;
+	}
+
+	return result;
+}
+
+/**
+ * Clean up specific node reference (nodeId:outputId) from JSON content
+ */
+export function cleanupSpecificNodeReferenceInJsonContent(
+	jsonContent: unknown,
+	nodeId: NodeId,
+	outputId: OutputId,
+): unknown {
+	if (!jsonContent || typeof jsonContent !== "object") {
+		return jsonContent;
+	}
+
+	const content = jsonContent as Record<string, unknown>;
+
+	// If this is a Source node with the specific nodeId and outputId, remove it
+	if (
+		content.type === "Source" &&
+		typeof content.attrs === "object" &&
+		content.attrs !== null
+	) {
+		const attrs = content.attrs as Record<string, unknown>;
+		if (
+			attrs.node !== null &&
+			typeof attrs.node === "object" &&
+			attrs.node !== null
+		) {
+			const node = attrs.node as Record<string, unknown>;
+			if (node.id === nodeId && attrs.outputId === outputId) {
+				return null;
+			}
+		}
+	}
+
+	// Recursively process content array
+	if (Array.isArray(content.content)) {
+		content.content = content.content
+			.map((child: unknown) =>
+				cleanupSpecificNodeReferenceInJsonContent(child, nodeId, outputId),
+			)
+			.filter((child: unknown) => child !== null);
+	}
+
+	// Remove empty paragraph nodes
+	if (content.type === "paragraph" && Array.isArray(content.content)) {
+		if (content.content.length === 0) {
+			return null;
+		}
+		// Check if paragraph only contains empty text nodes
+		const hasOnlyEmptyText = content.content.every((child: unknown) => {
+			if (typeof child === "object" && child !== null) {
+				const textNode = child as Record<string, unknown>;
+				return (
+					textNode.type === "text" &&
+					(textNode.text === "" || textNode.text === " ")
+				);
+			}
+			return false;
+		});
+		if (hasOnlyEmptyText) {
+			return null;
+		}
+	}
+
+	return content;
+}
+
+/**
+ * Clean up specific node reference (nodeId:outputId) from text
+ */
+export function cleanupSpecificNodeReferenceInText(
+	text: string,
+	nodeId: NodeId,
+	outputId: OutputId,
+): string {
+	// Handle JSON content (rich text from TipTap editor)
+	if (isJsonContent(text)) {
+		try {
+			const jsonContent = JSON.parse(text);
+			const cleaned = cleanupSpecificNodeReferenceInJsonContent(
+				jsonContent,
+				nodeId,
+				outputId,
+			);
+			return JSON.stringify(cleaned);
+		} catch (error) {
+			console.error("Failed to parse JSON content:", error);
+		}
+	}
+
+	// Handle plain text with specific {{nodeId:outputId}} reference
+	const targetReference = formatNodeReference(nodeId, outputId);
+	let result = text;
+	let searchStart = 0;
+
+	while (true) {
+		const startIndex = result.indexOf(targetReference, searchStart);
+		if (startIndex === -1) break;
+
+		const endIndex = startIndex + targetReference.length;
+		result = result.substring(0, startIndex) + result.substring(endIndex);
+		searchStart = startIndex;
+	}
+
+	return result;
+}

--- a/packages/text-editor-utils/src/detect-source-changes.ts
+++ b/packages/text-editor-utils/src/detect-source-changes.ts
@@ -1,0 +1,58 @@
+import type { NodeId, OutputId } from "@giselle-sdk/data-type";
+import type { JSONContent } from "@tiptap/core";
+
+export interface SourceNode {
+	nodeId: NodeId;
+	outputId: OutputId;
+}
+
+/**
+ * Extract all Source nodes from TipTap JSONContent
+ */
+export function extractSourceNodes(content: JSONContent): SourceNode[] {
+	const sources: SourceNode[] = [];
+
+	function traverse(node: JSONContent) {
+		if (node.type === "Source") {
+			// Extract valid sources with complete attrs
+			if (node.attrs?.node?.id && node.attrs?.outputId) {
+				sources.push({
+					nodeId: node.attrs.node.id,
+					outputId: node.attrs.outputId,
+				});
+			}
+			// Log any Source nodes with incomplete attrs for debugging
+			else {
+				console.log('Found Source node with incomplete attrs:', node);
+			}
+		}
+
+		if (node.content) {
+			for (const child of node.content) {
+				traverse(child);
+			}
+		}
+	}
+
+	traverse(content);
+	return sources;
+}
+
+/**
+ * Find Source nodes that were removed between two JSON states
+ */
+export function findRemovedSources(
+	oldContent: JSONContent,
+	newContent: JSONContent,
+): SourceNode[] {
+	const oldSources = extractSourceNodes(oldContent);
+	const newSources = extractSourceNodes(newContent);
+
+	const newSourcesSet = new Set(
+		newSources.map((s) => `${s.nodeId}:${s.outputId}`),
+	);
+
+	return oldSources.filter(
+		(source) => !newSourcesSet.has(`${source.nodeId}:${source.outputId}`),
+	);
+}

--- a/packages/text-editor-utils/src/detect-source-changes.ts
+++ b/packages/text-editor-utils/src/detect-source-changes.ts
@@ -1,7 +1,7 @@
 import type { NodeId, OutputId } from "@giselle-sdk/data-type";
 import type { JSONContent } from "@tiptap/core";
 
-export interface SourceNode {
+export interface NodeOutputReference {
 	nodeId: NodeId;
 	outputId: OutputId;
 }
@@ -9,8 +9,10 @@ export interface SourceNode {
 /**
  * Extract all Source nodes from TipTap JSONContent
  */
-export function extractSourceNodes(content: JSONContent): SourceNode[] {
-	const sources: SourceNode[] = [];
+export function extractSourceNodes(
+	content: JSONContent,
+): NodeOutputReference[] {
+	const sources: NodeOutputReference[] = [];
 
 	function traverse(node: JSONContent) {
 		if (node.type === "Source") {
@@ -23,7 +25,7 @@ export function extractSourceNodes(content: JSONContent): SourceNode[] {
 			}
 			// Log any Source nodes with incomplete attrs for debugging
 			else {
-				console.log('Found Source node with incomplete attrs:', node);
+				console.log("Found Source node with incomplete attrs:", node);
 			}
 		}
 
@@ -44,7 +46,7 @@ export function extractSourceNodes(content: JSONContent): SourceNode[] {
 export function findRemovedSources(
 	oldContent: JSONContent,
 	newContent: JSONContent,
-): SourceNode[] {
+): NodeOutputReference[] {
 	const oldSources = extractSourceNodes(oldContent);
 	const newSources = extractSourceNodes(newContent);
 

--- a/packages/text-editor-utils/src/index.ts
+++ b/packages/text-editor-utils/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./extensions";
 export * from "./is-json-content";
 export * from "./json-content-to-text";
+export * from "./node-reference";
+export * from "./detect-source-changes";

--- a/packages/text-editor-utils/src/node-reference.ts
+++ b/packages/text-editor-utils/src/node-reference.ts
@@ -1,0 +1,54 @@
+import type { NodeId, OutputId } from "@giselle-sdk/data-type";
+
+/**
+ * Get node reference prefix {{nodeId:
+ */
+function getNodeReferencePrefix(nodeId: NodeId): string {
+	return `{{${nodeId}:`;
+}
+
+/**
+ * Format node reference to {{nodeId:outputId}} format
+ */
+export function formatNodeReference(
+	nodeId: NodeId,
+	outputId: OutputId,
+): string {
+	return `${getNodeReferencePrefix(nodeId)}${outputId}}}`;
+}
+
+/**
+ * Check if text contains reference to specific node
+ */
+export function containsNodeReference(text: string, nodeId: NodeId): boolean {
+	return text.includes(getNodeReferencePrefix(nodeId));
+}
+
+/**
+ * Check if text contains specific node reference (nodeId:outputId)
+ */
+export function containsSpecificNodeReference(text: string, nodeId: NodeId, outputId: OutputId): boolean {
+	return text.includes(formatNodeReference(nodeId, outputId));
+}
+
+/**
+ * Find next node reference for a specific nodeId
+ * Returns the start and end indices, or null if not found
+ */
+export function findNextNodeReference(
+	text: string,
+	nodeId: NodeId,
+	startFrom = 0,
+): { start: number; end: number } | null {
+	const prefix = getNodeReferencePrefix(nodeId);
+	const startIndex = text.indexOf(prefix, startFrom);
+	if (startIndex === -1) return null;
+
+	const endIndex = text.indexOf("}}", startIndex);
+	if (endIndex === -1) return null;
+
+	return {
+		start: startIndex,
+		end: endIndex + 2,
+	};
+}

--- a/packages/text-editor/src/react/component.tsx
+++ b/packages/text-editor/src/react/component.tsx
@@ -1,6 +1,6 @@
 import type { Node } from "@giselle-sdk/data-type";
 import {
-	type SourceNode,
+	type NodeOutputReference,
 	extensions as baseExtensions,
 	findRemovedSources,
 } from "@giselle-sdk/text-editor-utils";
@@ -135,7 +135,7 @@ export function TextEditor({
 }: {
 	value?: string;
 	onValueChange?: (value: string) => void;
-	onSourceRemoved?: (removedSources: SourceNode[]) => void;
+	onSourceRemoved?: (removedSources: NodeOutputReference[]) => void;
 	tools?: (editor: Editor) => ReactNode;
 	nodes?: Node[];
 }) {

--- a/packages/text-editor/src/react/component.tsx
+++ b/packages/text-editor/src/react/component.tsx
@@ -1,5 +1,9 @@
 import type { Node } from "@giselle-sdk/data-type";
-import { extensions as baseExtensions } from "@giselle-sdk/text-editor-utils";
+import {
+	type SourceNode,
+	extensions as baseExtensions,
+	findRemovedSources,
+} from "@giselle-sdk/text-editor-utils";
 import { type Editor, EditorProvider, useCurrentEditor } from "@tiptap/react";
 import clsx from "clsx/lite";
 import {
@@ -10,7 +14,7 @@ import {
 	StrikethroughIcon,
 } from "lucide-react";
 import { Toolbar as ToolbarPrimitive } from "radix-ui";
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useEffect, useMemo, useRef } from "react";
 import { SourceExtensionReact } from "./source-extension-react";
 
 function Toolbar({
@@ -125,14 +129,17 @@ function Toolbar({
 export function TextEditor({
 	value,
 	onValueChange,
+	onSourceRemoved,
 	tools,
 	nodes,
 }: {
 	value?: string;
 	onValueChange?: (value: string) => void;
+	onSourceRemoved?: (removedSources: SourceNode[]) => void;
 	tools?: (editor: Editor) => ReactNode;
 	nodes?: Node[];
 }) {
+	const previousContentRef = useRef<string | undefined>(value);
 	const extensions = useMemo(
 		() =>
 			nodes === undefined
@@ -145,9 +152,16 @@ export function TextEditor({
 					],
 		[nodes],
 	);
+
+	// Create a key to force re-mount when nodes change
+	const editorKey = useMemo(() => {
+		return nodes ? JSON.stringify(nodes.map((n) => n.id).sort()) : "no-nodes";
+	}, [nodes]);
+
 	return (
 		<div className="flex flex-col h-full w-full">
 			<EditorProvider
+				key={editorKey}
 				slotBefore={<Toolbar tools={tools} />}
 				extensions={extensions}
 				content={
@@ -161,7 +175,24 @@ export function TextEditor({
 					className: "flex-1 overflow-hidden",
 				}}
 				onUpdate={(p) => {
-					onValueChange?.(JSON.stringify(p.editor.getJSON()));
+					const newJson = p.editor.getJSON();
+					const newContent = JSON.stringify(newJson);
+
+					// Check for removed sources if callback is provided
+					if (onSourceRemoved && previousContentRef.current) {
+						try {
+							const oldJson = JSON.parse(previousContentRef.current);
+							const removedSources = findRemovedSources(oldJson, newJson);
+							if (removedSources.length > 0) {
+								onSourceRemoved(removedSources);
+							}
+						} catch (error) {
+							console.error("Error checking for removed sources:", error);
+						}
+					}
+
+					previousContentRef.current = newContent;
+					onValueChange?.(newContent);
 				}}
 				immediatelyRender={false}
 				editorProps={{
@@ -170,7 +201,24 @@ export function TextEditor({
 							"prompt-editor border-[0.5px] border-white-900 rounded-[8px] p-[16px] h-full overflow-y-auto",
 					},
 				}}
-			/>
+			>
+				<NodeUpdater nodes={nodes} />
+			</EditorProvider>
 		</div>
 	);
+}
+
+function NodeUpdater({ nodes }: { nodes?: Node[] }) {
+	const { editor } = useCurrentEditor();
+
+	useEffect(() => {
+		if (editor && nodes) {
+			// Update the Source extension storage when nodes change
+			if (editor.storage.Source) {
+				editor.storage.Source.nodes = nodes;
+			}
+		}
+	}, [editor, nodes]);
+
+	return null;
 }

--- a/packages/workflow-designer/src/react/workflow-designer-context.tsx
+++ b/packages/workflow-designer/src/react/workflow-designer-context.tsx
@@ -35,7 +35,7 @@ import {
 	isClonedFileDataPayload,
 } from "@giselle-sdk/node-utils";
 import {
-	type SourceNode,
+	type NodeOutputReference,
 	containsNodeReference,
 	containsSpecificNodeReference,
 	isJsonContent,
@@ -88,7 +88,7 @@ export interface WorkflowDesignerContextValue
 	) => Promise<Node | undefined>;
 	deleteNode: (nodeId: NodeId | string) => Promise<void>;
 	deleteConnectionWithCleanup: (connectionId: ConnectionId) => void;
-	handleSourceRemoved: (removedSources: SourceNode[]) => void;
+	handleSourceRemoved: (removedSources: NodeOutputReference[]) => void;
 	llmProviders: LanguageModelProvider[];
 	isLoading: boolean;
 }
@@ -442,7 +442,7 @@ export function WorkflowDesignerProvider({
 	);
 
 	const handleSourceRemoved = useCallback(
-		(removedSources: SourceNode[]) => {
+		(removedSources: NodeOutputReference[]) => {
 			const currentWorkspace = workflowDesignerRef.current.getData();
 
 			for (const removedSource of removedSources) {
@@ -501,8 +501,8 @@ export function WorkflowDesignerProvider({
 			);
 
 			if (connection) {
-				// Create a SourceNode object for the specific connection being removed
-				const removedSource: SourceNode = {
+				// Create a NodeOutputReference object for the specific connection being removed
+				const removedSource: NodeOutputReference = {
 					nodeId: connection.outputNode.id,
 					outputId: connection.outputId,
 				};


### PR DESCRIPTION
## Summary
Fixes #1099: UI deletion button for connections doesn't clean up `{{nodeId:outputId}}` references in text areas.

## Problem
When users delete connections via the trash button in Input panels, the `{{nodeId:outputId}}` references remain in text fields even though the connection is removed. This caused confusion as the references appear broken.

## Solution
### Connection deletion cleanup
- Added `deleteConnectionWithCleanup` function that:
  - Identifies the specific node output being disconnected
  - Scans all nodes for references to that specific connection
  - Cleans up only the targeted `{{nodeId:outputId}}` references
  - Updates affected nodes to remove orphaned references

### TipTap editor integration  
- Added `onSourceRemoved` callback to TextEditor component
- Added source change detection that triggers when Sources are deleted from the editor
- Added `NodeUpdater` component to sync editor storage when nodes change
- Enhanced text editors in prompt and query panels with cleanup capabilities

### Updated all input panels
- **Text Generation**: Updated to use `deleteConnectionWithCleanup`
- **Image Generation**: Updated to use `deleteConnectionWithCleanup`  
- **Query**: Updated to use `deleteConnectionWithCleanup`

## Dependencies
This PR depends on #1127 (node reference utilities) for the `containsSpecificNodeReference` and `NodeOutputReference` utilities.

## Testing
1. Create connections between nodes with references in text fields
2. Delete connections via UI trash buttons
3. Verify specific `{{nodeId:outputId}}` references are removed
4. Delete Sources directly from TipTap editor (using backspace/delete)
5. Verify cleanup is triggered automatically