### PR TITLE
Fix lint warnings in github-tool

### DIFF
--- a/packages/github-tool/src/blob-loader.ts
+++ b/packages/github-tool/src/blob-loader.ts
@@ -207,7 +207,7 @@ async function loadBlob(
 				path,
 			},
 		};
-	} catch (error: unknown) {
+	} catch (_error: unknown) {
 		// Binary content will throw an error when trying to decode
 		return null;
 	}

--- a/packages/github-tool/src/lib/diff-compression.test.ts
+++ b/packages/github-tool/src/lib/diff-compression.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { PR_22_DIFF, PR_1118_DIFF } from "./__fixtures__";
-import { compressLargeDiff, type FileDiff } from "./diff-compression";
+import { compressLargeDiff } from "./diff-compression";
 
 describe("diff compression", () => {
 	it("should return original diff when under maxSize", () => {

--- a/packages/github-tool/src/tools.ts
+++ b/packages/github-tool/src/tools.ts
@@ -12,7 +12,7 @@ export function githubTools(octokit: Octokit) {
 				owner: z.string().describe("Repository owner"),
 				repo: z.string().describe("Repository name"),
 			}),
-			execute: async (params) => {
+			execute: async (_params) => {
 				const { body, issueNumber, owner, repo } = params;
 				const response = await octokit.request(
 					"POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
@@ -519,7 +519,7 @@ export function githubTools(octokit: Octokit) {
 					.describe("Optional: reason the session was created")
 					.optional(),
 			}),
-			execute: async (params) => {
+			execute: async (_params) => {
 				const response = await octokit.request("GET /user");
 				return response.data;
 			},

--- a/packages/github-tool/src/webhooks.ts
+++ b/packages/github-tool/src/webhooks.ts
@@ -78,7 +78,7 @@ export async function handleWebhook(args: {
 	const webhookEventNames = Object.keys(args.on) as EmitterWebhookEventName[];
 	for (const webhookEventName of webhookEventNames) {
 		eventHandler.on(webhookEventName, async (event) => {
-			const typedEvent = {
+			const _typedEvent = {
 				name: webhookEventName,
 				data: event,
 			};


### PR DESCRIPTION
## Summary
- address biome lint warnings by renaming unused variables

## Testing
- `pnpm -F github-tool test`
- `pnpm biome check ./packages/github-tool --error-on-warnings --max-diagnostics=none`


------
https://chatgpt.com/codex/tasks/task_e_68667b12e7dc832f9e5f108bb799a5e0