### PR TITLE
fix: add duplicate repository validation to prevent unique constraint errors

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
@@ -9,53 +9,87 @@ import { createId } from "@paralleldrive/cuid2";
 import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 
+type ActionResult = { success: true } | { success: false; error: string };
+
 export async function registerRepositoryIndex(
 	owner: string,
 	repo: string,
 	installationId: number,
-) {
-	const team = await fetchCurrentTeam();
+): Promise<ActionResult> {
+	try {
+		const team = await fetchCurrentTeam();
 
-	// check if the user have access to the installation
-	// FIXME: When the installation is managed by the team, we should use the team's installation instead
-	const githubIdentityState = await getGitHubIdentityState();
-	if (githubIdentityState.status !== "authorized") {
-		throw new Error("User is not authorized to access the repository");
-	}
-	const userClient = githubIdentityState.gitHubUserClient;
-	const installationData = await userClient.getInstallations();
-	const installation = installationData.installations.find(
-		(installation) => installation.id === installationId,
-	);
-	if (!installation) {
-		throw new Error("Installation not found");
-	}
+		// check if the user have access to the installation
+		// FIXME: When the installation is managed by the team, we should use the team's installation instead
+		const githubIdentityState = await getGitHubIdentityState();
+		if (githubIdentityState.status !== "authorized") {
+			return {
+				success: false,
+				error: "GitHub account authentication is required",
+			};
+		}
+		const userClient = githubIdentityState.gitHubUserClient;
+		const installationData = await userClient.getInstallations();
+		const installation = installationData.installations.find(
+			(installation) => installation.id === installationId,
+		);
+		if (!installation) {
+			return { success: false, error: "Installation not found" };
+		}
 
-	// check if the installation can access the repository
-	const installationClient = await buildAppInstallationClient(installationId);
+		// check if the installation can access the repository
+		const installationClient = await buildAppInstallationClient(installationId);
 
-	// check if the repository is already registered
-	const repository = await installationClient.request(
-		"GET /repos/{owner}/{repo}",
-		{
+		// check if the repository is already registered
+		const repository = await installationClient.request(
+			"GET /repos/{owner}/{repo}",
+			{
+				owner,
+				repo,
+			},
+		);
+		if (repository.status !== 200) {
+			return { success: false, error: "Repository not found" };
+		}
+
+		// Check if the repository is already registered for this team
+		const existingIndex = await db
+			.select()
+			.from(githubRepositoryIndex)
+			.where(
+				and(
+					eq(githubRepositoryIndex.owner, owner),
+					eq(githubRepositoryIndex.repo, repo),
+					eq(githubRepositoryIndex.teamDbId, team.dbId),
+				),
+			)
+			.limit(1);
+
+		if (existingIndex.length > 0) {
+			return {
+				success: false,
+				error: `Repository ${owner}/${repo} is already registered for this team`,
+			};
+		}
+
+		const newIndexId = `gthbi_${createId()}` as GitHubRepositoryIndexId;
+		await db.insert(githubRepositoryIndex).values({
+			id: newIndexId,
 			owner,
 			repo,
-		},
-	);
-	if (repository.status !== 200) {
-		throw new Error("Repository not found");
+			teamDbId: team.dbId,
+			installationId,
+		});
+
+		revalidatePath("/settings/team/vector-stores");
+		return { success: true };
+	} catch (error) {
+		console.error("Error registering repository index:", error);
+		return {
+			success: false,
+			error: "An error occurred while registering the repository",
+		};
 	}
-
-	const newIndexId = `gthbi_${createId()}` as GitHubRepositoryIndexId;
-	await db.insert(githubRepositoryIndex).values({
-		id: newIndexId,
-		owner,
-		repo,
-		teamDbId: team.dbId,
-		installationId,
-	});
-
-	revalidatePath("/settings/team/vector-stores");
 }
 
 export async function deleteRepositoryIndex(indexId: GitHubRepositoryIndexId) {

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-registration-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-registration-dialog.tsx
@@ -39,7 +39,7 @@ type RepositoryRegistrationDialogProps = {
 		owner: string,
 		repo: string,
 		installationId: number,
-	) => Promise<void>;
+	) => Promise<{ success: true } | { success: false; error: string }>;
 };
 
 export function RepositoryRegistrationDialog({
@@ -71,28 +71,31 @@ export function RepositoryRegistrationDialog({
 		}
 
 		startTransition(async () => {
-			try {
-				const owner = installationsWithRepos.find(
-					(i) => String(i.installation.id) === ownerId,
-				)?.installation.name;
-				if (!owner) {
-					setError("Owner not found");
-					return;
-				}
-				const repo = repositoryOptions.find(
-					(r) => String(r.id) === repositoryId,
-				)?.name;
-				if (!repo) {
-					setError("Repository not found");
-					return;
-				}
-				await registerRepositoryIndexAction(owner, repo, Number(ownerId));
+			const owner = installationsWithRepos.find(
+				(i) => String(i.installation.id) === ownerId,
+			)?.installation.name;
+			if (!owner) {
+				setError("Owner not found");
+				return;
+			}
+			const repo = repositoryOptions.find(
+				(r) => String(r.id) === repositoryId,
+			)?.name;
+			if (!repo) {
+				setError("Repository not found");
+				return;
+			}
+			const result = await registerRepositoryIndexAction(
+				owner,
+				repo,
+				Number(ownerId),
+			);
+			if (result.success) {
 				setIsOpen(false);
 				setOwnerId("");
 				setRepositoryId("");
-			} catch (error) {
-				setError("An error occurred");
-				console.error(error);
+			} else {
+				setError(result.error);
 			}
 		});
 	};


### PR DESCRIPTION
## Summary
- Added validation to check if a repository is already registered before attempting to insert
- Implemented proper Next.js Server Action error handling pattern
- Fixed error message visibility in production builds

## Problem
When attempting to register a repository that was already registered for a team, the application would throw a database constraint violation error:
```
error: duplicate key value violates unique constraint "github_repository_index_owner_repo_team_db_id_unique"
```

## Solution
1. **Pre-insertion validation**: Check if the repository already exists for the team before attempting to insert
2. **Server Action error handling**: Return explicit result types instead of throwing exceptions
3. **Production-friendly errors**: Error messages are now properly displayed even in production builds

## Changes
- Modified `registerRepositoryIndex` to return `ActionResult` type with success/error states
- Added duplicate check query before insertion
- Updated client-side error handling to properly display server messages
- All error messages are now in English for consistency

## Test plan
- [ ] Register a new repository - should succeed
- [ ] Attempt to register the same repository again - should show "Repository owner/repo is already registered for this team"
- [ ] Test other error cases (unauthorized, installation not found, repository not found)
- [ ] Verify error messages display correctly in production build

🤖 Generated with [Claude Code](https://claude.ai/code)