### PR TITLE
fix: Fix dropdown menu z-index issue in ImageGenerationNode

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
@@ -1,8 +1,5 @@
 import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
-import {
-	type ImageGenerationNode,
-	Node,
-} from "@giselle-sdk/data-type";
+import { type ImageGenerationNode, Node } from "@giselle-sdk/data-type";
 import {
 	defaultName,
 	useWorkflowDesigner,

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
@@ -1,5 +1,5 @@
+import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
 import {
-	ConnectionId,
 	type ImageGenerationNode,
 	Node,
 } from "@giselle-sdk/data-type";
@@ -9,9 +9,7 @@ import {
 } from "@giselle-sdk/giselle-engine/react";
 import { TextEditor } from "@giselle-sdk/text-editor/react-internal";
 import { createSourceExtensionJSONContent } from "@giselle-sdk/text-editor-utils";
-import clsx from "clsx/lite";
 import { AtSignIcon } from "lucide-react";
-import { DropdownMenu, Toolbar } from "radix-ui";
 import { useMemo } from "react";
 import { useConnectedSources } from "./sources";
 
@@ -35,120 +33,35 @@ export function PromptPanel({ node }: { node: ImageGenerationNode }) {
 			}}
 			nodes={nodes}
 			tools={(editor) => (
-				<DropdownMenu.Root>
-					<Toolbar.Button
-						value="bulletList"
-						aria-label="Bulleted list"
-						data-toolbar-item
-						asChild
-					>
-						<DropdownMenu.Trigger>
-							<AtSignIcon className="w-[18px]" />
-						</DropdownMenu.Trigger>
-					</Toolbar.Button>
-					<DropdownMenu.Portal>
-						<DropdownMenu.Content
-							className={clsx(
-								"relative w-[300px] rounded py-[8px]",
-								"rounded-[8px] border-[1px] bg-transparent backdrop-blur-[8px]",
-								"shadow-[-2px_-1px_0px_0px_rgba(0,0,0,0.1),1px_1px_8px_0px_rgba(0,0,0,0.25)]",
-							)}
-							onCloseAutoFocus={(e) => {
-								e.preventDefault();
-							}}
-						>
-							<div
-								className={clsx(
-									"absolute z-0 rounded-[8px] inset-0 border-[1px] mask-fill bg-gradient-to-br bg-origin-border bg-clip-boarder border-transparent",
-									"from-[hsl(232,_36%,_72%)]/40 to-[hsl(218,_58%,_21%)]/90",
-								)}
-							/>
-							<div className="relative flex flex-col gap-[8px]">
-								<div className="flex px-[16px] text-white-900">
-									Insert Sources
-								</div>
-								<div className="flex flex-col py-[4px]">
-									<div className="border-t border-black-300/20" />
-								</div>
-
-								<DropdownMenu.RadioGroup
-									className="flex flex-col pb-[8px] gap-[8px]"
-									onValueChange={(connectionIdLike) => {
-										const parsedConnectionId =
-											ConnectionId.safeParse(connectionIdLike);
-										if (!parsedConnectionId.success) {
-											return;
-										}
-										const connectionId = parsedConnectionId.data;
-										const connectedSource = connectedSources.find(
-											(connectedSource) =>
-												connectedSource.connection.id === connectionId,
-										);
-										if (connectedSource === undefined) {
-											return;
-										}
-										const embedNode = {
-											outputId: connectedSource.connection.outputId,
-											node: connectedSource.connection.outputNode,
-										};
-										editor
-											.chain()
-											.focus()
-											.insertContentAt(
-												editor.state.selection.$anchor.pos,
-												createSourceExtensionJSONContent({
-													node: connectedSource.connection.outputNode,
-													outputId: embedNode.outputId,
-												}),
-											)
-											.insertContent(" ")
-											.run();
-									}}
-								>
-									<div className="flex flex-col px-[8px]">
-										{connectedSources.map((source) => (
-											<DropdownMenu.RadioItem
-												key={source.connection.id}
-												className="p-[8px] rounded-[8px] text-white-900 hover:bg-primary-900/50 transition-colors cursor-pointer text-[12px] outline-none select-none"
-												value={source.connection.id}
-											>
-												{defaultName(source.node)} / {source.output.label}
-											</DropdownMenu.RadioItem>
-										))}
-									</div>
-								</DropdownMenu.RadioGroup>
-							</div>
-						</DropdownMenu.Content>
-					</DropdownMenu.Portal>
-				</DropdownMenu.Root>
+				<DropdownMenu
+					trigger={<AtSignIcon className="w-[18px]" />}
+					items={connectedSources.map((source) => ({
+						id: source.connection.id,
+						source,
+					}))}
+					renderItem={(item) =>
+						`${defaultName(item.source.node)} / ${item.source.output.label}`
+					}
+					onSelect={(_, item) => {
+						const embedNode = {
+							outputId: item.source.connection.outputId,
+							node: item.source.connection.outputNode,
+						};
+						editor
+							.chain()
+							.focus()
+							.insertContentAt(
+								editor.state.selection.$anchor.pos,
+								createSourceExtensionJSONContent({
+									node: item.source.connection.outputNode,
+									outputId: embedNode.outputId,
+								}),
+							)
+							.insertContent(" ")
+							.run();
+					}}
+				/>
 			)}
