### PR TITLE
Fix path validation to allow Next.js catch-all routes

### DIFF
--- a/packages/github-tool/src/blob-download-loader.ts
+++ b/packages/github-tool/src/blob-download-loader.ts
@@ -94,9 +94,9 @@ export function createGitHubBlobDownloadLoader(
 
 	function isValidPath(path: string): boolean {
 		// Prevent path traversal attacks
-		return (
-			!path.includes("..") && !path.startsWith("/") && !path.includes("\0")
-		);
+		const segments = path.split(/[/\\]/);
+		const hasTraversal = segments.some((segment) => segment === "..");
+		return !hasTraversal && !path.startsWith("/") && !path.includes("\0");
 	}
 
 	const loadMetadata = async function* (): AsyncIterable<GitHubBlobMetadata> {


### PR DESCRIPTION
## Summary
- Fixed overly strict path validation that was rejecting valid Next.js catch-all route patterns like `[...next-giselle]`
- Changed validation to check for actual directory traversal segments (`..`) instead of substring matching
- Maintains security while allowing valid Next.js patterns

## Test plan
- [ ] Verify that Next.js catch-all routes like `apps/playground/app/api/giselle/[...next-giselle]/route.ts` are now properly ingested
- [ ] Confirm that actual path traversal attempts like `../../../etc/passwd` are still blocked
- [ ] Test with various valid and invalid path patterns to ensure security is maintained

🤖 Generated with [Claude Code](https://claude.ai/code)