### PR TITLE
Add staged toggle to manual trigger properties panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
@@ -28,7 +28,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 	const [isPending, startTransition] = useTransition();
 	const [parameters, setParameters] = useState<ManualTriggerParameter[]>([]);
 	const [staged, setStaged] = useState(false);
-	const { experimental_storage } = useFeatureFlag();
+	const { experimental_storage, stage } = useFeatureFlag();
 
 	const handleAddParameter = useCallback<FormEventHandler<HTMLFormElement>>(
 		(e) => {
@@ -216,14 +216,16 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 				</div>
 			</div>
 
-			<div className="mt-[8px]">
-				<Toggle name="staged" checked={staged} onCheckedChange={setStaged}>
-					<label className="text-[12px]" htmlFor="staged">
-						Staged
-					</label>
-					<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30" />
-				</Toggle>
-			</div>
+			{stage && (
+				<div className="mt-[8px]">
+					<Toggle name="staged" checked={staged} onCheckedChange={setStaged}>
+						<label className="text-[12px]" htmlFor="staged">
+							Staged
+						</label>
+						<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30" />
+					</Toggle>
+				</div>
+			)}
 
 			<form onSubmit={handleSubmit}>
 				<button

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
@@ -1,3 +1,4 @@
+import { Toggle } from "@giselle-internal/ui/toggle";
 import {
 	ManualTriggerParameter,
 	ManualTriggerParameterId,
@@ -26,6 +27,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 	const client = useGiselleEngine();
 	const [isPending, startTransition] = useTransition();
 	const [parameters, setParameters] = useState<ManualTriggerParameter[]>([]);
+	const [staged, setStaged] = useState(false);
 	const { experimental_storage } = useFeatureFlag();
 
 	const handleAddParameter = useCallback<FormEventHandler<HTMLFormElement>>(
@@ -82,7 +84,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 								id: "manual",
 								parameters,
 							},
-							staged: false, // todo next pull request
+							staged,
 						},
 					},
 					useExperimentalStorage: experimental_storage,
@@ -101,7 +103,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 				});
 			});
 		},
-		[parameters, client, node, workspace?.id, updateNodeData],
+		[parameters, staged, client, node, workspace?.id, updateNodeData],
 	);
 
 	if (node.content.state.status === "configured") {
@@ -212,6 +214,15 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 						</button>
 					</form>
 				</div>
+			</div>
+
+			<div className="mt-[8px]">
+				<Toggle name="staged" checked={staged} onCheckedChange={setStaged}>
+					<label className="text-[12px]" htmlFor="staged">
+						Staged
+					</label>
+					<div className="flex-grow mx-[12px] h-[1px] bg-black-200/30" />
+				</Toggle>
 			</div>
 
 			<form onSubmit={handleSubmit}>


### PR DESCRIPTION
### **User description**
## Summary
Added a "Staged" toggle option to the Manual Trigger Properties Panel when the stage feature flag is enabled.

## Changes
- Imported the Toggle component from the UI library
- Added state management for the staged property with `useState(false)`
- Added the staged property to the feature flag destructuring
- Updated the node configuration to include the staged value
- Added the staged parameter to the dependency array of the submit handler
- Added a UI toggle for the staged option that only appears when the stage feature flag is enabled

## Testing
Verify that the "Staged" toggle appears in the Manual Trigger Properties Panel when the stage feature flag is enabled, and that toggling it correctly updates the node configuration.


___

### **PR Type**
Enhancement


___

### **Description**
- Add staged toggle to manual trigger properties panel

- Enable staged configuration when stage feature flag is active

- Update node configuration to include staged property

- Add UI toggle component with proper state management


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Feature Flag Check"] --> B["Toggle Component"]
  B --> C["State Management"]
  C --> D["Node Configuration"]
  D --> E["Submit Handler"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manual-trigger-properties-panel.tsx</strong><dd><code>Add staged toggle with feature flag integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx

<li>Import <code>Toggle</code> component from UI library<br> <li> Add <code>staged</code> state with <code>useState(false)</code> hook<br> <li> Extract <code>stage</code> feature flag from <code>useFeatureFlag()</code><br> <li> Update node configuration to use <code>staged</code> state instead of hardcoded <br><code>false</code><br> <li> Add <code>staged</code> parameter to submit handler dependency array<br> <li> Add conditional UI toggle that appears when <code>stage</code> feature flag is <br>enabled


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1416/files#diff-5824573996ecd19b90f66f240449e13605ede1027aa3d8d09cb613b001055b14">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle option to mark the manual trigger configuration as "staged" when the relevant feature flag is enabled.

* **User Interface**
  * Introduced a new toggle control below the parameter configuration section, visible only if the feature is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->