### PR TITLE
Simplify Supabase storage driver by removing atomic write functionality

### DIFF
--- a/packages/supabase-driver/src/storage/supabase-storage-driver.ts
+++ b/packages/supabase-driver/src/storage/supabase-storage-driver.ts
@@ -1,10 +1,8 @@
-import { randomUUID } from "node:crypto";
 import { Readable } from "node:stream";
 import {
 	CopyObjectCommand,
 	DeleteObjectCommand,
 	GetObjectCommand,
-	HeadObjectCommand,
 	PutObjectCommand,
 	S3Client,
 } from "@aws-sdk/client-s3";
@@ -37,10 +35,6 @@ async function streamToUint8Array(stream: Readable): Promise<Uint8Array> {
 	return new Uint8Array(Buffer.concat(chunks));
 }
 
-function normalizeKey(key: string): string {
-	return key.replace(/^\/+/, "");
-}
-
 export function supabaseStorageDriver(
 	config: SupabaseStorageDriverConfig,
 ): GiselleStorage {
@@ -53,79 +47,6 @@ export function supabaseStorageDriver(
 		},
 		forcePathStyle: true,
 	});
-
-	const bucket = config.bucket;
-	const maxRetry = 3;
-
-	async function atomicWrite(
-		key: string,
-		body: string | Uint8Array | Buffer,
-		contentType?: string,
-		cacheControl?: string,
-	): Promise<void> {
-		const targetKey = normalizeKey(key);
-
-		let etag: string | undefined;
-		try {
-			const headRes = await client.send(
-				new HeadObjectCommand({ Bucket: bucket, Key: targetKey }),
-			);
-			etag = headRes.ETag?.replace(/"/g, "");
-		} catch (e: unknown) {
-			const err = e as { $metadata?: { httpStatusCode?: number } };
-			if (err.$metadata?.httpStatusCode !== 404) throw e;
-		}
-
-		const tempKey = `${targetKey}.tmp-${randomUUID()}`;
-		await client.send(
-			new PutObjectCommand({
-				Bucket: bucket,
-				Key: tempKey,
-				Body: body,
-				ContentType: contentType,
-				CacheControl: cacheControl,
-			}),
-		);
-
-		const cleanupTemp = () =>
-			client
-				.send(new DeleteObjectCommand({ Bucket: bucket, Key: tempKey }))
-				.catch(() => {});
-
-		for (let attempt = 0; attempt < maxRetry; attempt++) {
-			try {
-				await client.send(
-					new CopyObjectCommand({
-						Bucket: bucket,
-						Key: targetKey,
-						CopySource: `/${bucket}/${encodeURIComponent(tempKey)}`,
-						CopySourceIfMatch: etag,
-						MetadataDirective: "REPLACE",
-						ContentType: contentType,
-						CacheControl: cacheControl,
-					}),
-				);
-				await cleanupTemp();
-				return;
-			} catch (e: unknown) {
-				const err = e as {
-					$metadata?: { httpStatusCode?: number };
-					name?: string;
-				};
-				const precond =
-					err.$metadata?.httpStatusCode === 412 ||
-					err.name === "PreconditionFailed";
-				if (!precond || attempt === maxRetry - 1) {
-					await cleanupTemp();
-					throw e;
-				}
-				const headRes = await client.send(
-					new HeadObjectCommand({ Bucket: bucket, Key: targetKey }),
-				);
-				etag = headRes.ETag?.replace(/"/g, "");
-			}
-		}
-	}
 
 	return {
 		async getJson<T extends z.ZodObject>(
@@ -149,7 +70,14 @@ export function supabaseStorageDriver(
 				? params.schema.parse(params.data)
 				: params.data;
 			const body = JSON.stringify(data);
-			await atomicWrite(params.path, body, "application/json");
+			await client.send(
+				new PutObjectCommand({
+					Bucket: config.bucket,
+					Key: params.path,
+					Body: body,
+					ContentType: "application/json",
+				}),
+			);
 		},
 
 		async getBlob(path: string): Promise<Uint8Array> {


### PR DESCRIPTION
## Summary
Simplified the Supabase storage driver by removing the atomic write functionality and replacing it with a direct write approach.

## Changes
- Removed the `atomicWrite` function and its associated helper functions
- Removed unused imports (`randomUUID`, `HeadObjectCommand`)
- Simplified the `writeJson` method to use a direct `PutObjectCommand` instead of the atomic write process
- Removed the `normalizeKey` function and its usage
- Removed temporary file creation, cleanup, and retry logic

## Testing
The simplified storage driver should be tested to ensure that direct writes function correctly without the atomic write guarantees.

## Other Information
This change trades atomic write guarantees for simplicity. The previous implementation used a temporary file and conditional copy approach to ensure atomic writes, while the new implementation performs direct writes to the target path.