### PR TITLE
Fix openai web page handling

### DIFF
--- a/apps/studio.giselles.ai/app/giselle-engine.ts
+++ b/apps/studio.giselles.ai/app/giselle-engine.ts
@@ -4,7 +4,7 @@ import { onConsumeAgentTime } from "@/packages/lib/on-consume-agent-time";
 import supabaseStorageDriver from "@/supabase-storage-driver";
 import { WorkspaceId } from "@giselle-sdk/data-type";
 import { emitTelemetry } from "@giselle-sdk/giselle-engine";
-import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next-internal";
+import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next";
 import { supabaseVaultDriver } from "@giselle-sdk/supabase-driver";
 import { openaiVectorStore } from "@giselle-sdk/vector-store-adapters";
 import { createStorage } from "unstorage";

--- a/apps/studio.giselles.ai/app/giselle-engine.ts
+++ b/apps/studio.giselles.ai/app/giselle-engine.ts
@@ -4,7 +4,7 @@ import { onConsumeAgentTime } from "@/packages/lib/on-consume-agent-time";
 import supabaseStorageDriver from "@/supabase-storage-driver";
 import { WorkspaceId } from "@giselle-sdk/data-type";
 import { emitTelemetry } from "@giselle-sdk/giselle-engine";
-import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next";
+import { NextGiselleEngine } from "@giselle-sdk/giselle-engine/next-internal";
 import { supabaseVaultDriver } from "@giselle-sdk/supabase-driver";
 import { openaiVectorStore } from "@giselle-sdk/vector-store-adapters";
 import { createStorage } from "unstorage";

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -206,7 +206,6 @@ async function buildGenerationMessageForTextGeneration(
 							replaceKeyword,
 							fileContents
 								.map((fileContent) => {
-									console.log(fileContent);
 									if (fileContent.type !== "file") {
 										return null;
 									}

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -198,31 +198,47 @@ async function buildGenerationMessageForTextGeneration(
 					contextNode.content,
 					fileResolver,
 				);
-				if (llmProvider === "openai") {
-					userMessage = userMessage.replace(
-						replaceKeyword,
-						fileContents
-							.map((fileContent) => {
-								if (fileContent.type !== "file") {
-									return null;
-								}
-								if (!(fileContent.data instanceof Uint8Array)) {
-									return null;
-								}
-								const text = new TextDecoder().decode(fileContent.data);
-								return `<WebPage name=${fileContent.filename}>${text}</WebPage>`;
-							})
-							.filter((data): data is string => data !== null)
-							.join(),
-					);
-				} else {
-					userMessage = userMessage.replace(
-						replaceKeyword,
-						getFilesDescription(attachedFiles.length, fileContents.length),
-					);
+				switch (llmProvider) {
+					case "anthropic":
+					case "openai":
+					case "perplexity":
+						userMessage = userMessage.replace(
+							replaceKeyword,
+							fileContents
+								.map((fileContent) => {
+									console.log(fileContent);
+									if (fileContent.type !== "file") {
+										return null;
+									}
+									if (
+										!(
+											fileContent.data instanceof Uint8Array ||
+											fileContent.data instanceof ArrayBuffer
+										)
+									) {
+										console.log("?>?>");
+										return null;
+									}
+									const text = new TextDecoder().decode(fileContent.data);
+									return `<WebPage name=${fileContent.filename}>${text}</WebPage>`;
+								})
+								.filter((data): data is string => data !== null)
+								.join(),
+						);
+						break;
+					case "google":
+						userMessage = userMessage.replace(
+							replaceKeyword,
+							getFilesDescription(attachedFiles.length, fileContents.length),
+						);
 
-					attachedFiles.push(...fileContents);
-					attachedFileNodeIds.push(contextNode.id);
+						attachedFiles.push(...fileContents);
+						attachedFileNodeIds.push(contextNode.id);
+						break;
+					default: {
+						const _exhaustiveCheck: never = llmProvider;
+						throw new Error(`Unhandled type: ${_exhaustiveCheck}`);
+					}
 				}
 				break;
 			}
@@ -245,55 +261,18 @@ async function buildGenerationMessageForTextGeneration(
 			}
 		}
 	}
-
-	switch (llmProvider) {
-		case "openai": {
-			return [
+	return [
+		{
+			role: "user",
+			content: [
+				...attachedFiles,
 				{
-					role: "user",
-					content: [
-						...attachedFiles,
-						{
-							type: "text",
-							text: userMessage,
-						},
-					],
+					type: "text",
+					text: userMessage,
 				},
-			];
-		}
-		case "anthropic":
-		case "google": {
-			return [
-				{
-					role: "user",
-					content: [
-						...attachedFiles,
-						{
-							type: "text",
-							text: userMessage,
-						},
-					],
-				},
-			];
-		}
-		case "perplexity": {
-			return [
-				{
-					role: "user",
-					content: [
-						{
-							type: "text",
-							text: userMessage,
-						},
-					],
-				},
-			];
-		}
-		default: {
-			const _exhaustiveCheck: never = llmProvider;
-			throw new Error(`Unhandled provider: ${_exhaustiveCheck}`);
-		}
-	}
+			],
+		},
+	];
 }
 
 function getOrdinal(n: number): string {

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -215,7 +215,6 @@ async function buildGenerationMessageForTextGeneration(
 											fileContent.data instanceof ArrayBuffer
 										)
 									) {
-										
 										return null;
 									}
 									const text = new TextDecoder().decode(fileContent.data);

