### PR TITLE
Refactor: E2E test for login session reuse

### DIFF
--- a/apps/studio.giselles.ai/.gitignore
+++ b/apps/studio.giselles.ai/.gitignore
@@ -53,3 +53,4 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.auth/

--- a/apps/studio.giselles.ai/.gitignore
+++ b/apps/studio.giselles.ai/.gitignore
@@ -54,3 +54,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 .auth/
+tests/e2e/.auth/

--- a/apps/studio.giselles.ai/playwright.config.ts
+++ b/apps/studio.giselles.ai/playwright.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: "on-first-retry",
+		// Use the saved storage state for all tests
+		storageState: "./tests/e2e/.auth/storageState.json",
 	},
 
 	/* Configure projects for major browsers */
@@ -76,4 +78,7 @@ export default defineConfig({
 	//   url: 'http://127.0.0.1:3000',
 	//   reuseExistingServer: !process.env.CI,
 	// },
+
+	// Add globalSetup to generate storageState.json before tests
+	globalSetup: "./tests/e2e/global-setup.ts",
 });

--- a/apps/studio.giselles.ai/tests/e2e/global-setup.ts
+++ b/apps/studio.giselles.ai/tests/e2e/global-setup.ts
@@ -1,0 +1,32 @@
+import { chromium } from "@playwright/test";
+
+async function globalSetup() {
+	const baseUrl = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+	const loginEmail = process.env.PLAYWRIGHT_LOGIN_EMAIL;
+	const loginPassword = process.env.PLAYWRIGHT_LOGIN_PASSWORD;
+
+	if (!loginEmail || !loginPassword) {
+		throw new Error(
+			"PLAYWRIGHT_LOGIN_EMAIL and PLAYWRIGHT_LOGIN_PASSWORD must be set in environment variables.",
+		);
+	}
+
+	const browser = await chromium.launch();
+	const page = await browser.newPage();
+
+	await page.goto(`${baseUrl}/login`);
+	await page.getByRole("textbox", { name: "Email" }).fill(loginEmail);
+	await page.getByRole("textbox", { name: "Password" }).fill(loginPassword);
+	await Promise.all([
+		page.waitForURL(`${baseUrl}/apps`, { timeout: 15000 }),
+		page.getByRole("button", { name: "Log in" }).click(),
+	]);
+
+	// Save storage state
+	const storagePath = "./tests/e2e/.auth/storageState.json";
+	await page.context().storageState({ path: storagePath });
+
+	await browser.close();
+}
+
+export default globalSetup;

--- a/apps/studio.giselles.ai/tests/e2e/global-setup.ts
+++ b/apps/studio.giselles.ai/tests/e2e/global-setup.ts
@@ -12,21 +12,23 @@ async function globalSetup() {
 	}
 
 	const browser = await chromium.launch();
-	const page = await browser.newPage();
+	try {
+		const page = await browser.newPage();
 
-	await page.goto(`${baseUrl}/login`);
-	await page.getByRole("textbox", { name: "Email" }).fill(loginEmail);
-	await page.getByRole("textbox", { name: "Password" }).fill(loginPassword);
-	await Promise.all([
-		page.waitForURL(`${baseUrl}/apps`, { timeout: 15000 }),
-		page.getByRole("button", { name: "Log in" }).click(),
-	]);
+		await page.goto(`${baseUrl}/login`);
+		await page.getByRole("textbox", { name: "Email" }).fill(loginEmail);
+		await page.getByRole("textbox", { name: "Password" }).fill(loginPassword);
+		await Promise.all([
+			page.waitForURL(`${baseUrl}/apps`, { timeout: 15000 }),
+			page.getByRole("button", { name: "Log in" }).click(),
+		]);
 
-	// Save storage state
-	const storagePath = "./tests/e2e/.auth/storageState.json";
-	await page.context().storageState({ path: storagePath });
-
-	await browser.close();
+		// Save storage state
+		const storagePath = "./tests/e2e/.auth/storageState.json";
+		await page.context().storageState({ path: storagePath });
+	} finally {
+		await browser.close();
+	}
 }
 
 export default globalSetup;

