### PR TITLE
Fix copyAgent to duplicate agent names

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/apps/actions.ts
@@ -67,7 +67,8 @@ export async function copyAgent(
 		}
 
 		const newAgentId = `agnt_${createId()}` as AgentId;
-		const newName = `Copy of ${agent.name ?? agentId}`;
+		const baseName = agent.name?.trim() || agentId;
+		const newName = `Copy of ${baseName}`;
 		const workspace = await giselleEngine.copyWorkspace(
 			agent.workspaceId,
 			newName,

--- a/apps/studio.giselles.ai/app/(main)/apps/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/apps/actions.ts
@@ -67,10 +67,14 @@ export async function copyAgent(
 		}
 
 		const newAgentId = `agnt_${createId()}` as AgentId;
-		const workspace = await giselleEngine.copyWorkspace(agent.workspaceId);
+		const newName = `Copy of ${agent.name ?? agentId}`;
+		const workspace = await giselleEngine.copyWorkspace(
+			agent.workspaceId,
+			newName,
+		);
 		await db.insert(agents).values({
 			id: newAgentId,
-			name: `Copy of ${agent.name ?? agentId}`,
+			name: newName,
 			teamDbId: team.dbId,
 			creatorDbId: user.dbId,
 			graphUrl: agent.graphUrl, // TODO: This field is not used in the new playground and will be removed in the future

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -65,8 +65,8 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		callbacks: config.callbacks,
 	};
 	return {
-		copyWorkspace: async (workspaceId: WorkspaceId) => {
-			return await copyWorkspace({ context, workspaceId });
+		copyWorkspace: async (workspaceId: WorkspaceId, name?: string) => {
+			return await copyWorkspace({ context, workspaceId, name });
 		},
 		createWorkspace: async () => {
 			return await createWorkspace({ context });

--- a/packages/giselle-engine/src/core/workspaces/copy-workspace.ts
+++ b/packages/giselle-engine/src/core/workspaces/copy-workspace.ts
@@ -9,6 +9,7 @@ import { copyFiles, getWorkspace, setWorkspace } from "./utils";
 export async function copyWorkspace(args: {
 	context: GiselleEngineContext;
 	workspaceId: WorkspaceId;
+	name?: string;
 }) {
 	const sourceWorkspace = await getWorkspace({
 		storage: args.context.storage,
@@ -19,7 +20,7 @@ export async function copyWorkspace(args: {
 
 	const workspaceCopy: Workspace = {
 		...newWorkspace,
-		name: `Copy of ${sourceWorkspace.name ?? ""}`,
+		name: args.name ?? `Copy of ${sourceWorkspace.name ?? ""}`,
 		nodes: sourceWorkspace.nodes,
 		connections: sourceWorkspace.connections,
 		ui: sourceWorkspace.ui,


### PR DESCRIPTION
### **User description**
## Summary
- preserve the workspace name when copying an agent
- expose name parameter on `copyWorkspace`
- pass the name through copyAgent when duplicating

https://github.com/user-attachments/assets/d6332002-03c4-4c9a-817f-80fe2b12e722

------
https://chatgpt.com/codex/tasks/task_e_6850f19a8cf48325b10ce94d799c7529


___

### **PR Type**
Bug fix


___

### **Description**
• Fix agent name duplication in copyAgent function
• Expose name parameter in copyWorkspace method
• Ensure consistent naming when copying agents


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Pass agent name to workspace copy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/apps/actions.ts

• Generate new agent name before calling copyWorkspace<br> • Pass the <br>generated name to copyWorkspace method<br> • Use consistent naming <br>variable for both workspace and agent


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1156/files#diff-91bf7f43202611af84b83a2ab7060e56adf19e9030ac1d45b60f853ebd4f1450">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add name parameter to copyWorkspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle-engine/src/core/index.ts

• Add optional name parameter to copyWorkspace method signature<br> • <br>Forward name parameter to copyWorkspace implementation


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1156/files#diff-cd6492ace9f2db673fa5bf30e3015df7ad7d302c8d7927cee1145bc95f9aaf0d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>copy-workspace.ts</strong><dd><code>Support custom naming in workspace copy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle-engine/src/core/workspaces/copy-workspace.ts

• Add optional name parameter to function arguments<br> • Use provided <br>name or fallback to default naming pattern<br> • Preserve workspace name <br>when specified


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1156/files#diff-47ec6c7056a83c08bd1b5f6645b30577a79b51af44212b2c33f029266be513dc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - When duplicating an agent or workspace, copies are now automatically named using the original name or ID with a "Copy of " prefix, improving clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->