### PR TITLE
Abstract workspace index operations

### DIFF
--- a/packages/giselle-engine/src/core/data-source/get-workspace-data-sources.ts
+++ b/packages/giselle-engine/src/core/data-source/get-workspace-data-sources.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceId } from "@giselle-sdk/data-type";
-import { z } from "zod/v4";
 import type { GiselleEngineContext } from "../types";
+import { getWorkspaceIndex } from "../utils/workspace-index";
 import { workspaceDataSourceIndexPath } from "./paths";
 import { DataSourceIndexObject } from "./types/object";
 
@@ -8,12 +8,9 @@ export async function getWorkspaceDataSources(args: {
 	context: GiselleEngineContext;
 	workspaceId: WorkspaceId;
 }) {
-	const workspaceDataSourceIndexLike = await args.context.storage.getItem(
-		workspaceDataSourceIndexPath(args.workspaceId),
-	);
-
-	const parse = z
-		.array(DataSourceIndexObject)
-		.safeParse(workspaceDataSourceIndexLike);
-	return parse.success ? parse.data : [];
+	return await getWorkspaceIndex({
+		storage: args.context.storage,
+		indexPath: workspaceDataSourceIndexPath(args.workspaceId),
+		itemSchema: DataSourceIndexObject,
+	});
 }

--- a/packages/giselle-engine/src/core/secrets/get-workspace-secrets.ts
+++ b/packages/giselle-engine/src/core/secrets/get-workspace-secrets.ts
@@ -1,16 +1,15 @@
 import { SecretIndex, type WorkspaceId } from "@giselle-sdk/data-type";
-import { z } from "zod/v4";
 import type { GiselleEngineContext } from "../types";
+import { getWorkspaceIndex } from "../utils/workspace-index";
 import { workspaceSecretIndexPath } from "./paths";
 
 export async function getWorkspaceSecrets(args: {
 	context: GiselleEngineContext;
 	workspaceId: WorkspaceId;
 }) {
-	const workspaceSecretIndexLike = await args.context.storage.getItem(
-		workspaceSecretIndexPath(args.workspaceId),
-	);
-
-	const parse = z.array(SecretIndex).safeParse(workspaceSecretIndexLike);
-	return parse.success ? parse.data : [];
+	return await getWorkspaceIndex({
+		storage: args.context.storage,
+		indexPath: workspaceSecretIndexPath(args.workspaceId),
+		itemSchema: SecretIndex,
+	});
 }

--- a/packages/giselle-engine/src/core/utils/workspace-index.ts
+++ b/packages/giselle-engine/src/core/utils/workspace-index.ts
@@ -1,0 +1,25 @@
+import type { Storage } from "unstorage";
+import { z } from "zod/v4";
+
+export async function addWorkspaceIndexItem<I>(args: {
+	storage: Storage;
+	indexPath: string;
+	item: I;
+	itemSchema: z.ZodType<I>;
+}) {
+	const indexLike = await args.storage.getItem(args.indexPath);
+	const parse = z.array(args.itemSchema).safeParse(indexLike);
+	const current = parse.success ? parse.data : [];
+	const item = args.itemSchema.parse(args.item);
+	await args.storage.setItem(args.indexPath, [...current, item]);
+}
+
+export async function getWorkspaceIndex<I>(args: {
+	storage: Storage;
+	indexPath: string;
+	itemSchema: z.ZodType<I>;
+}): Promise<I[]> {
+	const indexLike = await args.storage.getItem(args.indexPath);
+	const parse = z.array(args.itemSchema).safeParse(indexLike);
+	return parse.success ? parse.data : [];
+}


### PR DESCRIPTION
## Summary
- add `workspace-index` utility for reading/writing workspace indexes
- refactor secret and data source logic to use the new util

## Testing
- `turbo format --cache=local:rw`
- `turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`
- `turbo check-types --cache=local:rw`
- `turbo test --cache=local:rw`


------
https://chatgpt.com/codex/tasks/task_e_684fcd0ae3c0832f9e67af1b63059c96