### PR TITLE
Fix Biome warnings in data-mod package

### DIFF
--- a/packages/data-mod/src/mods/rename-action-to-operation.test.ts
+++ b/packages/data-mod/src/mods/rename-action-to-operation.test.ts
@@ -1,7 +1,6 @@
 import { Generation } from "@giselle-sdk/data-type";
 import type { $ZodIssue } from "@zod/core";
 import { expect, test } from "vitest";
-import { z } from "zod/v4";
 import generationJson from "./fixtures/rename-action-to-operation/generation1.json";
 import { renameActionToOperation } from "./rename-action-to-operation";
 

--- a/packages/data-mod/src/mods/rename-action-to-operation.ts
+++ b/packages/data-mod/src/mods/rename-action-to-operation.ts
@@ -91,7 +91,7 @@ export function renameActionToOperation(data: unknown, issue: $ZodIssue) {
 						transformedNode,
 					);
 					// Remove the old field properly with delete
-					const templateInNewData = getValueAtPath(newData, templatePath);
+					const _templateInNewData = getValueAtPath(newData, templatePath);
 					return newData;
 				}
 
@@ -148,7 +148,10 @@ export function renameActionToOperation(data: unknown, issue: $ZodIssue) {
 					context.actionNode,
 				);
 				// Remove the old field using delete instead of undefined
-				const contextInNewData = getValueAtPath(newData, generationContextPath);
+				const _contextInNewData = getValueAtPath(
+					newData,
+					generationContextPath,
+				);
 				return newData;
 			}
 		}


### PR DESCRIPTION
### **User description**
## Summary
- remove unused `zod/v4` import in rename-action-to-operation.test.ts
- mark intentionally unused variables in rename-action-to-operation.ts

## Testing
- `pnpm biome check --write packages/data-mod/src/mods/rename-action-to-operation.test.ts`
- `pnpm biome check --write packages/data-mod/src/mods/rename-action-to-operation.ts`
- `pnpm biome check ./packages/data-mod --error-on-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6866687c2e54832f9085fa218c2e47e6


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unused `zod/v4` import from test file

- Mark intentionally unused variables with underscore prefix


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Test file"] -- "remove unused import" --> B["Clean imports"]
  C["Source file"] -- "prefix unused vars" --> D["Suppress warnings"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rename-action-to-operation.test.ts</strong><dd><code>Remove unused import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/data-mod/src/mods/rename-action-to-operation.test.ts

- Remove unused `zod/v4` import statement


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1345/files#diff-0892a67a3a64691bd0a82f4de8b5d0bc52ba88c85760357f8526a81b5289b897">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rename-action-to-operation.ts</strong><dd><code>Mark unused variables with underscore prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/data-mod/src/mods/rename-action-to-operation.ts

<li>Prefix unused variables <code>templateInNewData</code> and <code>contextInNewData</code> with <br>underscore<br> <li> Suppress Biome warnings for intentionally unused variables


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1345/files#diff-4b98210e2bfcf044c230193bc64056ec2ce3d75572eba856f47bada39e30e2b5">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code clarity by updating variable naming conventions for unused variables.
* **Chores**
  * Cleaned up unused import statements in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->