### PR TITLE
Add stage flag to feature context

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -21,6 +21,7 @@ export default async function Layout({
 				layoutV2: true,
 				layoutV3: true,
 				experimental_storage: true,
+				stage: true,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -10,6 +10,7 @@ import {
 	layoutV3Flag,
 	runV3Flag,
 	sidemenuFlag,
+	stageFlag,
 	webSearchActionFlag,
 } from "@/flags";
 import { getGitHubVectorStores } from "@/lib/vector-stores/github";
@@ -50,6 +51,7 @@ export default async function Layout({
 	const layoutV2 = await layoutV2Flag();
 	const layoutV3 = await layoutV3Flag();
 	const experimental_storage = await experimental_storageFlag();
+	const stage = await stageFlag();
 	return (
 		<WorkspaceProvider
 			workspaceId={workspaceId}
@@ -83,6 +85,7 @@ export default async function Layout({
 				layoutV2,
 				layoutV3,
 				experimental_storage,
+				stage,
 			}}
 		>
 			{children}

--- a/packages/giselle-engine/src/react/feature-flags/context.ts
+++ b/packages/giselle-engine/src/react/feature-flags/context.ts
@@ -8,6 +8,7 @@ export interface FeatureFlagContextValue {
 	layoutV2: boolean;
 	layoutV3: boolean;
 	experimental_storage: boolean;
+	stage: boolean;
 }
 export const FeatureFlagContext = createContext<
 	FeatureFlagContextValue | undefined

--- a/packages/giselle-engine/src/react/workspace/provider.tsx
+++ b/packages/giselle-engine/src/react/workspace/provider.tsx
@@ -64,6 +64,7 @@ export function WorkspaceProvider({
 				layoutV2: featureFlag?.layoutV2 ?? false,
 				layoutV3: featureFlag?.layoutV3 ?? false,
 				experimental_storage: featureFlag?.experimental_storage ?? false,
+				stage: featureFlag?.stage ?? false,
 			}}
 		>
 			<TelemetryProvider settings={telemetry}>


### PR DESCRIPTION
## Summary
- support `stage` in `FeatureFlagContext`
- expose the new flag from `WorkspaceProvider`
- always enable stage in playground layout
- fetch `stageFlag` for studio workspace layout

## Testing
- `npx turbo test --cache=local:rw`
- `npx turbo check-types --filter="@giselle-sdk/giselle-engine" --cache=local:rw` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_686f492709a8832f9c0ca533b27328f0