### PR TITLE
Fix Biome warning in is-json-content

### DIFF
--- a/packages/text-editor-utils/src/is-json-content.ts
+++ b/packages/text-editor-utils/src/is-json-content.ts
@@ -8,7 +8,7 @@ export function isJsonContent(args: unknown): args is JSONContent {
 	if (typeof args === "string") {
 		try {
 			candidate = JSON.parse(args);
-		} catch (error) {
+		} catch (_error) {
 			return false;
 		}
 	}


### PR DESCRIPTION
### **User description**
## Summary
- rename unused `error` variable to `_error` in `is-json-content.ts`

## Testing
- `pnpm biome check ./packages/text-editor-utils --error-on-warnings --max-diagnostics=none`


------
https://chatgpt.com/codex/tasks/task_e_68667bb6ddf8832faa9719581cbdd61a


___

### **PR Type**
Other


___

### **Description**
- Rename unused `error` variable to `_error` in catch block


___

### **Changes diagram**

```mermaid
flowchart LR
  A["catch (error)"] --> B["catch (_error)"]
  B --> C["Biome warning resolved"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>is-json-content.ts</strong><dd><code>Fix unused variable warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/text-editor-utils/src/is-json-content.ts

- Rename unused `error` parameter to `_error` in catch block


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1352/files#diff-61244e630b987f6266a0cc16aa4f621fda78f18fd55396c70e736d588488632e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>