### PR TITLE
fix: use defaultName for consistent node display names across UI

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
@@ -1,24 +1,19 @@
 import {
 	ConnectionId,
 	type ImageGenerationNode,
-	isTextGenerationNode,
 	Node,
 } from "@giselle-sdk/data-type";
-import { useWorkflowDesigner } from "@giselle-sdk/giselle-engine/react";
+import {
+	defaultName,
+	useWorkflowDesigner,
+} from "@giselle-sdk/giselle-engine/react";
 import { TextEditor } from "@giselle-sdk/text-editor/react-internal";
 import { createSourceExtensionJSONContent } from "@giselle-sdk/text-editor-utils";
 import clsx from "clsx/lite";
 import { AtSignIcon } from "lucide-react";
 import { DropdownMenu, Toolbar } from "radix-ui";
 import { useMemo } from "react";
-import { type Source, useConnectedSources } from "./sources";
-
-function getDefaultNodeName(source: Source): string {
-	if (isTextGenerationNode(source.node)) {
-		return source.node.content.llm.id;
-	}
-	return source.node.type;
-}
+import { useConnectedSources } from "./sources";
 
 export function PromptPanel({ node }: { node: ImageGenerationNode }) {
 	const { updateNodeDataContent } = useWorkflowDesigner();
@@ -117,8 +112,7 @@ export function PromptPanel({ node }: { node: ImageGenerationNode }) {
 												className="p-[8px] rounded-[8px] text-white-900 hover:bg-primary-900/50 transition-colors cursor-pointer text-[12px] outline-none select-none"
 												value={source.connection.id}
 											>
-												{source.node.name ?? getDefaultNodeName(source)}/{" "}
-												{source.output.label}
+												{defaultName(source.node)} / {source.output.label}
 											</DropdownMenu.RadioItem>
 										))}
 									</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -1,10 +1,9 @@
 import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
+import { isVectorStoreNode, type QueryNode } from "@giselle-sdk/data-type";
 import {
-	isTextGenerationNode,
-	isVectorStoreNode,
-	type QueryNode,
-} from "@giselle-sdk/data-type";
-import { useWorkflowDesigner } from "@giselle-sdk/giselle-engine/react";
+	defaultName,
+	useWorkflowDesigner,
+} from "@giselle-sdk/giselle-engine/react";
 import { TextEditor } from "@giselle-sdk/text-editor/react-internal";
 import { createSourceExtensionJSONContent } from "@giselle-sdk/text-editor-utils";
 import { AtSignIcon, DatabaseZapIcon, X } from "lucide-react";
@@ -12,13 +11,6 @@ import { Toolbar } from "radix-ui";
 import { useMemo } from "react";
 import { GitHubIcon } from "../../../icons";
 import { type ConnectedSource, useConnectedSources } from "./sources";
