### PR TITLE
Fix: Synchronize pnpm.lock with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1290,22 +1290,6 @@ importers:
         specifier: 'catalog:'
         version: 8.3.5(jiti@2.4.2)(postcss@8.5.5)(typescript@5.7.3)(yaml@2.7.0)
 
-  packages/vector-store:
-    dependencies:
-      react:
-        specifier: 'catalog:'
-        version: 19.1.0
-    devDependencies:
-      '@giselle/giselle-sdk-tsconfig':
-        specifier: workspace:*
-        version: link:../../tools/tsconfig
-      '@types/react':
-        specifier: 'catalog:'
-        version: 19.1.0
-      tsup:
-        specifier: 'catalog:'
-        version: 8.3.5(jiti@2.4.2)(postcss@8.5.5)(typescript@5.7.3)(yaml@2.7.0)
-
   packages/vector-store-adapters:
     dependencies:
       '@giselle-sdk/giselle-engine':


### PR DESCRIPTION
### **User description**
This PR updates the pnpm.lock file to synchronize it with package.json, resolving dependency version mismatches.

### Changes
- Updated pnpm-lock.yaml to match dependencies defined in package.json
- No functional code changes


___

### **PR Type**
Other


___

### **Description**
- Remove `packages/vector-store` entry from pnpm-lock.yaml

- Synchronize lock file with current package.json structure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Remove vector-store package dependencies entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

<li>Removed complete <code>packages/vector-store</code> section with React dependencies<br> <li> Eliminated outdated package entry to match current workspace structure


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1219/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+0/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>