### PR TITLE
Fetch user teams dynamically for stage page

### DIFF
--- a/apps/studio.giselles.ai/app/stage/page.tsx
+++ b/apps/studio.giselles.ai/app/stage/page.tsx
@@ -11,11 +11,7 @@ import {
 import { Mic } from "lucide-react";
 import { notFound } from "next/navigation";
 import { stageFlag } from "@/flags";
-
-const teamOptions = [
-	{ id: "app", label: "teams/app" },
-	{ id: "core", label: "teams/core" },
-];
+import { fetchUserTeams } from "@/services/teams";
 
 const flowOptions = [
 	{ id: "flow", label: "flow" },
@@ -78,6 +74,8 @@ export default async function StagePage() {
 	if (!enableStage) {
 		return notFound();
 	}
+	const teams = await fetchUserTeams();
+	const teamOptions = teams.map((team) => ({ id: team.id, label: team.name }));
 	return (
 		<div className="p-[24px] space-y-6">
 			<div className="text-center text-[24px] font-sans text-white-100">


### PR DESCRIPTION
## Summary
Replaced hardcoded team options with dynamically fetched user teams in the Stage page.

## Changes
- Added import for `fetchUserTeams` from teams service
- Removed hardcoded team options array
- Added async call to fetch user teams
- Transformed fetched teams into the required format for dropdown options

## Testing
Verify that the Stage page now displays the user's actual teams in the dropdown instead of the previously hardcoded "teams/app" and "teams/core" options.