### PR TITLE
feat(studio): add re-link functionality for invalid GitHub installations

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
@@ -9,7 +9,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 
-import type { ActionResult } from "./types";
+import type { ActionResult, DiagnosticResult } from "./types";
 
 export async function registerRepositoryIndex(
 	owner: string,
@@ -102,5 +102,110 @@ export async function deleteRepositoryIndex(indexId: GitHubRepositoryIndexId) {
 				eq(githubRepositoryIndex.id, indexId),
 			),
 		);
+	revalidatePath("/settings/team/vector-stores");
+}
+
+export async function diagnoseRepositoryConnection(
+	indexId: GitHubRepositoryIndexId,
+): Promise<DiagnosticResult> {
+	try {
+		const team = await fetchCurrentTeam();
+
+		const [repositoryIndex] = await db
+			.select()
+			.from(githubRepositoryIndex)
+			.where(
+				and(
+					eq(githubRepositoryIndex.teamDbId, team.dbId),
+					eq(githubRepositoryIndex.id, indexId),
+				),
+			)
+			.limit(1);
+
+		if (!repositoryIndex) {
+			return {
+				canBeFixed: false,
+				reason: "repository-not-found",
+				errorMessage: "Repository index not found",
+			};
+		}
+
+		const githubIdentityState = await getGitHubIdentityState();
+		if (githubIdentityState.status !== "authorized") {
+			return {
+				canBeFixed: false,
+				reason: "diagnosis-failed",
+				errorMessage: "GitHub authentication required",
+			};
+		}
+
+		const userClient = githubIdentityState.gitHubUserClient;
+		const installationData = await userClient.getInstallations();
+
+		let validInstallationId: number | null = null;
+		for (const installation of installationData.installations) {
+			try {
+				const installationClient = await buildAppInstallationClient(
+					installation.id,
+				);
+				const response = await installationClient.request(
+					"GET /repos/{owner}/{repo}",
+					{
+						owner: repositoryIndex.owner,
+						repo: repositoryIndex.repo,
+					},
+				);
+
+				if (response.status === 200) {
+					validInstallationId = installation.id;
+					break;
+				}
+			} catch (error) {}
+		}
+
+		if (!validInstallationId) {
+			return {
+				canBeFixed: false,
+				reason: "no-installation",
+				errorMessage:
+					"No GitHub App installation has access to this repository",
+			};
+		}
+
+		return {
+			canBeFixed: true,
+			newInstallationId: validInstallationId,
+		};
+	} catch (error) {
+		console.error("Error diagnosing repository connection:", error);
+		return {
+			canBeFixed: false,
+			reason: "diagnosis-failed",
+			errorMessage: "Failed to diagnose the connection issue",
+		};
+	}
+}
+
+export async function updateRepositoryInstallation(
+	indexId: GitHubRepositoryIndexId,
+	newInstallationId: number,
+): Promise<void> {
+	const team = await fetchCurrentTeam();
+
+	await db
+		.update(githubRepositoryIndex)
+		.set({
+			installationId: newInstallationId,
+			status: "idle",
+			errorCode: null,
+			retryAfter: null,
+		})
+		.where(
+			and(
+				eq(githubRepositoryIndex.teamDbId, team.dbId),
+				eq(githubRepositoryIndex.id, indexId),
+			),
+		);
+
 	revalidatePath("/settings/team/vector-stores");
 }

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/diagnostic-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/diagnostic-modal.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import type { githubRepositoryIndex } from "@/drizzle";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Check, Loader2 } from "lucide-react";
+import { useEffect, useState, useTransition } from "react";
+import {
+	GlassDialogContent,
+	GlassDialogFooter,
+	GlassDialogHeader,
+} from "../components/glass-dialog-content";
+import {
+	diagnoseRepositoryConnection,
+	updateRepositoryInstallation,
+} from "./actions";
+import type { DiagnosticResult } from "./types";
+
+type DiagnosticModalProps = {
+	repositoryIndex: typeof githubRepositoryIndex.$inferSelect;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onComplete?: () => void;
+	onDelete?: () => void;
+};
+
+export function DiagnosticModal({
+	repositoryIndex,
+	open,
+	onOpenChange,
+	onComplete,
+	onDelete,
+}: DiagnosticModalProps) {
+	const [diagnosisResult, setDiagnosisResult] =
+		useState<DiagnosticResult | null>(null);
+	const [isFixing, startFixTransition] = useTransition();
+	const [isDiagnosing, setIsDiagnosing] = useState(false);
+
+	useEffect(() => {
+		if (open) {
+			runDiagnosis();
+		} else {
+			setDiagnosisResult(null);
+		}
+	}, [open]);
+
+	const runDiagnosis = async () => {
+		setIsDiagnosing(true);
+
+		try {
+			const result = await diagnoseRepositoryConnection(repositoryIndex.id);
+			setDiagnosisResult(result);
+		} catch (error) {
+			console.error("Diagnosis failed:", error);
+			setDiagnosisResult({
+				canBeFixed: false,
+				reason: "diagnosis-failed",
+				errorMessage: "Failed to diagnose the connection issue",
+			});
+		} finally {
+			setIsDiagnosing(false);
+		}
+	};
+
+	const handleFix = () => {
+		startFixTransition(async () => {
+			try {
+				if (diagnosisResult?.canBeFixed && diagnosisResult.newInstallationId) {
+					await updateRepositoryInstallation(
+						repositoryIndex.id,
+						diagnosisResult.newInstallationId,
+					);
+					onComplete?.();
+					onOpenChange(false);
+				}
+			} catch (error) {
+				console.error("Failed to fix repository:", error);
+			}
+		});
+	};
+
+	const renderDiagnosisResult = () => {
+		if (!diagnosisResult) return null;
+
+		if (diagnosisResult.canBeFixed) {
+			return (
+				<div className="mt-6 p-4 rounded-lg bg-[#39FF7F]/10 border border-[#39FF7F]/20">
+					<div className="flex items-center gap-2 mb-2">
+						<Check className="h-5 w-5 text-[#39FF7F]" />
+						<h4 className="text-white-400 font-medium text-[16px] font-sans">
+							Connection can be restored
+						</h4>
+					</div>
+					<p className="text-black-300 text-[14px] font-geist">
+						The GitHub App installation has been updated. Click "Restore
+						Connection" to fix this repository.
+					</p>
+				</div>
+			);
+		}
+
+		return (
+			<div className="mt-6 p-4 rounded-lg bg-[#FF3D71]/10 border border-[#FF3D71]/20">
+				<div className="flex items-center gap-2 mb-2">
+					<h4 className="text-white-400 font-medium text-[16px] font-sans">
+						Repository no longer accessible
+					</h4>
+				</div>
+				<p className="text-black-300 text-[14px] font-geist">
+					{diagnosisResult.errorMessage ||
+						"This repository has been deleted or is no longer accessible with current permissions."}
+				</p>
+			</div>
+		);
+	};
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<GlassDialogContent>
+				<GlassDialogHeader
+					title="Checking Repository Access"
+					description={`${repositoryIndex.owner}/${repositoryIndex.repo}`}
+					onClose={() => onOpenChange(false)}
+				/>
+
+				<div className="py-6">
+					{isDiagnosing ? (
+						<div className="flex items-center justify-center py-8">
+							<Loader2 className="h-8 w-8 text-[#1663F3] animate-spin" />
+							<span className="ml-3 text-[14px] font-geist text-black-300">
+								Checking repository access...
+							</span>
+						</div>
+					) : (
+						diagnosisResult && renderDiagnosisResult()
+					)}
+				</div>
+
+				{diagnosisResult && (
+					<GlassDialogFooter
+						onCancel={() => onOpenChange(false)}
+						onConfirm={
+							diagnosisResult.canBeFixed
+								? handleFix
+								: () => {
+										onDelete?.();
+										onOpenChange(false);
+									}
+						}
+						confirmLabel={
+							diagnosisResult.canBeFixed
+								? "Restore Connection"
+								: "Delete Repository"
+						}
+						isPending={isFixing}
+						variant={diagnosisResult.canBeFixed ? "default" : "destructive"}
+					/>
+				)}
+
+				{!diagnosisResult && (
+					<GlassDialogFooter
+						onCancel={() => onOpenChange(false)}
+						isPending={isDiagnosing}
+						confirmLabel="Processing..."
+					/>
+				)}
+			</GlassDialogContent>
+		</Dialog.Root>
+	);
+}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/types.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/types.ts
@@ -23,3 +23,14 @@ export type InstallationWithRepos = {
 export type ActionResult =
 	| { success: true }
 	| { success: false; error: string };
+
+export type DiagnosticResult =
+	| {
+			canBeFixed: true;
+			newInstallationId: number;
+	  }
+	| {
+			canBeFixed: false;
+			reason: "no-installation" | "repository-not-found" | "diagnosis-failed";
+			errorMessage?: string;
+	  };

--- a/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts
@@ -78,7 +78,7 @@ async function getRepositoryIndexInfo(
 	}
 
 	const { dbId, status, lastIngestedCommitSha } = repositoryIndex[0];
-	const isInitialIngest = status === "idle" || lastIngestedCommitSha === null;
+	const isInitialIngest = lastIngestedCommitSha === null;
 
 	return { repositoryIndexDbId: dbId, isInitialIngest };
 }


