### PR TITLE
Hide Input tab in Query Node when layoutV2 feature flag is enabled

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
@@ -75,7 +75,6 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 		query,
 	]);
 
-	const { layoutV2 } = useFeatureFlag();
 	return (
 		<PropertiesPanelRoot>
 			<PropertiesPanelHeader

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
@@ -75,6 +75,7 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 		query,
 	]);
 
+	const { layoutV2 } = useFeatureFlag();
 	return (
 		<PropertiesPanelRoot>
 			<PropertiesPanelHeader
@@ -123,7 +124,9 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 								>
 									<Tabs.List className="flex gap-[16px] text-[14px] font-accent **:p-[4px] **:border-b **:cursor-pointer **:data-[state=active]:text-white-900 **:data-[state=active]:border-white-900 **:data-[state=inactive]:text-black-400 **:data-[state=inactive]:border-transparent">
 										<Tabs.Trigger value="query">Query</Tabs.Trigger>
-										<Tabs.Trigger value="input">Input</Tabs.Trigger>
+										{!layoutV2 && (
+											<Tabs.Trigger value="input">Input</Tabs.Trigger>
+										)}
 									</Tabs.List>
 									<Tabs.Content
 										value="query"


### PR DESCRIPTION
> [!NOTE]
> This pull request applies something I forgot in #1302

### **User description**
## Description

This PR addresses the issue where the Input tab in the Query Node Properties Panel was causing problems with the "Select Sources" functionality when the `layoutV2` feature flag is enabled.

## Changes Made

- Added feature flag check (`layoutV2`) to conditionally render the Input tab
- When `layoutV2` is enabled, the Input tab is hidden to prevent the unusable "Select Sources" functionality
- The Query tab remains available and functional in both layoutV2 and legacy modes

## Technical Details

- Modified `QueryNodePropertiesPanel` component to use `useFeatureFlag()` hook
- Added conditional rendering logic: `{!layoutV2 && <Tabs.Trigger value="input">Input</Tabs.Trigger>}`
- This prevents the problematic Input tab from being displayed when layoutV2 is active

## Testing

- [x] Input tab is hidden when layoutV2 feature flag is enabled
- [x] Input tab is visible when layoutV2 feature flag is disabled
- [x] Query tab remains functional in both scenarios
- [x] No breaking changes to existing functionality

## Related Issues

Fixes #1297 - Select Sources option unusable in Generator/Query Node's Input tab (layoutV2)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


___

### **PR Type**
Bug fix


___

### **Description**
- Hide Input tab in Query Node when `layoutV2` feature flag is enabled

- Prevent unusable "Select Sources" functionality in layoutV2 mode

- Maintain backward compatibility with legacy mode


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Feature Flag Check"] --> B["layoutV2 Enabled?"]
  B -->|Yes| C["Hide Input Tab"]
  B -->|No| D["Show Input Tab"]
  C --> E["Query Tab Only"]
  D --> F["Both Query and Input Tabs"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Conditional Input tab rendering based on feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx

<li>Added <code>useFeatureFlag()</code> hook to access <code>layoutV2</code> flag<br> <li> Wrapped Input tab trigger with conditional rendering based on <code>layoutV2</code><br> <li> Input tab is hidden when <code>layoutV2</code> is enabled, shown otherwise


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1304/files#diff-dfe99cf690df09195db7ce1994a627001ceb79864cc3380f785fc36e770ae631">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>