### PR TITLE
Add group example to dropdown menu

### DIFF
--- a/apps/playground/app/ui/dropdown-menu/page.tsx
+++ b/apps/playground/app/ui/dropdown-menu/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Button } from "@giselle-internal/ui/button";
 import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
 
@@ -9,7 +7,7 @@ export default function () {
 			<h2 className="text-text mb-6">Dropdown Menu</h2>
 			<div className="space-y-8">
 				<div>
-					<p className="text-text mb-2 text-sm">Demo</p>
+					<p className="text-text mb-2 text-sm">Basic Demo</p>
 					<div className="bg-transparent p-8 rounded-[4px] border border-border shadow-sm text-sans">
 						<div className="space-y-4">
 							<DropdownMenu
@@ -19,7 +17,51 @@ export default function () {
 									{ id: 3, name: "melon" },
 								]}
 								renderItem={(option) => option.name}
-								trigger={<Button>Hello</Button>}
+								trigger={<Button>Basic Example</Button>}
+							/>
+						</div>
+					</div>
+				</div>
+				
+				<div>
+					<p className="text-text mb-2 text-sm">Group Demo</p>
+					<div className="bg-transparent p-8 rounded-[4px] border border-border shadow-sm text-sans">
+						<div className="space-y-4">
+							<DropdownMenu
+								items={[
+									{
+										groupId: "fruits",
+										groupLabel: "Fruits",
+										items: [
+											{ id: 1, name: "Apple" },
+											{ id: 2, name: "Banana" },
+											{ id: 3, name: "Orange" },
+										],
+									},
+									{
+										groupId: "vegetables",
+										groupLabel: "Vegetables",
+										items: [
+											{ id: 4, name: "Carrot" },
+											{ id: 5, name: "Broccoli" },
+											{ id: 6, name: "Spinach" },
+										],
+									},
+									{
+										groupId: "grains",
+										groupLabel: "Grains",
+										items: [
+											{ id: 7, name: "Rice" },
+											{ id: 8, name: "Wheat" },
+											{ id: 9, name: "Oats" },
+										],
+									},
+								]}
+								renderItem={(option) => option.name}
+								trigger={<Button>Group Example</Button>}
+								onSelect={(event, option) => {
+									console.log("Selected:", option);
+								}}
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary
Adds a group example to the Dropdown Menu playground page to demonstrate the `GroupItem` functionality.

## Related Issue
N/A

## Changes
- Added a new "Group Demo" section to `apps/playground/app/ui/dropdown-menu/page.tsx`.
- The new demo showcases `DropdownMenu` with multiple `GroupItem`s (e.g., Fruits, Vegetables, Grains).
- Renamed the existing demo to "Basic Demo" and updated its trigger text for clarity.
- Removed the unnecessary `"use client"` directive from the page to resolve a linter error and align with other playground pages.

## Testing
Manual verification of the new "Group Demo" on the playground page, including `onSelect` callback logging to the console.

## Other Information
The `"use client"` directive was removed as the `DropdownMenu` component itself is already a client component, and its presence on the page was causing a linter error.