### PR TITLE
Fix workspace tour not showing in V2 layout

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/v2-placeholder.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/v2-placeholder.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useFeatureFlag } from "giselle-sdk/react";
+import { useWorkflowDesigner } from "giselle-sdk/react";
 import { useCallback, useState } from "react";
 import { ReadOnlyBanner } from "../../ui/read-only-banner";
+import { WorkspaceTour, tourSteps } from "../workspace-tour";
 import { V2Container, V2Footer, V2Header } from "./components";
 import { RootProvider } from "./components/provider";
 import type { LeftPanelValue, V2LayoutState } from "./state";
@@ -16,10 +18,12 @@ export function V2Placeholder({
 	userRole?: "viewer" | "guest" | "editor" | "owner";
 	onNameChange?: (name: string) => Promise<void>;
 }) {
+	const { data } = useWorkflowDesigner();
 	const [showReadOnlyBanner, setShowReadOnlyBanner] = useState(isReadOnly);
 	const [layoutState, setLayoutState] = useState<V2LayoutState>({
 		leftPanel: null,
 	});
+	const [isTourOpen, setIsTourOpen] = useState(data.nodes.length === 0);
 
 	const handleDismissBanner = useCallback(() => {
 		setShowReadOnlyBanner(false);
@@ -75,6 +79,11 @@ export function V2Placeholder({
 					/>
 				)}
 			</RootProvider>
+			<WorkspaceTour
+				steps={tourSteps}
+				isOpen={isTourOpen}
+				onOpenChange={setIsTourOpen}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
- Add WorkspaceTour component to V2Placeholder
- Import necessary dependencies (useWorkflowDesigner, WorkspaceTour, tourSteps)
- Implement tour display logic: show when workspace has no nodes (data.nodes.length === 0)
- Maintain consistency with original Editor component behavior
- Fix issue where layoutV2 flag prevented tour from displaying
- Ensure tour works in both playground and studio.giselles.ai environments

## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
