### PR TITLE
Set empty search path for Supabase vault functions

### DIFF
--- a/packages/supabase-driver/src/vault/supabase-rpc.sql
+++ b/packages/supabase-driver/src/vault/supabase-rpc.sql
@@ -1,9 +1,17 @@
-create or replace function create_secret(plaintext text) returns text as $$
-  select vault.create_secret(plaintext);
-$$ language sql;
+CREATE OR REPLACE FUNCTION public.create_secret(plaintext text)
+RETURNS text
+LANGUAGE sql
+SET search_path = ''
+AS $$
+  SELECT vault.create_secret(plaintext);
+$$;
 
-create or replace function decrypt_secret(secret_id uuid) returns text as $$
-  select decrypted_secret
-  from vault.decrypted_secrets
-  where id = secret_id;
-$$ language sql;
+CREATE OR REPLACE FUNCTION public.decrypt_secret(secret_id uuid)
+RETURNS text
+LANGUAGE sql
+SET search_path = ''
+AS $$
+  SELECT decrypted_secret
+  FROM vault.decrypted_secrets
+  WHERE id = secret_id;
+$$;


### PR DESCRIPTION
### **User description**
## Summary
Enhanced security of vault functions by explicitly setting an empty search path

## Background

We identified a vulnerability in our create_secret and decrypt_secret database functions due to missing explicit search_path settings. Without this, a caller could manipulate their search path, potentially leading to privilege escalation or unauthorized data access by referencing unintended schema objects.

To fix this, we added SET search_path = '' to both functions, ensuring all objects must be explicitly schema-qualified and preventing search path manipulation.

This update significantly improves security by eliminating a possible attack vector. Moving forward, we recommend reviewing all functions to enforce explicit search_path settings and adopting this as a standard for new functions.

## Changes
- Modified `create_secret` and `decrypt_secret` functions to use explicit SQL formatting
- Added `SET search_path = ''` to both functions to prevent search path injection attacks
- Improved code formatting with consistent capitalization and spacing

## Testing

- [ ] Verify using secret on GitHub tool and PostgreSQL Tool

## Other Information
This change helps prevent potential SQL injection attacks that could occur through search path manipulation. By explicitly setting an empty search path, we ensure the functions only access objects from explicitly specified schemas.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Set empty search path for Supabase vault functions

- Prevent search path injection attacks in database functions

- Improve SQL formatting with explicit schema qualifications

- Enhance security by eliminating privilege escalation vectors


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Original Functions"] --> B["Add SET search_path = ''"]
  B --> C["Explicit Schema Qualification"]
  C --> D["Enhanced Security"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>supabase-rpc.sql</strong><dd><code>Secure vault functions with empty search path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/supabase-driver/src/vault/supabase-rpc.sql

<li>Added <code>SET search_path = ''</code> to both <code>create_secret</code> and <code>decrypt_secret</code> <br>functions<br> <li> Improved SQL formatting with consistent capitalization and explicit <br>schema references<br> <li> Enhanced security by preventing search path manipulation attacks<br> <li> Made schema qualifications explicit (e.g., <code>public.create_secret</code>, <br><code>vault.create_secret</code>)


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1406/files#diff-7a55155165bf814d4822e84bed9d020fc0caa14dcd5fce768bac97a41e66925f">+16/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved formatting and declaration style of secret management functions for enhanced clarity and consistency.
  * Updated configuration to explicitly clear the search path during function execution for increased security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->