### PR TITLE
Fix Biome warnings in engine

### DIFF
--- a/packages/giselle-engine/src/core/experimental_vector-store/types/interface.ts
+++ b/packages/giselle-engine/src/core/experimental_vector-store/types/interface.ts
@@ -1,9 +1,9 @@
-import type { VectorStoreId, VectorStoreObject } from "./object";
+import type { VectorStoreObject } from "./object";
 
 type CreateVectorStore = () => Promise<VectorStoreObject>;
-type RetrieveVectorStore = (parameters: {
-	vectorStoreId: VectorStoreId;
-}) => Promise<VectorStoreObject>;
+// type RetrieveVectorStore = (parameters: {
+//      vectorStoreId: VectorStoreId;
+// }) => Promise<VectorStoreObject>;
 // type DeleteVectorStore = () => Promise<void>;
 // type SearchVectorStore = () => Promise<void>;
 // type AddFile = (parameters: {

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -45,7 +45,7 @@ export function generateText(args: {
 			setGeneration,
 			fileResolver,
 			generationContentResolver,
-			workspaceId,
+			_workspaceId,
 			completeGeneration,
 		}) => {
 			const operationNode = generationContext.operationNode;
@@ -236,7 +236,7 @@ export function generateText(args: {
 							sources,
 						});
 					}
-					const completedGeneration = await completeGeneration({
+					const _completedGeneration = await completeGeneration({
 						outputs: generationOutputs,
 						usage: event.usage,
 						messages: appendResponseMessages({

--- a/packages/giselle-engine/src/core/generations/internal/use-generation-executor.ts
+++ b/packages/giselle-engine/src/core/generations/internal/use-generation-executor.ts
@@ -1,6 +1,5 @@
 import {
 	type CompletedGeneration,
-	type FileData,
 	type FileId,
 	type Generation,
 	GenerationContext,

--- a/packages/giselle-engine/src/core/github/event-handlers.test.ts
+++ b/packages/giselle-engine/src/core/github/event-handlers.test.ts
@@ -31,7 +31,7 @@ function createEnsureWebhookEventMock(shouldMatch = true) {
 		.mockImplementation(
 			<T extends WebhookEventName>(
 				event: WebhookEvent<WebhookEventName>,
-				expectedName: T,
+				_expectedName: T,
 			): event is WebhookEvent<T> => shouldMatch,
 		) as unknown as typeof ensureWebhookEvent;
 }
@@ -674,7 +674,7 @@ describe("GitHub Event Handlers", () => {
 			});
 
 			// Act
-			const result = await processEvent({
+			const _result = await processEvent({
 				event,
 				context: {
 					llmProviders: [],

--- a/packages/giselle-engine/src/core/github/utils.ts
+++ b/packages/giselle-engine/src/core/github/utils.ts
@@ -149,7 +149,7 @@ export function parseGitHubUrl(url: string): GitHubUrlInfo | null {
 			default:
 				return null;
 		}
-	} catch (error) {
+	} catch (_error) {
 		return null;
 	}
 }

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -13,7 +13,6 @@ import type {
 	Workspace,
 	WorkspaceId,
 } from "@giselle-sdk/data-type";
-import { calculateDisplayCost } from "@giselle-sdk/language-model";
 import { getLanguageModelProviders } from "./configurations/get-language-model-providers";
 import { createDataSource, getWorkspaceDataSources } from "./data-source";
 import type { DataSourceProviderObject } from "./data-source/types/object";

--- a/packages/giselle-engine/src/core/operations/execute-query.ts
+++ b/packages/giselle-engine/src/core/operations/execute-query.ts
@@ -261,7 +261,7 @@ async function queryVectorStore(
 	// Default values for query parameters
 	// TODO: Make these configurable via the UI
 	const LIMIT = 10;
-	const SIMILARITY_THRESHOLD = 0.2;
+	const _SIMILARITY_THRESHOLD = 0.2;
 
 	const results = await Promise.all(
 		vectorStoreNodes

--- a/packages/giselle-engine/src/core/operations/utils.ts
+++ b/packages/giselle-engine/src/core/operations/utils.ts
@@ -1,6 +1,5 @@
 import {
 	type GenerationContext,
-	type OutputId as InputId,
 	isCompletedGeneration,
 	type NodeId,
 	type Output,
@@ -34,7 +33,7 @@ export async function connectionResolver(args: {
 	}
 	let output: Output | undefined;
 	for (const sourceNode of args.context.sourceNodes) {
-		for (const sourceOutput of sourceNode.outputs) {
+		for (const _sourceOutput of sourceNode.outputs) {
 			// if (sourceOutput.accessor === args.inputAccessor) {
 			// 	output = sourceOutput;
 			// 	break;

--- a/packages/giselle-engine/src/core/telemetry/index.ts
+++ b/packages/giselle-engine/src/core/telemetry/index.ts
@@ -171,7 +171,7 @@ function extractInputOutputForTextGeneration(
 }
 
 function extractInputForImageGeneration(
-	generation: CompletedGeneration,
+	_generation: CompletedGeneration,
 	operationNode: ImageGenerationNode,
 ) {
 	const input = extractPromptInput(operationNode);

--- a/packages/giselle-engine/src/core/telemetry/types.ts
+++ b/packages/giselle-engine/src/core/telemetry/types.ts
@@ -1,7 +1,3 @@
-import type {
-	CompletedGeneration,
-	RunningGeneration,
-} from "@giselle-sdk/data-type";
 import type { TelemetrySettings as AI_TelemetrySettings } from "ai";
 
 export interface TelemetrySettings {

--- a/packages/giselle-engine/src/core/workspaces/update-workspace.ts
+++ b/packages/giselle-engine/src/core/workspaces/update-workspace.ts
@@ -1,4 +1,4 @@
-import type { Workspace, WorkspaceId } from "@giselle-sdk/data-type";
+import type { Workspace } from "@giselle-sdk/data-type";
 import type { GiselleEngineContext } from "../types";
 import { setWorkspace } from "./utils";
 

--- a/packages/giselle-engine/src/next/next-giselle-engine.ts
+++ b/packages/giselle-engine/src/next/next-giselle-engine.ts
@@ -1,13 +1,8 @@
-import type {
-	CompletedGeneration,
-	TextGenerationLanguageModelData,
-} from "@giselle-sdk/data-type";
 import { GenerationId } from "@giselle-sdk/data-type";
 import {
 	GitHubWebhookUnauthorizedError,
 	verifyRequest as verifyRequestAsGitHubWebook,
 } from "@giselle-sdk/github-tool";
-import { calculateDisplayCost } from "@giselle-sdk/language-model";
 import { after } from "next/server";
 import { GiselleEngine, type GiselleEngineConfig } from "../core";
 import {

--- a/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
+++ b/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
@@ -66,9 +66,6 @@ export interface FetchNodeGenerationsParams {
 	nodeId: NodeId;
 	origin: GenerationOrigin;
 }
-type FetchNodeGenerations = (
-	params: FetchNodeGenerationsParams,
-) => Promise<void>;
 
 interface GenerationRunnerSystemContextType {
 	generateTextApi: string;


### PR DESCRIPTION
## Summary
- remove unused imports and variables
- silence unused variable warnings in tests and utils
- clean up commented types and unused parameters

## Testing
- `pnpm biome check ./packages/giselle-engine --error-on-warnings --max-diagnostics=none`

------
https://chatgpt.com/codex/tasks/task_e_68667ae968c0832fa2fb05a0b2240971