### PR TITLE
Fix Biome lint warning in supabase vault driver

### DIFF
--- a/packages/supabase-driver/src/vault/supabase-vault-driver.ts
+++ b/packages/supabase-driver/src/vault/supabase-vault-driver.ts
@@ -19,7 +19,7 @@ export function supabaseVaultDriver(
 	const supabase = createClient(url, serviceKey);
 
 	return {
-		async encrypt(plaintext, options): Promise<string> {
+		async encrypt(plaintext, _options): Promise<string> {
 			// Create a secret in the Supabase Vault
 			const { data, error } = await supabase.rpc("create_secret", {
 				plaintext,


### PR DESCRIPTION
### **User description**
## Summary
- fix unused parameter warning by renaming `options` to `_options`

## Testing
- `pnpm biome check ./packages/supabase-driver --error-on-warnings --max-diagnostics=none`


------
https://chatgpt.com/codex/tasks/task_e_68667b73201c832f97b8a46eb79d2715


___

### **PR Type**
Bug fix


___

### **Description**
- Fix unused parameter warning in Supabase vault driver


___

### **Changes diagram**

```mermaid
flowchart LR
  A["encrypt method"] -- "rename parameter" --> B["_options parameter"]
  B -- "resolves" --> C["Biome lint warning"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>supabase-vault-driver.ts</strong><dd><code>Fix unused parameter lint warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/supabase-driver/src/vault/supabase-vault-driver.ts

- Rename unused `options` parameter to `_options` in encrypt method


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1351/files#diff-3ee6dde44fd6f25ff06cd2297c81a48393df962d233abc4b2f5d4d4936c66bfc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>