### PR TITLE
Fix dynamic cleanup bug for edge deletion

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { InputId, isActionNode, OutputId } from "@giselle-sdk/data-type";
+import {
+	InputId,
+	isActionNode,
+	isOperationNode,
+	OutputId,
+} from "@giselle-sdk/data-type";
 import {
 	type Connection,
 	type Edge,
@@ -160,8 +165,8 @@ function V2NodeCanvas() {
 				);
 				if (
 					targetNode &&
-					targetNode.type === "operation" &&
-					targetNode.content.type !== "action"
+					isOperationNode(targetNode) &&
+					!isActionNode(targetNode)
 				) {
 					const updatedInputs = targetNode.inputs.filter(
 						(input) => input.id !== connection.inputId,


### PR DESCRIPTION
## Summary
- ensure edge cleanup only happens for operation nodes
- import `isOperationNode`

## Testing
- `pnpm biome check --write internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx`
- `pnpm -F workflow-designer-ui check-types`


------
https://chatgpt.com/codex/tasks/task_e_6867407b0174832fad019acc78b12218