### PR TITLE
Add loading state to run history refresh button

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/run-history/run-history-table.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/run-history/run-history-table.tsx
@@ -12,7 +12,7 @@ import {
 	useGiselleEngine,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
-import { RefreshCcwIcon } from "lucide-react";
+import { LoaderIcon, RefreshCcwIcon } from "lucide-react";
 import useSWR from "swr";
 
 function formatDateTime(timestamp: number): string {
@@ -32,7 +32,7 @@ function formatDuration(ms: number): string {
 export function RunHistoryTable() {
 	const client = useGiselleEngine();
 	const { data: workspace } = useWorkflowDesigner();
-	const { data, isLoading, mutate } = useSWR(
+	const { data, isLoading, isValidating, mutate } = useSWR(
 		{
 			namespace: "getWorkspaceFlowRuns",
 			workspaceId: workspace.id,
@@ -53,9 +53,16 @@ export function RunHistoryTable() {
 					variant="outline"
 					size="compact"
 					onClick={() => mutate()}
-					leftIcon={<RefreshCcwIcon className="size-[12px]" />}
+					disabled={isValidating}
+					leftIcon={
+						isValidating ? (
+							<LoaderIcon className="size-[12px] animate-spin" />
+						) : (
+							<RefreshCcwIcon className="size-[12px]" />
+						)
+					}
 				>
-					Refresh
+					{isValidating ? "Refreshing..." : "Refresh"}
 				</Button>
 			</div>
 			{data === undefined || data.length < 1 ? (


### PR DESCRIPTION
### **User description**
## Summary
Enhanced the refresh functionality in the Run History Table by adding visual feedback during data validation.

## Changes
- Added `isValidating` state from the `useSWR` hook to track when data is being refreshed
- Added a loading spinner icon that displays during refresh operations
- Changed the refresh button text to "Refreshing..." during validation
- Disabled the refresh button while validation is in progress
- Imported the `LoaderIcon` from lucide-react for the loading animation

## Testing
Verified that the refresh button now shows appropriate loading state with animation when clicked, and returns to normal state when data fetching completes.


___

### **PR Type**
Enhancement


___

### **Description**
- Added loading state to run history refresh button

- Displays spinner animation and "Refreshing..." text during data validation

- Disabled button interaction while refresh is in progress

- Enhanced user experience with visual feedback


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User clicks refresh"] --> B["Button shows loading state"]
  B --> C["Spinner animation displays"]
  B --> D["Text changes to 'Refreshing...'"]
  B --> E["Button becomes disabled"]
  E --> F["Data validation completes"]
  F --> G["Button returns to normal state"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-history-table.tsx</strong><dd><code>Enhanced refresh button with loading state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/run-history/run-history-table.tsx

<li>Added <code>LoaderIcon</code> import from lucide-react<br> <li> Extracted <code>isValidating</code> state from useSWR hook<br> <li> Added conditional loading spinner with animation<br> <li> Changed button text to "Refreshing..." during validation<br> <li> Disabled button while validation is in progress


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1370/files#diff-a264446dd8a7a9c10e97794642344c3e8f3c44e29cfb34a778d1c58bc5292167">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the refresh button in the run history table to display a loading spinner and update its label to "Refreshing..." while data is being refreshed, providing clearer feedback during data fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->