--- a/apps/studio.giselles.ai/tests/e2e/login.spec.ts
+++ b/apps/studio.giselles.ai/tests/e2e/login.spec.ts
@@ -1,27 +1,13 @@
 import { expect, test } from "@playwright/test";
 
-// E2E test for login
-test("Login", async ({ page }) => {
-	// Use environment variables for configuration
+// E2E test for login session reuse
+// Assumes storageState.json is used, so user is already logged in
+
+test("Should be logged in and access Apps page", async ({ page }) => {
 	const baseUrl = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
-	const loginEmail = process.env.PLAYWRIGHT_LOGIN_EMAIL;
-	const loginPassword = process.env.PLAYWRIGHT_LOGIN_PASSWORD;
-
-	// Navigate to login page
-	await page.goto(`${baseUrl}/login`);
-
-	// Fill in email
-	await page.getByRole("textbox", { name: "Email" }).fill(loginEmail);
-
-	// Fill in password
-	await page.getByRole("textbox", { name: "Password" }).fill(loginPassword);
-
-	// Click login button and wait for navigation
-	await Promise.all([
-		page.waitForURL(`${baseUrl}/apps`, { timeout: 15000 }),
-		page.getByRole("button", { name: "Log in" }).click(),
-	]);
-
-	// Assert navigation to the Apps page
+	// Go directly to the Apps page
+	await page.goto(`${baseUrl}/apps`);
+	// Assert navigation to the Apps page (user should be logged in)
 	await expect(page).toHaveURL(`${baseUrl}/apps`, { timeout: 15000 });
+	// Optionally, check for a UI element that only appears when logged in
 });


### PR DESCRIPTION
### **User description**
## Summary
Refactor: E2E test for login session reuse

## Testing
Run e2e test from [GitHub Actions](https://github.com/giselles-ai/giselle/actions/workflows/e2e.yml).

## Other Information
As a preliminary step in increasing the number of E2E test cases, we decided to reuse the login session.


___

### **PR Type**
Tests


___

### **Description**
• Implement global setup for login session reuse in E2E tests
• Configure Playwright to use saved authentication state
• Refactor login test to verify session persistence
• Add authentication storage directory structure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.config.ts</strong><dd><code>Configure Playwright for session reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/playwright.config.ts

• Add <code>storageState</code> configuration to reuse saved authentication<br> • <br>Configure <code>globalSetup</code> to run authentication setup before tests


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1140/files#diff-204f983003086b0a76d4f0e189aa26bc5ecfb21636b52c83b38c7bd85fe9d525">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>global-setup.ts</strong><dd><code>Add global authentication setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/tests/e2e/global-setup.ts

• Create global setup function for automated login<br> • Save <br>authentication state to <code>storageState.json</code><br> • Handle environment <br>variables for login credentials<br> • Navigate to login page and perform <br>authentication


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1140/files#diff-ac49e863cb825f82faf78ca082655cbbbec3882d1db5eafd8a12b88dea2241fb">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>login.spec.ts</strong><dd><code>Refactor login test for session reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/tests/e2e/login.spec.ts

• Remove manual login steps from test<br> • Simplify test to verify <br>session persistence<br> • Update test to assume user is already <br>authenticated


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1140/files#diff-7c438058673458262c1006237c5f2416bac04d5b8655592e9cbc85c8d666b1ec">+8/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>.gitkeep</strong></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1140/files#diff-4f62618fe54750ddb4d9608796aacb4aa723f73220233bb8d9a4b490b3733ff5">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test configuration to reuse authenticated sessions, improving consistency and speed of end-to-end tests.
  - Added a global setup script to automate login and save authentication state for testing.
  - Updated .gitignore to exclude authentication state files from version control.

- **Tests**
  - Simplified login test to assume an authenticated session, streamlining test flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->