### PR TITLE
Enable sidemenu and layout V2 features by default

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -80,7 +80,7 @@ export const sidemenuFlag = flag<boolean>({
 		}
 		const edgeConfig = await get(`flag__${this.key}`);
 		if (edgeConfig === undefined) {
-			return false;
+			return true;
 		}
 		return edgeConfig === true || edgeConfig === "true";
 	},
@@ -99,7 +99,7 @@ export const layoutV2Flag = flag<boolean>({
 		}
 		const edgeConfig = await get(`flag__${this.key}`);
 		if (edgeConfig === undefined) {
-			return false;
+			return true;
 		}
 		return edgeConfig === true || edgeConfig === "true";
 	},


### PR DESCRIPTION
## Summary

This PR enables the sidemenu and layout V2 features by default in the studio application by updating their feature flag default values.

## Changes

### Modified Files
- `apps/studio.giselles.ai/flags.ts`

### Implementation Details
- **sidemenuFlag**: Changed default return value from `false` to `true`
- **layoutV2Flag**: Changed default return value from `false` to `true`

Both flags now return `true` by default when no edge config value is set, enabling these UI features for all users without requiring explicit activation.

## Impact

- **User Experience**: Users will now see the improved sidemenu and layout V2 interface by default
- **Feature Adoption**: These UI improvements will be available to all users immediately
- **Backward Compatibility**: Edge config overrides still function as expected

## Testing

- [ ] Verify sidemenu displays correctly by default
- [ ] Verify layout V2 renders properly by default  
- [ ] Confirm edge config overrides still work
- [ ] Test on preview environment before requesting review

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

**Note**: This PR is marked as draft to allow testing on preview environment before requesting review.