### PR TITLE
Fix dynamic input cleanup on edge deletion

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -158,11 +158,7 @@ function V2NodeCanvas() {
 				const targetNode = data.nodes.find(
 					(node) => node.id === connection.inputNode.id,
 				);
-				if (
-					targetNode &&
-					targetNode.type === "operation" &&
-					targetNode.content.type !== "action"
-				) {
+				if (targetNode && !isActionNode(targetNode)) {
 					const updatedInputs = targetNode.inputs.filter(
 						(input) => input.id !== connection.inputId,
 					);


### PR DESCRIPTION
## Summary
- use `isActionNode` to detect non-action nodes when deleting edges

## Testing
- `turbo test --cache=local:rw`

------
https://chatgpt.com/codex/tasks/task_e_686733c92a3c832f9519fae60a3cfac9