### PR TITLE
Remove githubVectorStoreFlag feature flag

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -14,7 +14,6 @@ export default async function Layout({
 		<WorkspaceProvider
 			workspaceId={workspaceId}
 			featureFlag={{
-				githubVectorStore: true,
 				runV3: true,
 				sidemenu: true,
 				githubTools: true,

--- a/apps/studio.giselles.ai/app/(main)/layout.tsx
+++ b/apps/studio.giselles.ai/app/(main)/layout.tsx
@@ -1,13 +1,11 @@
 import { GiselleLogo } from "@/components/giselle-logo";
-import { githubVectorStoreFlag } from "@/flags";
 import { UserButton } from "@/services/accounts/components";
 import { TeamSelection } from "@/services/teams/components/team-selection";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { Nav } from "./nav";
 
-export default async function Layout({ children }: { children: ReactNode }) {
-	const githubVectorStore = await githubVectorStoreFlag();
+export default function Layout({ children }: { children: ReactNode }) {
 	return (
 		<div className="h-screen overflow-y-hidden bg-black-900 flex flex-col">
 			<header className="flex flex-col">
@@ -33,7 +31,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
 					</div>
 				</div>
 
-				<Nav githubVectorStoreFlag={githubVectorStore} />
+				<Nav />
 
 				{/* Border line below navigation */}
 				<div className="h-[1px] w-full bg-black-70/50" />

--- a/apps/studio.giselles.ai/app/(main)/nav.tsx
+++ b/apps/studio.giselles.ai/app/(main)/nav.tsx
@@ -14,12 +14,7 @@ const menuItems = [
 	{ name: "Team Settings", path: "/settings/team" },
 ];
 
-// receive githubVectorStoreFlag as props
-interface NavProps {
-	githubVectorStoreFlag: boolean;
-}
-
-export const Nav: FC<NavProps> = ({ githubVectorStoreFlag }) => {
+export const Nav: FC = () => {
 	const pathname = usePathname();
 
 	// hide nav on settings/account page
@@ -27,16 +22,11 @@ export const Nav: FC<NavProps> = ({ githubVectorStoreFlag }) => {
 		return null;
 	}
 
-	// remove Vector Store link
-	const filteredMenuItems = githubVectorStoreFlag
-		? menuItems
-		: menuItems.filter((item) => item.name !== "Vector Stores");
-
 	// find the best match path
 	let bestMatchPath = "";
 	let bestMatchIndex = -1;
 
-	filteredMenuItems.forEach((item, index) => {
+	menuItems.forEach((item, index) => {
 		if (
 			pathname.startsWith(item.path) &&
 			item.path.length > bestMatchPath.length
@@ -49,7 +39,7 @@ export const Nav: FC<NavProps> = ({ githubVectorStoreFlag }) => {
 	return (
 		<div className="flex items-center px-[24px] py-0 border-t border-black-900/50">
 			<div className="flex items-center space-x-[12px]">
-				{filteredMenuItems.map((item, index) => {
+				{menuItems.map((item, index) => {
 					const isActive = index === bestMatchIndex;
 					return (
 						<Link

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
@@ -1,21 +1,14 @@
 import { Card } from "@/components/ui/card";
 import { db, githubRepositoryIndex } from "@/drizzle";
-import { githubVectorStoreFlag } from "@/flags";
 import { getGitHubIdentityState } from "@/services/accounts";
 import { fetchCurrentTeam } from "@/services/teams";
 import { desc, eq } from "drizzle-orm";
 import { AlertCircle, ExternalLink } from "lucide-react";
-import { notFound } from "next/navigation";
 import { deleteRepositoryIndex, registerRepositoryIndex } from "./actions";
 import { RepositoryItem } from "./repository-item";
 import { RepositoryRegistrationDialog } from "./repository-registration-dialog";
 
 export default async function TeamVectorStorePage() {
-	const vectorStoreFlag = await githubVectorStoreFlag();
-	if (!vectorStoreFlag) {
-		return notFound();
-	}
-
 	const githubIdentityState = await getGitHubIdentityState();
 	if (
 		githubIdentityState.status === "unauthorized" ||

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -2,7 +2,6 @@ import { getGitHubVectorStores } from "@/app/services/vector-store";
 import { db } from "@/drizzle";
 import {
 	githubToolsFlag,
-	githubVectorStoreFlag,
 	layoutV2Flag,
 	runV3Flag,
 	sidemenuFlag,
@@ -41,7 +40,6 @@ export default async function Layout({
 		return notFound();
 	}
 	const usageLimits = await getUsageLimitsForTeam(currentTeam);
-	const githubVectorStore = await githubVectorStoreFlag();
 	const gitHubVectorStores = await getGitHubVectorStores(currentTeam.dbId);
 	const runV3 = await runV3Flag();
 	const sidemenu = await sidemenuFlag();
@@ -74,7 +72,7 @@ export default async function Layout({
 				},
 			}}
 			featureFlag={{
-				githubVectorStore,
+				githubVectorStore: true,
 				runV3,
 				sidemenu,
 				githubTools,

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -40,19 +40,6 @@ export const githubToolsFlag = flag<boolean>({
 	],
 });
 
-export const githubVectorStoreFlag = flag<boolean>({
-	key: "github-vector-store",
-	decide() {
-		return takeLocalEnv("GITHUB_VECTOR_STORE_FLAG");
-	},
-	description: "Enable GitHub Vector Store",
-	defaultValue: false,
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const webSearchActionFlag = flag<boolean>({
 	key: "web-search-action",
 	decide() {

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -93,11 +93,11 @@ export function Toolbar() {
 	const [selectedCategory, setSelectedCategory] = useState<string>("All");
 	const { llmProviders } = useWorkflowDesigner();
 	const limits = useUsageLimits();
-	const { githubVectorStore, webSearchAction } = useFeatureFlag();
+	const { webSearchAction } = useFeatureFlag();
 	const vectorStore = useVectorStore();
 	const canUseGithubVectorStore = useMemo(
-		() => !!vectorStore?.github && githubVectorStore,
-		[vectorStore, githubVectorStore],
+		() => !!vectorStore?.github,
+		[vectorStore],
 	);
 
 	const modelsFilteredBySearchOnly = languageModels

--- a/packages/workspace/src/react/feature-flag.ts
+++ b/packages/workspace/src/react/feature-flag.ts
@@ -1,7 +1,6 @@
 import { createContext, useContext } from "react";
 
 export interface FeatureFlagContextValue {
-	githubVectorStore: boolean;
 	runV3: boolean;
 	sidemenu: boolean;
 	githubTools: boolean;

--- a/packages/workspace/src/react/workspace.tsx
+++ b/packages/workspace/src/react/workspace.tsx
@@ -63,7 +63,6 @@ export function WorkspaceProvider({
 							<GenerationRunnerSystemProvider>
 								<FeatureFlagContext
 									value={{
-										githubVectorStore: featureFlag?.githubVectorStore ?? false,
 										runV3: featureFlag?.runV3 ?? false,
 										sidemenu: featureFlag?.sidemenu ?? false,
 										githubTools: featureFlag?.githubTools ?? false,


### PR DESCRIPTION
## Summary
- Removed the githubVectorStoreFlag feature flag entirely from the codebase
- GitHub Vector Store functionality is now always enabled
- This simplifies the codebase by removing conditional logic

## Changes
- ✅ Removed flag definition from `flags.ts`
- ✅ Updated studio and playground layouts to no longer use the flag
- ✅ Removed flag prop from Nav component
- ✅ Removed feature gate from vector-stores settings page
- ✅ Updated workspace package's feature flag interface
- ✅ Updated toolbar component to check only vector store availability

## Test plan
- [ ] Verify GitHub Vector Store functionality is accessible in the UI
- [ ] Confirm navigation menu shows "Vector Stores" item
- [ ] Test that vector stores settings page is accessible
- [ ] Verify toolbar shows GitHub Vector Store options when repositories are configured
- [ ] No TypeScript errors in the build

🤖 Generated with [Claude Code](https://claude.ai/code)