### PR DESCRIPTION
### **User description**
## Summary

This PR implements the re-link functionality for Vector Stores when GitHub App installation IDs become invalid, as part of Option B mentioned in #1270.

Related to #1270 - This is the re-link functionality implementation mentioned in that PR.

## Changes

### Error Handling UI
- Added clickable error badge with "Check" action for `DOCUMENT_NOT_FOUND` errors
- Created diagnostic modal to check repository access permissions
- Added visual feedback during diagnosis process

### Repository Access Diagnosis
- Implemented `diagnoseRepositoryConnection` action to validate current installations
- Checks all available GitHub App installations for repository access
- Determines if the issue can be fixed by updating the installation ID

### Repository Restoration
- Added `updateRepositoryInstallation` action to fix invalid installation IDs
- Allows restoration even when installation ID is unchanged (to reset error state)
- Provides delete option for permanently inaccessible repositories

### Additional Changes
- Modified `isInitialIngest` detection to only check `lastIngestedCommitSha`
- Removed `status === 'idle'` condition to align with the new restoration flow

## Test Plan

1. Create a repository in Vector Stores
2. Manually update the installation ID in the database to an invalid value
3. Verify the error badge shows "error • Check ↗"
4. Click the badge to open the diagnostic modal
5. Verify the modal correctly identifies if the repository can be restored
6. Test both restoration and deletion flows

