### PR TITLE
Add BlobLike type to storage drivers

### DIFF
--- a/packages/giselle-engine/src/core/experimental_storage/fs-storage-driver.ts
+++ b/packages/giselle-engine/src/core/experimental_storage/fs-storage-driver.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import { dirname, join } from "node:path";
 import type { z } from "zod/v4";
+import { type BlobLike, blobLikeToUint8Array } from "./types/blob-like";
 import type {
 	GetJsonParams,
 	GiselleStorage,
@@ -44,10 +45,10 @@ export function fsStorageDriver(config: FsStorageDriverConfig): GiselleStorage {
 			return new Uint8Array(buffer);
 		},
 
-		async setBlob(path: string, data: Uint8Array): Promise<void> {
+		async setBlob(path: string, data: BlobLike): Promise<void> {
 			const fullPath = join(config.root, path);
 			await ensureDir(fullPath);
-			await fs.writeFile(fullPath, data);
+			await fs.writeFile(fullPath, blobLikeToUint8Array(data));
 		},
 
 		async copy(source: string, destination: string): Promise<void> {

--- a/packages/giselle-engine/src/core/experimental_storage/index.ts
+++ b/packages/giselle-engine/src/core/experimental_storage/index.ts
@@ -1,3 +1,4 @@
 export * from "./fs-storage-driver";
 export * from "./memory-storage-driver";
+export * from "./types/blob-like";
 export * from "./types/interface";

--- a/packages/giselle-engine/src/core/experimental_storage/memory-storage-driver.ts
+++ b/packages/giselle-engine/src/core/experimental_storage/memory-storage-driver.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod/v4";
+import type { BlobLike } from "./types/blob-like";
 import type {
 	GetJsonParams,
 	GiselleStorage,
@@ -54,7 +55,7 @@ export function memoryStorageDriver(
 			return Promise.resolve(new Uint8Array(data));
 		},
 
-		setBlob(path: string, data: Uint8Array): Promise<void> {
+		setBlob(path: string, data: BlobLike): Promise<void> {
 			blobStore.set(path, new Uint8Array(data));
 			return Promise.resolve();
 		},

--- a/packages/giselle-engine/src/core/experimental_storage/types/interface.ts
+++ b/packages/giselle-engine/src/core/experimental_storage/types/interface.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod/v4";
+import type { BlobLike } from "./blob-like";
 
 export type JsonSchema = z.ZodObject | z.ZodDiscriminatedUnion | z.ZodArray;
 export interface GetJsonParams<T extends JsonSchema> {
@@ -22,7 +23,7 @@ type SetJson = <T extends JsonSchema>(
 
 type GetBlob = (path: string) => Promise<Uint8Array>;
 
-type SetBlob = (path: string, data: Uint8Array) => Promise<void>;
+type SetBlob = (path: string, data: BlobLike) => Promise<void>;
 
 type Copy = (source: string, destination: string) => Promise<void>;
 

--- a/packages/supabase-driver/src/storage/supabase-storage-driver.ts
+++ b/packages/supabase-driver/src/storage/supabase-storage-driver.ts
@@ -6,11 +6,13 @@ import {
 	PutObjectCommand,
 	S3Client,
 } from "@aws-sdk/client-s3";
-import type {
-	GetJsonParams,
-	GiselleStorage,
-	JsonSchema,
-	SetJsonParams,
+import {
+	type BlobLike,
+	blobLikeToUint8Array,
+	type GetJsonParams,
+	type GiselleStorage,
+	type JsonSchema,
+	type SetJsonParams,
 } from "@giselle-sdk/giselle-engine";
 import type { z } from "zod/v4";
 
@@ -97,9 +99,13 @@ export function supabaseStorageDriver(
 			return await streamToUint8Array(res.Body as Readable);
 		},
 
-		async setBlob(path: string, data: Uint8Array): Promise<void> {
+		async setBlob(path: string, data: BlobLike): Promise<void> {
 			await client.send(
-				new PutObjectCommand({ Bucket: config.bucket, Key: path, Body: data }),
+				new PutObjectCommand({
+					Bucket: config.bucket,
+					Key: path,
+					Body: blobLikeToUint8Array(data),
+				}),
 			);
 		},
 


### PR DESCRIPTION
## Summary
Added support for BlobLike type in storage drivers to allow more flexible blob data handling.

## Changes
- Created a new BlobLike type to support different blob data formats
- Updated the `setBlob` method signature in storage interfaces to accept BlobLike instead of just Uint8Array
- Implemented `blobLikeToUint8Array` utility function to convert different blob formats
- Modified fs-storage-driver, memory-storage-driver, and supabase-storage-driver to use the new BlobLike type
- Exported the new blob-like types from the experimental_storage module

## Testing
Storage drivers now accept more flexible input formats for blob data while maintaining compatibility with existing code.