### PR TITLE
fix: handle GitHub API rate limit errors without retry

### DIFF
--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/route.ts
@@ -53,9 +53,12 @@ async function processRepository(
 
 		await updateRepositoryStatusToCompleted(dbId, commit.sha);
 	} catch (error) {
-		console.error(`Failed to ingest ${owner}/${repo}:`, error);
+		console.error(
+			`Failed to ingest team ${teamDbId} repository ${owner}/${repo}:`,
+			error,
+		);
 		captureException(error, {
-			extra: { owner, repo },
+			extra: { owner, repo, teamDbId },
 		});
 		await updateRepositoryStatusToFailed(dbId);
 	}


### PR DESCRIPTION
## Summary
- Fixed GitHub API rate limit errors (403/429) to fail immediately without retry
- Added proper error handling for all octokit.request calls
- Centralized error handling logic in a common function

## Changes
- 403/429 errors: Throw immediately without retry
- 5xx errors: Retry with exponential backoff (1s, 2s, 4s)
- 404 errors: Include helpful message about permissions
- Added teamDbId to error logs for better debugging

## Test plan
- [ ] Verify that rate limit errors fail immediately without retry
- [ ] Confirm 5xx errors trigger retry mechanism
- [ ] Check that 404 errors display helpful permission messages

🤖 Generated with [Claude Code](https://claude.ai/code)