### PR TITLE
Update command from `pnpm prune` to `pnpm tidy` in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,14 @@
 Keep every implementation as small and obvious as possible.
 - Prefer the simplest data structures and APIs that work.
 - Avoid needless abstractions; refactor only when duplication hurts.
-- Remove dead code early — `pnpm prune` scans the repo for unused files/deps and lets you delete them in one command.
+- Remove dead code early — `pnpm tidy` scans the repo for unused files/deps and lets you delete them in one command.
 - Before adding a dependency, ask, “Can we do this with what we already have?”
 
 # Workflow
 After every code change, run:
 
 - `pnpm format`
-- `pnpm prune`
+- `pnpm tidy`
 - `pnpm check-types`
 - `pnpm test`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,14 @@ Keep every implementation as small and obvious as possible.
 - Before adding a dependency, ask, “Can we do this with what we already have?”
 
 # Workflow
-After every code change, run:
+**MANDATORY**: After every code change, you MUST immediately run these commands in order:
 
-- `pnpm format`
-- `pnpm tidy`
-- `pnpm check-types`
-- `pnpm test`
+1. `pnpm format`
+2. `pnpm tidy`
+3. `pnpm check-types`
+4. `pnpm test`
+
+**DO NOT consider any code change complete until all four commands pass successfully.**
 
 (CI also runs these steps; your PR will fail if any step fails.)
 


### PR DESCRIPTION
### **User description**
## Summary
Update documentation to reflect the renamed command `pnpm tidy` (previously `pnpm prune`)

## Changes
- Updated references to `pnpm prune` to `pnpm tidy` in CLAUDE.md
- Changed command name in both the code removal section and workflow checklist

## Other Information
This appears to be a documentation update to reflect a command that was renamed from `prune` to `tidy`, likely to avoid confusion with npm's built-in `prune` command which has different functionality.


___

### **PR Type**
Documentation


___

### **Description**
- Updated `pnpm prune` command references to `pnpm tidy`

- Enhanced workflow section with mandatory emphasis and formatting


___

### **Changes diagram**

```mermaid
flowchart LR
  A["pnpm prune"] --> B["pnpm tidy"]
  C["Basic workflow"] --> D["Mandatory workflow with emphasis"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update pnpm command and enhance workflow instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<li>Updated command reference from <code>pnpm prune</code> to <code>pnpm tidy</code> in code removal <br>section<br> <li> Enhanced workflow section with mandatory emphasis and numbered list <br>format<br> <li> Added strong warning about completing all four commands successfully


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1468/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions to use `pnpm tidy` instead of `pnpm prune`.
  * Clarified that running formatting, tidying, type checking, and tests in a specific order is mandatory after every code change.
  * Reformatted the command list to a numbered sequence to highlight the required order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->