### PR TITLE
feat: add orphaned repository warning for GitHub vector store nodes

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/lib/use-github-vector-store-status.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/lib/use-github-vector-store-status.ts
@@ -1,0 +1,29 @@
+import type { Node, VectorStoreNode } from "@giselle-sdk/data-type";
+import { isVectorStoreNode } from "@giselle-sdk/data-type";
+import { useVectorStore } from "giselle-sdk/react";
+import { useMemo } from "react";
+
+export function useGitHubVectorStoreStatus(node: Node) {
+	const vectorStore = useVectorStore();
+	const github = vectorStore?.github;
+
+	return useMemo(() => {
+		if (
+			!isVectorStoreNode(node, "github") ||
+			node.content.source.state.status !== "configured"
+		) {
+			return { isOrphaned: false, repositoryId: undefined };
+		}
+
+		const { owner, repo } = node.content.source.state;
+		const vectorStoreInfos = github ?? [];
+		const foundInfo = vectorStoreInfos.find(
+			(info) => info.reference.owner === owner && info.reference.repo === repo,
+		);
+
+		return {
+			isOrphaned: !foundInfo,
+			repositoryId: foundInfo?.id,
+		};
+	}, [node, github]);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx
@@ -4,9 +4,9 @@ import {
 	isTriggerNode,
 	isVectorStoreNode,
 } from "@giselle-sdk/data-type";
-import { useVectorStore } from "giselle-sdk/react";
 import { CircleAlertIcon } from "lucide-react";
-import { type ReactElement, useMemo } from "react";
+import type { ReactElement } from "react";
+import { useGitHubVectorStoreStatus } from "../../lib/use-github-vector-store-status";
 import {
 	GitHubRepositoryBadge,
 	GitHubRepositoryBadgeFromRepo,
@@ -25,24 +25,8 @@ function RequiresSetupBadge(): ReactElement {
 }
 
 export function GitHubNodeInfo({ node }: { node: Node }): ReactElement | null {
-	const vectorStore = useVectorStore();
-	const github = vectorStore?.github;
-
-	const isOrphanedVectorNode = useMemo(() => {
-		if (
-			!isVectorStoreNode(node, "github") ||
-			node.content.source.state.status !== "configured"
-		) {
-			return false;
-		}
-
-		const { owner, repo } = node.content.source.state;
-		const vectorStoreInfos = github ?? [];
-		const exists = vectorStoreInfos.some(
-			(info) => info.reference.owner === owner && info.reference.repo === repo,
-		);
-		return !exists;
-	}, [node, github]);
+	const { isOrphaned: isVectorStoreOrphaned } =
+		useGitHubVectorStoreStatus(node);
 
 	if (isTriggerNode(node, "github")) {
 		return node.content.state.status === "configured" ? (
@@ -71,7 +55,7 @@ export function GitHubNodeInfo({ node }: { node: Node }): ReactElement | null {
 
 	if (isVectorStoreNode(node, "github")) {
 		return node.content.source.state.status === "configured" &&
-			!isOrphanedVectorNode ? (
+			!isVectorStoreOrphaned ? (
 			<div className="px-[16px] relative">
 				<GitHubRepositoryBadge
 					owner={node.content.source.state.owner}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
@@ -1,7 +1,6 @@
 import type { VectorStoreNode } from "@giselle-sdk/data-type";
 import { useVectorStore, useWorkflowDesigner } from "giselle-sdk/react";
 import Link from "next/link";
-import { useMemo } from "react";
 import { TriangleAlert } from "../../../../icons";
 import {
 	Select,
@@ -10,6 +9,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "../../../../ui/select";
+import { useGitHubVectorStoreStatus } from "../../../lib/use-github-vector-store-status";
 
 type GitHubVectorStoreNodePropertiesPanelProps = {
 	node: VectorStoreNode;
@@ -24,21 +24,7 @@ export function GitHubVectorStoreNodePropertiesPanel({
 	const settingPath = vectorStore?.settingPath;
 	const vectorStoreInfos = github ?? [];
 
-	const { currentSelectedRepoId, isOrphaned } = useMemo(() => {
-		const sourceState = node.content.source.state;
-		if (sourceState.status === "configured") {
-			const foundInfo = vectorStoreInfos.find(
-				(info) =>
-					info.reference.owner === sourceState.owner &&
-					info.reference.repo === sourceState.repo,
-			);
-			return {
-				currentSelectedRepoId: foundInfo?.id,
-				isOrphaned: !foundInfo,
-			};
-		}
-		return { currentSelectedRepoId: undefined, isOrphaned: false };
-	}, [node.content.source, vectorStoreInfos]);
+	const { isOrphaned, repositoryId } = useGitHubVectorStoreStatus(node);
 
 	const handleRepositoryChange = (selectedId: string) => {
 		const selectedInfo = vectorStoreInfos.find(
@@ -79,10 +65,7 @@ export function GitHubVectorStoreNodePropertiesPanel({
 						</span>
 					</div>
 				)}
-				<Select
-					value={currentSelectedRepoId}
-					onValueChange={handleRepositoryChange}
-				>
+				<Select value={repositoryId} onValueChange={handleRepositoryChange}>
 					<SelectTrigger className="w-full">
 						<SelectValue placeholder="Select a repository" />
 					</SelectTrigger>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
@@ -2,6 +2,7 @@ import type { VectorStoreNode } from "@giselle-sdk/data-type";
 import { useVectorStore, useWorkflowDesigner } from "giselle-sdk/react";
 import Link from "next/link";
 import { useMemo } from "react";
+import { TriangleAlert } from "../../../../icons";
 import {
 	Select,
 	SelectContent,
@@ -23,7 +24,7 @@ export function GitHubVectorStoreNodePropertiesPanel({
 	const settingPath = vectorStore?.settingPath;
 	const vectorStoreInfos = github ?? [];
 
-	const currentSelectedRepoId = useMemo(() => {
+	const { currentSelectedRepoId, isOrphaned } = useMemo(() => {
 		const sourceState = node.content.source.state;
 		if (sourceState.status === "configured") {
 			const foundInfo = vectorStoreInfos.find(
@@ -31,9 +32,12 @@ export function GitHubVectorStoreNodePropertiesPanel({
 					info.reference.owner === sourceState.owner &&
 					info.reference.repo === sourceState.repo,
 			);
-			return foundInfo?.id;
+			return {
+				currentSelectedRepoId: foundInfo?.id,
+				isOrphaned: !foundInfo,
+			};
 		}
-		return undefined;
+		return { currentSelectedRepoId: undefined, isOrphaned: false };
 	}, [node.content.source, vectorStoreInfos]);
 
 	const handleRepositoryChange = (selectedId: string) => {
@@ -61,6 +65,20 @@ export function GitHubVectorStoreNodePropertiesPanel({
 				<p className="text-[14px] py-[1.5px] text-white-400">
 					GitHub Repository
 				</p>
+				{isOrphaned && node.content.source.state.status === "configured" && (
+					<div className="flex items-center gap-[6px] text-error-900 text-[13px] mb-[8px]">
+						<TriangleAlert className="size-[16px]" />
+						<span>
+							The repository{" "}
+							<span className="font-mono font-semibold">
+								{node.content.source.state.owner}/
+								{node.content.source.state.repo}
+							</span>{" "}
+							is no longer available in your vector stores. Please select a
+							different repository or set up this repository again.
+						</span>
+					</div>
+				)}
 				<Select
 					value={currentSelectedRepoId}
 					onValueChange={handleRepositoryChange}


### PR DESCRIPTION
### **User description**
## Summary
- Add visual feedback when a GitHub vector store node references a repository that no longer exists in the user's vector stores
- Display warning message and "REQUIRES SETUP" badge for orphaned nodes
- Improve user experience by clearly indicating when repository reconfiguration is needed

<img width="1251" alt="スクリーンショット 2025-06-26 12 32 01" src="https://github.com/user-attachments/assets/bf9cd771-2031-438b-bc6c-240fc6905b3b" />



## Changes
- Added orphaned repository detection logic in `github-node-info.tsx`
- Added warning message UI in the properties panel for orphaned repositories
- Shows specific repository name that is no longer available

## Test plan
- [x] Create a GitHub vector store node and configure it with a repository
- [x] Remove the repository from vector stores
- [x] Verify the node shows "REQUIRES SETUP" badge
- [x] Verify the properties panel shows warning message with repository name
- [x] Verify selecting a new repository removes the warning

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add orphaned repository detection for GitHub vector store nodes

- Display warning message and "REQUIRES SETUP" badge for missing repositories

- Show specific repository name in properties panel warning

- Improve user experience with clear visual feedback


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github-node-info.tsx</strong><dd><code>Add orphaned repository detection and badge display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx

<li>Add orphaned repository detection logic using <code>useVectorStore</code> hook<br> <li> Show "REQUIRES SETUP" badge for vector store nodes with missing <br>repositories<br> <li> Check if configured repository exists in available vector stores


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1241/files#diff-04a432f5330b71ae1b0607d73e3e5f13b6fd8e61211f48e922424e0527ee48c7">+26/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add orphaned repository warning in properties panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx

<li>Add warning message for orphaned repositories in properties panel<br> <li> Display specific repository name that is no longer available<br> <li> Import <code>TriangleAlert</code> icon for warning display<br> <li> Track orphaned state alongside current selected repository ID


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1241/files#diff-f211cde95d4ce69b93154909e24da0f2d6c4f672e4db0a273c3288e0cb3f0476">+21/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to detect and indicate "orphaned" GitHub vector store nodes, preventing badges from displaying for repositories no longer present.
  * Displayed an alert message when a configured repository is missing, prompting users to select or set up a new repository.

* **Refactor**
  * Improved internal handling of repository selection and orphaned state detection for better reliability and user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->