### PR TITLE
Add BlobLike type and conversion utility for binary data

### DIFF
--- a/packages/giselle-engine/src/core/experimental_storage/types/blob-like.ts
+++ b/packages/giselle-engine/src/core/experimental_storage/types/blob-like.ts
@@ -1,0 +1,25 @@
+export type BlobLike = Buffer | Uint8Array | ArrayBuffer;
+/**
+ * Converts any BlobLike data to a Uint8Array.
+ * This helper function handles the conversion logic for different binary data types.
+ *
+ * @param data - The binary data to convert
+ * @returns A new Uint8Array containing the binary data
+ *
+ * @example
+ * ```typescript
+ * const buffer = Buffer.from("Hello");
+ * const uint8Array = blobLikeToUint8Array(buffer);
+ * console.log(uint8Array); // Uint8Array(5) [72, 101, 108, 108, 111]
+ * ```
+ */
+export function blobLikeToUint8Array(data: BlobLike) {
+	if (data instanceof Uint8Array) {
+		return new Uint8Array(data);
+	}
+	if (data instanceof ArrayBuffer) {
+		return new Uint8Array(data);
+	}
+	// Fallback should not happen with proper typing
+	throw new Error("Invalid BlobLike data type");
+}


### PR DESCRIPTION
## Summary
Added a new `BlobLike` type and utility function to standardize binary data handling in the experimental storage system.

## Changes
- Created a new `BlobLike` type that represents different binary data formats (Buffer, Uint8Array, ArrayBuffer)
- Implemented `blobLikeToUint8Array()` utility function to convert any BlobLike data to a Uint8Array
- Added JSDoc documentation with example usage for the conversion function

## Testing
The implementation includes type safety checks and appropriate error handling for invalid data types.

## Other Information
This addition will help standardize how binary data is handled throughout the storage system, making it easier to work with different binary formats consistently.