### PR TITLE
Update domain filter validation

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/domain-tag-input.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/domain-tag-input.tsx
@@ -9,7 +9,7 @@ export type DomainTag = {
 };
 
 // Maximum number of domains allowed
-const MAX_DOMAINS = 10;
+export const MAX_DOMAINS = 10;
 
 type DomainTagInputProps = {
 	domains: DomainTag[];
@@ -18,6 +18,12 @@ type DomainTagInputProps = {
 	placeholder?: string;
 	className?: string;
 	label?: string;
+	/**
+	 * Indicates whether the maximum allowed number of domains
+	 * has been reached. When provided, this value overrides the
+	 * default per-list validation.
+	 */
+	isMaxReached?: boolean;
 };
 
 export function DomainTagInput({
@@ -27,18 +33,19 @@ export function DomainTagInput({
 	placeholder = "Enter text to add",
 	className = "",
 	label,
+	isMaxReached,
 }: DomainTagInputProps) {
 	const [inputValue, setInputValue] = useState("");
 
-	// Check if maximum domains limit reached
-	const isMaxReached = domains.length >= MAX_DOMAINS;
+	// Determine if adding new domains should be disabled
+	const maxReached = isMaxReached ?? domains.length >= MAX_DOMAINS;
 
 	const handleAddDomain = () => {
 		const value = inputValue.trim();
 		if (!value) return;
 
 		// Prevent adding if max limit reached
-		if (isMaxReached) return;
+		if (maxReached) return;
 
 		onAddDomain(value);
 		setInputValue("");
@@ -80,7 +87,7 @@ export function DomainTagInput({
 			</div>
 
 			{/* Maximum domains warning */}
-			{isMaxReached && (
+			{maxReached && (
 				<div className="ml-[150px] mb-4">
 					<p className="max-domains-warning text-red-700 text-[12px]">
 						You can add up to {MAX_DOMAINS} domains only.
@@ -101,13 +108,13 @@ export function DomainTagInput({
 						onChange={(e) => setInputValue(e.target.value)}
 						onKeyDown={handleKeyDown}
 						maxLength={100}
-						disabled={isMaxReached}
+						disabled={maxReached}
 					/>
 					<Button
 						className="ml-2 px-2 py-1 text-sm text-gray-300 opacity-50 hover:opacity-100"
 						variant="ghost"
 						onClick={handleAddDomain}
-						disabled={!inputValue.trim() || isMaxReached}
+						disabled={!inputValue.trim() || maxReached}
 					>
 						Add
 					</Button>

--- a/internal-packages/workflow-designer-ui/src/ui/search-domain-filter-enhanced.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/search-domain-filter-enhanced.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { type DomainTag, DomainTagInput } from "./domain-tag-input";
-
-const MAX_DOMAINS = 10;
+import {
+	type DomainTag,
+	DomainTagInput,
+	MAX_DOMAINS,
+} from "./domain-tag-input";
 
 export type SearchDomainFilterEnhancedProps = {
 	onFilterChange?: (include: string[], exclude: string[]) => void;
@@ -131,6 +133,7 @@ export function SearchDomainFilterEnhanced({
 				onAddDomain={handleAddIncludeDomain}
 				onRemoveDomain={handleRemoveIncludeDomain}
 				placeholder={includePlaceholder}
+				isMaxReached={isMaxReached}
 				label="Allow List"
 			/>
 
@@ -140,6 +143,7 @@ export function SearchDomainFilterEnhanced({
 				onAddDomain={handleAddExcludeDomain}
 				onRemoveDomain={handleRemoveExcludeDomain}
 				placeholder={excludePlaceholder}
+				isMaxReached={isMaxReached}
 				label="Deny List"
 			/>
 		</div>


### PR DESCRIPTION
### **User description**
## Summary
- share MAX_DOMAINS constant in `DomainTagInput`
- allow `DomainTagInput` to be disabled from parent via `isMaxReached`
- enforce domain limit across allow and deny lists in `SearchDomainFilterEnhanced`

## Testing
- `npx turbo test --cache=local:rw` *(fails: ENETUNREACH)*
- `npx turbo check-types --cache=local:rw` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6853775863988325af6a0aa231759100


___

### **PR Type**
Enhancement


___

### **Description**
• Export MAX_DOMAINS constant for shared usage
• Add isMaxReached prop to DomainTagInput component
• Enforce domain limit across allow and deny lists
• Update validation logic to use external max reached state


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>domain-tag-input.tsx</strong><dd><code>Add external validation override capability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/domain-tag-input.tsx

• Export MAX_DOMAINS constant for external usage<br> • Add optional <br>isMaxReached prop to override default validation<br> • Update validation <br>logic to use external max reached state<br> • Rename internal variable <br>from isMaxReached to maxReached


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1176/files#diff-87f8623296045f2d7442ab6c19bbcc326c2ec9673bb966b4045cbc0da175346f">+14/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search-domain-filter-enhanced.tsx</strong><dd><code>Implement shared domain limit validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/search-domain-filter-enhanced.tsx

• Import MAX_DOMAINS from domain-tag-input instead of local constant<br> • <br>Pass isMaxReached prop to both allow and deny list inputs<br> • Enforce <br>domain limit across both lists combined


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1176/files#diff-cc4b5cf1a6e288508b9f7cef018bab7af855a6d4a8562ad6e2a9beac4206ff34">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved domain tag input fields to display and enforce the maximum allowed domains more consistently.
	- Inputs and add buttons are now properly disabled when the maximum number of domains is reached, with clearer warning messages.

- **Enhancements**
	- The maximum domain limit is now managed centrally and consistently across related components for a more unified user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->