### PR TITLE
Allow members to leave a team

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/account/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/actions.ts
@@ -139,7 +139,6 @@ export async function leaveTeam(
 	const formData = new FormData();
 	formData.set("userId", userId);
 	formData.set("role", role);
-	// FIXME: Current implementation requires current user to be an admin of the team. It's better to allow any user to leave the team.
 	const result = await deleteTeamMember(formData);
 
 	if (result.success) {


### PR DESCRIPTION
### **User description**

ref: https://github.com/giselles-ai/giselle/issues/705

## Summary
- let any member leave a team from Account settings
- prevent removing the last member from a team
- allow deleting self without admin privileges

## Testing
- `npx turbo format --cache=local:rw` *(fails: playground#format)*
- `npx turbo check-types --cache=local:rw` *(fails: playground#check-types)*
- `npx turbo test --cache=local:rw` *(fails: studio.giselles.ai#test)*
- `npx turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`

------
https://chatgpt.com/codex/tasks/task_e_685397c25ed48325b657f3da392ae098


___

### **PR Type**
Enhancement


___

### **Description**
• Allow team members to leave teams without admin privileges
• Prevent removal of last team member to maintain team integrity
• Restrict admin-only removal to other members, not self


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Remove outdated admin requirement comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/account/actions.ts

• Removed FIXME comment about admin requirement for leaving teams


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1188/files#diff-7836508d0584f10780f5adf49b80269c4ebe8b00d5065a9d483676d4143e51aa">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Implement flexible team member removal logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/actions.ts

• Modified permission logic to allow self-removal without admin <br>privileges<br> • Added validation to prevent removing last team member<br> • <br>Restructured user data fetching and permission checks<br> • Enhanced error <br>handling for team member removal scenarios


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1188/files#diff-9c391e21a587fcb12de4d739d67013b37a6a46bad1c8b34d6a4608303093dc49">+23/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved team member removal logic to allow users to remove themselves from a team, even if they are not admins.
  - Ensured teams cannot be left without any members by preventing deletion if only one member remains.

- **Refactor**
  - Updated permission checks for deleting team members to enhance clarity and maintain correct access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->