### PR TITLE
fix: use REQUIRED_COLUMN_KEYS constant instead of hardcoded column names

### DIFF
--- a/packages/rag/src/query-service/postgres/index.ts
+++ b/packages/rag/src/query-service/postgres/index.ts
@@ -4,10 +4,11 @@ import type { z } from "zod/v4";
 import { createColumnMapping } from "../../database";
 import { PoolManager } from "../../database/postgres";
 import { ensurePgVectorTypes } from "../../database/postgres/pgvector-registry";
-import type {
-	ColumnMapping,
-	DatabaseConfig,
-	RequiredColumns,
+import {
+	type ColumnMapping,
+	type DatabaseConfig,
+	REQUIRED_COLUMN_KEYS,
+	type RequiredColumns,
 } from "../../database/types";
 import type { EmbedderFunction } from "../../embedder";
 import { createDefaultEmbedder } from "../../embedder";
@@ -177,11 +178,9 @@ export function createPostgresQueryService<
 				paramIndex++;
 			}
 
+			const requiredKeys = new Set<string>(REQUIRED_COLUMN_KEYS);
 			const metadataColumns = Object.entries(columnMapping)
-				.filter(
-					([key]) =>
-						!["documentKey", "content", "index", "embedding"].includes(key),
-				)
+				.filter(([key]) => !requiredKeys.has(key))
 				.map(([metadataKey, dbColumn]) => {
 					if (typeof dbColumn !== "string") {
 						throw ConfigurationError.invalidValue(


### PR DESCRIPTION
### **User description**
## Summary
- Replace hardcoded column filter array with the centralized `REQUIRED_COLUMN_KEYS` constant
- Fix missing columns: the hardcoded array was missing `chunkContent`, `chunkIndex`, and `version`
- Simplify filtering logic using `Set` for better readability and performance

## Details
The previous implementation had hardcoded column names `["documentKey", "content", "index", "embedding"]` which didn't match the actual `REQUIRED_COLUMN_KEYS` constant that contains:
- `documentKey`
- `chunkContent` (was missing)
- `chunkIndex` (was missing) 
- `embedding`
- `version` (was missing)

This change ensures consistency by using the centralized constant and prevents future sync issues.

## Test plan
- [x] Verify that query service still filters metadata columns correctly
- [ ] Ensure no required columns appear in metadata results
- [ ] Check that all metadata columns are properly extracted

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace hardcoded column names with centralized `REQUIRED_COLUMN_KEYS` constant

- Fix missing columns: `chunkContent`, `chunkIndex`, and `version`

- Improve filtering logic using `Set` for better performance

- Ensure consistency between column filtering and required columns definition


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Replace hardcoded columns with centralized constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/query-service/postgres/index.ts

<li>Import <code>REQUIRED_COLUMN_KEYS</code> constant from database types<br> <li> Replace hardcoded column array with <code>REQUIRED_COLUMN_KEYS</code> constant<br> <li> Use <code>Set</code> for efficient column filtering instead of array includes<br> <li> Fix metadata column filtering to exclude all required columns


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1246/files#diff-9ae84bd50fb275c4c066b2b1c26651804763a6d893a85bcdb2718a6c6f9010d7">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for filtering metadata columns, resulting in more consistent handling of required fields. No visible changes to the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->