### PR TITLE
refactor(engine): create reusable workspace index utility functions

### DIFF
--- a/packages/giselle-engine/src/core/data-source/get-workspace-data-sources.ts
+++ b/packages/giselle-engine/src/core/data-source/get-workspace-data-sources.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceId } from "@giselle-sdk/data-type";
-import { z } from "zod/v4";
 import type { GiselleEngineContext } from "../types";
+import { getWorkspaceIndex } from "../utils/workspace-index";
 import { workspaceDataSourceIndexPath } from "./paths";
 import { DataSourceIndexObject } from "./types/object";
 
@@ -8,12 +8,9 @@ export async function getWorkspaceDataSources(args: {
 	context: GiselleEngineContext;
 	workspaceId: WorkspaceId;
 }) {
-	const workspaceDataSourceIndexLike = await args.context.storage.getItem(
-		workspaceDataSourceIndexPath(args.workspaceId),
-	);
-
-	const parse = z
-		.array(DataSourceIndexObject)
-		.safeParse(workspaceDataSourceIndexLike);
-	return parse.success ? parse.data : [];
+	return await getWorkspaceIndex({
+		storage: args.context.storage,
+		indexPath: workspaceDataSourceIndexPath(args.workspaceId),
+		itemSchema: DataSourceIndexObject,
+	});
 }

--- a/packages/giselle-engine/src/core/secrets/get-workspace-secrets.ts
+++ b/packages/giselle-engine/src/core/secrets/get-workspace-secrets.ts
@@ -1,16 +1,15 @@
 import { SecretIndex, type WorkspaceId } from "@giselle-sdk/data-type";
-import { z } from "zod/v4";
 import type { GiselleEngineContext } from "../types";
+import { getWorkspaceIndex } from "../utils/workspace-index";
 import { workspaceSecretIndexPath } from "./paths";
 
 export async function getWorkspaceSecrets(args: {
 	context: GiselleEngineContext;
 	workspaceId: WorkspaceId;
 }) {
-	const workspaceSecretIndexLike = await args.context.storage.getItem(
-		workspaceSecretIndexPath(args.workspaceId),
-	);
-
-	const parse = z.array(SecretIndex).safeParse(workspaceSecretIndexLike);
-	return parse.success ? parse.data : [];
+	return await getWorkspaceIndex({
+		storage: args.context.storage,
+		indexPath: workspaceSecretIndexPath(args.workspaceId),
+		itemSchema: SecretIndex,
+	});
 }

--- a/packages/giselle-engine/src/core/utils/workspace-index.ts
+++ b/packages/giselle-engine/src/core/utils/workspace-index.ts
@@ -1,0 +1,25 @@
+import type { Storage } from "unstorage";
+import { z } from "zod/v4";
+
+export async function addWorkspaceIndexItem<I>(args: {
+	storage: Storage;
+	indexPath: string;
+	item: I;
+	itemSchema: z.ZodType<I>;
+}) {
+	const indexLike = await args.storage.getItem(args.indexPath);
+	const parse = z.array(args.itemSchema).safeParse(indexLike);
+	const current = parse.success ? parse.data : [];
+	const item = args.itemSchema.parse(args.item);
+	await args.storage.setItem(args.indexPath, [...current, item]);
+}
+
+export async function getWorkspaceIndex<I>(args: {
+	storage: Storage;
+	indexPath: string;
+	itemSchema: z.ZodType<I>;
+}): Promise<I[]> {
+	const indexLike = await args.storage.getItem(args.indexPath);
+	const parse = z.array(args.itemSchema).safeParse(indexLike);
+	return parse.success ? parse.data : [];
+}


### PR DESCRIPTION
## Summary

This PR introduces a new utility module for managing workspace indices, eliminating code duplication between data sources and secrets management.

## Changes

### 🆕 New Features
- **workspace-index.ts**: Added generic workspace index management utilities
  - `addWorkspaceIndexItem()`: Generic function for adding items to workspace indices
  - `getWorkspaceIndex()`: Generic function for retrieving workspace indices with validation
  - Type-safe implementation using Zod schemas

### 🔄 Refactoring
- **Data Sources**: Updated `createDataSource()` and `getWorkspaceDataSources()` to use new utilities
- **Secrets**: Updated `addSecret()` and `getWorkspaceSecrets()` to use new utilities
- **Code Cleanup**: Removed duplicate `addWorkspaceSecretIndex()` function

## Benefits

- **DRY Principle**: Eliminates ~30 lines of duplicate code
- **Type Safety**: Consistent Zod validation across all workspace indices
- **Maintainability**: Single source of truth for workspace index operations
- **Extensibility**: Easy to extend for future workspace index types

## Test Plan

- [x] Code formatted with Biome
- [x] Changes split into logical commits:
  1. Add new utility functions
  2. Refactor existing code to use utilities
- [x] All existing functionality preserved
- [ ] Type checking passes (blocked by pre-existing dependency issues)

## Migration

This is a pure refactoring with no breaking changes. All existing APIs remain unchanged and functionality is preserved.