### PR TITLE
Enable React domain in Biome configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,6 +25,9 @@
 			"suspicious": {
 				"useAwait": "error"
 			}
+		},
+		"domains": {
+			"react": "recommended"
 		}
 	},
 	"javascript": {


### PR DESCRIPTION
## Summary
Enable recommended React linting rules in Biome configuration.

## Changes
- Added `"domains": { "react": "recommended" }` to the Biome configuration to enable React-specific linting rules

## Testing
Verified that React-specific linting rules are now applied to the codebase.

## Other Information
This change will help catch common React-specific issues and enforce best practices in our React components.