### PR TITLE
Add refresh button to run history table

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/run-history/run-history-table.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/run-history/run-history-table.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@giselle-internal/ui/button";
 import { EmptyState } from "@giselle-internal/ui/empty-state";
 import {
 	Table,
@@ -11,6 +12,7 @@ import {
 	useGiselleEngine,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
+import { RefreshCcwIcon } from "lucide-react";
 import useSWR from "swr";
 
 function formatDateTime(timestamp: number): string {
@@ -30,7 +32,7 @@ function formatDuration(ms: number): string {
 export function RunHistoryTable() {
 	const client = useGiselleEngine();
 	const { data: workspace } = useWorkflowDesigner();
-	const { data, isLoading } = useSWR(
+	const { data, isLoading, mutate } = useSWR(
 		{
 			namespace: "getWorkspaceFlowRuns",
 			workspaceId: workspace.id,
@@ -45,6 +47,17 @@ export function RunHistoryTable() {
 
 	return (
 		<div className="pl-4 pb-4 pt-2 h-full">
+			<div className="flex justify-end pb-2">
+				<Button
+					type="button"
+					variant="outline"
+					size="compact"
+					onClick={() => mutate()}
+					leftIcon={<RefreshCcwIcon className="size-[12px]" />}
+				>
+					Refresh
+				</Button>
+			</div>
 			{data === undefined || data.length < 1 ? (
 				<EmptyState title="No run" description="No runs have been executed." />
 			) : (


### PR DESCRIPTION
### **User description**
## Summary
Added a refresh button to the Run History table to allow users to manually refresh the run history data.

## Changes
- Imported `Button` component from `@giselle-internal/ui/button`
- Imported `RefreshCcwIcon` from `lucide-react`
- Extracted `mutate` function from the useSWR hook
- Added a refresh button with an icon in the top-right corner of the run history table
- The button triggers the `mutate()` function to refresh the data when clicked

## Testing
Verified that clicking the refresh button updates the run history table with the latest data.


___

### **PR Type**
Enhancement


___

### **Description**
- Added refresh button to run history table

- Imported Button component and RefreshCcwIcon

- Extracted mutate function from useSWR hook

- Button positioned in top-right corner with icon


___

### **Changes diagram**

```mermaid
flowchart LR
  A["useSWR Hook"] --> B["Extract mutate function"]
  B --> C["Add Button Component"]
  C --> D["RefreshCcwIcon"]
  D --> E["Refresh Run History"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-history-table.tsx</strong><dd><code>Add refresh functionality to run history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/run-history/run-history-table.tsx

<li>Added Button and RefreshCcwIcon imports<br> <li> Extracted mutate function from useSWR hook<br> <li> Added refresh button with icon in table header<br> <li> Button triggers data refresh when clicked


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1369/files#diff-a264446dd8a7a9c10e97794642344c3e8f3c44e29cfb34a778d1c58bc5292167">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Refresh" button above the run history table, allowing users to manually update and view the latest run data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->