### PR TITLE
Refactor tool provider dialogs

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
@@ -8,6 +8,7 @@ import {
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
 import type { TextGenerationNode } from "@giselle-sdk/data-type";
+import { useWorkflowDesigner } from "@giselle-sdk/giselle-engine/react";
 import clsx from "clsx/lite";
 import {
 	CheckIcon,
@@ -17,6 +18,7 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import { Checkbox } from "radix-ui";
+import { useCallback } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import {
 	ToolConfigurationDialog,
@@ -107,7 +109,12 @@ function GitHubToolConnectionDialog({
 			open={open}
 			onOpenChange={onOpenChange}
 		>
-			<Tabs value={tabValue} onValueChange={setTabValue}>
+			<Tabs
+				value={tabValue}
+				onValueChange={(value) =>
+					setTabValue(ToolProviderSecretType.parse(value))
+				}
+			>
 				<TabsList className="mb-[12px]">
 					<TabsTrigger value="create">Paste New Token</TabsTrigger>
 					<TabsTrigger value="select">Use Saved Token</TabsTrigger>
@@ -116,7 +123,7 @@ function GitHubToolConnectionDialog({
 					<Input
 						type="hidden"
 						name="secretType"
-						value={ToolProviderSecretType.create}
+						value={ToolProviderSecretType.enum.create}
 					/>
 					<div className="flex flex-col gap-[12px]">
 						<fieldset className="flex flex-col">
@@ -182,7 +189,7 @@ function GitHubToolConnectionDialog({
 									<Input
 										type="hidden"
 										name="secretType"
-										value={ToolProviderSecretType.select}
+										value={ToolProviderSecretType.enum.select}
 									/>
 									<fieldset className="flex flex-col">
 										<label

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
@@ -2,14 +2,8 @@ import { Button } from "@giselle-internal/ui/button";
 import { EmptyState } from "@giselle-internal/ui/empty-state";
 import { Input } from "@giselle-internal/ui/input";
 import { Select } from "@giselle-internal/ui/select";
-import { SecretId, type TextGenerationNode } from "@giselle-sdk/data-type";
-import {
-	useGiselleEngine,
-	useWorkflowDesigner,
-} from "@giselle-sdk/giselle-engine/react";
 import type { TextGenerationNode } from "@giselle-sdk/data-type";
 import { useWorkflowDesigner } from "@giselle-sdk/giselle-engine/react";
-import clsx from "clsx/lite";
 import {
 	CheckIcon,
 	MoveUpRightIcon,

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
@@ -2,14 +2,8 @@ import { Button } from "@giselle-internal/ui/button";
 import { EmptyState } from "@giselle-internal/ui/empty-state";
 import { Input } from "@giselle-internal/ui/input";
 import { Select } from "@giselle-internal/ui/select";
-import { SecretId, type TextGenerationNode } from "@giselle-sdk/data-type";
-import {
-	useGiselleEngine,
-	useWorkflowDesigner,
-} from "@giselle-sdk/giselle-engine/react";
 import type { TextGenerationNode } from "@giselle-sdk/data-type";
 import { useWorkflowDesigner } from "@giselle-sdk/giselle-engine/react";
-import clsx from "clsx/lite";
 import { CheckIcon, PlusIcon, Settings2Icon, TrashIcon } from "lucide-react";
 import { Checkbox } from "radix-ui";
 import { useCallback } from "react";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
@@ -8,9 +8,11 @@ import {
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
 import type { TextGenerationNode } from "@giselle-sdk/data-type";
+import { useWorkflowDesigner } from "@giselle-sdk/giselle-engine/react";
 import clsx from "clsx/lite";
 import { CheckIcon, PlusIcon, Settings2Icon, TrashIcon } from "lucide-react";
 import { Checkbox } from "radix-ui";
+import { useCallback } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import {
 	ToolConfigurationDialog,
@@ -98,7 +100,12 @@ function PostgresToolConnectionDialog({
 			open={open}
 			onOpenChange={onOpenChange}
 		>
-			<Tabs value={tabValue} onValueChange={setTabValue}>
+			<Tabs
+				value={tabValue}
+				onValueChange={(value) =>
+					setTabValue(ToolProviderSecretType.parse(value))
+				}
+			>
 				<TabsList className="mb-[12px]">
 					<TabsTrigger value="create">Paste connection string</TabsTrigger>
 					<TabsTrigger value="select">Use Saved string</TabsTrigger>
@@ -107,7 +114,7 @@ function PostgresToolConnectionDialog({
 					<Input
 						type="hidden"
 						name="secretType"
-						value={ToolProviderSecretType.create}
+						value={ToolProviderSecretType.enum.create}
 					/>
 					<div className="flex flex-col gap-[12px]">
 						<fieldset className="flex flex-col">
@@ -163,7 +170,7 @@ function PostgresToolConnectionDialog({
 									<Input
 										type="hidden"
 										name="secretType"
-										value={ToolProviderSecretType.select}
+										value={ToolProviderSecretType.enum.select}
 									/>
 									<fieldset className="flex flex-col">
 										<label

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx
@@ -11,19 +11,16 @@ import { useCallback, useMemo, useState, useTransition } from "react";
 import z from "zod/v4";
 import { useWorkspaceSecrets } from "../../../../lib/use-workspace-secrets";
 
-export const ToolProviderSecretType = {
-	create: "create",
-	select: "select",
-} as const;
+export const ToolProviderSecretType = z.enum(["create", "select"]);
 
 const ToolProviderSetupPayload = z.discriminatedUnion("secretType", [
 	z.object({
-		secretType: z.literal(ToolProviderSecretType.create),
+		secretType: z.literal(ToolProviderSecretType.enum.create),
 		label: z.string().min(1),
 		value: z.string().min(1),
 	}),
 	z.object({
-		secretType: z.literal(ToolProviderSecretType.select),
+		secretType: z.literal(ToolProviderSecretType.enum.select),
 		secretId: SecretId.schema,
 	}),
 ]);
@@ -36,7 +33,7 @@ export function useToolProviderConnection<T extends keyof ToolSet>(config: {
 	secretTags: string[];
 	toolKey: T;
 	node: TextGenerationNode;
-	buildToolConfig: (secretId: string) => ToolSet[T];
+	buildToolConfig: (secretId: SecretId) => ToolSet[T];
 }) {
 	const { secretTags, toolKey, node, buildToolConfig } = config;
 	const [presentDialog, setPresentDialog] = useState(false);

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx
@@ -1,0 +1,132 @@
+import {
+	SecretId,
+	type TextGenerationNode,
+	type ToolSet,
+} from "@giselle-sdk/data-type";
+import {
+	useGiselleEngine,
+	useWorkflowDesigner,
+} from "@giselle-sdk/giselle-engine/react";
+import { useCallback, useMemo, useState, useTransition } from "react";
+import z from "zod/v4";
+import { useWorkspaceSecrets } from "../../../../lib/use-workspace-secrets";
+
+export const ToolProviderSecretType = {
+	create: "create",
+	select: "select",
+} as const;
+
+const ToolProviderSetupPayload = z.discriminatedUnion("secretType", [
+	z.object({
+		secretType: z.literal(ToolProviderSecretType.create),
+		label: z.string().min(1),
+		value: z.string().min(1),
+	}),
+	z.object({
+		secretType: z.literal(ToolProviderSecretType.select),
+		secretId: SecretId.schema,
+	}),
+]);
+
+export type ToolProviderSecretType =
+	(typeof ToolProviderSecretType)[keyof typeof ToolProviderSecretType];
+export type ToolProviderSetupPayload = z.infer<typeof ToolProviderSetupPayload>;
+
+export function useToolProviderConnection<T extends keyof ToolSet>(config: {
+	secretTags: string[];
+	toolKey: T;
+	node: TextGenerationNode;
+	buildToolConfig: (secretId: string) => ToolSet[T];
+}) {
+	const { secretTags, toolKey, node, buildToolConfig } = config;
+	const [presentDialog, setPresentDialog] = useState(false);
+	const [tabValue, setTabValue] = useState<"create" | "select">("create");
+	const { updateNodeDataContent, data: workspace } = useWorkflowDesigner();
+	const { isLoading, data, mutate } = useWorkspaceSecrets(secretTags);
+	const client = useGiselleEngine();
+	const [isPending, startTransition] = useTransition();
+
+	const isConfigured = useMemo(
+		() => node.content.tools?.[toolKey] !== undefined,
+		[node, toolKey],
+	);
+
+	const handleSubmit = useCallback<React.FormEventHandler<HTMLFormElement>>(
+		(e) => {
+			e.preventDefault();
+			const formData = new FormData(e.currentTarget);
+			const secretType = formData.get("secretType");
+			const label = formData.get("label");
+			const value = formData.get("value");
+			const secretId = formData.get("secretId");
+			const parse = ToolProviderSetupPayload.safeParse({
+				secretType,
+				label,
+				value,
+				secretId,
+			});
+			if (!parse.success) {
+				/** @todo Implement error handling */
+				console.log(parse.error);
+				return;
+			}
+			const payload = parse.data;
+			switch (payload.secretType) {
+				case "create":
+					startTransition(async () => {
+						const result = await client.addSecret({
+							workspaceId: workspace.id,
+							label: payload.label,
+							value: payload.value,
+							tags: secretTags,
+						});
+						mutate([...(data ?? []), result.secret]);
+						updateNodeDataContent(node, {
+							...node.content,
+							tools: {
+								...node.content.tools,
+								[toolKey]: buildToolConfig(result.secret.id),
+							},
+						});
+					});
+					break;
+				case "select":
+					updateNodeDataContent(node, {
+						...node.content,
+						tools: {
+							...node.content.tools,
+							[toolKey]: buildToolConfig(payload.secretId),
+						},
+					});
+					break;
+				default: {
+					const _exhaustiveCheck: never = payload;
+					throw new Error(`Unhandled secretType: ${_exhaustiveCheck}`);
+				}
+			}
+		},
+		[
+			node,
+			updateNodeDataContent,
+			client,
+			workspace.id,
+			data,
+			mutate,
+			secretTags,
+			toolKey,
+			buildToolConfig,
+		],
+	);
+
+	return {
+		presentDialog,
+		setPresentDialog,
+		tabValue,
+		setTabValue,
+		isPending,
+		isConfigured,
+		isLoading,
+		secrets: data,
+		handleSubmit,
+	} as const;
+}


### PR DESCRIPTION
### **User description**
## Summary
- Refactored GitHub and PostgreSQL tool provider dialogs
- Extracted duplicated connection logic into `useToolProviderConnection` hook
- Standardized the tool provider connection flow across different providers
- Improved type safety with Zod schema for secret type validation

## Testing
- `turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw` *(fails: No package found)*
- `turbo check-types --cache=local:rw`
- `turbo test --cache=local:rw`

------
https://chatgpt.com/codex/tasks/task_e_6864fc9f864c832f9ac89f0c6249c9b9


___

### **PR Type**
Enhancement


___

### **Description**
- Extract duplicated connection logic into reusable hook

- Standardize tool provider connection flow across providers

- Improve type safety with Zod schema validation

- Remove redundant imports and code duplication


___

### **Changes diagram**

```mermaid
flowchart LR
  A["GitHub Tool Provider"] --> C["useToolProviderConnection Hook"]
  B["PostgreSQL Tool Provider"] --> C
  C --> D["Shared Connection Logic"]
  C --> E["Zod Schema Validation"]
  C --> F["Secret Management"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.tsx</strong><dd><code>Refactor GitHub provider to use shared hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx

<li>Remove duplicated connection state management logic<br> <li> Replace local state with <code>useToolProviderConnection</code> hook<br> <li> Update component props to use shared hook values<br> <li> Replace local Zod schema with shared <code>ToolProviderSecretType</code>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1322/files#diff-122425196c8136251eb216cd110a334c4894b71bbf455312bb9920599703d1dc">+56/-109</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postgres.tsx</strong><dd><code>Refactor PostgreSQL provider to use shared hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx

<li>Remove duplicated connection state management logic<br> <li> Replace local state with <code>useToolProviderConnection</code> hook<br> <li> Update component props to use shared hook values<br> <li> Fix typo in connection string label text


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1322/files#diff-bb42f9f9489951538610adc3910ed3c3392a6fd0e87693bcc19f9e7de46fb18e">+56/-108</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-tool-provider-connection.tsx</strong><dd><code>Add shared tool provider connection hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx

<li>Create new custom hook for tool provider connections<br> <li> Implement shared Zod schema for secret type validation<br> <li> Centralize connection state management and form handling<br> <li> Support generic tool configuration building


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1322/files#diff-8a42c7a31d9b233c9a6b01cc2595cba20650ea2c3ac755bdc14ca1bb658f75e7">+129/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and centralized tool connection dialogs for GitHub and PostgreSQL by using a shared connection management hook.
  * Dialog components now rely on the shared hook for state, secrets management, and form handling, reducing internal logic and improving consistency.

* **New Features**
  * Introduced a reusable hook to manage tool provider connections, streamlining secret selection and creation workflows across supported tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->