### PR TITLE
Add FlowTriggerContext and provider to workspace

### DIFF
--- a/packages/giselle-engine/src/react/flow-trigger/context.ts
+++ b/packages/giselle-engine/src/react/flow-trigger/context.ts
@@ -1,0 +1,21 @@
+import type { FlowTrigger } from "@giselle-sdk/data-type";
+import { createContext, useContext } from "react";
+
+type FlowTriggerUpdateCallback = (flowTrigger: FlowTrigger) => Promise<void>;
+export interface FlowTriggerContextValue {
+	callbacks?: {
+		flowTriggerUpdate?: FlowTriggerUpdateCallback;
+	};
+}
+
+export const FlowTriggerContext = createContext<
+	FlowTriggerContextValue | undefined
+>(undefined);
+
+export function useFlowTrigger() {
+	const context = useContext(FlowTriggerContext);
+	if (!context) {
+		throw new Error("useFlowTrigger must be used within a FlowTriggerProvider");
+	}
+	return context;
+}

--- a/packages/giselle-engine/src/react/workspace/provider.tsx
+++ b/packages/giselle-engine/src/react/workspace/provider.tsx
@@ -8,6 +8,10 @@ import {
 	type FeatureFlagContextValue,
 } from "../feature-flags";
 import { WorkflowDesignerProvider } from "../flow";
+import {
+	FlowTriggerContext,
+	type FlowTriggerContextValue,
+} from "../flow-trigger/context";
 import { GenerationRunnerSystemProvider } from "../generations";
 import {
 	IntegrationProvider,
@@ -29,6 +33,7 @@ export function WorkspaceProvider({
 	telemetry,
 	featureFlag,
 	vectorStore,
+	flowTrigger,
 }: {
 	children: ReactNode;
 	workspaceId: WorkspaceId;
@@ -37,6 +42,7 @@ export function WorkspaceProvider({
 	telemetry?: TelemetrySettings;
 	featureFlag?: FeatureFlagContextValue;
 	vectorStore?: VectorStoreContextValue;
+	flowTrigger?: FlowTriggerContextValue;
 }) {
 	const client = useGiselleEngine();
 
@@ -68,17 +74,19 @@ export function WorkspaceProvider({
 			}}
 		>
 			<TelemetryProvider settings={telemetry}>
-				<UsageLimitsProvider limits={usageLimits}>
-					<IntegrationProvider {...integration}>
-						<VectorStoreProvider value={vectorStore}>
-							<WorkflowDesignerProvider data={workspace}>
-								<GenerationRunnerSystemProvider>
-									{children}
-								</GenerationRunnerSystemProvider>
-							</WorkflowDesignerProvider>
-						</VectorStoreProvider>
-					</IntegrationProvider>
-				</UsageLimitsProvider>
+				<FlowTriggerContext value={flowTrigger}>
+					<UsageLimitsProvider limits={usageLimits}>
+						<IntegrationProvider {...integration}>
+							<VectorStoreProvider value={vectorStore}>
+								<WorkflowDesignerProvider data={workspace}>
+									<GenerationRunnerSystemProvider>
+										{children}
+									</GenerationRunnerSystemProvider>
+								</WorkflowDesignerProvider>
+							</VectorStoreProvider>
+						</IntegrationProvider>
+					</UsageLimitsProvider>
+				</FlowTriggerContext>
 			</TelemetryProvider>
 		</FeatureFlagContext>
 	);


### PR DESCRIPTION
## Summary
Added a new FlowTrigger context to manage flow trigger updates in the React component tree.

## Changes
- Created a new `context.ts` file for FlowTrigger with context definition and hook
- Added FlowTriggerContext provider to the WorkspaceProvider component
- Implemented a useFlowTrigger hook for consuming components to access flow trigger functionality

## Testing
Verified that the FlowTriggerContext is properly integrated into the provider hierarchy and that the hook throws an appropriate error when used outside of a provider.

## Other Information
This change enables components to access and update flow triggers through React context, maintaining a consistent pattern with other context providers in the application.