### PR TITLE
(e2e test) Allow PLAYWRIGHT_BASE_URL to be set via workflow_dispatch input

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,10 @@ name: E2E Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      PLAYWRIGHT_BASE_URL:
+        description: 'Base URL for Playwright'
+        required: false
   schedule:
     - cron: "0 0,9 * * 1-5" # Weekdays 9:00 and 18:00 JST
 
@@ -36,6 +40,6 @@ jobs:
         run: pnpm test:e2e
         working-directory: apps/studio.giselles.ai
         env:
-          PLAYWRIGHT_BASE_URL: ${{ secrets.PLAYWRIGHT_BASE_URL }}
+          PLAYWRIGHT_BASE_URL: ${{ github.event.inputs.PLAYWRIGHT_BASE_URL != '' && github.event.inputs.PLAYWRIGHT_BASE_URL || secrets.PLAYWRIGHT_BASE_URL }}
           PLAYWRIGHT_LOGIN_EMAIL: ${{ secrets.PLAYWRIGHT_LOGIN_EMAIL }}
           PLAYWRIGHT_LOGIN_PASSWORD: ${{ secrets.PLAYWRIGHT_LOGIN_PASSWORD }}


### PR DESCRIPTION
### **User description**
## Summary
Allow PLAYWRIGHT_BASE_URL to be set via workflow_dispatch input in CI.

## Changes
- Added workflow_dispatch input for PLAYWRIGHT_BASE_URL
- The workflow now prioritizes the input value; if not provided, it falls back to the secret

## Testing
I confirmed that the environment variable `PLAYWRIGHT_BASE_URL` can be specified from `input` in `workflow_dispatch`.

https://github.com/giselles-ai/giselle/actions/runs/15840035103/job/44650895347#step:9:7

## Other Information

E2E tests are passing locally, but failing in our Vercel preview environment.
To help debug this, I've updated our workflow to allow setting the PLAYWRIGHT_BASE_URL with the Vercel preview URL via a workflow_dispatch input on each pull request.

___

### **PR Type**
Enhancement


___

### **Description**
- Add workflow_dispatch input for `PLAYWRIGHT_BASE_URL` configuration

- Implement fallback logic prioritizing input over secret value


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e.yml</strong><dd><code>Add configurable PLAYWRIGHT_BASE_URL input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e.yml

<li>Added <code>PLAYWRIGHT_BASE_URL</code> input parameter to workflow_dispatch trigger<br> <li> Modified environment variable to use input value with fallback to <br>secret<br> <li> Implemented conditional logic to prioritize manual input over stored <br>secret


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1209/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated E2E test workflow to allow manual runs with a custom Playwright base URL. If provided, this URL will be used for tests; otherwise, the default setting remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->