### PR TITLE
Reorder FeatureFlagContext to wrap all providers

### DIFF
--- a/packages/giselle-engine/src/react/workspace/provider.tsx
+++ b/packages/giselle-engine/src/react/workspace/provider.tsx
@@ -55,31 +55,30 @@ export function WorkspaceProvider({
 		return null;
 	}
 	return (
-		<TelemetryProvider settings={telemetry}>
-			<UsageLimitsProvider limits={usageLimits}>
-				<IntegrationProvider {...integration}>
-					<VectorStoreProvider value={vectorStore}>
-						<WorkflowDesignerProvider data={workspace}>
-							<GenerationRunnerSystemProvider>
-								<FeatureFlagContext
-									value={{
-										runV3: featureFlag?.runV3 ?? false,
-										sidemenu: featureFlag?.sidemenu ?? false,
-										githubTools: featureFlag?.githubTools ?? false,
-										webSearchAction: featureFlag?.webSearchAction ?? false,
-										layoutV2: featureFlag?.layoutV2 ?? false,
-										layoutV3: featureFlag?.layoutV3 ?? false,
-										experimental_storage:
-											featureFlag?.experimental_storage ?? false,
-									}}
-								>
+		<FeatureFlagContext
+			value={{
+				runV3: featureFlag?.runV3 ?? false,
+				sidemenu: featureFlag?.sidemenu ?? false,
+				githubTools: featureFlag?.githubTools ?? false,
+				webSearchAction: featureFlag?.webSearchAction ?? false,
+				layoutV2: featureFlag?.layoutV2 ?? false,
+				layoutV3: featureFlag?.layoutV3 ?? false,
+				experimental_storage: featureFlag?.experimental_storage ?? false,
+			}}
+		>
+			<TelemetryProvider settings={telemetry}>
+				<UsageLimitsProvider limits={usageLimits}>
+					<IntegrationProvider {...integration}>
+						<VectorStoreProvider value={vectorStore}>
+							<WorkflowDesignerProvider data={workspace}>
+								<GenerationRunnerSystemProvider>
 									{children}
-								</FeatureFlagContext>
-							</GenerationRunnerSystemProvider>
-						</WorkflowDesignerProvider>
-					</VectorStoreProvider>
-				</IntegrationProvider>
-			</UsageLimitsProvider>
-		</TelemetryProvider>
+								</GenerationRunnerSystemProvider>
+							</WorkflowDesignerProvider>
+						</VectorStoreProvider>
+					</IntegrationProvider>
+				</UsageLimitsProvider>
+			</TelemetryProvider>
+		</FeatureFlagContext>
 	);
 }


### PR DESCRIPTION
## Summary
Moved the `FeatureFlagContext` provider to be the outermost wrapper in the component tree hierarchy within the `WorkspaceProvider` component.

## Changes
- Restructured the nesting order of context providers in the `WorkspaceProvider` component
- Moved `FeatureFlagContext` from being nested inside other providers to being the top-level wrapper
- Maintained all the same feature flag values and default fallbacks

## Testing
Verified that all feature flags continue to be accessible throughout the component tree with the new provider hierarchy.

## Other Information
This change ensures feature flags are available earlier in the component tree, which may be necessary for components that need access to these flags before other contexts are initialized.