### PR TITLE
Add DropdownMenu group example

### DIFF
--- a/apps/playground/app/ui/dropdown-menu/page.tsx
+++ b/apps/playground/app/ui/dropdown-menu/page.tsx
@@ -24,6 +24,35 @@ export default function () {
 						</div>
 					</div>
 				</div>
+				<div>
+					<p className="text-text mb-2 text-sm">Group</p>
+					<div className="bg-transparent p-8 rounded-[4px] border border-border shadow-sm text-sans">
+						<div className="space-y-4">
+							<DropdownMenu
+								items={[
+									{
+										id: "fruits",
+										groupLabel: "Fruits",
+										items: [
+											{ id: 1, name: "apple" },
+											{ id: 2, name: "banana" },
+										],
+									},
+									{
+										id: "vegetables",
+										groupLabel: "Vegetables",
+										items: [
+											{ id: 3, name: "carrot" },
+											{ id: 4, name: "broccoli" },
+										],
+									},
+								]}
+								renderItem={(option) => option.name}
+								trigger={<Button>Group</Button>}
+							/>
+						</div>
+					</div>
+				</div>
 			</div>
 		</>
 	);


### PR DESCRIPTION
## Summary
- showcase grouped dropdown menu example in the playground

## Testing
- `turbo test --cache=local:rw`
- `pnpm -F playground check-types` *(fails: Parameter 'connectedSource' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_6864945dcd90832f8bb4c069c1386771