## Screenshots

https://github.com/user-attachments/assets/85745279-eb9e-414b-8af9-7347566453c6

https://github.com/user-attachments/assets/301426d5-ae21-4181-a93f-3b240302d5c5



🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add re-link functionality for invalid GitHub installations

- Implement diagnostic modal for repository access issues

- Add repository restoration and deletion options

- Simplify initial ingest detection logic


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Error Badge"] --> B["Diagnostic Modal"]
  B --> C["Repository Diagnosis"]
  C --> D["Valid Installation Found?"]
  D -->|Yes| E["Restore Connection"]
  D -->|No| F["Delete Repository"]
  E --> G["Update Installation ID"]
  F --> H["Remove Repository"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Add repository diagnosis and restoration actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts

<li>Add <code>diagnoseRepositoryConnection</code> function to validate GitHub <br>installations<br> <li> Add <code>updateRepositoryInstallation</code> function to fix invalid installation <br>IDs<br> <li> Import new <code>DiagnosticResult</code> type for diagnosis responses


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1315/files#diff-c366d76c09210ba11343bfdbd3731fb7db9d49fbaf5d73dc015cbd229d4615f4">+106/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add diagnostic result type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/types.ts

<li>Add <code>DiagnosticResult</code> type for repository connection diagnosis<br> <li> Define union type for fixable and non-fixable diagnosis results


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1315/files#diff-f057d7fb6408aecdacf57a67c03eb0003bfc5aa25f126caa10043190922d3052">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>diagnostic-modal.tsx</strong><dd><code>Add diagnostic modal for repository issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/diagnostic-modal.tsx

<li>Create new diagnostic modal component for repository access checking<br> <li> Add loading states and result display for diagnosis process<br> <li> Implement restore and delete actions based on diagnosis results


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1315/files#diff-0eda9ef7357befb5d4980a628163d58a46f5a772d16ea9ad0fc69696f8926cd0">+169/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repository-item.tsx</strong><dd><code>Add interactive error handling to repository items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx

<li>Add clickable "Check" action to error status badges<br> <li> Integrate diagnostic modal with repository items<br> <li> Update <code>StatusBadge</code> to support verification callback


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1315/files#diff-7081ecafde073350a2fc722beae87dd986b2f8d55ca73cd48ffdfe62908296c6">+57/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ingest-github-repository.ts</strong><dd><code>Simplify initial ingest detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/api/vector-stores/github/ingest/ingest-github-repository.ts

<li>Remove <code>status === 'idle'</code> condition from <code>isInitialIngest</code> check<br> <li> Simplify logic to only check <code>lastIngestedCommitSha</code> for initial <br>ingestion


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1315/files#diff-2c5974f819b55054e8e23d5d62bfa5f851e330022696c1477cafce78ed3dc635">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic modal to help identify and resolve GitHub repository connection issues within team settings.
  * Users can now attempt to restore repository connections or delete problematic repositories directly from the modal.

* **Enhancements**
  * Repository items now display a "Check" button for failed connections, allowing quick access to diagnostic tools.

* **Bug Fixes**
  * Improved logic for determining initial GitHub repository ingestion, ensuring more accurate sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->