### PR TITLE
Fix combined domain filter limit

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/domain-tag-input.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/domain-tag-input.tsx
@@ -18,6 +18,11 @@ type DomainTagInputProps = {
 	placeholder?: string;
 	className?: string;
 	label?: string;
+	/**
+	 * When provided, overrides the internal max domains check.
+	 * This allows parent components to enforce a global limit.
+	 */
+	maxReached?: boolean;
 };
 
 export function DomainTagInput({
@@ -27,11 +32,13 @@ export function DomainTagInput({
 	placeholder = "Enter text to add",
 	className = "",
 	label,
+	maxReached: maxReachedProp,
 }: DomainTagInputProps) {
 	const [inputValue, setInputValue] = useState("");
 
-	// Check if maximum domains limit reached
-	const isMaxReached = domains.length >= MAX_DOMAINS;
+	// Check if maximum domains limit reached. Allow parent components to
+	// override the calculation when enforcing a global domain limit.
+	const isMaxReached = maxReachedProp ?? domains.length >= MAX_DOMAINS;
 
 	const handleAddDomain = () => {
 		const value = inputValue.trim();

--- a/internal-packages/workflow-designer-ui/src/ui/search-domain-filter-enhanced.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/search-domain-filter-enhanced.tsx
@@ -132,6 +132,7 @@ export function SearchDomainFilterEnhanced({
 				onRemoveDomain={handleRemoveIncludeDomain}
 				placeholder={includePlaceholder}
 				label="Allow List"
+				maxReached={isMaxReached}
 			/>
 
 			{/* Exclude domain input and tags */}
@@ -141,6 +142,7 @@ export function SearchDomainFilterEnhanced({
 				onRemoveDomain={handleRemoveExcludeDomain}
 				placeholder={excludePlaceholder}
 				label="Deny List"
+				maxReached={isMaxReached}
 			/>
 		</div>
 	);


### PR DESCRIPTION
### **User description**
## Summary
- enforce global domain limit via new `maxReached` prop
- update domain filter component to use the global limit

> Limit Filter Size: You can add a maximum of 10 domains. Using fewer, more targeted domains often yields better results.
>
> via: https://docs.giselles.ai/models/providers/perplexity

## Testing
- `npx turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`
- `npx turbo check-types --cache=local:rw` *(fails: ENETUNREACH)*
- `npx turbo test --cache=local:rw` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6853775863988325af6a0aa231759100


___

### **PR Type**
Enhancement


___

### **Description**
• Add `maxReached` prop to `DomainTagInput` component for global domain limit enforcement
• Update domain filter to pass global limit state to both include/exclude inputs
• Replace local domain count check with parent-controlled limit validation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>domain-tag-input.tsx</strong><dd><code>Add maxReached prop for external limit control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/domain-tag-input.tsx

• Add optional <code>maxReached</code> prop to override internal domain limit check<br> <br>• Update <code>isMaxReached</code> logic to use parent-provided limit when <br>available<br> • Add JSDoc documentation for the new prop parameter


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1175/files#diff-87f8623296045f2d7442ab6c19bbcc326c2ec9673bb966b4045cbc0da175346f">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search-domain-filter-enhanced.tsx</strong><dd><code>Apply global limit to domain filter inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/search-domain-filter-enhanced.tsx

• Pass <code>isMaxReached</code> prop to both include and exclude <code>DomainTagInput</code> <br>components<br> • Enable global domain limit enforcement across both filter <br>types


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1175/files#diff-cc4b5cf1a6e288508b9f7cef018bab7af855a6d4a8562ad6e2a9beac4206ff34">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for externally controlling the maximum number of domains that can be selected in the domain tag input.
  - The domain tag input now respects an override from parent components when the maximum domain limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->