-
-function getDefaultNodeName(input: ConnectedSource): string {
-	if (isTextGenerationNode(input.node)) {
-		return input.node.content.llm.id;
-	}
-	return input.node.name ?? "";
-}
 
 function getDataSourceDisplayInfo(input: ConnectedSource) {
 	const node = input.node;
@@ -164,7 +156,7 @@ export function QueryPanel({ node }: { node: QueryNode }) {
 								source,
 							}))}
 							renderItem={(item) =>
-								`${item.source.node.name ?? getDefaultNodeName(item.source)} / ${item.source.output.label}`
+								`${defaultName(item.source.node)} / ${item.source.output.label}`
 							}
 							onSelect={(_, item) => {
 								const embedNode = {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -1,20 +1,13 @@
 import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
+import type { TextGenerationNode } from "@giselle-sdk/data-type";
 import {
-	isTextGenerationNode,
-	type TextGenerationNode,
-} from "@giselle-sdk/data-type";
-import { useWorkflowDesigner } from "@giselle-sdk/giselle-engine/react";
+	defaultName,
+	useWorkflowDesigner,
+} from "@giselle-sdk/giselle-engine/react";
 import { TextEditor } from "@giselle-sdk/text-editor/react-internal";
 import { createSourceExtensionJSONContent } from "@giselle-sdk/text-editor-utils";
 import { AtSignIcon } from "lucide-react";
-import { type OutputWithDetails, useConnectedOutputs } from "./outputs";
-
-function getDefaultNodeName(source: OutputWithDetails): string {
-	if (isTextGenerationNode(source.node)) {
-		return source.node.content.llm.id;
-	}
-	return source.node.type;
-}
+import { useConnectedOutputs } from "./outputs";
 
 export function PromptPanel({ node }: { node: TextGenerationNode }) {
 	const { updateNodeDataContent } = useWorkflowDesigner();
@@ -33,7 +26,7 @@ export function PromptPanel({ node }: { node: TextGenerationNode }) {
 					trigger={<AtSignIcon className="w-[18px]" />}
 					items={connectedSources}
 					renderItem={(connectedSource) =>
-						`${connectedSource.node.name ?? getDefaultNodeName(connectedSource)} / ${connectedSource.label}`
+						`${defaultName(connectedSource.node)} / ${connectedSource.label}`
 					}
 					onSelect={(_, connectedSource) => {
 						const embedNode = {


### PR DESCRIPTION
### **User description**
## Summary
This PR fixes the issue where Query nodes were displayed as "operation" in property panel dropdowns.

## Problem
- Query nodes showed "operation" instead of "Query" in property panel dropdowns
- Inconsistent node naming between different parts of the UI

## Solution
Updated all property panels and text editor to use the `defaultName` function from `giselle-engine`, ensuring consistent node display names across the entire UI.

## Changes
- Updated text-generation-node-properties-panel to use `defaultName`
- Updated image-generation-node-properties-panel to use `defaultName`
- Updated query-node-properties-panel to use `defaultName`
- Text editor already uses `defaultName`, so now all displays are consistent

## Result
Now all node types display appropriate names consistently:
- **Text/Image Generation nodes**: Shows LLM ID (e.g., "claude-3-5-sonnet")
- **Query nodes**: Shows "Query" ✅
- **Other nodes**: Shows type-specific default names
- **Custom named nodes**: Shows user-defined names

The same names appear in:
- Property panel dropdowns
- Text editor inline references (e.g., `@NodeName / Output`)

## Test Plan
1. Create a workflow with various node types
2. Check property panel dropdowns - Query nodes should show "Query" not "operation"
3. Insert node references in text editors - names should match dropdown displays
4. Verify custom-named nodes show their custom names everywhere

Fixes #1426

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace local `getDefaultNodeName` functions with centralized `defaultName` from `giselle-engine`

- Fix Query nodes displaying "operation" instead of "Query" in property panels

- Ensure consistent node naming across all UI components


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Local getDefaultNodeName functions"] --> B["Centralized defaultName function"]
  B --> C["Consistent node names in dropdowns"]
  B --> D["Query nodes show 'Query' not 'operation'"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Replace local naming with centralized defaultName</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx

<li>Remove local <code>getDefaultNodeName</code> function<br> <li> Import and use <code>defaultName</code> from <code>giselle-engine</code><br> <li> Update dropdown item rendering to use centralized naming


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1436/files#diff-a8e7545975c958bbc2f1b3b29e9a6bad5d8a0f4e6072c7cd04a3b2028974b6bc">+6/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query-panel.tsx</strong><dd><code>Fix Query node naming in property panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx

<li>Remove local <code>getDefaultNodeName</code> function<br> <li> Import and use <code>defaultName</code> from <code>giselle-engine</code><br> <li> Update dropdown rendering for consistent node names


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1436/files#diff-2f277cc52b1175885fefa342e968f15baeb98b0ab10803c97192777b2cbfd05e">+5/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Standardize text generation node naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx

<li>Remove local <code>getDefaultNodeName</code> function<br> <li> Import and use <code>defaultName</code> from <code>giselle-engine</code><br> <li> Update dropdown item rendering for consistent naming


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1436/files#diff-b948e855ed4caae9a25e3a70cdf48c528051a145191609c3acff7fad495ae4bf">+6/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified node naming in dropdown menus by replacing custom logic with a standardized naming function across multiple panels.
  * Improved code consistency and maintainability by consolidating naming logic into a shared utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->