### PR TITLE
Proofreading: Manual Trigger Node

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
@@ -184,7 +184,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 								)}
 							>
 								<option value="text">Text</option>
-								<option value="multiline-text">Text(multi-line)</option>
+								<option value="multiline-text">Text (multi-line)</option>
 								<option value="number">Number</option>
 							</select>
 						</div>

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx
@@ -156,7 +156,7 @@ export function TriggerInputDialog({
 									</ul>
 									<p className="text-red-700 text-[12px] mt-[8px]">
 										Please connect all required inputs in the workflow designer
-										before running this flow.
+										before running.
 									</p>
 								</div>
 							</div>
@@ -240,8 +240,8 @@ export function TriggerInputDialog({
 							{isSubmitting
 								? "Running..."
 								: requiresActionNodes.length > 0
-									? "Fix connections to run"
-									: "Run with params"}
+									? "Fix Connections to Run"
+									: "Run"}
 						</Button>
 					</div>
 				</form>

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx
@@ -123,7 +123,7 @@ export function TriggerInputDialog({
 					onSubmit={handleSubmit}
 				>
 					<p className="text-[12px] mb-[8px] text-black-400 font-sans font-semibold">
-						Execute this workflow with custom input values
+						Execute this flow with custom input values
 					</p>
 
 					{requiresActionNodes.length > 0 && (

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx
@@ -123,7 +123,7 @@ export function TriggerInputDialog({
 					onSubmit={handleSubmit}
 				>
 					<p className="text-[12px] mb-[8px] text-black-400 font-sans font-semibold">
-						Execute this flow with custom input values
+						Execute this workflow with custom input values
 					</p>
 
 					{requiresActionNodes.length > 0 && (

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/helpers.ts
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/helpers.ts
@@ -15,7 +15,7 @@ import type { z } from "zod";
 export function buttonLabel(node: TriggerNode) {
 	switch (node.content.provider) {
 		case "manual":
-			return "Start Manual Flow";
+			return "Start Manual Workflow";
 		case "github":
 			return "Test with dummy data";
 		default: {

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/helpers.ts
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/helpers.ts
@@ -15,7 +15,7 @@ import type { z } from "zod";
 export function buttonLabel(node: TriggerNode) {
 	switch (node.content.provider) {
 		case "manual":
-			return "Start Manual Workflow";
+			return "Start Manual Flow";
 		case "github":
 			return "Test with dummy data";
 		default: {


### PR DESCRIPTION
### **User description**
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Some minor text changes to Manual Trigger Node windows.

## Related Issue
<!-- Mention the related issue number if applicable. -->
N/A

## Changes
<!-- List the main changes made in this PR. -->
- Add a missing space
- Trim some verbose sentences
- `flow` -> `workflow`

## Testing
<!-- Briefly describe the testing steps or results. -->
Open the preview and create a Manual Trigger Node from the workflow editor.

## Other Information
<!-- Add any other relevant information for the reviewer. -->
N/A


___

### **PR Type**
Documentation


___

### **Description**
• Fix spacing in "Text (multi-line)" option
• Change "flow" terminology to "workflow" throughout
• Simplify button text and error messages
• Improve readability of UI text elements


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.ts</strong><dd><code>Update button label terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/helpers.ts

• Change button label from "Start Manual Flow" to "Start Manual <br>Workflow"


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1139/files#diff-1911155895960954f40298121cb8ef03461fe85df22a452ae45fa9f065ab3467">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manual-trigger-properties-panel.tsx</strong><dd><code>Fix spacing in dropdown option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx

• Add missing space in "Text (multi-line)" option text


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1139/files#diff-5824573996ecd19b90f66f240449e13605ede1027aa3d8d09cb613b001055b14">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dialog.tsx</strong><dd><code>Update terminology and simplify UI text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/dialog.tsx

• Change "Execute this flow" to "Execute this workflow"<br> • Simplify <br>error message from "before running this flow" to "before running"<br> • <br>Update button text from "Run with params" to "Run"<br> • Capitalize "Fix <br>Connections to Run" button text


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1139/files#diff-1fa9aaf8a68bdcfbe603b445f1be3c437d49f2379102f1495ff3a5c2b6aea501">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated option label in the dropdown from "Text(multi-line)" to "Text (multi-line)" for improved readability.
  - Refined user-facing text in the trigger input dialog for clarity and consistency, including button label capitalization and simplified instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->