### PR TITLE
Remove feature flag and simplify text generation panel UI

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -26,7 +26,6 @@ import {
 	PropertiesPanelContent,
 	PropertiesPanelHeader,
 	PropertiesPanelRoot,
-	ResizableSectionHandle,
 	ResizeHandle,
 } from "../ui";
 import { GenerationPanel } from "./generation-panel";
@@ -53,7 +52,6 @@ export function TextGenerationNodePropertiesPanel({
 	const { all: connectedSources } = useConnectedOutputs(node);
 	const usageLimitsReached = useUsageLimitsReached();
 	const { error } = useToasts();
-	const { layoutV2 } = useFeatureFlag();
 
 	const uiState = useMemo(() => data.ui.nodeState[node.id], [data, node.id]);
 
@@ -149,63 +147,34 @@ export function TextGenerationNodePropertiesPanel({
 			/>
 
 			<PropertiesPanelContent>
-				{layoutV2 ? (
-					<PanelGroup direction="vertical" className="flex-1 flex flex-col">
-						<Panel>
-							<PropertiesPanelContent>
-								<TextGenerationTabContent
-									node={node}
-									uiState={uiState}
-									setUiNodeState={setUiNodeState}
-									updateNodeDataContent={updateNodeDataContent}
-									updateNodeData={updateNodeData}
-									data={data}
-									deleteConnection={deleteConnection}
-									githubTools={githubTools}
-									sidemenu={sidemenu}
-								/>
-							</PropertiesPanelContent>
-						</Panel>
-						<PanelResizeHandle className="h-[12px] flex items-center justify-center cursor-row-resize">
-							<ResizeHandle direction="vertical" />
-						</PanelResizeHandle>
-						<Panel>
-							<PropertiesPanelContent>
-								<GenerationPanel
-									node={node}
-									onClickGenerateButton={generateText}
-								/>
-							</PropertiesPanelContent>
-						</Panel>
-					</PanelGroup>
-				) : (
-					<PanelGroup direction="vertical" className="flex-1 flex flex-col">
-						<Panel>
-							<PropertiesPanelContent>
-								<TextGenerationTabContent
-									node={node}
-									uiState={uiState}
-									setUiNodeState={setUiNodeState}
-									updateNodeDataContent={updateNodeDataContent}
-									updateNodeData={updateNodeData}
-									data={data}
-									deleteConnection={deleteConnection}
-									githubTools={githubTools}
-									sidemenu={sidemenu}
-								/>
-							</PropertiesPanelContent>
-						</Panel>
-						<ResizableSectionHandle />
-						<Panel>
-							<PropertiesPanelContent>
-								<GenerationPanel
-									node={node}
-									onClickGenerateButton={generateText}
-								/>
-							</PropertiesPanelContent>
-						</Panel>
-					</PanelGroup>
-				)}
+				<PanelGroup direction="vertical" className="flex-1 flex flex-col">
+					<Panel>
+						<PropertiesPanelContent>
+							<TextGenerationTabContent
+								node={node}
+								uiState={uiState}
+								setUiNodeState={setUiNodeState}
+								updateNodeDataContent={updateNodeDataContent}
+								updateNodeData={updateNodeData}
+								data={data}
+								deleteConnection={deleteConnection}
+								githubTools={githubTools}
+								sidemenu={sidemenu}
+							/>
+						</PropertiesPanelContent>
+					</Panel>
+					<PanelResizeHandle className="h-[12px] flex items-center justify-center cursor-row-resize">
+						<ResizeHandle direction="vertical" />
+					</PanelResizeHandle>
+					<Panel>
+						<PropertiesPanelContent>
+							<GenerationPanel
+								node={node}
+								onClickGenerateButton={generateText}
+							/>
+						</PropertiesPanelContent>
+					</Panel>
+				</PanelGroup>
 			</PropertiesPanelContent>
 			<KeyboardShortcuts
 				generate={() => {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/resizable-section.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/resizable-section.tsx
@@ -2,7 +2,7 @@
 
 import clsx from "clsx/lite";
 import type { ReactNode } from "react";
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { Panel, PanelGroup } from "react-resizable-panels";
 
 interface ResizableSectionProps {
 	children: ReactNode;
@@ -16,11 +16,6 @@ interface ResizableSectionProps {
 
 interface ResizableSectionGroupProps {
 	children: ReactNode;
-	direction?: "horizontal" | "vertical";
-	className?: string;
-}
-
-interface ResizableSectionHandleProps {
 	direction?: "horizontal" | "vertical";
 	className?: string;
 }
@@ -71,46 +66,6 @@ export function ResizableSection({
 			)}
 			<div className="flex-1 overflow-hidden h-full">{children}</div>
 		</Panel>
-	);
-}
-
-export function ResizableSectionHandle({
-	direction = "vertical",
-	className,
-}: ResizableSectionHandleProps) {
-	const isVertical = direction === "vertical";
-
-	return (
-		<PanelResizeHandle
-			className={clsx(
-				"transition-colors duration-100 ease-in-out",
-				isVertical
-					? [
-							"h-[3px] bg-border cursor-row-resize",
-							"data-[resize-handle-state=hover]:bg-[#4a90e2]",
-							"data-[resize-handle-state=drag]:bg-[#4a90e2]",
-						]
-					: [
-							"w-[3px] bg-border cursor-col-resize",
-							"data-[resize-handle-state=hover]:bg-[#4a90e2]",
-							"data-[resize-handle-state=drag]:bg-[#4a90e2]",
-						],
-				className,
-			)}
-		/>
-	);
-}
-
-function _ResizableSectionHandleWithIcon({
-	direction = "vertical",
-	className,
-}: ResizableSectionHandleProps) {
-	return (
-		<PanelResizeHandle
-			className={clsx("flex items-center justify-center", className)}
-		>
-			<ResizeHandle direction={direction} />
-		</PanelResizeHandle>
 	);
 }
 


### PR DESCRIPTION
### **User description**
## Summary
Removed the feature flag for layout V2 and standardized the text generation node properties panel to use the new layout. Also removed the unused `ResizableSectionHandle` component since it's been replaced by the new resize handle implementation.

## Changes
- Removed the `layoutV2` feature flag check in the text generation node properties panel
- Standardized the panel to always use the new layout with `PanelResizeHandle`
- Removed the unused `ResizableSectionHandle` component and related code
- Kept only the modern resize handle implementation

## Testing
The text generation node properties panel has been tested to ensure it renders correctly with the standardized layout and resize functionality works as expected.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove feature flag check for layoutV2 in text generation panel

- Standardize panel to always use new PanelResizeHandle layout

- Remove unused ResizableSectionHandle component and related code

- Simplify UI by eliminating conditional rendering logic


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Feature Flag Check"] --> B["Conditional Rendering"]
  B --> C["Two Different Layouts"]
  D["Standardized Layout"] --> E["Single PanelResizeHandle"]
  F["Remove ResizableSectionHandle"] --> G["Cleaner Codebase"]
  A -.-> |"Remove"| D
  C -.-> |"Simplify"| E
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Standardize panel layout and remove feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx

<li>Remove <code>layoutV2</code> feature flag import and usage check<br> <li> Eliminate conditional rendering between two layout versions<br> <li> Standardize to always use <code>PanelResizeHandle</code> with <code>ResizeHandle</code><br> <li> Remove <code>ResizableSectionHandle</code> import reference


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1478/files#diff-b1f2287bb552bf4b22b33e8ad29c9c365a3e751e24ee9b8f29eb16687aba37d6">+28/-59</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resizable-section.tsx</strong><dd><code>Remove unused ResizableSectionHandle component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/resizable-section.tsx

<li>Remove unused <code>ResizableSectionHandle</code> component function<br> <li> Remove <code>ResizableSectionHandleProps</code> interface definition<br> <li> Remove <code>PanelResizeHandle</code> import since no longer used<br> <li> Clean up unused helper function <code>_ResizableSectionHandleWithIcon</code>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1478/files#diff-82400ad2a92c506a84d0870234782454b420424e3e12515d5c00864d4ac3b852">+1/-46</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified the panel resizing layout in the text generation properties panel for a more consistent user experience.
  * Removed legacy and unused resizing components to streamline the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->