### PR TITLE
Fix telemetry to skip query nodes

### DIFF
--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -6,6 +6,7 @@ import {
 	type ImageGenerationNode,
 	type TextGenerationNode,
 	isImageGenerationNode,
+	isQueryNode,
 	isTextGenerationNode,
 } from "@giselle-sdk/data-type";
 import {
@@ -389,6 +390,10 @@ export async function emitTelemetry(
 	try {
 		const operationNode = generation.context.operationNode;
 		const nodeType = operationNode.content.type;
+
+		if (isQueryNode(operationNode)) {
+			return;
+		}
 
 		if (
 			!isTextGenerationNode(operationNode) &&


### PR DESCRIPTION
### **User description**
## Summary
- ignore query nodes when emitting telemetry

## Testing
- `npx turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`
- `npx turbo check-types --filter '@giselle-sdk/telemetry' --cache=local:rw`
- `npx turbo format --filter '@giselle-sdk/telemetry' --cache=local:rw`
- `npx turbo test --cache=local:rw` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684bc68094048325adbfc60491dbab35


___

### **PR Type**
Bug fix


___

### **Description**
• Skip query nodes in telemetry emission to prevent errors
• Add early return for query node types before validation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add query node filtering in telemetry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/telemetry/src/index.ts

• Import <code>isQueryNode</code> function from data-type package<br> • Add early <br>return in <code>emitTelemetry</code> function for query nodes<br> • Skip telemetry <br>processing when operation node is a query type


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1135/files#diff-f0d19cc43c041918e9b49384b437d03ff35e1ee26a23267a55b5dcbbc3d9589d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Telemetry data is no longer emitted for query nodes, ensuring improved data accuracy and privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->