--- a/packages/giselle-engine/src/core/generations/utils.ts
+++ b/packages/giselle-engine/src/core/generations/utils.ts
@@ -215,7 +215,7 @@ async function buildGenerationMessageForTextGeneration(
 											fileContent.data instanceof ArrayBuffer
 										)
 									) {
-										console.log("?>?>");
+										
 										return null;
 									}
 									const text = new TextDecoder().decode(fileContent.data);


### PR DESCRIPTION
### **User description**
This pull request fixes how OpenAI models handle web page content by changing from file attachments to inline text processing. 

### Key Changes

The core change is in `buildGenerationMessageForTextGeneration` function where file content handling is now provider-specific: 

Previously, all providers except Perplexity would attach files as separate content parts. Now, for OpenAI, Anthropic, and Perplexity, web page files are decoded and inlined as XML-formatted text within the user message using `<WebPage name=${filename}>${content}</WebPage>` tags.

### Technical Impact

**Message Structure Changes:**
- **Before**: OpenAI received files as separate `FilePart` objects in the content array
- **After**: OpenAI receives web page content as inline text within the user message

**Provider-Specific Handling:**
The new logic branches by LLM provider: [3](#0-2) 
- OpenAI, Anthropic, Perplexity: Inline web page text with XML wrapper
- Google: Maintains original file description approach

### Why This Change

This addresses how OpenAI models process web page content. Instead of treating web pages as file attachments, they're now embedded directly in the prompt text, which likely improves the model's ability to reference and process the web content contextually.

The change specifically targets web page handling (checking for `Uint8Array` or `ArrayBuffer` data types) and uses `TextDecoder` to convert binary data to readable text before inlining it.

## Notes

The PR includes debug console.log statements that should probably be removed before merging. The change only affects how web page content is processed - other file types (PDFs, images) continue to use the existing attachment mechanism. Google models maintain the original behavior, suggesting this optimization is specific to how OpenAI processes textual web content.

Wiki pages you might want to explore:
- [Core Architecture (giselles-ai/giselle)](/wiki/giselles-ai/giselle#2)
- [Generation System (giselles-ai/giselle)](/wiki/giselles-ai/giselle#2.2)

------
https://chatgpt.com/codex/tasks/task_e_685c9fa61308832f9eba4188929a01b3


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Inline web page content for OpenAI, Anthropic, and Perplexity providers

- Replace file attachment approach with XML-wrapped text embedding

- Simplify message structure by removing provider-specific branching

- Maintain Google provider's original file attachment behavior


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Provider-specific web page content handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle-engine/src/core/generations/utils.ts

<li>Add provider-specific web page content handling logic<br> <li> Inline web page text with XML wrapper for OpenAI/Anthropic/Perplexity<br> <li> Decode binary data to text using TextDecoder<br> <li> Simplify message structure by removing provider-specific return logic


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1234/files#diff-f39b159d53eaeef165dced6fcc1e975dfbd6c3a5b7e22090c0fce3c5450895af">+51/-53</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of web page content in user messages for different AI providers, ensuring accurate formatting and attachment of files based on the provider used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->