### PR TITLE
Update Anthropic Models and Improve Fallback Logic

### DIFF
--- a/packages/language-model/src/anthropic.test.ts
+++ b/packages/language-model/src/anthropic.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { AnthropicLanguageModelId } from "./anthropic";
+
+describe("anthropic llm", () => {
+	describe("AnthropicLanguageModelId", () => {
+		it("should parse valid enum values successfully", () => {
+			expect(AnthropicLanguageModelId.parse("claude-4-opus-20250514")).toBe(
+				"claude-4-opus-20250514",
+			);
+			expect(AnthropicLanguageModelId.parse("claude-4-sonnet-20250514")).toBe(
+				"claude-4-sonnet-20250514",
+			);
+			expect(AnthropicLanguageModelId.parse("claude-3-7-sonnet-20250219")).toBe(
+				"claude-3-7-sonnet-20250219",
+			);
+			expect(AnthropicLanguageModelId.parse("claude-3-5-haiku-20241022")).toBe(
+				"claude-3-5-haiku-20241022",
+			);
+		});
+
+		it("should fallback claude-opus-4-* to claude-4-opus-20250514", () => {
+			expect(AnthropicLanguageModelId.parse("claude-4-opus-4-foo")).toBe(
+				"claude-4-opus-20250514",
+			);
+		});
+
+		it("should fallback claude-sonnet-4-* to claude-4-sonnet-20250514", () => {
+			expect(AnthropicLanguageModelId.parse("claude-4-sonnet-4-bar")).toBe(
+				"claude-4-sonnet-20250514",
+			);
+		});
+
+		it("should fallback claude-3-7-sonnet-* to claude-3-7-sonnet-20250219", () => {
+			expect(AnthropicLanguageModelId.parse("claude-3-7-sonnet-xyz")).toBe(
+				"claude-3-7-sonnet-20250219",
+			);
+		});
+
+		it("should fallback claude-3-5-haiku-* to claude-3-5-haiku-20241022", () => {
+			expect(AnthropicLanguageModelId.parse("claude-3-5-haiku-abc")).toBe(
+				"claude-3-5-haiku-20241022",
+			);
+		});
+
+		it("should fallback claude-3-5-sonnet-* to claude-3-7-sonnet-20250219", () => {
+			expect(AnthropicLanguageModelId.parse("claude-3-5-sonnet-foo")).toBe(
+				"claude-3-7-sonnet-20250219",
+			);
+		});
+
+		it("should fallback claude-3-opus-* to claude-4-opus-20250514", () => {
+			expect(AnthropicLanguageModelId.parse("claude-3-opus-foo")).toBe(
+				"claude-4-opus-20250514",
+			);
+		});
+
+		it("should fallback claude-3-sonnet-* to claude-3-7-sonnet-20250219", () => {
+			expect(AnthropicLanguageModelId.parse("claude-3-sonnet-foo")).toBe(
+				"claude-3-7-sonnet-20250219",
+			);
+		});
+
+		it("should fallback claude-3-haiku-* to claude-3-5-haiku-20241022", () => {
+			expect(AnthropicLanguageModelId.parse("claude-3-haiku-bar")).toBe(
+				"claude-3-5-haiku-20241022",
+			);
+		});
+
+		it("should fallback unknown or non-matching variants to claude-3-5-haiku-20241022", () => {
+			expect(AnthropicLanguageModelId.parse("anthropic-unknown-model")).toBe(
+				"claude-3-5-haiku-20241022",
+			);
+			expect(AnthropicLanguageModelId.parse("anthropic-foo-bar")).toBe(
+				"claude-3-5-haiku-20241022",
+			);
+			expect(AnthropicLanguageModelId.parse("random-model")).toBe(
+				"claude-3-5-haiku-20241022",
+			);
+		});
+	});
+});

--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -23,7 +23,6 @@ const AnthropicLanguageModelId = z
 		"claude-4-opus-20250514",
 		"claude-4-sonnet-20250514",
 		"claude-3-7-sonnet-20250219",
-		"claude-3-5-sonnet-20241022",
 		"claude-3-5-haiku-20241022",
 	])
 	.catch("claude-3-5-haiku-20241022");
@@ -70,16 +69,7 @@ const claude37Sonnet: AnthropicLanguageModel = {
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
 };
