### PR TITLE
Enhance DropdownMenu component with group support and v2 layout option

### DIFF
--- a/internal-packages/ui/components/dropdown-menu.tsx
+++ b/internal-packages/ui/components/dropdown-menu.tsx
@@ -10,23 +10,12 @@ interface Identifiable {
 }
 
 interface GroupItem<T extends Identifiable> {
-	id: string | number;
+	groupId: string | number;
 	groupLabel: string;
 	items: Array<T>;
 }
 
 type ItemLike = Identifiable | GroupItem<Identifiable>;
-
-type RenderItem<
-	T extends ItemLike,
-	TRenderItemAsChild extends boolean,
-> = T extends GroupItem<infer I>
-	? (
-			item: I,
-		) => TRenderItemAsChild extends true ? React.ReactElement : React.ReactNode
-	: (
-			item: T,
-		) => TRenderItemAsChild extends true ? React.ReactElement : React.ReactNode;
 
 interface DropdownMenuProps<
 	T extends Array<ItemLike>,
@@ -35,7 +24,17 @@ interface DropdownMenuProps<
 	items: T;
 	trigger: React.ReactNode;
 	renderItemAsChild?: TRenderItemAsChild;
-	renderItem: RenderItem<T[number], TRenderItemAsChild>;
+	renderItem: T[number] extends GroupItem<infer I>
+		? (
+				item: I,
+			) => TRenderItemAsChild extends true
+				? React.ReactElement
+				: React.ReactNode
+		: (
+				item: T[number],
+			) => TRenderItemAsChild extends true
+				? React.ReactElement
+				: React.ReactNode;
 	onSelect?: T[number] extends GroupItem<infer I>
 		? (event: Event, option: I) => void
 		: (event: Event, option: T[number]) => void;
