### PR TITLE
Refactor: Store secrets in a password field & disable autocomplete

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tools-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tools-panel.tsx
@@ -181,7 +181,10 @@ function GitHubToolSetting({ node }: { node: TextGenerationNode }) {
 								</a>
 							</div>
 							<input
-								type="text"
+								type="password"
+								autoComplete="off"
+								data-1p-ignore
+								data-lpignore="true"
 								id="pat"
 								name="value"
 								className={clsx(

--- a/internal-packages/workflow-designer-ui/src/editor/secret/secret-table.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/secret/secret-table.tsx
@@ -127,7 +127,10 @@ export function SecretTable() {
 										</label>
 									</div>
 									<input
-										type="text"
+										type="password"
+										autoComplete="off"
+										data-1p-ignore
+										data-lpignore="true"
 										id="pat"
 										name="value"
 										className={clsx(


### PR DESCRIPTION
### **User description**
## Summary
Refactor: Store secrets in a password field & disable autocomplete

## Related Issue
https://github.com/giselles-ai/giselle/pull/1138#discussion_r2144543310

## Changes
Fix: Displaying secret values in a plain text input exposes them to shoulder surfing and the browser’s auto-fill.

Supporting password managers:
- 1Password: [Ignore offers to save or fill specific fields​ ](https://developer.1password.com/docs/web/compatible-website-design/#ignore-offers-to-save-or-fill-specific-fields)
- LastPass: [How do I prevent fields from being filled automatically?﻿ ](https://support.lastpass.com/s/document-item?language=en_US&bundleId=lastpass&topicId=LastPass/c_lp_prevent_fields_from_being_filled_automatically.html&_LANG=enus)
- bitwarden: [Web Developer Autofill Exclusion](https://bitwarden.com/help/releasenotes/)

## Testing

**main branch:**

https://github.com/user-attachments/assets/9a2d74b9-c467-43a6-b2a6-bbc25f6df415

**this branch:**

https://github.com/user-attachments/assets/1407cf3d-6108-438f-91c1-4c24c9196728


## Other Information


___

### **PR Type**
Enhancement


___

### **Description**
• Convert secret input fields from text to password type
• Add autocomplete prevention attributes for password managers
• Improve security by hiding secret values from shoulder surfing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tools-panel.tsx</strong><dd><code>Secure GitHub PAT input field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tools-panel.tsx

• Changed GitHub PAT input from text to password type<br> • Added <br>autocomplete="off" and password manager ignore attributes<br> • Enhanced <br>security for GitHub token input field


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1192/files#diff-c5e2443d0e26d210e0d1ff896da00d8a134640e2ec9762234bd5f6ddcea157b6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>secret-table.tsx</strong><dd><code>Secure secret value input field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/secret/secret-table.tsx

• Changed secret value input from text to password type<br> • Added <br>autocomplete="off" and password manager ignore attributes<br> • Enhanced <br>security for secret value input field


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1192/files#diff-5c2ee2389f36a451d8a59900678af3e9a5ae01589f3b210678da9006e8d8b394">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced privacy for sensitive input fields by masking Personal Access Token and secret value entries.
  - Disabled browser autocomplete and password manager autofill for these fields to improve security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->