### PR TITLE
Fix workspace cache issue causing data persistence problems

### DIFF
--- a/apps/playground/supabase-storage-driver.ts
+++ b/apps/playground/supabase-storage-driver.ts
@@ -113,7 +113,7 @@ export default defineDriver((options: SupabaseStorageDriverOptions) => {
 		},
 
 		async setItem(key, value, opts) {
-			const cacheControl = opts?.cacheControlMaxAge;
+			const cacheControl = opts?.cacheControl;
 			const contentType = opts?.contentType;
 
 			const { data, error } = await supabase.storage

--- a/apps/studio.giselles.ai/supabase-storage-driver.ts
+++ b/apps/studio.giselles.ai/supabase-storage-driver.ts
@@ -124,10 +124,7 @@ export default defineDriver((options: SupabaseStorageDriverOptions) => {
 		},
 
 		async setItem(key, value, opts) {
-			const cacheControl =
-				opts?.cacheControlMaxAge !== undefined
-					? `max-age=${opts.cacheControlMaxAge}`
-					: undefined;
+			const cacheControl = opts?.cacheControl;
 			const contentType = opts?.contentType;
 
 			const { data, error } = await supabase.storage

--- a/apps/studio.giselles.ai/supabase-storage-driver.ts
+++ b/apps/studio.giselles.ai/supabase-storage-driver.ts
@@ -124,7 +124,10 @@ export default defineDriver((options: SupabaseStorageDriverOptions) => {
 		},
 
 		async setItem(key, value, opts) {
-			const cacheControl = opts?.cacheControlMaxAge;
+			const cacheControl =
+				opts?.cacheControlMaxAge !== undefined
+					? `max-age=${opts.cacheControlMaxAge}`
+					: undefined;
 			const contentType = opts?.contentType;
 
 			const { data, error } = await supabase.storage

--- a/packages/giselle-engine/src/core/workspaces/utils.ts
+++ b/packages/giselle-engine/src/core/workspaces/utils.ts
@@ -16,7 +16,7 @@ export async function setWorkspace({
 	workspace: Workspace;
 }) {
 	await storage.setItem(workspacePath(workspaceId), workspace, {
-		// Disable caching by setting cacheControlMaxAge to 0 for Vercel Blob storage
+		// Disable caching by setting cacheControlMaxAge to 0 for Supabase storage
 		cacheControlMaxAge: 0,
 	});
 }
@@ -28,7 +28,9 @@ export async function getWorkspace({
 	storage: Storage;
 	workspaceId: WorkspaceId;
 }) {
-	const result = await storage.getItem(workspacePath(workspaceId));
+	const result = await storage.getItem(workspacePath(workspaceId), {
+		bypassingCache: true,
+	});
 	const workspace = parseAndMod(
 		Workspace,
 		result,

--- a/packages/giselle-engine/src/core/workspaces/utils.ts
+++ b/packages/giselle-engine/src/core/workspaces/utils.ts
@@ -16,8 +16,8 @@ export async function setWorkspace({
 	workspace: Workspace;
 }) {
 	await storage.setItem(workspacePath(workspaceId), workspace, {
-		// Disable caching by setting cacheControlMaxAge to 0 for Supabase storage
-		cacheControlMaxAge: 0,
+		// Disable caching by setting cacheControl to 0 for Supabase storage
+		cacheControl: 0,
 	});
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- Fixed workspace changes appearing to be lost when navigating away (#1096)
- The issue was caused by cache returning stale data, not save failures

## Changes
- Convert `cacheControlMaxAge` to proper Cache-Control header format in supabase-storage-driver
- Add `bypassingCache` option when loading workspace to ensure fresh data

## Test plan
- [x] Add a node to workspace
- [x] Navigate to another page 
- [x] Return to workspace - node should still be present
- [x] Delete a node from workspace
- [x] Navigate to another page
- [x] Return to workspace - node should remain deleted

## Details
The root cause was that while saves were successful, the storage cache was returning outdated data on subsequent loads. This made it appear as if changes were not persisted. The fix ensures:
1. Write operations set `Cache-Control: max-age=0` correctly
2. Read operations bypass cache to always get fresh data

Fixes #1096


___

### **PR Type**
Bug fix


___

### **Description**
- Fix workspace cache issue causing data persistence problems

- Convert `cacheControlMaxAge` to proper Cache-Control header format

- Add `bypassingCache` option to ensure fresh workspace data

- Resolve issue where workspace changes appeared lost after navigation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Storage Driver"] --> B["Fix Cache-Control Header"]
  C["Workspace Utils"] --> D["Add Bypass Cache Option"]
  B --> E["Proper Cache Headers"]
  D --> F["Fresh Data Loading"]
  E --> G["Workspace Changes Persist"]
  F --> G
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>supabase-storage-driver.ts</strong><dd><code>Fix Cache-Control header format in storage driver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/supabase-storage-driver.ts

<li>Convert <code>cacheControlMaxAge</code> to proper <code>Cache-Control: max-age=X</code> header <br>format<br> <li> Add conditional check for undefined <code>cacheControlMaxAge</code> values


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1263/files#diff-13074662ed6a4fe77407e78cb85916f9b72550ea035735641d48516c164c4da3">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Add cache bypass option for workspace loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle-engine/src/core/workspaces/utils.ts

<li>Add <code>bypassingCache: true</code> option to <code>getWorkspace</code> function<br> <li> Update comment to reference Supabase instead of Vercel Blob


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1263/files#diff-e11c7dcfd0424235ec77ad46ff5727c61347b8c7ec2a601d9bde9722b867a411">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cache control settings to ensure compatibility and correct formatting when storing items.
  * Workspace retrieval now explicitly bypasses cache to provide the most up-to-date data.

* **Documentation**
  * Updated comments to clarify cache control behavior for Supabase storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->