### PR TITLE
Update Gemini models

### DIFF
--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -221,7 +221,7 @@ export const anthropicTokenPricing: ModelPriceTable = {
 
 export const googleTokenPricing: ModelPriceTable = {
 	// https://ai.google.dev/gemini-api/docs/pricing
-	"gemini-2.5-flash-preview-05-20": {
+	"gemini-2.5-flash": {
 		prices: [
 			{
 				validFrom: "2025-06-01T00:00:00Z",
@@ -252,7 +252,7 @@ export const googleTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"gemini-2.5-pro-preview-06-05": {
+	"gemini-2.5-pro": {
 		prices: [
 			{
 				validFrom: "2025-06-12T02:00:00Z",
@@ -262,36 +262,6 @@ export const googleTokenPricing: ModelPriceTable = {
 					},
 					output: {
 						costPerMegaToken: 10.0,
-					},
-				},
-			},
-		],
-	},
-	"gemini-2.0-flash": {
-		prices: [
-			{
-				validFrom: "2025-05-20T00:00:00Z",
-				price: {
-					input: {
-						costPerMegaToken: 0.1,
-					},
-					output: {
-						costPerMegaToken: 0.4,
-					},
-				},
-			},
-		],
-	},
-	"gemini-2.0-flash-lite": {
-		prices: [
-			{
-				validFrom: "2025-06-01T00:00:00Z",
-				price: {
-					input: {
-						costPerMegaToken: 0.075,
-					},
-					output: {
-						costPerMegaToken: 0.3,
 					},
 				},
 			},

--- a/packages/language-model/src/google.test.ts
+++ b/packages/language-model/src/google.test.ts
@@ -4,38 +4,35 @@ import { GoogleLanguageModelId } from "./google";
 describe("google llm", () => {
 	describe("GoogleLanguageModelId", () => {
 		it("should parse valid enum values successfully", () => {
-			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-06-05")).toBe(
-				"gemini-2.5-pro-preview-06-05",
+			expect(GoogleLanguageModelId.parse("gemini-2.5-pro")).toBe(
+				"gemini-2.5-pro",
 			);
-			expect(
-				GoogleLanguageModelId.parse("gemini-2.5-flash-preview-05-20"),
-			).toBe("gemini-2.5-flash-preview-05-20");
+			expect(GoogleLanguageModelId.parse("gemini-2.5-flash")).toBe(
+				"gemini-2.5-flash",
+			);
 			expect(
 				GoogleLanguageModelId.parse("gemini-2.5-flash-lite-preview-06-17"),
 			).toBe("gemini-2.5-flash-lite-preview-06-17");
-			expect(GoogleLanguageModelId.parse("gemini-2.0-flash")).toBe(
-				"gemini-2.0-flash",
-			);
-			expect(GoogleLanguageModelId.parse("gemini-2.0-flash-lite")).toBe(
-				"gemini-2.0-flash-lite",
+			expect(GoogleLanguageModelId.parse("gemini-2.5-flash")).toBe(
+				"gemini-2.5-flash",
 			);
 		});
 
-		it("should fallback gemini-2.5-pro-preview variants to gemini-2.5-pro-preview-06-05", () => {
+		it("should fallback gemini-2.5-pro-preview variants to gemini-2.5-pro", () => {
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-03-25")).toBe(
-				"gemini-2.5-pro-preview-06-05",
+				"gemini-2.5-pro",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-01-01")).toBe(
-				"gemini-2.5-pro-preview-06-05",
+				"gemini-2.5-pro",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-12-31")).toBe(
-				"gemini-2.5-pro-preview-06-05",
+				"gemini-2.5-pro",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-2.5-pro-preview-")).toBe(
-				"gemini-2.5-pro-preview-06-05",
+				"gemini-2.5-pro",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-1.5-flash")).toBe(
-				"gemini-2.0-flash",
+				"gemini-2.5-flash",
 			);
 		});
 	});

--- a/packages/language-model/src/google.ts
+++ b/packages/language-model/src/google.ts
@@ -20,26 +20,24 @@ const defaultConfigurations: GoogleLanguageModelConfigurations = {
 
 export const GoogleLanguageModelId = z
 	.enum([
-		"gemini-2.5-pro-preview-06-05",
-		"gemini-2.5-flash-preview-05-20",
+		"gemini-2.5-pro",
+		"gemini-2.5-flash",
 		"gemini-2.5-flash-lite-preview-06-17",
-		"gemini-2.0-flash",
-		"gemini-2.0-flash-lite",
 	])
 	.catch((ctx) => {
 		if (typeof ctx.value !== "string") {
-			return "gemini-2.0-flash";
+			return "gemini-2.5-flash";
 		}
 		if (ctx.value.startsWith("gemini-2.5-pro-preview-")) {
-			return "gemini-2.5-pro-preview-06-05";
+			return "gemini-2.5-pro";
 		}
 		if (ctx.value.startsWith("gemini-2.5-flash-preview-")) {
-			return "gemini-2.5-flash-preview-05-20";
+			return "gemini-2.5-flash";
 		}
 		if (ctx.value.startsWith("gemini-2.5-flash-lite-preview-")) {
 			return "gemini-2.5-flash-lite-preview-06-17";
 		}
-		return "gemini-2.0-flash";
+		return "gemini-2.5-flash";
 	});
 
 const GoogleLanguageModel = LanguageModelBase.extend({
@@ -49,9 +47,9 @@ const GoogleLanguageModel = LanguageModelBase.extend({
 });
 type GoogleLanguageModel = z.infer<typeof GoogleLanguageModel>;
 
-const gemini25ProPreview: GoogleLanguageModel = {
+const gemini25Pro: GoogleLanguageModel = {
 	provider: "google",
-	id: "gemini-2.5-pro-preview-06-05",
+	id: "gemini-2.5-pro",
 	capabilities:
 		Capability.TextGeneration |
 		Capability.GenericFileInput |
@@ -61,9 +59,9 @@ const gemini25ProPreview: GoogleLanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-const gemini25FlashPreview: GoogleLanguageModel = {
+const gemini25Flash: GoogleLanguageModel = {
 	provider: "google",
-	id: "gemini-2.5-flash-preview-05-20",
+	id: "gemini-2.5-flash",
 	capabilities:
 		Capability.TextGeneration |
 		Capability.GenericFileInput |
@@ -84,35 +82,7 @@ const gemini25FlashLitePreview: GoogleLanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-const gemini20Flash: GoogleLanguageModel = {
-	provider: "google",
-	id: "gemini-2.0-flash",
-	capabilities:
-		Capability.TextGeneration |
-		Capability.OptionalSearchGrounding |
-		Capability.GenericFileInput,
-	tier: Tier.enum.free,
-	configurations: defaultConfigurations,
-};
-
-const gemini20FlashLite: GoogleLanguageModel = {
-	provider: "google",
-	id: "gemini-2.0-flash-lite",
-	capabilities:
-		Capability.TextGeneration |
-		Capability.OptionalSearchGrounding |
-		Capability.GenericFileInput,
-	tier: Tier.enum.free,
-	configurations: defaultConfigurations,
-};
-
-export const models = [
-	gemini25ProPreview,
-	gemini25FlashPreview,
-	gemini25FlashLitePreview,
-	gemini20Flash,
-	gemini20FlashLite,
-];
+export const models = [gemini25Pro, gemini25Flash, gemini25FlashLitePreview];
 
 export const LanguageModel = GoogleLanguageModel;
 export type LanguageModel = GoogleLanguageModel;


### PR DESCRIPTION
### **User description**
## Summary
- update Gemini Flash and Pro models to GA names
- remove older Gemini 2.0 models
- keep fallback logic for preview names
- update pricing table and tests

## Testing
- `npx turbo format --filter @giselle-sdk/language-model --filter @giselle-sdk/data-mod --filter @giselle-sdk/data-type --cache=local:rw`
- `npx turbo check-types --filter @giselle-sdk/language-model --cache=local:rw`
- `npx turbo test --filter @giselle-sdk/language-model --cache=local:rw`

------
https://chatgpt.com/codex/tasks/task_e_685230f5a2508325a904e1b080d510ec


___

### **PR Type**
Enhancement


___

### **Description**
• Update Gemini models to GA names (2.5-pro, 2.5-flash)
• Remove deprecated Gemini 2.0 models
• Maintain fallback logic for preview model names
• Update pricing table and test cases


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Update model pricing for GA Gemini versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

• Rename <code>gemini-2.5-flash-preview-05-20</code> to <code>gemini-2.5-flash</code><br> • Rename <br><code>gemini-2.5-pro-preview-06-05</code> to <code>gemini-2.5-pro</code><br> • Remove pricing <br>entries for <code>gemini-2.0-flash</code> and <code>gemini-2.0-flash-lite</code>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1164/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+2/-32</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google.test.ts</strong><dd><code>Update tests for GA Gemini model names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/google.test.ts

• Update test cases to use GA model names instead of preview names<br> • <br>Change fallback expectations from preview to GA model names<br> • Update <br>default fallback from <code>gemini-2.0-flash</code> to <code>gemini-2.5-flash</code>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1164/files#diff-ae9898676b66011e8ce8b6144a551ab4eea474608a5d9473a76f7d136a813e91">+13/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google.ts</strong><dd><code>Migrate to GA Gemini model definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/google.ts

• Replace preview model IDs with GA versions in enum<br> • Update fallback <br>logic to return GA model names<br> • Remove deprecated Gemini 2.0 model <br>definitions<br> • Rename model constants to match GA naming


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1164/files#diff-0bce79e94f5fbf67fc0fbd3c072e51e6e96635e0e59ff755774a03d551528811">+11/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated available Google Gemini models to include only the latest stable versions: "gemini-2.5-pro", "gemini-2.5-flash", and "gemini-2.5-flash-lite-preview".

- **Bug Fixes**
	- Improved model selection and fallback behavior to use the latest stable model identifiers.

- **Chores**
	- Removed outdated Gemini model options and preview variants from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->