### PR TITLE
Rename ToolProviderSecretType to ToolProviderSecretTypeValue

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
@@ -19,7 +19,7 @@ import {
 	type ToolConfigurationDialogProps,
 } from "../ui/tool-configuration-dialog";
 import {
-	ToolProviderSecretType,
+	ToolProviderSecretTypeValue,
 	useToolProviderConnection,
 } from "./use-tool-provider-connection";
 
@@ -106,7 +106,7 @@ function GitHubToolConnectionDialog({
 			<Tabs
 				value={tabValue}
 				onValueChange={(value) =>
-					setTabValue(ToolProviderSecretType.parse(value))
+					setTabValue(ToolProviderSecretTypeValue.parse(value))
 				}
 			>
 				<TabsList className="mb-[12px]">
@@ -117,7 +117,7 @@ function GitHubToolConnectionDialog({
 					<Input
 						type="hidden"
 						name="secretType"
-						value={ToolProviderSecretType.enum.create}
+						value={ToolProviderSecretTypeValue.enum.create}
 					/>
 					<div className="flex flex-col gap-[12px]">
 						<fieldset className="flex flex-col">
@@ -183,7 +183,7 @@ function GitHubToolConnectionDialog({
 									<Input
 										type="hidden"
 										name="secretType"
-										value={ToolProviderSecretType.enum.select}
+										value={ToolProviderSecretTypeValue.enum.select}
 									/>
 									<fieldset className="flex flex-col">
 										<label

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx
@@ -13,7 +13,7 @@ import {
 	type ToolConfigurationDialogProps,
 } from "../ui/tool-configuration-dialog";
 import {
-	ToolProviderSecretType,
+	ToolProviderSecretTypeValue,
 	useToolProviderConnection,
 } from "./use-tool-provider-connection";
 
@@ -97,7 +97,7 @@ function PostgresToolConnectionDialog({
 			<Tabs
 				value={tabValue}
 				onValueChange={(value) =>
-					setTabValue(ToolProviderSecretType.parse(value))
+					setTabValue(ToolProviderSecretTypeValue.parse(value))
 				}
 			>
 				<TabsList className="mb-[12px]">
@@ -108,7 +108,7 @@ function PostgresToolConnectionDialog({
 					<Input
 						type="hidden"
 						name="secretType"
-						value={ToolProviderSecretType.enum.create}
+						value={ToolProviderSecretTypeValue.enum.create}
 					/>
 					<div className="flex flex-col gap-[12px]">
 						<fieldset className="flex flex-col">
@@ -164,7 +164,7 @@ function PostgresToolConnectionDialog({
 									<Input
 										type="hidden"
 										name="secretType"
-										value={ToolProviderSecretType.enum.select}
+										value={ToolProviderSecretTypeValue.enum.select}
 									/>
 									<fieldset className="flex flex-col">
 										<label

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx
@@ -11,22 +11,22 @@ import { useCallback, useMemo, useState, useTransition } from "react";
 import z from "zod/v4";
 import { useWorkspaceSecrets } from "../../../../lib/use-workspace-secrets";
 
-export const ToolProviderSecretType = z.enum(["create", "select"]);
+export const ToolProviderSecretTypeValue = z.enum(["create", "select"]);
 
 const ToolProviderSetupPayload = z.discriminatedUnion("secretType", [
 	z.object({
-		secretType: z.literal(ToolProviderSecretType.enum.create),
+		secretType: z.literal(ToolProviderSecretTypeValue.enum.create),
 		label: z.string().min(1),
 		value: z.string().min(1),
 	}),
 	z.object({
-		secretType: z.literal(ToolProviderSecretType.enum.select),
+		secretType: z.literal(ToolProviderSecretTypeValue.enum.select),
 		secretId: SecretId.schema,
 	}),
 ]);
 
 export type ToolProviderSecretType =
-	(typeof ToolProviderSecretType)[keyof typeof ToolProviderSecretType];
+	(typeof ToolProviderSecretTypeValue)[keyof typeof ToolProviderSecretTypeValue];
 export type ToolProviderSetupPayload = z.infer<typeof ToolProviderSetupPayload>;
 
 export function useToolProviderConnection<T extends keyof ToolSet>(config: {


### PR DESCRIPTION
### **User description**


### **Description**
- Rename `ToolProviderSecretType` to `ToolProviderSecretTypeValue` across codebase

- Update import statements and type references

- Maintain existing functionality with new naming convention


___

### **Changes diagram**

```mermaid
flowchart LR
  A["ToolProviderSecretType"] -- "rename to" --> B["ToolProviderSecretTypeValue"]
  B --> C["Update imports"]
  B --> D["Update type references"]
  B --> E["Update enum usage"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.tsx</strong><dd><code>Update GitHub tool provider type references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx

<li>Update import from <code>ToolProviderSecretType</code> to <br><code>ToolProviderSecretTypeValue</code><br> <li> Replace all references to use new type name in tab handling and form <br>values


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1324/files#diff-122425196c8136251eb216cd110a334c4894b71bbf455312bb9920599703d1dc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>postgres.tsx</strong><dd><code>Update Postgres tool provider type references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/postgres.tsx

<li>Update import from <code>ToolProviderSecretType</code> to <br><code>ToolProviderSecretTypeValue</code><br> <li> Replace all references to use new type name in tab handling and form <br>values


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1324/files#diff-bb42f9f9489951538610adc3910ed3c3392a6fd0e87693bcc19f9e7de46fb18e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-tool-provider-connection.tsx</strong><dd><code>Rename core type definition and exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/use-tool-provider-connection.tsx

<li>Rename exported constant from <code>ToolProviderSecretType</code> to <br><code>ToolProviderSecretTypeValue</code><br> <li> Update type alias to reference new constant name<br> <li> Update discriminated union schema to use new enum values


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1324/files#diff-8a42c7a31d9b233c9a6b01cc2595cba20650ea2c3ac755bdc14ca1bb658f75e7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal naming for secret type handling in tool connection dialogs for GitHub and Postgres integrations. No changes to user-facing behavior or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->