### PR TITLE
Add team-based flow selection component to stage page

### DIFF
--- a/apps/studio.giselles.ai/app/stage/flow-select.tsx
+++ b/apps/studio.giselles.ai/app/stage/flow-select.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Button } from "@giselle-internal/ui/button";
+import { Select } from "@giselle-internal/ui/select";
+import type { FlowTriggerId } from "@giselle-sdk/data-type";
+import type { InferSelectModel } from "drizzle-orm";
+import { useState } from "react";
+import type { teams } from "@/drizzle";
+
+type TeamId = InferSelectModel<typeof teams>["id"];
+export interface TeamOption {
+	id: TeamId;
+	label: string;
+}
+
+export interface FlowTriggerUIItem {
+	id: FlowTriggerId;
+	teamId: TeamId;
+	label: string;
+}
+
+interface FlowSelectProps {
+	teamOptions: TeamOption[];
+	flowTriggers: FlowTriggerUIItem[];
+}
+
+export function FlowSelect({ teamOptions, flowTriggers }: FlowSelectProps) {
+	const [selectedTeamId, setSelectedTeamId] = useState<TeamId | undefined>();
+
+	const filteredFlowTriggers = flowTriggers.filter(
+		(flowTrigger) => flowTrigger.teamId === selectedTeamId,
+	);
+
+	return (
+		<div className="flex items-center gap-2 justify-center">
+			<Select
+				id="team"
+				placeholder="Select team"
+				options={teamOptions}
+				renderOption={(o) => o.label}
+				widthClassName="w-[150px]"
+				onValueChange={(value) => setSelectedTeamId(value as TeamId)}
+			/>
+			<Select
+				id="flow"
+				placeholder="Select flow"
+				options={
+					selectedTeamId === undefined
+						? []
+						: filteredFlowTriggers.length === 0
+							? [
+									{
+										id: "no-flow",
+										label: "No flows available",
+									},
+								]
+							: filteredFlowTriggers.map((flowTrigger) => ({
+									id: flowTrigger.id,
+									label: flowTrigger.label,
+								}))
+				}
+				renderOption={(o) => o.label}
+				widthClassName="w-[120px]"
+			/>
+		</div>
+	);
+}

--- a/apps/studio.giselles.ai/app/stage/flow-select.tsx
+++ b/apps/studio.giselles.ai/app/stage/flow-select.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Button } from "@giselle-internal/ui/button";
 import { Select } from "@giselle-internal/ui/select";
 import type { FlowTriggerId } from "@giselle-sdk/data-type";
 import type { InferSelectModel } from "drizzle-orm";
@@ -8,7 +7,7 @@ import { useState } from "react";
 import type { teams } from "@/drizzle";
 
 type TeamId = InferSelectModel<typeof teams>["id"];
-export interface TeamOption {
+interface TeamOption {
 	id: TeamId;
 	label: string;
 }


### PR DESCRIPTION
### **User description**
## Summary
Added a new FlowSelect component to the stage page that allows users to filter and select flows based on team selection. The component replaces the previous static select elements with dynamic options populated from the database.

## Changes
- Created a new `flow-select.tsx` component that provides a two-step selection process for teams and flows
- Modified the stage page to fetch flow triggers from the database and pass them to the FlowSelect component
- Implemented filtering logic to only show flows that belong to the selected team
- Added handling for cases when no flows are available for a selected team
- Removed the static flow options and voice button from the previous implementation

## Testing
The component should display team options and, upon team selection, show only the flows associated with that team. When no flows are available for a team, it should display "No flows available".

## Other Information
This change improves the user experience by providing contextual flow options based on team selection rather than showing all flows at once.


___

### **PR Type**
Enhancement


___

### **Description**
- Add team-based flow selection component with two-step filtering

- Replace static flow options with dynamic database-driven selection

- Implement flow filtering based on selected team

- Remove unused voice button and static flow data


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Team Selection"] --> B["Filter Flows by Team"]
  B --> C["Display Available Flows"]
  C --> D["Handle No Flows Case"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flow-select.tsx</strong><dd><code>Add FlowSelect component for team-based filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/stage/flow-select.tsx

<li>Create new FlowSelect component with team and flow dropdowns<br> <li> Implement filtering logic to show flows by selected team<br> <li> Handle empty state when no flows available for team<br> <li> Define TypeScript interfaces for team and flow trigger data


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1467/files#diff-c220a6adc03f0cf7695a3469e8eaf634ce4d12315e9f7eb2a29cb46aafd38418">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Refactor stage page with dynamic flow data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/stage/page.tsx

<li>Replace static flow options with database-driven flow triggers<br> <li> Add database queries to fetch flow triggers by team<br> <li> Integrate workspace and node data for flow labeling<br> <li> Remove unused Select import and voice button


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1467/files#diff-4a5f7db3314bab810f9315a8b037e497ba2e4cf8f110f7bf8514106a1e7c856c">+46/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a streamlined team and flow selection experience with a new combined dropdown component.
  * Flow options are now dynamically filtered based on the selected team, with clear messaging when no flows are available.

* **Refactor**
  * Replaced separate team and flow selectors with a unified selection component for improved usability and cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->