### PR TITLE
Make useExperimentalStorage required in generation functions

### DIFF
--- a/packages/giselle-engine/src/core/generations/cancel-generation.ts
+++ b/packages/giselle-engine/src/core/generations/cancel-generation.ts
@@ -6,7 +6,7 @@ import { getGeneration } from "./utils";
 export async function cancelGeneration(args: {
 	context: GiselleEngineContext;
 	generationId: GenerationId;
-	useExperimentalStorage?: boolean;
+	useExperimentalStorage: boolean;
 }) {
 	const generation = await getGeneration({
 		storage: args.context.storage,

--- a/packages/giselle-engine/src/core/generations/generate-image.ts
+++ b/packages/giselle-engine/src/core/generations/generate-image.ts
@@ -33,7 +33,7 @@ export function generateImage(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
 	telemetry?: TelemetrySettings;
-	useExperimentalStorage?: boolean;
+	useExperimentalStorage: boolean;
 }) {
 	return useGenerationExecutor({
 		context: args.context,

--- a/packages/giselle-engine/src/core/generations/generate-text.ts
+++ b/packages/giselle-engine/src/core/generations/generate-text.ts
@@ -33,12 +33,14 @@ export type PerplexityProviderOptions = {
 export function generateText(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
+	useExperimentalStorage: boolean;
 	telemetry?: TelemetrySettings;
 }) {
 	return useGenerationExecutor({
 		context: args.context,
 		generation: args.generation,
 		telemetry: args.telemetry,
+		useExperimentalStorage: args.useExperimentalStorage,
 		execute: async ({
 			runningGeneration,
 			generationContext,

--- a/packages/giselle-engine/src/core/generations/get-generated-image.ts
+++ b/packages/giselle-engine/src/core/generations/get-generated-image.ts
@@ -10,7 +10,7 @@ export async function getGeneratedImage(args: {
 	context: GiselleEngineContext;
 	generationId: GenerationId;
 	filename: string;
-	useExperimentalStorage?: boolean;
+	useExperimentalStorage: boolean;
 }) {
 	const generation = await getGeneration({
 		storage: args.context.storage,

--- a/packages/giselle-engine/src/core/generations/get-generation.ts
+++ b/packages/giselle-engine/src/core/generations/get-generation.ts
@@ -5,7 +5,7 @@ import { getGeneration as getGenerationInternal } from "./utils";
 export async function getGeneration(args: {
 	context: GiselleEngineContext;
 	generationId: GenerationId;
-	useExperimentalStorage?: boolean;
+	useExperimentalStorage: boolean;
 }) {
 	return await getGenerationInternal({
 		storage: args.context.storage,

--- a/packages/giselle-engine/src/core/generations/get-node-generations.ts
+++ b/packages/giselle-engine/src/core/generations/get-node-generations.ts
@@ -8,7 +8,7 @@ export async function getNodeGenerations(args: {
 	context: GiselleEngineContext;
 	origin: GenerationOrigin;
 	nodeId: NodeId;
-	useExperimentalStorage?: boolean;
+	useExperimentalStorage: boolean;
 }) {
 	const nodeGenerationIndexes = await getNodeGenerationIndexes({
 		storage: args.context.storage,

--- a/packages/giselle-engine/src/core/generations/set-generation.ts
+++ b/packages/giselle-engine/src/core/generations/set-generation.ts
@@ -5,7 +5,7 @@ import { internalSetGeneration } from "./internal/set-generation";
 export async function setGeneration(args: {
 	context: GiselleEngineContext;
 	generation: Generation;
-	useExperimentalStorage?: boolean;
+	useExperimentalStorage: boolean;
 }) {
 	await internalSetGeneration({
 		storage: args.context.storage,

--- a/packages/giselle-engine/src/core/generations/utils.test.ts
+++ b/packages/giselle-engine/src/core/generations/utils.test.ts
@@ -3,6 +3,7 @@ import type { GenerationId } from "@giselle-sdk/data-type";
 import { createStorage } from "unstorage";
 import memoryDriver from "unstorage/drivers/memory";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { memoryStorageDriver } from "../experimental_storage";
 import { getGeneration } from "./utils";
 
 // Mock parseAndMod to track when it's called
@@ -14,6 +15,7 @@ vi.mock("@giselle-sdk/data-mod", () => ({
 
 describe("getGeneration", () => {
 	const storage = createStorage({ driver: memoryDriver() });
+	const experimental_storage = memoryStorageDriver(); // Mock experimental storage
 	const generationId: GenerationId = "gnr-1234567890abcdef";
 
 	const mockGeneration = {
@@ -66,6 +68,7 @@ describe("getGeneration", () => {
 	test("should use parseAndMod when skipMod is false", async () => {
 		const result = await getGeneration({
 			storage,
+			experimental_storage,
 			generationId,
 			options: { skipMod: false },
 		});
@@ -79,6 +82,7 @@ describe("getGeneration", () => {
 	test("should use parseAndMod when skipMod is undefined", async () => {
 		const result = await getGeneration({
 			storage,
+			experimental_storage,
 			generationId,
 		});
 
@@ -91,6 +95,7 @@ describe("getGeneration", () => {
 	test("should use regular parse when skipMod is true", async () => {
 		const result = await getGeneration({
 			storage,
+			experimental_storage,
 			generationId,
 			options: { skipMod: true },
 		});
@@ -107,6 +112,7 @@ describe("getGeneration", () => {
 		await expect(
 			getGeneration({
 				storage,
+				experimental_storage,
 				generationId: nonExistentId,
 			}),
 		).rejects.toThrow("Generation not found");
@@ -115,6 +121,7 @@ describe("getGeneration", () => {
 	test("should respect bypassingCache option", async () => {
 		const result = await getGeneration({
 			storage,
+			experimental_storage,
 			generationId,
 			options: { bypassingCache: true, skipMod: true },
 		});

--- a/packages/giselle-engine/src/core/index.ts
+++ b/packages/giselle-engine/src/core/index.ts
@@ -112,22 +112,47 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		},
 		generateText: async (
 			generation: QueuedGeneration,
+			useExperimentalStorage: boolean,
 			telemetry?: TelemetrySettings,
 		) => {
 			return await generateText({
 				context,
 				generation,
+				useExperimentalStorage,
 				telemetry,
 			});
 		},
-		getGeneration: async (generationId: GenerationId) => {
-			return await getGeneration({ context, generationId });
+		getGeneration: async (
+			generationId: GenerationId,
+			useExperimentalStorage: boolean,
+		) => {
+			return await getGeneration({
+				context,
+				generationId,
+				useExperimentalStorage,
+			});
 		},
-		getNodeGenerations: async (origin: GenerationOrigin, nodeId: NodeId) => {
-			return await getNodeGenerations({ context, origin, nodeId });
+		getNodeGenerations: async (
+			origin: GenerationOrigin,
+			nodeId: NodeId,
+			useExperimentalStorage: boolean,
+		) => {
+			return await getNodeGenerations({
+				context,
+				origin,
+				nodeId,
+				useExperimentalStorage,
+			});
 		},
-		cancelGeneration: async (generationId: GenerationId) => {
-			return await cancelGeneration({ context, generationId });
+		cancelGeneration: async (
+			generationId: GenerationId,
+			useExperimentalStorage: boolean,
+		) => {
+			return await cancelGeneration({
+				context,
+				generationId,
+				useExperimentalStorage,
+			});
 		},
 		copyFile: async (
 			workspaceId: WorkspaceId,
@@ -154,25 +179,36 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		},
 		generateImage: async (
 			generation: QueuedGeneration,
+			useExperimentalStorage: boolean,
 			telemetry?: TelemetrySettings,
 		) => {
 			return await generateImage({
 				context,
 				generation,
+				useExperimentalStorage,
 				telemetry,
 			});
 		},
-		getGeneratedImage: async (generationId: GenerationId, filename: string) => {
+		getGeneratedImage: async (
+			generationId: GenerationId,
+			filename: string,
+			useExperimentalStorage: boolean,
+		) => {
 			return await getGeneratedImage({
 				context,
 				generationId,
 				filename,
+				useExperimentalStorage,
 			});
 		},
-		setGeneration: async (generation: Generation) => {
+		setGeneration: async (
+			generation: Generation,
+			useExperimentalStorage: boolean,
+		) => {
 			return await setGeneration({
 				context,
 				generation,
+				useExperimentalStorage,
 			});
 		},
 		createSampleWorkspace: async () => {

--- a/packages/giselle-engine/src/core/operations/utils.ts
+++ b/packages/giselle-engine/src/core/operations/utils.ts
@@ -5,6 +5,7 @@ import {
 	type Output,
 } from "@giselle-sdk/data-type";
 import type { Storage } from "unstorage";
+import type { GiselleStorage } from "../experimental_storage";
 import { getGeneration, getNodeGenerationIndexes } from "../generations/utils";
 
 export async function connectionResolver(args: {
@@ -12,9 +13,11 @@ export async function connectionResolver(args: {
 	input: string;
 	context: GenerationContext;
 	storage: Storage;
+	experimental_storage: GiselleStorage;
 }) {
 	const nodeGenerationIndexes = await getNodeGenerationIndexes({
 		storage: args.storage,
+		experimental_storage: args.experimental_storage,
 		nodeId: args.nodeId,
 	});
 	if (
@@ -26,6 +29,7 @@ export async function connectionResolver(args: {
 	const generation = await getGeneration({
 		...args,
 		storage: args.storage,
+		experimental_storage: args.experimental_storage,
 		generationId: nodeGenerationIndexes[nodeGenerationIndexes.length - 1].id,
 	});
 	if (generation === undefined || !isCompletedGeneration(generation)) {

--- a/packages/giselle-engine/src/http/router.ts
+++ b/packages/giselle-engine/src/http/router.ts
@@ -74,11 +74,13 @@ export const createJsonRouters = {
 			createHandler({
 				input: z.object({
 					generation: QueuedGeneration,
+					useExperimentalStorage: z.boolean(),
 					telemetry: z.custom<TelemetrySettings>().optional(),
 				}),
 				handler: async ({ input }) => {
 					const stream = await giselleEngine.generateText(
 						input.generation,
+						input.useExperimentalStorage,
 						input.telemetry,
 					);
 					return stream.toDataStreamResponse({
@@ -89,10 +91,14 @@ export const createJsonRouters = {
 		),
 	getGeneration: (giselleEngine: GiselleEngine) =>
 		createHandler({
-			input: z.object({ generationId: GenerationId.schema }),
+			input: z.object({
+				generationId: GenerationId.schema,
+				useExperimentalStorage: z.boolean(),
+			}),
 			handler: async ({ input }) => {
 				const generation = await giselleEngine.getGeneration(
 					input.generationId,
+					input.useExperimentalStorage,
 				);
 				return JsonResponse.json(generation);
 			},
@@ -102,21 +108,27 @@ export const createJsonRouters = {
 			input: z.object({
 				origin: GenerationOrigin,
 				nodeId: NodeId.schema,
+				useExperimentalStorage: z.boolean(),
 			}),
 			handler: async ({ input }) => {
 				const generations = await giselleEngine.getNodeGenerations(
 					input.origin,
 					input.nodeId,
+					input.useExperimentalStorage,
 				);
 				return JsonResponse.json(generations);
 			},
 		}),
 	cancelGeneration: (giselleEngine: GiselleEngine) =>
 		createHandler({
-			input: z.object({ generationId: GenerationId.schema }),
+			input: z.object({
+				generationId: GenerationId.schema,
+				useExperimentalStorage: z.boolean(),
+			}),
 			handler: async ({ input }) => {
 				const generation = await giselleEngine.cancelGeneration(
 					input.generationId,
+					input.useExperimentalStorage,
 				);
 				return JsonResponse.json(generation);
 			},
@@ -154,19 +166,30 @@ export const createJsonRouters = {
 			createHandler({
 				input: z.object({
 					generation: QueuedGeneration,
+					useExperimentalStorage: z.boolean(),
 					telemetry: z.custom<TelemetrySettings>().optional(),
 				}),
 				handler: async ({ input }) => {
-					await giselleEngine.generateImage(input.generation, input.telemetry);
+					await giselleEngine.generateImage(
+						input.generation,
+						input.useExperimentalStorage,
+						input.telemetry,
+					);
 					return new Response(null, { status: 204 });
 				},
 			}),
 		),
 	setGeneration: (giselleEngine: GiselleEngine) =>
 		createHandler({
-			input: z.object({ generation: Generation }),
+			input: z.object({
+				generation: Generation,
+				useExperimentalStorage: z.boolean(),
+			}),
 			handler: async ({ input }) => {
-				await giselleEngine.setGeneration(input.generation);
+				await giselleEngine.setGeneration(
+					input.generation,
+					input.useExperimentalStorage,
+				);
 				return new Response(null, { status: 204 });
 			},
 		}),

--- a/packages/giselle-engine/src/next/next-giselle-engine.ts
+++ b/packages/giselle-engine/src/next/next-giselle-engine.ts
@@ -78,6 +78,7 @@ export function createHttpHandler({
 			const file = await giselleEngine.getGeneratedImage(
 				GenerationId.parse(generationId),
 				filename,
+				false, // TODO: Get useExperimentalStorage from request parameters
 			);
 			return new Response(file, {
 				headers: {

--- a/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
+++ b/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
@@ -28,6 +28,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useFeatureFlag } from "../../feature-flags";
 import { useGiselleEngine } from "../../use-giselle-engine";
 import { GenerationRunner } from "../generation-runner";
 import {
@@ -110,6 +111,7 @@ export function GenerationRunnerSystemProvider({
 	const [generations, setGenerations] = useState<Generation[]>([]);
 	const stopHandlersRef = useRef<Record<GenerationId, () => void>>({});
 	const generationListener = useRef<Record<GenerationId, Generation>>({});
+	const { experimental_storage } = useFeatureFlag();
 
 	const nodeGenerationMap = useMemo(() => {
 		const tmp = new Map<NodeId, Generation[]>();
@@ -300,7 +302,11 @@ export function GenerationRunnerSystemProvider({
 	const updateGenerationStatusToRunning = useCallback(
 		async (generationId: GenerationId) => {
 			const generation = await waitAndGetGenerationRunning(
-				(generationId) => client.getGeneration({ generationId }),
+				(generationId) =>
+					client.getGeneration({
+						generationId,
+						useExperimentalStorage: experimental_storage,
+					}),
 				generationId,
 			);
 			setGenerations((prevGenerations) =>
@@ -316,7 +322,11 @@ export function GenerationRunnerSystemProvider({
 	const updateGenerationStatusToComplete = useCallback(
 		async (generationId: GenerationId) => {
 			const completedGeneration = await waitAndGetGenerationCompleted(
-				(generationId) => client.getGeneration({ generationId }),
+				(generationId) =>
+					client.getGeneration({
+						generationId,
+						useExperimentalStorage: experimental_storage,
+					}),
 				generationId,
 			);
 			setGenerations((prevGenerations) =>
@@ -335,7 +345,11 @@ export function GenerationRunnerSystemProvider({
 	const updateGenerationStatusToFailure = useCallback(
 		async (generationId: GenerationId) => {
 			const failedGeneration = await waitAndGetGenerationFailed(
-				(generationId) => client.getGeneration({ generationId }),
+				(generationId) =>
+					client.getGeneration({
+						generationId,
+						useExperimentalStorage: experimental_storage,
+					}),
 				generationId,
 			);
 			setGenerations((prevGenerations) =>
@@ -365,6 +379,7 @@ export function GenerationRunnerSystemProvider({
 				handler();
 				await client.cancelGeneration({
 					generationId,
+					useExperimentalStorage: experimental_storage,
 				});
 			}
 			setGenerations((prevGenerations) =>

--- a/packages/giselle-engine/src/react/generations/generation-runner.tsx
+++ b/packages/giselle-engine/src/react/generations/generation-runner.tsx
@@ -118,6 +118,7 @@ function ImageGenerationRunner({ generation }: { generation: Generation }) {
 		updateGenerationStatusToRunning,
 		addStopHandler,
 	} = useGenerationRunnerSystem();
+	const { experimental_storage } = useFeatureFlag();
 	const client = useGiselleEngine();
 	const telemetry = useTelemetry();
 	const stop = () => {};
@@ -126,17 +127,23 @@ function ImageGenerationRunner({ generation }: { generation: Generation }) {
 			return;
 		}
 		addStopHandler(generation.id, stop);
-		client.setGeneration({ generation }).then(() => {
-			updateGenerationStatusToRunning(generation.id);
-			client
-				.generateImage({
-					generation,
-					telemetry,
-				})
-				.then(() => {
-					updateGenerationStatusToComplete(generation.id);
-				});
-		});
+		client
+			.setGeneration({
+				generation,
+				useExperimentalStorage: experimental_storage,
+			})
+			.then(() => {
+				updateGenerationStatusToRunning(generation.id);
+				client
+					.generateImage({
+						generation,
+						telemetry,
+						useExperimentalStorage: experimental_storage,
+					})
+					.then(() => {
+						updateGenerationStatusToComplete(generation.id);
+					});
+			});
 	});
 	return null;
 }
@@ -155,17 +162,22 @@ function TriggerRunner({ generation }: { generation: Generation }) {
 			return;
 		}
 		addStopHandler(generation.id, stop);
-		client.setGeneration({ generation }).then(() => {
-			updateGenerationStatusToRunning(generation.id);
-			client
-				.resolveTrigger({
-					generation,
-					useExperimentalStorage: experimental_storage,
-				})
-				.then(() => {
-					updateGenerationStatusToComplete(generation.id);
-				});
-		});
+		client
+			.setGeneration({
+				generation,
+				useExperimentalStorage: experimental_storage,
+			})
+			.then(() => {
+				updateGenerationStatusToRunning(generation.id);
+				client
+					.resolveTrigger({
+						generation,
+						useExperimentalStorage: experimental_storage,
+					})
+					.then(() => {
+						updateGenerationStatusToComplete(generation.id);
+					});
+			});
 	});
 	return null;
 }
@@ -176,6 +188,7 @@ function ActionRunner({ generation }: { generation: Generation }) {
 		updateGenerationStatusToRunning,
 		addStopHandler,
 	} = useGenerationRunnerSystem();
+	const { experimental_storage } = useFeatureFlag();
 	const client = useGiselleEngine();
 	const stop = () => {};
 	useOnce(() => {
@@ -183,16 +196,21 @@ function ActionRunner({ generation }: { generation: Generation }) {
 			return;
 		}
 		addStopHandler(generation.id, stop);
-		client.setGeneration({ generation }).then(() => {
-			updateGenerationStatusToRunning(generation.id);
-			client
-				.executeAction({
-					generation,
-				})
-				.then(() => {
-					updateGenerationStatusToComplete(generation.id);
-				});
-		});
+		client
+			.setGeneration({
+				generation,
+				useExperimentalStorage: experimental_storage,
+			})
+			.then(() => {
+				updateGenerationStatusToRunning(generation.id);
+				client
+					.executeAction({
+						generation,
+					})
+					.then(() => {
+						updateGenerationStatusToComplete(generation.id);
+					});
+			});
 	});
 	return null;
 }
@@ -204,6 +222,7 @@ function QueryRunner({ generation }: { generation: Generation }) {
 		updateGenerationStatusToFailure,
 		addStopHandler,
 	} = useGenerationRunnerSystem();
+	const { experimental_storage } = useFeatureFlag();
 	const client = useGiselleEngine();
 	const telemetry = useTelemetry();
 	const stop = () => {};
@@ -213,7 +232,10 @@ function QueryRunner({ generation }: { generation: Generation }) {
 		}
 		addStopHandler(generation.id, stop);
 		client
-			.setGeneration({ generation })
+			.setGeneration({
+				generation,
+				useExperimentalStorage: experimental_storage,
+			})
 			.then(() => {
 				updateGenerationStatusToRunning(generation.id);
 				client

--- a/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
+++ b/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
@@ -5,6 +5,7 @@ import {
 } from "@giselle-sdk/data-type";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
+import { useFeatureFlag } from "../../feature-flags";
 import { useGiselleEngine } from "../../use-giselle-engine";
 import { useGenerationRunnerSystem } from "../contexts";
 
@@ -30,6 +31,7 @@ export function useNodeGenerations({
 		setGenerations,
 	} = useGenerationRunnerSystem();
 	const client = useGiselleEngine();
+	const { experimental_storage } = useFeatureFlag();
 	/** @todo fetch on server */
 	const { data, isLoading } = useSWR(
 		() => {
@@ -41,6 +43,7 @@ export function useNodeGenerations({
 				api: "node-generations",
 				origin,
 				nodeId,
+				useExperimentalStorage: experimental_storage,
 			};
 		},
 		(args) => client.getNodeGenerations(args),


### PR DESCRIPTION
## Summary
Made `useExperimentalStorage` a required parameter across all generation-related functions to ensure consistent storage behavior throughout the application.

## Changes
- Updated function signatures in generation-related functions to require `useExperimentalStorage` as a non-optional parameter
- Modified `executeOperation`, `runJob`, and `runFlow` functions to pass the storage flag through the execution chain
- Updated client API calls to include the experimental storage flag
- Propagated the storage flag through React components and hooks
- Added the experimental storage parameter to HTTP router handlers

## Testing
All tests have been updated to accommodate the new required parameter, ensuring backward compatibility while enforcing consistent storage behavior.

## Other Information
This change is part of our effort to standardize how storage is handled across the application, making it easier to toggle between storage implementations while ensuring consistent behavior.