### PR TITLE
(test) Add E2E test: "Should create a new app and navigate to workspace page"

### DIFF
--- a/apps/studio.giselles.ai/tests/e2e/new-app.spec.ts
+++ b/apps/studio.giselles.ai/tests/e2e/new-app.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { escapeRegExp } from "./utils";
 
 // E2E test for New App creation
 // Assumes storageState.json is used, so user is already logged in
@@ -7,20 +8,24 @@ test("Should create a new app and navigate to workspace page", async ({
 	page,
 }) => {
 	const baseUrl = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
+	const baseUrlPattern = escapeRegExp(baseUrl);
 	// Go directly to the Apps page
 	await page.goto(`${baseUrl}/apps`);
 	await expect(page).toHaveURL(`${baseUrl}/apps`, { timeout: 15000 });
 
 	// Click the 'New App +' button and wait for navigation
 	await Promise.all([
-		page.waitForURL(new RegExp(`${baseUrl}/workspaces/[^/]+`), {
+		page.waitForURL(new RegExp(`${baseUrlPattern}/workspaces/[^/]+`), {
 			timeout: 15000,
 		}),
 		page.getByRole("button", { name: /new app \+/i }).click(),
 	]);
 
 	// Assert navigation to workspace page by checking URL and a unique element
-	await expect(page).toHaveURL(new RegExp(`${baseUrl}/workspaces/[^/]+`), {
-		timeout: 15000,
-	});
+	await expect(page).toHaveURL(
+		new RegExp(`${baseUrlPattern}/workspaces/[^/]+`),
+		{
+			timeout: 15000,
+		},
+	);
 });

--- a/apps/studio.giselles.ai/tests/e2e/utils.ts
+++ b/apps/studio.giselles.ai/tests/e2e/utils.ts
@@ -1,0 +1,4 @@
+// Utility to escape regex meta-characters in a string
+export function escapeRegExp(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
### **User description**
## Summary
 Add E2E test: "Should create a new app and navigate to workspace page"

## Testing
Run on GitHub Actions


___

### **PR Type**
Tests


___

### **Description**
• Add E2E test for new app creation workflow
• Test navigation from apps page to workspace page
• Verify URL patterns and button interactions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-app.spec.ts</strong><dd><code>Add new app creation E2E test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/tests/e2e/new-app.spec.ts

• Create new Playwright E2E test file<br> • Test "New App +" button click <br>functionality<br> • Verify navigation to workspace page with URL pattern <br>matching<br> • Include proper timeouts and error handling


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1148/files#diff-e7f062cec12a88f833636d6eef95b53ecddc47977f753238ffa7a4812949ab47">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new end-to-end test to verify that creating a new app successfully redirects users to the appropriate workspace page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->