### PR TITLE
Remove duplicate rule from knip config and simplify Source type usage

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -85,7 +85,6 @@ const nextPredefinedExternalPackages = [
 const config: KnipConfig = {
 	biome: false,
 	rules: {
-		duplicates: "off",
 		types: "off",
 		binaries: "off",
 		unlisted: "off",

--- a/packages/data-type/src/generation/output.ts
+++ b/packages/data-type/src/generation/output.ts
@@ -49,11 +49,9 @@ export const UrlSource = z.object({
 	providerMetadata: z.custom<ProviderMetadata>().optional(),
 }) as z.ZodType<UrlSource>;
 
-export const Source = UrlSource;
-
 export const SourceOutput = GenerationOutputBase.extend({
 	type: z.literal("source"),
-	sources: z.array(Source),
+	sources: z.array(UrlSource),
 });
 
 const VectorStoreSource = z.discriminatedUnion("provider", [


### PR DESCRIPTION
### **User description**
## Summary
Enable duplicate detection in Knip and simplify source type definition in data-type package.

## Changes
- Enabled duplicate detection in Knip by removing the `duplicates: "off"` rule
- Simplified the source type definition in the data-type package by directly using `UrlSource` instead of creating an alias `Source`

## Testing
Verified that Knip now detects duplicate imports and that the data-type package still functions correctly with the simplified type definition.


___

### **PR Type**
Enhancement


___

### **Description**
- Enable duplicate detection in Knip configuration

- Remove unused `Source` type alias in data-type package

- Update `SourceOutput` schema to use `UrlSource` directly


___

### **Changes diagram**

```mermaid
flowchart LR
  knip["Knip Config"] -- "remove duplicates: off" --> detection["Enable Duplicate Detection"]
  datatype["Data Type Package"] -- "remove Source alias" --> simplify["Simplified Type Usage"]
  simplify -- "use UrlSource directly" --> schema["Updated SourceOutput Schema"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>knip.ts</strong><dd><code>Enable duplicate detection in Knip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

knip.ts

<li>Remove <code>duplicates: "off"</code> rule from Knip configuration<br> <li> Enable duplicate detection by default


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1456/files#diff-a55fd3ab189e220a273770f57af40594369d9d7eb30d621d4d83fc78fd439288">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>output.ts</strong><dd><code>Remove Source alias and simplify types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/data-type/src/generation/output.ts

<li>Remove unused <code>Source</code> type alias<br> <li> Update <code>SourceOutput</code> schema to use <code>UrlSource</code> directly<br> <li> Simplify type definition structure


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1456/files#diff-a00b71007e06d4a9072a3ee1b007b729b08030479f7eb7378898002c7de1d386">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal type references for data sources, resulting in a more streamlined structure. No changes to the underlying data or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->