### PR TITLE
Fix edge deletion logic in v2 container

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -146,6 +146,35 @@ function V2NodeCanvas() {
 		[addConnection, data.nodes, toast, isSupportedConnection, updateNodeData],
 	);
 
+	const handleEdgesDelete = useCallback(
+		(edgesToDelete: Edge[]) => {
+			for (const edge of edgesToDelete) {
+				const connection = data.connections.find((conn) => conn.id === edge.id);
+				if (!connection) {
+					continue;
+				}
+
+				deleteConnection(connection.id);
+				const targetNode = data.nodes.find(
+					(node) => node.id === connection.inputNode.id,
+				);
+				if (
+					targetNode &&
+					targetNode.type === "operation" &&
+					targetNode.content.type !== "action"
+				) {
+					const updatedInputs = targetNode.inputs.filter(
+						(input) => input.id !== connection.inputId,
+					);
+					updateNodeData(targetNode, {
+						inputs: updatedInputs,
+					});
+				}
+			}
+		},
+		[data.nodes, data.connections, deleteConnection, updateNodeData],
+	);
+
 	const isValidConnection: IsValidConnection<ConnectorType> = (connection) => {
 		if (
 			!connection.sourceHandle ||
@@ -174,15 +203,7 @@ function V2NodeCanvas() {
 			edgeTypes={edgeTypes}
 			defaultViewport={data.ui.viewport}
 			onConnect={handleConnect}
-			onEdgesDelete={useCallback(
-				(edges: Edge[]) => {
-					for (const edge of edges) {
-						const conn = data.connections.find((c) => c.id === edge.id);
-						if (conn) deleteConnection(conn.id);
-					}
-				},
-				[data.connections, deleteConnection],
-			)}
+			onEdgesDelete={handleEdgesDelete}
 			isValidConnection={isValidConnection}
 			panOnScroll={true}
 			zoomOnScroll={false}


### PR DESCRIPTION
### **User description**
## Summary
- improve edge deletion handler in workflow designer v2 container
- call new handler via ReactFlow `onEdgesDelete`


https://github.com/user-attachments/assets/a51a25e0-a3d6-4989-aa93-e2136241a07f



## Testing
- `pnpm biome check --write internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx`
- `turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw` *(fails: No package found)*
- `turbo check-types --filter '@giselle-internal/workflow-designer-ui' --cache=local:rw` *(fails)*
- `turbo format --cache=local:rw`
- `turbo test --cache=local:rw`

------
https://chatgpt.com/codex/tasks/task_e_68672665cc5c832faa769962b2fb5440


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improve edge deletion logic in workflow designer v2 container

- Add proper node input cleanup when deleting connections

- Extract inline edge deletion handler to dedicated function

- Update operation node inputs after connection removal


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Edge Deletion"] --> B["Find Connection"]
  B --> C["Delete Connection"]
  C --> D["Check Target Node"]
  D --> E["Update Node Inputs"]
  E --> F["Remove Orphaned Inputs"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>v2-container.tsx</strong><dd><code>Enhanced edge deletion with input cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx

<li>Extract inline <code>onEdgesDelete</code> handler to dedicated <code>handleEdgesDelete</code> <br>function<br> <li> Add logic to clean up orphaned inputs from operation nodes after edge <br>deletion<br> <li> Improve connection lookup and node data updates during edge removal<br> <li> Replace inline callback with proper memoized handler function


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1358/files#diff-2d75399629db36d10f858317710b1faa4d19f16f00bfefc8956ce8deeea5d460">+30/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge deletion in the workflow editor to ensure that related node inputs are properly updated when connections are removed. This prevents orphaned inputs and maintains workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->