### PR TITLE
feat: GitHub repository ingestion continuation

### DIFF
--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
@@ -22,12 +22,10 @@ export async function ingestGitHubBlobs(params: {
 		params.teamDbId,
 	);
 
-	// Load processed paths into memory for fast lookup
 	const processedPaths = await loadProcessedPaths(
 		repositoryIndexDbId,
 		params.source.commitSha,
 	);
-
 	const githubLoader = createGitHubBlobLoader(params.octokitClient, {
 		maxBlobSize: 1 * 1024 * 1024,
 		shouldSkip: (path) => processedPaths.has(path),

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
@@ -1,4 +1,8 @@
-import { db, githubRepositoryIndex } from "@/drizzle";
+import {
+	db,
+	githubRepositoryEmbeddings,
+	githubRepositoryIndex,
+} from "@/drizzle";
 import { createGitHubBlobChunkStore } from "@/lib/vector-stores/github-blob-stores";
 import { createGitHubBlobLoader } from "@giselle-sdk/github-tool";
 import { createIngestPipeline } from "@giselle-sdk/rag";
@@ -18,8 +22,16 @@ export async function ingestGitHubBlobs(params: {
 		params.teamDbId,
 	);
 
+	// Load processed paths into memory for fast lookup
+	const processedPaths = await loadProcessedPaths(
+		repositoryIndexDbId,
+		params.source.commitSha,
+	);
+	console.log(`Loaded ${processedPaths.size} already processed paths`);
+
 	const githubLoader = createGitHubBlobLoader(params.octokitClient, {
 		maxBlobSize: 1 * 1024 * 1024,
+		shouldSkip: (path) => processedPaths.has(path),
 	});
 	const chunkStore = createGitHubBlobChunkStore(repositoryIndexDbId);
 
@@ -68,4 +80,24 @@ async function getRepositoryIndexDbId(
 	}
 
 	return repositoryIndex[0].dbId;
+}
+
+/**
+ * Load processed file paths into memory for fast lookup
+ */
+async function loadProcessedPaths(
+	repositoryIndexDbId: number,
+	commitSha: string,
+): Promise<Set<string>> {
+	const result = await db
+		.selectDistinct({ path: githubRepositoryEmbeddings.path })
+		.from(githubRepositoryEmbeddings)
+		.where(
+			and(
+				eq(githubRepositoryEmbeddings.repositoryIndexDbId, repositoryIndexDbId),
+				eq(githubRepositoryEmbeddings.commitSha, commitSha),
+			),
+		);
+
+	return new Set(result.map((r) => r.path));
 }

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
@@ -78,11 +78,6 @@ async function getRepositoryIndexDbId(
 
 /**
  * Load processed file paths into memory for fast lookup
- *
- * Note: We don't filter by commitSha because:
- * - Each repositoryIndexDbId contains only one commit's data at a time
- * - The unique constraint on (repositoryIndexDbId, path, chunkIndex) prevents duplicates
- * - For continuation purposes, we want to skip all previously processed files regardless of commitSha
  */
 async function loadProcessedPaths(
 	repositoryIndexDbId: number,

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
@@ -27,7 +27,6 @@ export async function ingestGitHubBlobs(params: {
 		repositoryIndexDbId,
 		params.source.commitSha,
 	);
-	console.log(`Loaded ${processedPaths.size} already processed paths`);
 
 	const githubLoader = createGitHubBlobLoader(params.octokitClient, {
 		maxBlobSize: 1 * 1024 * 1024,

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
 			await ingestGitHubBlobs({
 				octokitClient,
 				source,
-				teamDbId,
+				repositoryIndexDbId: dbId,
 			});
 
 			await updateRepositoryStatus(dbId, "completed", commitSha);

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/route.ts
@@ -48,10 +48,6 @@ export async function GET(request: NextRequest) {
 				commitSha,
 			};
 
-			console.log(
-				`Starting ingestion for ${owner}/${repo} at commit ${commitSha}`,
-			);
-
 			await ingestGitHubBlobs({
 				octokitClient,
 				source,

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/types.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/types.ts
@@ -5,4 +5,5 @@ export type TargetGitHubRepository = {
 	teamDbId: number;
 	installationId: number;
 	lastIngestedCommitSha: string | null;
+	currentIngestionCommitSha: string | null;
 };

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/utils.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/utils.ts
@@ -28,7 +28,7 @@ export function buildOctokit(installationId: number) {
 export async function fetchTargetGitHubRepositories(): Promise<
 	TargetGitHubRepository[]
 > {
-	// Consider running status as stale if it hasn't been updated for 15 minutes (> 800 seconds)
+	// To prevent the race condition, consider running status as stale if it hasn't been updated for 15 minutes (> 800 seconds)
 	const staleThreshold = new Date(Date.now() - 15 * 60 * 1000);
 
 	const records = await db

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/utils.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/utils.ts
@@ -44,6 +44,7 @@ export async function fetchTargetGitHubRepositories(): Promise<
 			or(
 				eq(githubRepositoryIndex.status, "idle"),
 				eq(githubRepositoryIndex.status, "running"),
+				eq(githubRepositoryIndex.status, "failed"),
 			),
 		);
 

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/utils.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/utils.ts
@@ -1,6 +1,6 @@
 import { db, githubRepositoryIndex } from "@/drizzle";
 import { octokit } from "@giselle-sdk/github-tool";
-import { eq } from "drizzle-orm";
+import { eq, or } from "drizzle-orm";
 import type { TargetGitHubRepository } from "./types";
 
 export function buildOctokit(installationId: number) {
@@ -34,7 +34,12 @@ export async function fetchTargetGitHubRepositories(): Promise<
 			teamDbId: githubRepositoryIndex.teamDbId,
 		})
 		.from(githubRepositoryIndex)
-		.where(eq(githubRepositoryIndex.status, "idle"));
+		.where(
+			or(
+				eq(githubRepositoryIndex.status, "idle"),
+				eq(githubRepositoryIndex.status, "running"),
+			),
+		);
 
 	return records.map((record) => ({
 		dbId: record.dbId,

--- a/apps/studio.giselles.ai/drizzle/schema.ts
+++ b/apps/studio.giselles.ai/drizzle/schema.ts
@@ -289,6 +289,7 @@ export const githubRepositoryIndex = pgTable(
 			.references(() => teams.dbId, { onDelete: "cascade" }),
 		installationId: integer("installation_id").notNull(),
 		lastIngestedCommitSha: text("last_ingested_commit_sha"),
+		currentIngestionCommitSha: text("current_ingestion_commit_sha"),
 		status: text("status")
 			.notNull()
 			.$type<GitHubRepositoryIndexStatus>()

--- a/apps/studio.giselles.ai/migrations/0034_empty_retro_girl.sql
+++ b/apps/studio.giselles.ai/migrations/0034_empty_retro_girl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "github_repository_index" ADD COLUMN "current_ingestion_commit_sha" text;

--- a/apps/studio.giselles.ai/migrations/meta/0034_snapshot.json
+++ b/apps/studio.giselles.ai/migrations/meta/0034_snapshot.json
@@ -1,0 +1,1314 @@
+{
+	"id": "2690406e-3c41-42bb-852b-0800ad2482c6",
+	"prevId": "212ee479-e672-4112-a0e0-7172010c7b57",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.agent_activities": {
+			"name": "agent_activities",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_duration_ms": {
+					"name": "total_duration_ms",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"usage_report_db_id": {
+					"name": "usage_report_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"agent_activities_agent_db_id_index": {
+					"name": "agent_activities_agent_db_id_index",
+					"columns": [
+						{
+							"expression": "agent_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agent_activities_ended_at_index": {
+					"name": "agent_activities_ended_at_index",
+					"columns": [
+						{
+							"expression": "ended_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agent_activities_agent_db_id_agents_db_id_fk": {
+					"name": "agent_activities_agent_db_id_agents_db_id_fk",
+					"tableFrom": "agent_activities",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk": {
+					"name": "agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk",
+					"tableFrom": "agent_activities",
+					"tableTo": "agent_time_usage_reports",
+					"columnsFrom": ["usage_report_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.agent_time_restrictions": {
+			"name": "agent_time_restrictions",
+			"schema": "",
+			"columns": {
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"agent_time_restrictions_team_db_id_index": {
+					"name": "agent_time_restrictions_team_db_id_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agent_time_restrictions_team_db_id_teams_db_id_fk": {
+					"name": "agent_time_restrictions_team_db_id_teams_db_id_fk",
+					"tableFrom": "agent_time_restrictions",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.agent_time_usage_reports": {
+			"name": "agent_time_usage_reports",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"accumulated_duration_ms": {
+					"name": "accumulated_duration_ms",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"minutes_increment": {
+					"name": "minutes_increment",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_meter_event_id": {
+					"name": "stripe_meter_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"agent_time_usage_reports_team_db_id_index": {
+					"name": "agent_time_usage_reports_team_db_id_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agent_time_usage_reports_created_at_index": {
+					"name": "agent_time_usage_reports_created_at_index",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agent_time_usage_reports_stripe_meter_event_id_index": {
+					"name": "agent_time_usage_reports_stripe_meter_event_id_index",
+					"columns": [
+						{
+							"expression": "stripe_meter_event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agent_time_usage_reports_team_db_id_teams_db_id_fk": {
+					"name": "agent_time_usage_reports_team_db_id_teams_db_id_fk",
+					"tableFrom": "agent_time_usage_reports",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.agents": {
+			"name": "agents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"graph_url": {
+					"name": "graph_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"creator_db_id": {
+					"name": "creator_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"agents_team_db_id_index": {
+					"name": "agents_team_db_id_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agents_team_db_id_teams_db_id_fk": {
+					"name": "agents_team_db_id_teams_db_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"agents_creator_db_id_users_db_id_fk": {
+					"name": "agents_creator_db_id_users_db_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "users",
+					"columnsFrom": ["creator_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"agents_id_unique": {
+					"name": "agents_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.github_integration_settings": {
+			"name": "github_integration_settings",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_db_id": {
+					"name": "agent_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"repository_full_name": {
+					"name": "repository_full_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"call_sign": {
+					"name": "call_sign",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event": {
+					"name": "event",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"flow_id": {
+					"name": "flow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_node_mappings": {
+					"name": "event_node_mappings",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_action": {
+					"name": "next_action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"github_integration_settings_agent_db_id_agents_db_id_fk": {
+					"name": "github_integration_settings_agent_db_id_agents_db_id_fk",
+					"tableFrom": "github_integration_settings",
+					"tableTo": "agents",
+					"columnsFrom": ["agent_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"github_integration_settings_id_unique": {
+					"name": "github_integration_settings_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.github_repository_embeddings": {
+			"name": "github_repository_embeddings",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"repository_index_db_id": {
+					"name": "repository_index_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"commit_sha": {
+					"name": "commit_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_sha": {
+					"name": "file_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"path": {
+					"name": "path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"node_id": {
+					"name": "node_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"embedding": {
+					"name": "embedding",
+					"type": "vector(1536)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"chunk_content": {
+					"name": "chunk_content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"chunk_index": {
+					"name": "chunk_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"github_repository_embeddings_embedding_index": {
+					"name": "github_repository_embeddings_embedding_index",
+					"columns": [
+						{
+							"expression": "embedding",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last",
+							"opclass": "vector_cosine_ops"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hnsw",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"github_repository_embeddings_repository_index_db_id_github_repository_index_db_id_fk": {
+					"name": "github_repository_embeddings_repository_index_db_id_github_repository_index_db_id_fk",
+					"tableFrom": "github_repository_embeddings",
+					"tableTo": "github_repository_index",
+					"columnsFrom": ["repository_index_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"github_repository_embeddings_repository_index_db_id_path_chunk_index_unique": {
+					"name": "github_repository_embeddings_repository_index_db_id_path_chunk_index_unique",
+					"nullsNotDistinct": false,
+					"columns": ["repository_index_db_id", "path", "chunk_index"]
+				}
+			}
+		},
+		"public.github_repository_index": {
+			"name": "github_repository_index",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"owner": {
+					"name": "owner",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"repo": {
+					"name": "repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"installation_id": {
+					"name": "installation_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_ingested_commit_sha": {
+					"name": "last_ingested_commit_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_ingestion_commit_sha": {
+					"name": "current_ingestion_commit_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'idle'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"github_repository_index_team_db_id_index": {
+					"name": "github_repository_index_team_db_id_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"github_repository_index_status_index": {
+					"name": "github_repository_index_status_index",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"github_repository_index_team_db_id_teams_db_id_fk": {
+					"name": "github_repository_index_team_db_id_teams_db_id_fk",
+					"tableFrom": "github_repository_index",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"github_repository_index_id_unique": {
+					"name": "github_repository_index_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"github_repository_index_owner_repo_team_db_id_unique": {
+					"name": "github_repository_index_owner_repo_team_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["owner", "repo", "team_db_id"]
+				}
+			}
+		},
+		"public.invitations": {
+			"name": "invitations",
+			"schema": "",
+			"columns": {
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"inviter_user_db_id": {
+					"name": "inviter_user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expired_at": {
+					"name": "expired_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"invitations_team_db_id_revoked_at_index": {
+					"name": "invitations_team_db_id_revoked_at_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "revoked_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"invitations_team_db_id_teams_db_id_fk": {
+					"name": "invitations_team_db_id_teams_db_id_fk",
+					"tableFrom": "invitations",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"invitations_inviter_user_db_id_users_db_id_fk": {
+					"name": "invitations_inviter_user_db_id_users_db_id_fk",
+					"tableFrom": "invitations",
+					"tableTo": "users",
+					"columnsFrom": ["inviter_user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"invitations_token_unique": {
+					"name": "invitations_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			}
+		},
+		"public.oauth_credentials": {
+			"name": "oauth_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_account_id": {
+					"name": "provider_account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_credentials_user_id_users_db_id_fk": {
+					"name": "oauth_credentials_user_id_users_db_id_fk",
+					"tableFrom": "oauth_credentials",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_credentials_user_id_provider_provider_account_id_unique": {
+					"name": "oauth_credentials_user_id_provider_provider_account_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_id", "provider", "provider_account_id"]
+				}
+			}
+		},
+		"public.subscriptions": {
+			"name": "subscriptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cancel_at_period_end": {
+					"name": "cancel_at_period_end",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cancel_at": {
+					"name": "cancel_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"canceled_at": {
+					"name": "canceled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_period_start": {
+					"name": "current_period_start",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"current_period_end": {
+					"name": "current_period_end",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created": {
+					"name": "created",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_start": {
+					"name": "trial_start",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_end": {
+					"name": "trial_end",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"subscriptions_team_db_id_teams_db_id_fk": {
+					"name": "subscriptions_team_db_id_teams_db_id_fk",
+					"tableFrom": "subscriptions",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"subscriptions_id_unique": {
+					"name": "subscriptions_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.supabase_user_mappings": {
+			"name": "supabase_user_mappings",
+			"schema": "",
+			"columns": {
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"supabase_user_id": {
+					"name": "supabase_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"supabase_user_mappings_user_db_id_users_db_id_fk": {
+					"name": "supabase_user_mappings_user_db_id_users_db_id_fk",
+					"tableFrom": "supabase_user_mappings",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"supabase_user_mappings_user_db_id_unique": {
+					"name": "supabase_user_mappings_user_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id"]
+				},
+				"supabase_user_mappings_supabase_user_id_unique": {
+					"name": "supabase_user_mappings_supabase_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["supabase_user_id"]
+				}
+			}
+		},
+		"public.team_memberships": {
+			"name": "team_memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_db_id": {
+					"name": "user_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"team_memberships_user_db_id_users_db_id_fk": {
+					"name": "team_memberships_user_db_id_users_db_id_fk",
+					"tableFrom": "team_memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"team_memberships_team_db_id_teams_db_id_fk": {
+					"name": "team_memberships_team_db_id_teams_db_id_fk",
+					"tableFrom": "team_memberships",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"team_memberships_user_db_id_team_db_id_unique": {
+					"name": "team_memberships_user_db_id_team_db_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["user_db_id", "team_db_id"]
+				}
+			}
+		},
+		"public.teams": {
+			"name": "teams",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'customer'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"teams_id_unique": {
+					"name": "teams_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			}
+		},
+		"public.user_seat_usage_reports": {
+			"name": "user_seat_usage_reports",
+			"schema": "",
+			"columns": {
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"team_db_id": {
+					"name": "team_db_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_db_id_list": {
+					"name": "user_db_id_list",
+					"type": "integer[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_meter_event_id": {
+					"name": "stripe_meter_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_delta": {
+					"name": "is_delta",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_seat_usage_reports_team_db_id_index": {
+					"name": "user_seat_usage_reports_team_db_id_index",
+					"columns": [
+						{
+							"expression": "team_db_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_seat_usage_reports_created_at_index": {
+					"name": "user_seat_usage_reports_created_at_index",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_seat_usage_reports_stripe_meter_event_id_index": {
+					"name": "user_seat_usage_reports_stripe_meter_event_id_index",
+					"columns": [
+						{
+							"expression": "stripe_meter_event_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_seat_usage_reports_team_db_id_teams_db_id_fk": {
+					"name": "user_seat_usage_reports_team_db_id_teams_db_id_fk",
+					"tableFrom": "user_seat_usage_reports",
+					"tableTo": "teams",
+					"columnsFrom": ["team_db_id"],
+					"columnsTo": ["db_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avatar_url": {
+					"name": "avatar_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"db_id": {
+					"name": "db_id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_id_unique": {
+					"name": "users_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				},
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			}
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/apps/studio.giselles.ai/migrations/meta/_journal.json
+++ b/apps/studio.giselles.ai/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
 			"when": 1747029097419,
 			"tag": "0033_eminent_white_tiger",
 			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1750659772815,
+			"tag": "0034_empty_retro_girl",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/github-tool/src/blob-loader.ts
+++ b/packages/github-tool/src/blob-loader.ts
@@ -1,7 +1,7 @@
 import type { Document, DocumentLoader } from "@giselle-sdk/rag";
 import type { Octokit } from "@octokit/core";
 
-export type GitHubBlobMetadata = {
+type GitHubBlobMetadata = {
 	owner: string;
 	repo: string;
 	commitSha: string;
@@ -10,13 +10,13 @@ export type GitHubBlobMetadata = {
 	nodeId: string;
 };
 
-export type GitHubBlobLoaderParams = {
+type GitHubBlobLoaderParams = {
 	owner: string;
 	repo: string;
 	commitSha: string;
 };
 
-export type GitHubBlobLoaderOptions = {
+type GitHubBlobLoaderOptions = {
 	maxBlobSize?: number;
 };
 

--- a/packages/github-tool/src/blob-loader.ts
+++ b/packages/github-tool/src/blob-loader.ts
@@ -53,6 +53,9 @@ export function createGitHubBlobLoader(
 				commitSha,
 				fileSha,
 				path,
+				// TODO: We can consider removing this from metadata.
+				// - nodeId is not used for now and
+				// - Tree API doesn't have nodeId.
 				nodeId: "",
 			};
 		}

--- a/packages/github-tool/src/blob-loader.ts
+++ b/packages/github-tool/src/blob-loader.ts
@@ -16,9 +16,14 @@ type GitHubBlobLoaderParams = {
 	commitSha: string;
 };
 
+export type GitHubBlobLoaderOptions = {
+	maxBlobSize?: number;
+	shouldSkip?: (path: string) => boolean | Promise<boolean>;
+};
+
 export function createGitHubBlobLoader(
 	octokit: Octokit,
-	options?: { maxBlobSize?: number },
+	options?: GitHubBlobLoaderOptions,
 ): DocumentLoader<GitHubBlobMetadata, GitHubBlobLoaderParams> {
 	const maxBlobSize = options?.maxBlobSize ?? 1024 * 1024; // 1MB default
 
@@ -41,6 +46,12 @@ export function createGitHubBlobLoader(
 				console.warn(
 					`Blob size is too large: ${size} bytes, skipping: ${path}`,
 				);
+				continue;
+			}
+
+			// Check if this file should be skipped
+			if (options?.shouldSkip && (await options.shouldSkip(path))) {
+				console.log(`Skipping already processed file: ${path}`);
 				continue;
 			}
 

--- a/packages/github-tool/src/blob-loader.ts
+++ b/packages/github-tool/src/blob-loader.ts
@@ -49,7 +49,6 @@ export function createGitHubBlobLoader(
 				continue;
 			}
 
-			// Check if this file should be skipped
 			if (options?.shouldSkip && (await options.shouldSkip(path))) {
 				continue;
 			}

--- a/packages/github-tool/src/blob-loader.ts
+++ b/packages/github-tool/src/blob-loader.ts
@@ -51,7 +51,6 @@ export function createGitHubBlobLoader(
 
 			// Check if this file should be skipped
 			if (options?.shouldSkip && (await options.shouldSkip(path))) {
-				console.log(`Skipping already processed file: ${path}`);
 				continue;
 			}
 

--- a/packages/rag/src/document-loader/index.ts
+++ b/packages/rag/src/document-loader/index.ts
@@ -1,1 +1,1 @@
-export type { Document, DocumentLoader, DocumentLoaderParams } from "./types";
+export type { Document, DocumentLoader } from "./types";

--- a/packages/rag/src/document-loader/types.ts
+++ b/packages/rag/src/document-loader/types.ts
@@ -13,7 +13,6 @@ export interface Document<
  */
 export interface DocumentLoader<
 	TMetadata extends Record<string, unknown> = Record<string, never>,
-	TDocumentKey = string,
 > {
 	/**
 	 * Load metadata for all documents (lightweight operation)
@@ -22,9 +21,9 @@ export interface DocumentLoader<
 	loadMetadata(): AsyncIterable<TMetadata>;
 
 	/**
-	 * Load a specific document by its key
-	 * @param documentKey The key identifying the document
+	 * Load a specific document by its metadata
+	 * @param metadata The metadata identifying the document
 	 * @returns The document with content, or null if not found
 	 */
-	loadDocument(documentKey: TDocumentKey): Promise<Document<TMetadata> | null>;
+	loadDocument(metadata: TMetadata): Promise<Document<TMetadata> | null>;
 }

--- a/packages/rag/src/document-loader/types.ts
+++ b/packages/rag/src/document-loader/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Document with content and metadata
+ */
 export interface Document<
 	TMetadata extends Record<string, unknown> = Record<string, never>,
 > {
@@ -5,18 +8,23 @@ export interface Document<
 	metadata: TMetadata;
 }
 
-export interface DocumentLoaderParams {
-	[key: string]: unknown;
-}
-
+/**
+ * Document loader interface for selective document loading.
+ */
 export interface DocumentLoader<
 	TMetadata extends Record<string, unknown> = Record<string, never>,
-	TParams extends DocumentLoaderParams = DocumentLoaderParams,
+	TDocumentKey = string,
 > {
 	/**
-	 * Load documents asynchronously
-	 * @param params loader-specific parameters
-	 * @returns AsyncIterable of Document
+	 * Load metadata for all documents (lightweight operation)
+	 * @returns AsyncIterable of metadata
 	 */
-	load(params: TParams): AsyncIterable<Document<TMetadata>>;
+	loadMetadata(): AsyncIterable<TMetadata>;
+
+	/**
+	 * Load a specific document by its key
+	 * @param documentKey The key identifying the document
+	 * @returns The document with content, or null if not found
+	 */
+	loadDocument(documentKey: TDocumentKey): Promise<Document<TMetadata> | null>;
 }


### PR DESCRIPTION
## Summary
- Implement continuation mechanism for timed-out GitHub repository ingestions
- Split DocumentLoader interface into separate metadata loading and document loading phases to enable selective document processing

## Changes

### Database Schema
- Add `currentIngestionCommitSha` field to `githubRepositoryIndex` table to track ingestion progress
- Update database schema and generate migration

### DocumentLoader Interface Redesign
- Split the previous single loading method into `loadMetadata` and `loadDocument` methods
- This separation allows IngestPipeline to determine which documents need to be loaded based on metadata
- Essential for implementing continuation ingestion where we can skip already processed documents

### Ingestion Continuation
- Track current ingestion commit SHA during processing
- Include failed and stale repositories in ingestion targets
- Resume from the stored commit SHA if previous ingestion timed out
- Skip already processed files by checking metadata before loading document content

### Code Cleanup
- Remove unnecessary type exports
- Clean up unused comments

## Test plan
- [x] Unit tests pass for all changes
- [x] GitHub repository ingestion completes successfully
- [x] Ingestion resumes correctly after timeout
- [x] Already processed documents are properly skipped on continuation

🤖 Generated with [Claude Code](https://claude.ai/code)