### PR TITLE
Use shared Input component in tool providers

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@giselle-internal/ui/button";
 import { EmptyState } from "@giselle-internal/ui/empty-state";
+import { Input } from "@giselle-internal/ui/input";
 import { Select } from "@giselle-internal/ui/select";
 import { SecretId, type TextGenerationNode } from "@giselle-sdk/data-type";
 import {
 	useGiselleEngine,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
-import clsx from "clsx/lite";
 import {
 	CheckIcon,
 	MoveUpRightIcon,
@@ -167,7 +167,7 @@ function GitHubToolConnectionDialog({
 					<TabsTrigger value="select">Use Saved Token</TabsTrigger>
 				</TabsList>
 				<TabsContent value="create">
-					<input
+					<Input
 						type="hidden"
 						name="secretType"
 						value={GitHubToolSetupSecretType.create}
@@ -177,15 +177,7 @@ function GitHubToolConnectionDialog({
 							<label htmlFor="label" className="text-text text-[13px] mb-[2px]">
 								Token Name
 							</label>
-							<input
-								type="text"
-								id="label"
-								name="label"
-								className={clsx(
-									"border border-border rounded-[4px] bg-editor-background outline-none px-[8px] py-[2px] text-[14px]",
-									"focus:border-border-focused",
-								)}
-							/>
+							<Input type="text" id="label" name="label" />
 							<p className="text-[11px] text-text-muted px-[4px] mt-[1px]">
 								Give this token a short name (e.g. “Prod-bot”). You’ll use it
 								when linking other nodes.
@@ -207,17 +199,13 @@ function GitHubToolConnectionDialog({
 									<MoveUpRightIcon className="size-[13px]" />
 								</a>
 							</div>
-							<input
+							<Input
 								type="password"
 								autoComplete="off"
 								data-1p-ignore
 								data-lpignore="true"
 								id="pat"
 								name="value"
-								className={clsx(
-									"border border-border rounded-[4px] bg-editor-background outline-none px-[8px] py-[2px] text-[14px]",
-									"focus:border-border-focused",
-								)}
 							/>
 							<p className="text-[11px] text-text-muted px-[4px] mt-[1px]">
 								We’ll encrypt the token with authenticated encryption before
@@ -245,7 +233,7 @@ function GitHubToolConnectionDialog({
 									<p className="text-[11px] text-text-muted my-[4px]">
 										Pick one of your encrypted tokens to connect.
 									</p>
-									<input
+									<Input
 										type="hidden"
 										name="secretType"
 										value={GitHubToolSetupSecretType.select}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@giselle-internal/ui/button";
 import { EmptyState } from "@giselle-internal/ui/empty-state";
+import { Input } from "@giselle-internal/ui/input";
 import { Select } from "@giselle-internal/ui/select";
 import { SecretId, type TextGenerationNode } from "@giselle-sdk/data-type";
 import {
 	useGiselleEngine,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
-import clsx from "clsx/lite";
 import { CheckIcon, PlusIcon, Settings2Icon, TrashIcon } from "lucide-react";
 import { Checkbox } from "radix-ui";
 import { useCallback, useMemo, useState, useTransition } from "react";
@@ -157,7 +157,7 @@ function PostgresToolConnectionDialog({
 					<TabsTrigger value="select">Use Saved string</TabsTrigger>
 				</TabsList>
 				<TabsContent value="create">
-					<input
+					<Input
 						type="hidden"
 						name="secretType"
 						value={PostgresToolSetupSecretType.create}
@@ -167,15 +167,7 @@ function PostgresToolConnectionDialog({
 							<label htmlFor="label" className="text-text text-[13px] mb-[2px]">
 								Connection Name
 							</label>
-							<input
-								type="text"
-								id="label"
-								name="label"
-								className={clsx(
-									"border border-border rounded-[4px] bg-editor-background outline-none px-[8px] py-[2px] text-[14px]",
-									"focus:border-border-focused",
-								)}
-							/>
+							<Input type="text" id="label" name="label" />
 							<p className="text-[11px] text-text-muted px-[4px] mt-[1px]">
 								Give this onnection a short name (e.g. “Prod-DB”). You’ll use it
 								when linking other nodes.
@@ -187,17 +179,13 @@ function PostgresToolConnectionDialog({
 									Connection String
 								</label>
 							</div>
-							<input
+							<Input
 								type="password"
 								autoComplete="off"
 								data-1p-ignore
 								data-lpignore="true"
 								id="pat"
 								name="value"
-								className={clsx(
-									"border border-border rounded-[4px] bg-editor-background outline-none px-[8px] py-[2px] text-[14px]",
-									"focus:border-border-focused",
-								)}
 							/>
 							<p className="text-[11px] text-text-muted px-[4px] mt-[1px]">
 								We’ll encrypt the connection string with authenticated
@@ -225,7 +213,7 @@ function PostgresToolConnectionDialog({
 									<p className="text-[11px] text-text-muted my-[4px]">
 										Pick one of your encrypted string to connect.
 									</p>
-									<input
+									<Input
 										type="hidden"
 										name="secretType"
 										value={PostgresToolSetupSecretType.select}


### PR DESCRIPTION
### **User description**
## Summary
- refactor GitHub and Postgres tool provider dialogs to use the shared `Input` component

## Testing
- `turbo build --filter @giselle-internal/workflow-designer-ui --filter @giselle-internal/ui --cache=local:rw`
- `turbo check-types --filter @giselle-internal/workflow-designer-ui --filter @giselle-internal/ui --cache=local:rw`
- `turbo test --filter @giselle-internal/workflow-designer-ui --filter @giselle-internal/ui --cache=local:rw` *(fails: missing task)*

------
https://chatgpt.com/codex/tasks/task_e_6864dc42d0d4832f8abd1cb9931b346c


___

### **PR Type**
Enhancement


___

### **Description**
- Replace custom input elements with shared `Input` component

- Remove clsx dependency and inline styling

- Standardize form inputs across GitHub and Postgres tool providers


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Custom input elements"] --> B["Shared Input component"]
  C["Inline styling with clsx"] --> D["Standardized component styling"]
  B --> E["Consistent UI across providers"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.tsx</strong><dd><code>Replace custom inputs with shared Input component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx

<li>Import shared <code>Input</code> component from UI library<br> <li> Replace three custom input elements with <code>Input</code> component<br> <li> Remove clsx import and inline className styling<br> <li> Maintain existing functionality for token name and PAT inputs


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1312/files#diff-122425196c8136251eb216cd110a334c4894b71bbf455312bb9920599703d1dc">+5/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postgres.tsx</strong><dd><code>Replace custom inputs with shared Input component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx

<li>Import shared <code>Input</code> component from UI library<br> <li> Replace three custom input elements with <code>Input</code> component<br> <li> Remove clsx import and inline className styling<br> <li> Maintain existing functionality for connection name and string inputs


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1312/files#diff-bb42f9f9489951538610adc3910ed3c3392a6fd0e87693bcc19f9e7de46fb18e">+5/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>