### PR TITLE
Add mapping for legacy OpenAI model names to current model IDs

### DIFF
--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -67,21 +67,6 @@ export const openAiTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"gpt-4o-mini": {
-		prices: [
-			{
-				validFrom: "2025-05-12T00:00:00Z",
-				price: {
-					input: {
-						costPerMegaToken: 0.15,
-					},
-					output: {
-						costPerMegaToken: 0.6,
-					},
-				},
-			},
-		],
-	},
 	o3: {
 		prices: [
 			{
@@ -103,21 +88,6 @@ export const openAiTokenPricing: ModelPriceTable = {
 					},
 					output: {
 						costPerMegaToken: 8.0,
-					},
-				},
-			},
-		],
-	},
-	"o3-mini": {
-		prices: [
-			{
-				validFrom: "2025-05-12T00:00:00Z",
-				price: {
-					input: {
-						costPerMegaToken: 1.1,
-					},
-					output: {
-						costPerMegaToken: 4.4,
 					},
 				},
 			},

--- a/packages/language-model/src/openai.test.ts
+++ b/packages/language-model/src/openai.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { OpenAILanguageModelId } from "./openai";
+
+describe("openai llm", () => {
+	describe("OpenAILanguageModelId", () => {
+		it("should map o-series models correctly", () => {
+			expect(OpenAILanguageModelId.parse("o3")).toBe("o3");
+			expect(OpenAILanguageModelId.parse("o1")).toBe("o3");
+			expect(OpenAILanguageModelId.parse("o4-mini")).toBe("o4-mini");
+			expect(OpenAILanguageModelId.parse("o3-mini")).toBe("o4-mini");
+			expect(OpenAILanguageModelId.parse("o1-mini")).toBe("o4-mini");
+		});
+
+		it("should map flagship chat models correctly", () => {
+			expect(OpenAILanguageModelId.parse("gpt-4.1")).toBe("gpt-4.1");
+			expect(OpenAILanguageModelId.parse("gpt-4o")).toBe("gpt-4o");
+		});
+
+		it("should map cost-optimized models correctly", () => {
+			expect(OpenAILanguageModelId.parse("gpt-4.1-mini")).toBe("gpt-4.1-mini");
+			expect(OpenAILanguageModelId.parse("gpt-4.1-nano")).toBe("gpt-4.1-nano");
+		});
+
+		it("should map gpt-4o-mini to gpt-4.1-mini", () => {
+			expect(OpenAILanguageModelId.parse("gpt-4o-mini")).toBe("gpt-4.1-mini");
+		});
+
+		it("should map older GPT models to gpt-4o", () => {
+			expect(OpenAILanguageModelId.parse("gpt-4-turbo")).toBe("gpt-4o");
+			expect(OpenAILanguageModelId.parse("gpt-4")).toBe("gpt-4o");
+			expect(OpenAILanguageModelId.parse("gpt-3.5-turbo")).toBe("gpt-4o");
+		});
+
+		it("should fallback unknown or non-matching variants to gpt-4.1-nano", () => {
+			expect(OpenAILanguageModelId.parse("openai-unknown-model")).toBe(
+				"gpt-4.1-nano",
+			);
+			expect(OpenAILanguageModelId.parse("openai-foo-bar")).toBe(
+				"gpt-4.1-nano",
+			);
+			expect(OpenAILanguageModelId.parse("random-model")).toBe("gpt-4.1-nano");
+			expect(OpenAILanguageModelId.parse("not-a-model-id")).toBe(
+				"gpt-4.1-nano",
+			);
+		});
+	});
+});

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -20,9 +20,27 @@ const defaultConfigurations: OpenAILanguageModelConfigurations = {
 	frequencyPenalty: 0.0,
 };
 
-const OpenAILanguageModelId = z
+export const OpenAILanguageModelId = z
 	.enum(["gpt-4o", "o3", "o4-mini", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"])
-	.catch("gpt-4.1-mini");
+	.catch((ctx) => {
+		if (typeof ctx.value !== "string") {
+			return "gpt-4.1-nano";
+		}
+		const v = ctx.value;
+		if (v === "o1") {
+			return "o3";
+		}
+		if (v === "o3-mini" || v === "o1-mini") {
+			return "o4-mini";
+		}
+		if (v === "gpt-4o-mini") {
+			return "gpt-4.1-mini";
+		}
+		if (v === "gpt-4-turbo" || v === "gpt-4" || v === "gpt-3.5-turbo") {
+			return "gpt-4o";
+		}
+		return "gpt-4.1-nano";
+	});
 
 const OpenAILanguageModel = LanguageModelBase.extend({
 	id: OpenAILanguageModelId,

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -21,19 +21,8 @@ const defaultConfigurations: OpenAILanguageModelConfigurations = {
 };
 
 const OpenAILanguageModelId = z
-	.enum([
-		"gpt-4o",
-		"gpt-4o-mini",
-		"o1-preview",
-		"o1-mini",
-		"o3",
-		"o3-mini",
-		"o4-mini",
-		"gpt-4.1",
-		"gpt-4.1-mini",
-		"gpt-4.1-nano",
-	])
-	.catch("gpt-4o-mini");
+	.enum(["gpt-4o", "o3", "o4-mini", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"])
+	.catch("gpt-4.1-mini");
 
 const OpenAILanguageModel = LanguageModelBase.extend({
 	id: OpenAILanguageModelId,
@@ -53,45 +42,10 @@ const gpt4o: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-const gpt4oMini: OpenAILanguageModel = {
-	provider: "openai",
-	id: "gpt-4o-mini",
-	capabilities:
-		Capability.ImageFileInput |
-		Capability.TextGeneration |
-		Capability.OptionalSearchGrounding,
-	tier: Tier.enum.free,
-	configurations: defaultConfigurations,
-};
-
-const o1Preview: OpenAILanguageModel = {
-	provider: "openai",
-	id: "o1-preview",
-	capabilities: Capability.TextGeneration,
-	tier: Tier.enum.free,
-	configurations: defaultConfigurations,
-};
-
-const o1Mini: OpenAILanguageModel = {
-	provider: "openai",
-	id: "o1-mini",
-	capabilities: Capability.TextGeneration,
-	tier: Tier.enum.free,
-	configurations: defaultConfigurations,
-};
-
 const o3: OpenAILanguageModel = {
 	provider: "openai",
 	id: "o3",
 	capabilities: Capability.ImageFileInput | Capability.TextGeneration,
-	tier: Tier.enum.pro,
-	configurations: defaultConfigurations,
-};
-
-const o3Mini: OpenAILanguageModel = {
-	provider: "openai",
-	id: "o3-mini",
-	capabilities: Capability.TextGeneration,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
 };
@@ -122,7 +76,7 @@ const gpt41mini: OpenAILanguageModel = {
 		Capability.ImageFileInput |
 		Capability.TextGeneration |
 		Capability.OptionalSearchGrounding,
-	tier: Tier.enum.pro,
+	tier: Tier.enum.free,
 	configurations: defaultConfigurations,
 };
 
@@ -130,20 +84,11 @@ const gpt41nano: OpenAILanguageModel = {
 	provider: "openai",
 	id: "gpt-4.1-nano",
 	capabilities: Capability.ImageFileInput | Capability.TextGeneration,
-	tier: Tier.enum.pro,
+	tier: Tier.enum.free,
 	configurations: defaultConfigurations,
 };
 
-export const models = [
-	gpt4o,
-	gpt4oMini,
-	o3,
-	o3Mini,
-	o4Mini,
-	gpt41,
-	gpt41mini,
-	gpt41nano,
-];
+export const models = [gpt4o, o3, o4Mini, gpt41, gpt41mini, gpt41nano];
 
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;

--- a/packages/workflow-utils/src/build-workflow-map.test.ts
+++ b/packages/workflow-utils/src/build-workflow-map.test.ts
@@ -24,7 +24,7 @@ const sampleNodes: Node[] = [
 			type: "textGeneration",
 			llm: {
 				provider: "openai",
-				id: "gpt-4o-mini",
+				id: "gpt-4.1-mini",
 				configurations: {
 					temperature: 0.7,
 					topP: 1,
@@ -51,7 +51,7 @@ const sampleNodes: Node[] = [
 			type: "textGeneration",
 			llm: {
 				provider: "openai",
-				id: "gpt-4o-mini",
+				id: "gpt-4.1-mini",
 				configurations: {
 					temperature: 0.7,
 					topP: 1,

--- a/packages/workflow-utils/src/helper.test.ts
+++ b/packages/workflow-utils/src/helper.test.ts
@@ -29,7 +29,7 @@ const sampleNodes: Node[] = [
 			type: "textGeneration",
 			llm: {
 				provider: "openai",
-				id: "gpt-4o-mini",
+				id: "gpt-4.1-mini",
 				configurations: {
 					temperature: 0.7,
 					topP: 1,


### PR DESCRIPTION
### **User description**
## Summary
This pull request updates the OpenAILanguageModelId schema to map legacy and alternative OpenAI model names (such as "gpt-4-turbo", "gpt-4", and "gpt-3.5-turbo") to the current "gpt-4o" model ID. This ensures backward compatibility and consistent model selection throughout the codebase.

## Changes
- Update OpenAI models in Giselle
- Improve UX by fallback OpenAI models in Giselle

## Testing
- Run `pnpm test`

## Other Information
- https://platform.openai.com/docs/models


___

### **PR Type**
Enhancement


___

### **Description**
• Streamlined OpenAI model schema with legacy model mapping
• Removed deprecated models and pricing configurations
• Added comprehensive test coverage for model ID transformations
• Updated tier assignments for cost-optimized models


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Remove deprecated model pricing configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

• Removed pricing configurations for deprecated models <code>gpt-4o-mini</code> and <br><code>o3-mini</code><br> • Cleaned up model price table to match current model lineup


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1169/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+0/-30</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.test.ts</strong><dd><code>Add comprehensive OpenAI model mapping tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/openai.test.ts

• Added comprehensive test suite for OpenAI model ID parsing<br> • Tests <br>cover o-series, GPT flagship, cost-optimized model mappings<br> • <br>Validates fallback behavior for unknown model names


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1169/files#diff-8b4baea6439bfd13875b567662a0d76c43d0e4b7d123fdb889e1588866be2e42">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Implement model mapping with legacy name support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/openai.ts

• Implemented smart model ID mapping with fallback logic<br> • Removed <br>deprecated model definitions (<code>gpt-4o-mini</code>, <code>o1-preview</code>, <code>o1-mini</code>, <br><code>o3-mini</code>)<br> • Updated tier assignments for <code>gpt-4.1-mini</code> and <code>gpt-4.1-nano</code> <br>to free tier<br> • Added legacy model name support (<code>gpt-4-turbo</code>, <code>gpt-4</code>, <br><code>gpt-3.5-turbo</code> → <code>gpt-4o</code>)


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1169/files#diff-1891a7f0ef98437d982f18296668e40c171f03da7e4b82d2dff4b3a2b3f791d8">+24/-61</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of legacy and alternate AI model identifiers, ensuring smoother compatibility with older or variant model names.

- **Bug Fixes**
  - Unknown or unsupported model identifiers now consistently default to the "gpt-4.1-nano" model.

- **Changes**
  - Some older and cost-optimized AI models have been removed from the available options.
  - The "gpt-4.1-mini" and "gpt-4.1-nano" models are now available to all users, not just pro users.

- **Tests**
  - Added comprehensive tests to verify correct mapping and fallback for model identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->