### PR TITLE
Remove auto-close behavior from workflow designer panels

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -38,7 +38,7 @@ interface V2ContainerProps extends V2LayoutState {
 	onLeftPanelClose?: () => void;
 }
 
-function V2NodeCanvas({ onLeftPanelClose }: { onLeftPanelClose?: () => void }) {
+function V2NodeCanvas() {
 	const {
 		data,
 		setUiNodeState,
@@ -223,11 +223,6 @@ function V2NodeCanvas({ onLeftPanelClose }: { onLeftPanelClose?: () => void }) {
 					addNode(selectedTool.node, { ui: { position } });
 				}
 				reset();
-
-				// // Close panel when clicking on canvas
-				// if (onLeftPanelClose) {
-				// 	onLeftPanelClose();
-				// }
 			}}
 			onNodeContextMenu={(event, node) => {
 				event.preventDefault();
@@ -290,7 +285,7 @@ export function V2Container({ leftPanel, onLeftPanelClose }: V2ContainerProps) {
 
 				{/* Main Content Area */}
 				<div className="flex-1 relative">
-					<V2NodeCanvas onLeftPanelClose={onLeftPanelClose} />
+					<V2NodeCanvas />
 
 					{/* Floating Properties Panel */}
 					<FloatingPropertiesPanel

--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -224,10 +224,10 @@ function V2NodeCanvas({ onLeftPanelClose }: { onLeftPanelClose?: () => void }) {
 				}
 				reset();
 
-				// Close panel when clicking on canvas
-				if (onLeftPanelClose) {
-					onLeftPanelClose();
-				}
+				// // Close panel when clicking on canvas
+				// if (onLeftPanelClose) {
+				// 	onLeftPanelClose();
+				// }
 			}}
 			onNodeContextMenu={(event, node) => {
 				event.preventDefault();
@@ -275,33 +275,6 @@ export function V2Container({ leftPanel, onLeftPanelClose }: V2ContainerProps) {
 
 	const mainRef = useRef<HTMLDivElement>(null);
 
-	// Handle click outside to close panel
-	useEffect(() => {
-		if (!leftPanel || !onLeftPanelClose) return;
-
-		const handleClickOutside = (event: MouseEvent) => {
-			const target = event.target as Element;
-
-			// Check if click is on panel trigger button
-			const isPanelTriggerButton = target.closest("[data-panel-trigger]");
-			if (isPanelTriggerButton) return;
-
-			// Check if click is inside the panel
-			const panelElement = document.querySelector("[data-panel-wrapper]");
-			if (panelElement?.contains(target)) return;
-
-			// Close panel for clicks outside
-			onLeftPanelClose();
-		};
-
-		// Use capture phase to ensure we catch the event before ReactFlow
-		document.addEventListener("mousedown", handleClickOutside, true);
-
-		return () => {
-			document.removeEventListener("mousedown", handleClickOutside, true);
-		};
-	}, [leftPanel, onLeftPanelClose]);
-
 	return (
 		<main
 			className="relative flex-1 bg-black-900 overflow-hidden"
@@ -309,13 +282,11 @@ export function V2Container({ leftPanel, onLeftPanelClose }: V2ContainerProps) {
 		>
 			<div className="h-full flex">
 				{/* Left Panel */}
-				<div data-panel-wrapper>
-					<PanelWrapper
-						isOpen={leftPanel !== null}
-						panelType={leftPanel}
-						onClose={() => onLeftPanelClose?.()}
-					/>
-				</div>
+				<PanelWrapper
+					isOpen={leftPanel !== null}
+					panelType={leftPanel}
+					onClose={() => onLeftPanelClose?.()}
+				/>
 
 				{/* Main Content Area */}
 				<div className="flex-1 relative">


### PR DESCRIPTION
### **User description**
## Summary
Removed the automatic closing of the left panel when clicking outside or on the canvas in the workflow designer UI.

## Changes
- Commented out the code that closes the panel when clicking on the canvas
- Removed the `useEffect` hook that handled closing the panel when clicking outside
- Simplified the panel wrapper structure by removing the extra `div` with `data-panel-wrapper` attribute

## Testing
Verify that the left panel in the workflow designer remains open when clicking on the canvas or outside the panel area.

## Other Information
This change improves the user experience by preventing accidental panel closures during workflow design.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove auto-close behavior from workflow designer left panel

- Prevent accidental panel closures during workflow design

- Simplify panel wrapper structure by removing extra div


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User clicks canvas"] --> B["Panel stays open"]
  C["User clicks outside panel"] --> D["Panel stays open"]
  E["Simplified panel wrapper"] --> F["Improved UX"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>v2-container.tsx</strong><dd><code>Remove panel auto-close and simplify wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx

<li>Commented out canvas click panel close functionality<br> <li> Removed <code>useEffect</code> hook for outside click detection<br> <li> Simplified panel wrapper by removing extra div with <code>data-panel-wrapper</code><br> <li> Maintained panel trigger button functionality


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1334/files#diff-2d75399629db36d10f858317710b1faa4d19f16f00bfefc8956ce8deeea5d460">+9/-38</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the panel wrapper markup for a cleaner structure.
  * Removed automatic closing of the left panel when clicking outside or on the canvas. The left panel will now remain open unless closed manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->