### PR TITLE
Add layoutV3 feature flag

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -19,6 +19,7 @@ export default async function Layout({
 				githubTools: true,
 				webSearchAction: false,
 				layoutV2: true,
+				layoutV3: false,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -3,6 +3,7 @@ import { db } from "@/drizzle";
 import {
 	githubToolsFlag,
 	layoutV2Flag,
+	layoutV3Flag,
 	runV3Flag,
 	sidemenuFlag,
 	webSearchActionFlag,
@@ -46,6 +47,7 @@ export default async function Layout({
 	const githubTools = await githubToolsFlag();
 	const webSearchAction = await webSearchActionFlag();
 	const layoutV2 = await layoutV2Flag();
+	const layoutV3 = await layoutV3Flag();
 	return (
 		<WorkspaceProvider
 			workspaceId={workspaceId}
@@ -77,6 +79,7 @@ export default async function Layout({
 				githubTools,
 				webSearchAction,
 				layoutV2,
+				layoutV3,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -109,3 +109,22 @@ export const layoutV2Flag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const layoutV3Flag = flag<boolean>({
+	key: "layout-v3",
+	async decide() {
+		if (process.env.NODE_ENV === "development") {
+			return takeLocalEnv("LAYOUT_V3_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return edgeConfig === true || edgeConfig === "true";
+	},
+	description: "Enable Layout V3",
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});

--- a/internal-packages/workflow-designer-ui/src/editor/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/index.tsx
@@ -46,6 +46,7 @@ import {
 	useToolbar,
 } from "./tool";
 import { V2Placeholder } from "./v2";
+import { V3Placeholder } from "./v3";
 import { WorkspaceTour, tourSteps } from "./workspace-tour";
 
 function NodeCanvas() {
@@ -445,7 +446,11 @@ export function Editor({
 		setShowReadOnlyBanner(false);
 	}, []);
 
-	const { sidemenu, layoutV2 } = useFeatureFlag();
+	const { sidemenu, layoutV2, layoutV3 } = useFeatureFlag();
+
+	if (layoutV3) {
+		return <V3Placeholder isReadOnly={isReadOnly} userRole={userRole} />;
+	}
 
 	if (layoutV2) {
 		return <V2Placeholder isReadOnly={isReadOnly} userRole={userRole} />;

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -27,7 +27,7 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 
 export function FileNodePropertiesPanel({ node }: { node: FileNode }) {
 	const { updateNodeData } = useWorkflowDesigner();
-	const { layoutV2 } = useFeatureFlag();
+	const { layoutV2, layoutV3 } = useFeatureFlag();
 
 	return (
 		<PropertiesPanelRoot>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
@@ -32,7 +32,7 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 			origin: { type: "workspace", id: data.id },
 		});
 	const { all: connectedSources } = useConnectedSources(node);
-	const { layoutV2 } = useFeatureFlag();
+	const { layoutV2, layoutV3 } = useFeatureFlag();
 
 	const generate = useCallback(() => {
 		createAndStartGeneration({
@@ -93,7 +93,7 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 			/>
 
 			<PropertiesPanelContent>
-				{layoutV2 ? (
+				{layoutV2 || layoutV3 ? (
 					<ResizableSectionGroup>
 						<ResizableSection title="Query" defaultSize={50} minSize={20}>
 							<div className="p-4">

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -64,7 +64,7 @@ export function TextGenerationNodePropertiesPanel({
 	const { all: connectedSources } = useConnectedOutputs(node);
 	const usageLimitsReached = useUsageLimitsReached();
 	const { error } = useToasts();
-	const { layoutV2 } = useFeatureFlag();
+	const { layoutV2, layoutV3 } = useFeatureFlag();
 
 	const uiState = useMemo(() => data.ui.nodeState[node.id], [data, node.id]);
 
@@ -160,7 +160,7 @@ export function TextGenerationNodePropertiesPanel({
 			/>
 
 			<PropertiesPanelContent>
-				{layoutV2 ? (
+				{layoutV2 || layoutV3 ? (
 					<PanelGroup direction="vertical" className="flex-1 flex flex-col">
 						<Panel>
 							<PropertiesPanelContent>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tab-content.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tab-content.tsx
@@ -50,7 +50,7 @@ export function TextGenerationTabContent({
 	githubTools,
 	sidemenu,
 }: TextGenerationTabContentProps) {
-	const { layoutV2 } = useFeatureFlag();
+	const { layoutV2, layoutV3 } = useFeatureFlag();
 
 	return (
 		<>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-node-properties-panel/index.tsx
@@ -12,7 +12,7 @@ import {
 
 export function TextNodePropertiesPanel({ node }: { node: TextNode }) {
 	const { updateNodeDataContent, updateNodeData } = useWorkflowDesigner();
-	const { layoutV2 } = useFeatureFlag();
+	const { layoutV2, layoutV3 } = useFeatureFlag();
 
 	return (
 		<PropertiesPanelRoot>
@@ -25,7 +25,7 @@ export function TextNodePropertiesPanel({ node }: { node: TextNode }) {
 				}}
 			/>
 			<PropertiesPanelContent>
-				{layoutV2 ? (
+				{layoutV2 || layoutV3 ? (
 					<ResizableSectionGroup>
 						<ResizableSection defaultSize={100}>
 							<TextEditor

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/properties-panel.tsx
@@ -34,19 +34,19 @@ export function PropertiesPanelHeader({
 	onChangeName?: (name?: string) => void;
 	action?: ReactNode;
 }) {
-	const { sidemenu, layoutV2 } = useFeatureFlag();
+	const { sidemenu, layoutV2, layoutV3 } = useFeatureFlag();
 	if (sidemenu) {
 		return (
 			<div className={getHeaderClasses(sidemenu)}>
 				<div className={`flex ${PANEL_SPACING.HEADER.ICON_GAP} items-center`}>
 					<div
 						className={
-							layoutV2
+							layoutV2 || layoutV3
 								? "bg-white-900 rounded-[4px] flex items-center justify-center"
 								: `w-[${PANEL_SPACING.HEADER.ICON_SIZE}] h-[${PANEL_SPACING.HEADER.ICON_SIZE}] bg-white-900 rounded-[4px] flex items-center justify-center`
 						}
 						style={
-							layoutV2
+							layoutV2 || layoutV3
 								? {
 										width: PANEL_SPACING.HEADER.ICON_SIZE,
 										height: PANEL_SPACING.HEADER.ICON_SIZE,
@@ -88,12 +88,12 @@ export function PropertiesPanelHeader({
 			<div className={`flex ${PANEL_SPACING.HEADER.ICON_GAP} items-center`}>
 				<div
 					className={
-						layoutV2
+						layoutV2 || layoutV3
 							? "bg-white-900 rounded-[4px] flex items-center justify-center"
 							: `w-[${PANEL_SPACING.HEADER.ICON_SIZE}] h-[${PANEL_SPACING.HEADER.ICON_SIZE}] bg-white-900 rounded-[4px] flex items-center justify-center`
 					}
 					style={
-						layoutV2
+						layoutV2 || layoutV3
 							? {
 									width: PANEL_SPACING.HEADER.ICON_SIZE,
 									height: PANEL_SPACING.HEADER.ICON_SIZE,

--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/file-node-properties-panel/index.tsx
@@ -27,10 +27,10 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 
 export function FileNodePropertiesPanel({ node }: { node: FileNode }) {
 	const { updateNodeData } = useWorkflowDesigner();
-	const { layoutV2, sidemenu } = useFeatureFlag();
+	const { layoutV2, layoutV3, sidemenu } = useFeatureFlag();
 
 	const getFilePanelContent = () => {
-		if (layoutV2) {
+		if (layoutV2 || layoutV3) {
 			return (
 				<div className={sidemenu ? "p-4" : "pl-0 pr-4 py-4"}>
 					<FilePanel node={node} config={fileType[node.content.category]} />

--- a/internal-packages/workflow-designer-ui/src/editor/v3/index.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/v3/index.ts
@@ -1,0 +1,1 @@
+export { V3Placeholder } from "./v3-placeholder";

--- a/internal-packages/workflow-designer-ui/src/editor/v3/v3-placeholder.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v3/v3-placeholder.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export function V3Placeholder({
+	isReadOnly = false,
+	userRole = "viewer",
+}: {
+	isReadOnly?: boolean;
+	userRole?: "viewer" | "guest" | "editor" | "owner";
+}) {
+	return <div className="text-text">V3(WIP)</div>;
+}

--- a/packages/workspace/src/react/feature-flag.ts
+++ b/packages/workspace/src/react/feature-flag.ts
@@ -6,6 +6,7 @@ export interface FeatureFlagContextValue {
 	githubTools: boolean;
 	webSearchAction: boolean;
 	layoutV2: boolean;
+	layoutV3: boolean;
 }
 export const FeatureFlagContext = createContext<
 	FeatureFlagContextValue | undefined

--- a/packages/workspace/src/react/workspace.tsx
+++ b/packages/workspace/src/react/workspace.tsx
@@ -68,6 +68,7 @@ export function WorkspaceProvider({
 										githubTools: featureFlag?.githubTools ?? false,
 										webSearchAction: featureFlag?.webSearchAction ?? false,
 										layoutV2: featureFlag?.layoutV2 ?? false,
+										layoutV3: featureFlag?.layoutV3 ?? false,
 									}}
 								>
 									{children}


### PR DESCRIPTION
## Summary
- add new `layoutV3Flag` definition
- expose `layoutV3` in feature flag context and workspace provider
- implement placeholder for Layout V3
- wire layoutV3 into studio and playground workspaces
- update workflow designer UI to recognise the new flag

## Testing
- `npx turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw`
- `npx turbo check-types --cache=local:rw`
- `npx turbo test --cache=local:rw`


------
https://chatgpt.com/codex/tasks/task_e_686231529a1c832f86aec38721cd4dd4