### PR TITLE
Fix web page node: use updateNodeData instead of workflow's updateName

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/web-page-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/web-page-node-properties-panel/index.tsx
@@ -141,7 +141,7 @@ function WebPageListItem({
 
 export function WebPageNodePropertiesPanel({ node }: { node: WebPageNode }) {
 	const client = useGiselleEngine();
-	const { data, updateName, updateNodeDataContent } = useWorkflowDesigner();
+	const { data, updateNodeData, updateNodeDataContent } = useWorkflowDesigner();
 	const { error } = useToasts();
 	const handleSubmit = useCallback<FormEventHandler<HTMLFormElement>>(
 		async (e) => {
@@ -246,7 +246,9 @@ export function WebPageNodePropertiesPanel({ node }: { node: WebPageNode }) {
 			<PropertiesPanelHeader
 				icon={<WebPageFileIcon className="size-[20px] text-black-900" />}
 				node={node}
-				onChangeName={(name) => updateName(name)}
+				onChangeName={(name) => {
+					updateNodeData(node, { name });
+				}}
 			/>
 			<PropertiesPanelContent>
 				<div>


### PR DESCRIPTION
### **User description**
## Summary
- Fix incorrect usage of `updateName` function in WebPageNodePropertiesPanel
- The previous code was mistakenly using `updateName` which updates the entire workflow's name, not the individual node's name
- Replace with `updateNodeData(node, { name })` to correctly update only the web page node's name

## Problem
The web page node's name change handler was incorrectly using the workflow's `updateName` function, which would change the entire workflow's name instead of just the node's name.

## Solution
Use `updateNodeData` with the specific node and name property, consistent with other node types in the codebase.

## Test plan
- [x] Open workflow designer
- [x] Add a web page node
- [x] Click on the node to open properties panel
- [x] Edit the node name
- [x] Verify only the node's name updates (not the workflow name)
- [x] Verify the workflow name in the header remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix web page node name update using correct function

- Replace `updateName` with `updateNodeData` for proper node-specific updates

- Prevent accidental workflow name changes when editing node names


___

### **Changes diagram**

```mermaid
flowchart LR
  A["WebPageNodePropertiesPanel"] --> B["onChangeName handler"]
  B --> C["updateName (incorrect)"]
  B --> D["updateNodeData (correct)"]
  C -.-> E["Updates workflow name"]
  D --> F["Updates node name only"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Fix node name update function usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/web-page-node-properties-panel/index.tsx

<li>Replace <code>updateName</code> import with <code>updateNodeData</code> from <code>useWorkflowDesigner</code><br> <li> Update <code>onChangeName</code> handler to use <code>updateNodeData(node, { name })</code> <br>instead of <code>updateName(name)</code><br> <li> Fix incorrect function usage that was updating workflow name instead <br>of node name


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1390/files#diff-60b9c3510a13126ac50509faa9761f7709576e9dae00259fecad3bf3590915fb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how node names are changed in the web page node properties panel, using a more general update method for node data. There is no visible change to the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->