@@ -84,7 +83,7 @@ export function DropdownMenu<
 						{items.map((option) => {
 							if (isGroupItem(option)) {
 								return (
-									<DropdownMenuPrimitive.Group key={option.id}>
+									<DropdownMenuPrimitive.Group key={option.groupId}>
 										<DropdownMenuPrimitive.Label className="text-text-tertiary px-[8px] py-[6px] text-[12px] font-medium">
 											{option.groupLabel}
 										</DropdownMenuPrimitive.Label>

--- a/internal-packages/ui/components/dropdown-menu.tsx
+++ b/internal-packages/ui/components/dropdown-menu.tsx
@@ -21,12 +21,12 @@ type RenderItem<
 	T extends ItemLike,
 	TRenderItemAsChild extends boolean,
 > = T extends GroupItem<infer I>
-	? TRenderItemAsChild extends true
-		? (item: I) => React.ReactElement
-		: (item: I) => React.ReactNode
-	: TRenderItemAsChild extends true
-		? (item: T) => React.ReactElement
-		: (item: T) => React.ReactNode;
+	? (
+			item: I,
+		) => TRenderItemAsChild extends true ? React.ReactElement : React.ReactNode
+	: (
+			item: T,
+		) => TRenderItemAsChild extends true ? React.ReactElement : React.ReactNode;
 
 interface DropdownMenuProps<
 	T extends Array<ItemLike>,

--- a/internal-packages/ui/components/dropdown-menu.tsx
+++ b/internal-packages/ui/components/dropdown-menu.tsx
@@ -11,9 +11,24 @@ interface Identifiable {
 
 interface GroupItem<T extends Identifiable> {
 	id: string | number;
-	label: string;
+	groupLabel: string;
 	items: Array<T>;
 }
+
+type RenderItem<
+	T extends Identifiable,
+	TRenderItemAsChild extends boolean,
+> = TRenderItemAsChild extends true
+	? (item: T) => React.ReactElement
+	: (item: T) => React.ReactNode;
+
+// IsArray extends true
+// 	? DoesRenderItemAsChild extends true
+// 		? (item: ItemLike[number]['items']) => React.ReactElement
+// 		: (item: ItemLike[number]) => React.ReactNode
+// 	: DoesRenderItemAsChild extends true
+// 		? (item: ItemLike) => React.ReactElement
+// 		: (item: ItemLike) => React.ReactNode;
 
 interface DropdownMenuProps<
 	T extends Identifiable,
@@ -22,9 +37,7 @@ interface DropdownMenuProps<
 	items: Array<T> | Array<GroupItem<T>>;
 	trigger: React.ReactNode;
 	renderItemAsChild?: TRenderItemAsChild;
-	renderItem: TRenderItemAsChild extends true
-		? (item: T) => React.ReactElement
-		: (item: T) => React.ReactNode;
+	renderItem: RenderItem<T, TRenderItemAsChild>;
 	onSelect?: (event: Event, option: T) => void;
 	widthClassName?: string;
 	sideOffset?: DropdownMenuPrimitive.DropdownMenuContentProps["sideOffset"];
@@ -36,7 +49,9 @@ interface DropdownMenuProps<
 function isGroupItem<T extends Identifiable>(
 	option: T | GroupItem<T>,
 ): option is GroupItem<T> {
-	return "items" in option && Array.isArray((option as GroupItem<T>).items);
+	return (
+		"groupLabel" in option && Array.isArray((option as GroupItem<T>).items)
+	);
 }
 
 export function DropdownMenu<
@@ -71,7 +86,7 @@ export function DropdownMenu<
 								return (
 									<DropdownMenuPrimitive.Group key={option.id}>
 										<DropdownMenuPrimitive.Label className="text-text-tertiary px-[8px] py-[6px] text-[12px] font-medium">
-											{option.label}
+											{option.groupLabel}
 										</DropdownMenuPrimitive.Label>
 										{option.items.map((item) => (
 											<DropdownMenuPrimitive.Item

--- a/internal-packages/ui/components/dropdown-menu.tsx
+++ b/internal-packages/ui/components/dropdown-menu.tsx
@@ -9,11 +9,17 @@ interface Identifiable {
 	id: string | number;
 }
 
+interface GroupItem<T extends Identifiable> {
+	id: string | number;
+	label: string;
+	items: Array<T>;
+}
+
 interface DropdownMenuProps<
 	T extends Identifiable,
 	TRenderItemAsChild extends boolean,
 > {
-	items: Array<T>;
+	items: Array<T> | Array<GroupItem<T>>;
 	trigger: React.ReactNode;
 	renderItemAsChild?: TRenderItemAsChild;
 	renderItem: TRenderItemAsChild extends true
@@ -25,6 +31,12 @@ interface DropdownMenuProps<
 	align?: DropdownMenuPrimitive.DropdownMenuContentProps["align"];
 	open?: DropdownMenuPrimitive.DropdownMenuProps["open"];
 	onOpenChange?: DropdownMenuPrimitive.DropdownMenuProps["onOpenChange"];
+}
+
+function isGroupItem<T extends Identifiable>(
+	option: T | GroupItem<T>,
+): option is GroupItem<T> {
+	return "items" in option && Array.isArray((option as GroupItem<T>).items);
 }
 
 export function DropdownMenu<
@@ -54,20 +66,45 @@ export function DropdownMenu<
 					className={clsx("z-10", widthClassName)}
 				>
 					<PopoverContent>
-						{items.map((option) => (
-							<DropdownMenuPrimitive.Item
-								asChild={renderItemAsChild}
-								key={option.id}
-								onSelect={(event) => onSelect?.(event, option)}
-								className={clsx(
-									"text-text outline-none cursor-pointer hover:bg-ghost-element-hover",
-									"rounded-[4px] px-[8px] py-[6px] text-[14px]",
-									"flex items-center justify-between gap-[4px]",
-								)}
-							>
-								{renderItem(option)}
-							</DropdownMenuPrimitive.Item>
-						))}
+						{items.map((option) => {
+							if (isGroupItem(option)) {
+								return (
+									<DropdownMenuPrimitive.Group key={option.id}>
+										<DropdownMenuPrimitive.Label className="text-text-tertiary px-[8px] py-[6px] text-[12px] font-medium">
+											{option.label}
+										</DropdownMenuPrimitive.Label>
+										{option.items.map((item) => (
+											<DropdownMenuPrimitive.Item
+												asChild={renderItemAsChild}
+												key={item.id}
+												onSelect={(event) => onSelect?.(event, item)}
+												className={clsx(
+													"text-text outline-none cursor-pointer hover:bg-ghost-element-hover",
+													"rounded-[4px] px-[8px] py-[6px] text-[14px]",
+													"flex items-center justify-between gap-[4px]",
+												)}
+											>
+												{renderItem(item)}
+											</DropdownMenuPrimitive.Item>
+										))}
+									</DropdownMenuPrimitive.Group>
+								);
+							}
+							return (
+								<DropdownMenuPrimitive.Item
+									asChild={renderItemAsChild}
+									key={option.id}
+									onSelect={(event) => onSelect?.(event, option)}
+									className={clsx(
+										"text-text outline-none cursor-pointer hover:bg-ghost-element-hover",
+										"rounded-[4px] px-[8px] py-[6px] text-[14px]",
+										"flex items-center justify-between gap-[4px]",
+									)}
+								>
+									{renderItem(option)}
+								</DropdownMenuPrimitive.Item>
+							);
+						})}
 					</PopoverContent>
 				</DropdownMenuPrimitive.Content>
 			</DropdownMenuPrimitive.Portal>

--- a/internal-packages/ui/components/dropdown-menu.tsx
+++ b/internal-packages/ui/components/dropdown-menu.tsx
@@ -15,30 +15,28 @@ interface GroupItem<T extends Identifiable> {
 	items: Array<T>;
 }
 
-type RenderItem<
-	T extends Identifiable,
-	TRenderItemAsChild extends boolean,
-> = TRenderItemAsChild extends true
-	? (item: T) => React.ReactElement
-	: (item: T) => React.ReactNode;
+type ItemLike = Identifiable | GroupItem<Identifiable>;
 
-// IsArray extends true
-// 	? DoesRenderItemAsChild extends true
-// 		? (item: ItemLike[number]['items']) => React.ReactElement
-// 		: (item: ItemLike[number]) => React.ReactNode
-// 	: DoesRenderItemAsChild extends true
-// 		? (item: ItemLike) => React.ReactElement
-// 		: (item: ItemLike) => React.ReactNode;
+type RenderItem<
+	T extends ItemLike,
+	TRenderItemAsChild extends boolean,
+> = T extends GroupItem<infer I>
+	? TRenderItemAsChild extends true
+		? (item: I) => React.ReactElement
+		: (item: I) => React.ReactNode
+	: TRenderItemAsChild extends true
+		? (item: T) => React.ReactElement
+		: (item: T) => React.ReactNode;
 
 interface DropdownMenuProps<
-	T extends Identifiable,
+	T extends Array<ItemLike>,
 	TRenderItemAsChild extends boolean,
 > {
-	items: Array<T> | Array<GroupItem<T>>;
+	items: T;
 	trigger: React.ReactNode;
 	renderItemAsChild?: TRenderItemAsChild;
-	renderItem: RenderItem<T, TRenderItemAsChild>;
-	onSelect?: (event: Event, option: T) => void;
+	renderItem: RenderItem<T[number], TRenderItemAsChild>;
+	onSelect?: (event: Event, option: T[number]) => void;
 	widthClassName?: string;
 	sideOffset?: DropdownMenuPrimitive.DropdownMenuContentProps["sideOffset"];
 	align?: DropdownMenuPrimitive.DropdownMenuContentProps["align"];
@@ -55,7 +53,7 @@ function isGroupItem<T extends Identifiable>(
 }
 
 export function DropdownMenu<
-	T extends Identifiable,
+	T extends Array<ItemLike>,
 	TRenderItemAsChild extends boolean = false,
 >({
 	trigger,

--- a/internal-packages/ui/components/dropdown-menu.tsx
+++ b/internal-packages/ui/components/dropdown-menu.tsx
@@ -36,7 +36,9 @@ interface DropdownMenuProps<
 	trigger: React.ReactNode;
 	renderItemAsChild?: TRenderItemAsChild;
 	renderItem: RenderItem<T[number], TRenderItemAsChild>;
-	onSelect?: (event: Event, option: T[number]) => void;
+	onSelect?: T[number] extends GroupItem<infer I>
+		? (event: Event, option: I) => void
+		: (event: Event, option: T[number]) => void;
 	widthClassName?: string;
 	sideOffset?: DropdownMenuPrimitive.DropdownMenuContentProps["sideOffset"];
 	align?: DropdownMenuPrimitive.DropdownMenuContentProps["align"];

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
@@ -9,14 +9,14 @@ import {
 	isTextNode,
 } from "@giselle-sdk/data-type";
 import { githubActionIdToLabel, githubActions } from "@giselle-sdk/flow";
-import { defaultName } from "@giselle-sdk/giselle-engine/react";
+import { defaultName, useFeatureFlag } from "@giselle-sdk/giselle-engine/react";
 import {
 	useGiselleEngine,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
 import clsx from "clsx/lite";
 import { TrashIcon, TriangleAlert } from "lucide-react";
-import { DropdownMenu } from "radix-ui";
+import { DropdownMenu as RadixDropdownMenu } from "radix-ui";
 import { useCallback, useMemo } from "react";
 import useSWR from "swr";
 import { NodeIcon } from "../../../../icons/node";
@@ -213,8 +213,8 @@ function SelectOutputPopover({
 	);
 
 	return (
-		<DropdownMenu.Root>
-			<DropdownMenu.Trigger
+		<RadixDropdownMenu.Root>
+			<RadixDropdownMenu.Trigger
 				className={clsx(
 					"flex items-center cursor-pointer p-[10px] rounded-[8px]",
 					"border border-transparent hover:border-white-800",
@@ -223,9 +223,9 @@ function SelectOutputPopover({
 				)}
 			>
 				Select Source
-			</DropdownMenu.Trigger>
-			<DropdownMenu.Portal>
-				<DropdownMenu.Content
+			</RadixDropdownMenu.Trigger>
+			<RadixDropdownMenu.Portal>
+				<RadixDropdownMenu.Content
 					className={clsx(
 						"relative w-[300px] py-[8px]",
 						"rounded-[8px] border-[1px] bg-black-900/60 backdrop-blur-[8px]",
@@ -243,15 +243,15 @@ function SelectOutputPopover({
 						<div className="grow flex flex-col pb-[8px] gap-[8px] overflow-y-auto min-h-0">
 							{groupedOutputs.map((groupedOutput) =>
 								groupedOutput.nodes.length === 0 ? null : (
-									<DropdownMenu.Group
+									<RadixDropdownMenu.Group
 										className="flex flex-col px-[8px]"
 										key={groupedOutput.label}
 									>
-										<DropdownMenu.Label className="py-[4px] px-[8px] text-black-400 text-[10px] font-[700]">
+										<RadixDropdownMenu.Label className="py-[4px] px-[8px] text-black-400 text-[10px] font-[700]">
 											{groupedOutput.label}
-										</DropdownMenu.Label>
+										</RadixDropdownMenu.Label>
 										{groupedOutput.nodes.map((output) => (
-											<DropdownMenu.Item
+											<RadixDropdownMenu.Item
 												key={output.id}
 												className={clsx(
 													"group flex p-[8px] justify-between rounded-[8px] hover:bg-primary-900/50 transition-colors cursor-pointer",
@@ -266,15 +266,15 @@ function SelectOutputPopover({
 												<p className="text-[12px] truncate">
 													{defaultName(output.node)} / {output.label}
 												</p>
-											</DropdownMenu.Item>
+											</RadixDropdownMenu.Item>
 										))}
-									</DropdownMenu.Group>
+									</RadixDropdownMenu.Group>
 								),
 							)}
 						</div>
 					</div>
-				</DropdownMenu.Content>
-			</DropdownMenu.Portal>
-		</DropdownMenu.Root>
+				</RadixDropdownMenu.Content>
+			</RadixDropdownMenu.Portal>
+		</RadixDropdownMenu.Root>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@giselle-internal/ui/button";
+import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
 import {
 	type ConnectionId,
 	type GitHubActionCommandConfiguredState,
@@ -211,6 +213,26 @@ function SelectOutputPopover({
 		},
 		[node, addConnection, input],
 	);
+
+	const { layoutV2 } = useFeatureFlag();
+	if (layoutV2) {
+		return (
+			<DropdownMenu
+				trigger={<Button>Select Source</Button>}
+				items={groupedOutputs.map((groupedOutput) => ({
+					id: groupedOutput.label,
+					groupLabel: groupedOutput.label,
+					items: groupedOutput.nodes,
+				}))}
+				renderItem={(item) => (
+					<p className="text-[12px] truncate">
+						{item.node.name ?? defaultName(item.node)} / {item.label}
+					</p>
+				)}
+				onSelect={(_event, item) => handleSelectOutput(item.node, item.id)}
+			/>
+		);
+	}
 
 	return (
 		<RadixDropdownMenu.Root>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
@@ -220,7 +220,7 @@ function SelectOutputPopover({
 			<DropdownMenu
 				trigger={<Button>Select Source</Button>}
 				items={groupedOutputs.map((groupedOutput) => ({
-					id: groupedOutput.label,
+					groupId: groupedOutput.label,
 					groupLabel: groupedOutput.label,
 					items: groupedOutput.nodes,
 				}))}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx
@@ -192,7 +192,7 @@ function SelectOutputPopover({
 		return [
 			{ label: "Generated Content", nodes: generatedNodes },
 			{ label: "Text", nodes: textNodes },
-		];
+		].filter((group) => group.nodes.length > 0);
 	}, [data.nodes, nodeId]);
 
 	const { addConnection } = useWorkflowDesigner();


### PR DESCRIPTION
### **User description**
## Overview

This PR enhances the `DropdownMenu` component with group support and introduces a v2 layout option for the select output dropdown in GitHub action properties panel.

## Key Changes

### 🔧 DropdownMenu Component Enhancements
- **Added group support**: Implemented `GroupItem<T>` interface to support grouped dropdown items with labels
- **Improved TypeScript types**: Enhanced generic constraints and conditional types for better type safety
- **Enhanced API**: Added `groupLabel` property and proper type inference for grouped vs. single items

### 🎨 UI Improvements
- **v2 Layout Option**: Added feature flag-gated v2 layout for select output dropdown in GitHub action properties
- **Better Organization**: Implemented proper grouping of "Generated Content" and "Text" node types
- **Empty Group Filtering**: Automatically filter out empty output groups to improve UX

### 🐛 Bug Fixes
- Fixed TypeScript generic constraints in `onSelect` callback
- Improved type conditional formatting for better code readability
- Renamed conflicting import (`DropdownMenu` → `RadixDropdownMenu`) to avoid naming conflicts

## Technical Details

### DropdownMenu Component Changes
- Supports both simple items (`Array<T>`) and grouped items (`Array<GroupItem<T>>`)
- Enhanced type safety with proper generic constraints and conditional types
- Maintains backward compatibility with existing usage

### GitHub Action Properties Integration
- Feature flag-gated v2 layout using `useFeatureFlag()` hook
- Proper grouping of output sources by type (Generated Content, Text)
- Improved item rendering with truncated text for better UX

## Files Modified
- `internal-packages/ui/components/dropdown-menu.tsx` - Core component enhancements
- `internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx` - UI integration

## Testing
- [ ] Dropdown menu renders correctly with grouped items
- [ ] v2 layout appears when feature flag is enabled
- [ ] Empty groups are properly filtered out
- [ ] TypeScript compilation passes without errors
- [ ] Backward compatibility maintained for existing dropdown usage

## Breaking Changes
None - all changes maintain backward compatibility.

## Feature Flag
The v2 layout is controlled by the `layoutV2` feature flag and can be safely rolled out progressively.


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced DropdownMenu component with group support and improved TypeScript types

- Added v2 layout option for GitHub action properties panel with feature flag

- Implemented automatic filtering of empty output groups

- Fixed import naming conflicts and improved type safety


___

### **Changes diagram**

```mermaid
flowchart LR
  A["DropdownMenu Component"] --> B["Group Support"]
  A --> C["Enhanced TypeScript Types"]
  D["GitHub Action Properties"] --> E["v2 Layout Option"]
  D --> F["Feature Flag Integration"]
  B --> G["Improved UI Organization"]
  E --> G
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dropdown-menu.tsx</strong><dd><code>Enhanced DropdownMenu with group support and improved types</code></dd></summary>
<hr>

internal-packages/ui/components/dropdown-menu.tsx

<li>Added <code>GroupItem<T></code> interface and <code>ItemLike</code> union type for group support<br> <li> Enhanced TypeScript generics with conditional types for better type <br>safety<br> <li> Implemented group rendering with labels and proper item organization<br> <li> Added <code>isGroupItem</code> type guard function for runtime type checking


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1301/files#diff-96bf3e47b673db0a8ea8e7ed7d025b208295d3254a6e685a8b07941f667c65f7">+73/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github-action-configured-view.tsx</strong><dd><code>Added v2 layout and group filtering for select output</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/ui/github-action-configured-view.tsx

<li>Added v2 layout option using <code>useFeatureFlag()</code> hook for progressive <br>rollout<br> <li> Implemented grouped dropdown rendering for "Generated Content" and <br>"Text" types<br> <li> Added automatic filtering of empty output groups to improve UX<br> <li> Renamed <code>DropdownMenu</code> import to <code>RadixDropdownMenu</code> to avoid conflicts


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1301/files#diff-f617ee5ccf4481d8b79e94dd43605ac99f4037fe4d38f1ac4e88105ef2e0a3cd">+39/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced dropdown menus to support grouped items, allowing for organized selection within groups.
  * Updated dropdowns in the output selection popover to use the new grouping feature when a specific layout is enabled.

* **Bug Fixes**
  * Output groups with no items are now excluded from dropdowns for a cleaner user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->