### PR TITLE
Refactor GitHubBlobLoader to functional style

### DIFF
--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
@@ -1,6 +1,6 @@
 import { db, githubRepositoryIndex } from "@/drizzle";
 import { createGitHubBlobChunkStore } from "@/lib/vector-stores/github-blob-stores";
-import { GitHubBlobLoader } from "@giselle-sdk/github-tool";
+import { createGitHubBlobLoader } from "@giselle-sdk/github-tool";
 import { createIngestPipeline } from "@giselle-sdk/rag2";
 import type { Octokit } from "@octokit/core";
 import { and, eq } from "drizzle-orm";
@@ -18,7 +18,7 @@ export async function ingestGitHubBlobs(params: {
 		params.teamDbId,
 	);
 
-	const githubLoader = new GitHubBlobLoader(params.octokitClient, {
+	const githubLoader = createGitHubBlobLoader(params.octokitClient, {
 		maxBlobSize: 1 * 1024 * 1024,
 	});
 	const chunkStore = createGitHubBlobChunkStore(repositoryIndexDbId);

--- a/packages/github-tool/src/blob-loader.ts
+++ b/packages/github-tool/src/blob-loader.ts
@@ -1,7 +1,7 @@
 import type { Document, DocumentLoader } from "@giselle-sdk/rag2";
 import type { Octokit } from "@octokit/core";
 
-type GitHubBlobMetadata = {
+export type GitHubBlobMetadata = {
 	owner: string;
 	repo: string;
 	commitSha: string;
@@ -10,39 +10,26 @@ type GitHubBlobMetadata = {
 	nodeId: string;
 };
 
-type GitHubBlobLoaderParams = {
+export type GitHubBlobLoaderParams = {
 	owner: string;
 	repo: string;
 	commitSha: string;
 };
 
-export class GitHubBlobLoader
-	implements DocumentLoader<GitHubBlobMetadata, GitHubBlobLoaderParams>
-{
-	private readonly maxBlobSize: number;
+export function createGitHubBlobLoader(
+	octokit: Octokit,
+	options?: { maxBlobSize?: number },
+): DocumentLoader<GitHubBlobMetadata, GitHubBlobLoaderParams> {
+	const maxBlobSize = options?.maxBlobSize ?? 1024 * 1024; // 1MB default
 
-	constructor(
-		private octokit: Octokit,
-		options?: {
-			maxBlobSize?: number;
-		},
-	) {
-		this.maxBlobSize = options?.maxBlobSize ?? 1024 * 1024; // 1MB default
-	}
-
-	async *load(
+	const load = async function* (
 		params: GitHubBlobLoaderParams,
 	): AsyncIterable<Document<GitHubBlobMetadata>> {
 		const { owner, repo, commitSha } = params;
 
 		console.log(`Loading repository ${owner}/${repo} at commit ${commitSha}`);
 
-		for await (const entry of traverseTree(
-			this.octokit,
-			owner,
-			repo,
-			commitSha,
-		)) {
+		for await (const entry of traverseTree(octokit, owner, repo, commitSha)) {
 			const { path, type, sha: fileSha, size } = entry;
 
 			// Process only blob entries (files)
@@ -50,7 +37,7 @@ export class GitHubBlobLoader
 				continue;
 			}
 
-			if (size > this.maxBlobSize) {
+			if (size > maxBlobSize) {
 				console.warn(
 					`Blob size is too large: ${size} bytes, skipping: ${path}`,
 				);
@@ -58,7 +45,7 @@ export class GitHubBlobLoader
 			}
 
 			const blob = await loadBlob(
-				this.octokit,
+				octokit,
 				{ owner, repo, path, fileSha },
 				commitSha,
 			);
@@ -72,7 +59,9 @@ export class GitHubBlobLoader
 				metadata: blob.metadata,
 			};
 		}
-	}
+	};
+
+	return { load };
 }
 
 type GitHubLoadBlobParams = {


### PR DESCRIPTION
## Summary
- refactor GitHubBlobLoader to a functional factory
- update ingestion to use new createGitHubBlobLoader

## Testing
- `pnpm biome check --write packages/github-tool/src/blob-loader.ts apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts`
- `npx turbo run check-types --filter=@giselle-sdk/github-tool --cache=local:rw`
- `pnpm -F @giselle-sdk/github-tool test`


------
https://chatgpt.com/codex/tasks/task_e_6853b3c1944c83288f1076d8c2624495

