### PR TITLE
Add Popover Component to UI Library

### DIFF
--- a/apps/playground/app/ui/layout.tsx
+++ b/apps/playground/app/ui/layout.tsx
@@ -17,6 +17,10 @@ const components = [
 		id: "dropdown-menu",
 		name: "Dropdown Menu",
 	},
+	{
+		id: "popover",
+		name: "Popover",
+	},
 ];
 export default function ({
 	children,

--- a/apps/playground/app/ui/popover/page.tsx
+++ b/apps/playground/app/ui/popover/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Button } from "@giselle-internal/ui/button";
+import { Popover } from "@giselle-internal/ui/popover";
+
+export default function () {
+	return (
+		<>
+			<h2 className="text-text mb-6">Dropdown Menu</h2>
+			<div className="space-y-8">
+				<div>
+					<p className="text-text mb-2 text-sm">Demo</p>
+					<div className="bg-transparent p-8 rounded-[4px] border border-border shadow-sm text-sans">
+						<div className="space-y-4">
+							<Popover trigger={<Button>Hello</Button>}>
+								<p>content</p>
+							</Popover>
+						</div>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/internal-packages/ui/components/popover.tsx
+++ b/internal-packages/ui/components/popover.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx/lite";
+import { Popover as PopoverPrimitive } from "radix-ui";
 
 export function PopoverContent(props: React.PropsWithChildren) {
 	return (
@@ -10,5 +11,23 @@ export function PopoverContent(props: React.PropsWithChildren) {
 			)}
 			{...props}
 		/>
+	);
+}
+
+export function Popover({
+	trigger,
+	children,
+}: React.PropsWithChildren<{
+	trigger: React.ReactNode;
+}>) {
+	return (
+		<PopoverPrimitive.Root>
+			<PopoverPrimitive.Trigger asChild>{trigger}</PopoverPrimitive.Trigger>
+			<PopoverPrimitive.Portal>
+				<PopoverPrimitive.Content asChild>
+					<PopoverContent>{children}</PopoverContent>
+				</PopoverPrimitive.Content>
+			</PopoverPrimitive.Portal>
+		</PopoverPrimitive.Root>
 	);
 }

--- a/internal-packages/ui/package.json
+++ b/internal-packages/ui/package.json
@@ -14,7 +14,8 @@
 		"./button": "./components/button.tsx",
 		"./select": "./components/select.tsx",
 		"./note": "./components/note.tsx",
-		"./dropdown-menu": "./components/dropdown-menu.tsx"
+		"./dropdown-menu": "./components/dropdown-menu.tsx",
+		"./popover": "./components/popover.tsx"
 	},
 	"dependencies": {
 		"clsx": "catalog:",


### PR DESCRIPTION
## Description
This PR adds a new Popover component to our UI component library, enhancing our component offering with a flexible popup overlay solution.

## Changes
- Created new `Popover` component in the UI package using Radix UI primitives
- Added component exports in the UI package.json
- Created a demo page in the playground app
- Updated UI navigation to include the Popover component

## Testing
The component can be tested in the playground app under the UI section.

## Screenshots
_Please add screenshots of the component in action if available_