-const claude35Sonnet: AnthropicLanguageModel = {
-	provider: "anthropic",
-	id: "claude-3-5-sonnet-20241022",
-	capabilities:
-		Capability.TextGeneration |
-		Capability.PdfFileInput |
-		Capability.ImageFileInput,
-	tier: Tier.enum.pro,
-	configurations: defaultConfigurations,
-};
+
 const claude35Haiku: AnthropicLanguageModel = {
 	provider: "anthropic",
 	id: "claude-3-5-haiku-20241022",
@@ -95,7 +85,6 @@ export const models = [
 	claude40Opus,
 	claude40Sonnet,
 	claude37Sonnet,
-	claude35Sonnet,
 	claude35Haiku,
 ];
 

--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -18,14 +18,44 @@ const defaultConfigurations: AnthropicLanguageModelConfigurations = {
 	reasoning: false,
 };
 
-const AnthropicLanguageModelId = z
+export const AnthropicLanguageModelId = z
 	.enum([
 		"claude-4-opus-20250514",
 		"claude-4-sonnet-20250514",
 		"claude-3-7-sonnet-20250219",
 		"claude-3-5-haiku-20241022",
 	])
-	.catch("claude-3-5-haiku-20241022");
+	.catch((ctx) => {
+		if (typeof ctx.value !== "string") {
+			return "claude-3-5-haiku-20241022";
+		}
+		const v = ctx.value;
+		if (/^claude-4-opus-4-/.test(v)) {
+			return "claude-4-opus-20250514";
+		}
+		if (/^claude-4-sonnet-4-/.test(v)) {
+			return "claude-4-sonnet-20250514";
+		}
+		if (/^claude-3-7-sonnet-/.test(v)) {
+			return "claude-3-7-sonnet-20250219";
+		}
+		if (/^claude-3-5-haiku-/.test(v)) {
+			return "claude-3-5-haiku-20241022";
+		}
+		if (/^claude-3-5-sonnet-/.test(v)) {
+			return "claude-3-7-sonnet-20250219";
+		}
+		if (/^claude-3-opus-/.test(v)) {
+			return "claude-4-opus-20250514";
+		}
+		if (/^claude-3-sonnet-/.test(v)) {
+			return "claude-3-7-sonnet-20250219";
+		}
+		if (/^claude-3-haiku-/.test(v)) {
+			return "claude-3-5-haiku-20241022";
+		}
+		return "claude-3-5-haiku-20241022";
+	});
 
 const AnthropicLanguageModel = LanguageModelBase.extend({
 	id: AnthropicLanguageModelId,

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -157,21 +157,6 @@ export const anthropicTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"claude-3-5-sonnet-20241022": {
-		prices: [
-			{
-				validFrom: "2025-05-19T00:00:00Z",
-				price: {
-					input: {
-						costPerMegaToken: 3.0,
-					},
-					output: {
-						costPerMegaToken: 15.0,
-					},
-				},
-			},
-		],
-	},
 	"claude-3-5-haiku-20241022": {
 		prices: [
 			{


### PR DESCRIPTION
### **User description**
## Summary
Update Anthropic Models and Improve Fallback Logic

## Changes
- Remove claude-3-5-sonnet-20241022
- Improve UX by fallback Anthropic models in Giselle

## Testing

I did the testing for the fallback logic working successfully. ✅ 

| main branch | this branch |
|--------|--------|
| <img width="1183" alt="image" src="https://github.com/user-attachments/assets/6b7c6889-dbd4-49e8-943a-471fd1cde7d9" /> | <img width="1185" alt="image" src="https://github.com/user-attachments/assets/dd1de495-cb10-45dd-ae15-2d63ec9cb77b" /> | 

## Other Information
https://docs.anthropic.com/en/docs/about-claude/models/overview


___

### **PR Type**
Enhancement


___

### **Description**
• Remove deprecated `claude-3-5-sonnet-20241022` model from Anthropic models
• Add intelligent fallback logic for model ID parsing with regex patterns
• Implement comprehensive test coverage for model fallback scenarios
• Update pricing configuration to reflect removed model


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>anthropic.test.ts</strong><dd><code>Add comprehensive tests for model fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/anthropic.test.ts

• Add comprehensive test suite for <code>AnthropicLanguageModelId</code> parsing<br> • <br>Test valid enum values and various fallback scenarios<br> • Cover edge <br>cases for unknown model variants


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1183/files#diff-31f3d68aac5b1b4f417c339174b564fa75bd6a55ab082b145fe45ed07da24886">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>anthropic.ts</strong><dd><code>Implement intelligent model fallback with regex patterns</code>&nbsp; </dd></summary>
<hr>

packages/language-model/src/anthropic.ts

• Remove <code>claude-3-5-sonnet-20241022</code> from enum and model definitions<br> • <br>Replace simple catch with intelligent regex-based fallback logic<br> • <br>Export <code>AnthropicLanguageModelId</code> for testing purposes<br> • Map deprecated <br>model patterns to current equivalents


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1183/files#diff-818c98cd1d89138649fe8f8c94d74cc511c448d8b18b0cd602051978bf0bc59b">+33/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Remove pricing for deprecated model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

• Remove pricing configuration for deprecated <br><code>claude-3-5-sonnet-20241022</code> model


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1183/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+0/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling and normalization of Anthropic language model identifiers, with enhanced fallback logic for unknown or variant model IDs.
	- Removed references to the "claude-3-5-sonnet-20241022" model from available models and pricing tables.

- **Tests**
	- Added a comprehensive test suite to verify correct parsing and fallback behavior for Anthropic model identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->