### PR TITLE
Add staged property with default false to ManualFlowTrigger

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
@@ -82,6 +82,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 								id: "manual",
 								parameters,
 							},
+							staged: false, // todo next pull request
 						},
 					},
 					useExperimentalStorage: experimental_storage,

--- a/packages/data-type/src/flow/trigger/manual.test.ts
+++ b/packages/data-type/src/flow/trigger/manual.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { ManualFlowTrigger } from "./manual";
+
+describe("ManualFlowTrigger", () => {
+	test("can parse object does not have staged", () => {
+		const manualFlowTriggerLike = {
+			provider: "manual",
+			event: {
+				id: "manual",
+				parameters: [],
+			},
+		};
+		const parse = ManualFlowTrigger.safeParse(manualFlowTriggerLike);
+		expect(parse.success).toBe(true);
+		expect(parse.data?.staged).toBe(false);
+	});
+});

--- a/packages/data-type/src/flow/trigger/manual.ts
+++ b/packages/data-type/src/flow/trigger/manual.ts
@@ -24,5 +24,6 @@ export type ManualFlowTriggerEvent = z.infer<typeof ManualFlowTriggerEvent>;
 export const ManualFlowTrigger = z.object({
 	provider: Provider,
 	event: ManualFlowTriggerEvent,
+	staged: z.boolean().default(false),
 });
 export type ManualFlowTrigger = z.infer<typeof ManualFlowTrigger>;


### PR DESCRIPTION
### **User description**
## Summary
Added a `staged` field with a default value of `false` to the `ManualFlowTrigger` schema and included a test to verify that objects without a `staged` property are correctly parsed with the default value.

## Changes
- Added `staged: z.boolean().default(false)` to the `ManualFlowTrigger` schema
- Created a new test file to verify that objects without the `staged` property are correctly parsed with `staged` defaulting to `false`

## Testing
Added a unit test that confirms the `ManualFlowTrigger.safeParse()` method correctly handles objects without a `staged` property, setting the default value to `false`.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `staged` property with default `false` to `ManualFlowTrigger` schema

- Include unit test to verify default value parsing

- Update UI component to set `staged` property


___

### **Changes diagram**

```mermaid
flowchart LR
  A["ManualFlowTrigger Schema"] --> B["Add staged property"]
  B --> C["Default value: false"]
  D["Unit Test"] --> E["Verify default parsing"]
  F["UI Component"] --> G["Set staged: false"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manual.ts</strong><dd><code>Add staged boolean property with default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/data-type/src/flow/trigger/manual.ts

<li>Add <code>staged: z.boolean().default(false)</code> to ManualFlowTrigger schema


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1413/files#diff-2e8c1041e2d8406f5d34a5eeb3f6adab2b08b3d977d5c10147c70b2b43e1b0c7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manual-trigger-properties-panel.tsx</strong><dd><code>Update UI to include staged property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx

<li>Add <code>staged: false</code> to configuration object<br> <li> Include TODO comment for next pull request


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1413/files#diff-5824573996ecd19b90f66f240449e13605ede1027aa3d8d09cb613b001055b14">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manual.test.ts</strong><dd><code>Add unit test for staged default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/data-type/src/flow/trigger/manual.test.ts

<li>Create new test file for ManualFlowTrigger<br> <li> Test parsing objects without staged property<br> <li> Verify default value is set to false


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1413/files#diff-77d65823cc3cd28245fe293fefcb8f8dddaec75fbed0d4456a9c122cf16aef94">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new property to manual triggers, allowing them to include a "staged" status with a default value of false.

* **Tests**
  * Introduced tests to ensure manual triggers correctly handle the new "staged" property, including cases where it is not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->