-			// tools={(editor) => (
-			// 	<NodeDropdown
-			// 		nodes={sourceNodes}
-			// 		trigerNode={
-			// 			<ToolbarPrimitive.Button
-			// 				value="bulletList"
-			// 				aria-label="Bulleted list"
-			// 				data-toolbar-item
-			// 				asChild
-			// 			>
-			// 				<DropdownMenuTrigger>
-			// 					<BracesIcon className="w-[18px]" />
-			// 				</DropdownMenuTrigger>
-			// 			</ToolbarPrimitive.Button>
-			// 		}
-			// 		onValueChange={(node) => {
-			// 			editor
-			// 				.chain()
-			// 				.focus()
-			// 				.insertContentAt(
-			// 					editor.state.selection.$anchor.pos,
-			// 					`{{${node.id}}}`,
-			// 				)
-			// 				.run();
-			// 		}}
-			// 	/>
-			// )}
 		/>
 	);
 }


### PR DESCRIPTION
### **User description**
## Summary
- Fix dropdown menu positioning issue in ImageGenerationNode where the @ icon dropdown was hidden behind other UI elements
- Unify dropdown menu implementation across all node types for consistency and maintainability

## Changes
- ✅ Replace radix-ui DropdownMenu with @giselle-internal/ui/dropdown-menu in ImageGenerationNode
- ✅ Remove manual dropdown implementation with custom z-index handling
- ✅ Clean up unused imports and legacy commented code
- ✅ Ensure consistent behavior across TextGenerationNode, QueryNode, and ImageGenerationNode

## Before
- ImageGenerationNode used direct radix-ui DropdownMenu without proper z-index
- Dropdown menu was hidden behind other UI elements
- Inconsistent implementation across node types (120+ lines of manual dropdown code)

## After  
- All node types use the same @giselle-internal/ui/dropdown-menu component
- Proper z-index handling built into the shared component
- Simplified implementation (30 lines vs 120+ lines)
- Consistent styling and behavior

## Test plan
- [x] Verify @ icon dropdown appears correctly in ImageGenerationNode
- [x] Check that dropdown is positioned above other UI elements
- [x] Confirm TextGenerationNode and QueryNode still work as expected
- [x] Test dropdown functionality (source selection and insertion)

🤖 Generated with [Claude Code](https://claude.ai/code)

<img width="461" height="382" alt="スクリーンショット 2025-07-14 14 01 27" src="https://github.com/user-attachments/assets/d332befa-c94b-41b4-be58-30317f179ae6" />


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix dropdown menu z-index issue in ImageGenerationNode

- Replace radix-ui DropdownMenu with shared component

- Remove 120+ lines of manual dropdown implementation

- Ensure consistent behavior across all node types


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Manual radix-ui DropdownMenu"] --> B["@giselle-internal/ui/dropdown-menu"]
  C["120+ lines of code"] --> D["30 lines of code"]
  E["Z-index issues"] --> F["Proper positioning"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Unify dropdown menu implementation and fix z-index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx

<li>Replace radix-ui DropdownMenu with @giselle-internal/ui/dropdown-menu<br> <li> Remove manual dropdown implementation (120+ lines to 30 lines)<br> <li> Clean up unused imports (clsx, Toolbar, ConnectionId)<br> <li> Remove commented legacy code


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1438/files#diff-a8e7545975c958bbc2f1b3b29e9a6bad5d8a0f4e6072c7cd04a3b2028974b6bc">+30/-120</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the dropdown menu in the prompt panel by replacing the previous implementation with a more streamlined and user-friendly dropdown component.
  * Improved the process for inserting connected sources into the editor, making it more intuitive and efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->