### PR TITLE
Remove layoutV2 feature flag and Input tab from image generation panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -1,6 +1,5 @@
 import type { ImageGenerationNode } from "@giselle-sdk/data-type";
 import {
-	useFeatureFlag,
 	useNodeGenerations,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle-engine/react";
@@ -74,8 +73,6 @@ export function ImageGenerationNodePropertiesPanel({
 		error,
 	]);
 
-	const { layoutV2 } = useFeatureFlag();
-
 	return (
 		<PropertiesPanelRoot>
 			{usageLimitsReached && <UsageLimitWarning />}
@@ -135,7 +132,6 @@ export function ImageGenerationNodePropertiesPanel({
 							>
 								<Tabs.Trigger value="prompt">Prompt</Tabs.Trigger>
 								<Tabs.Trigger value="model">Model</Tabs.Trigger>
-								{!layoutV2 && <Tabs.Trigger value="input">Input</Tabs.Trigger>}
 							</Tabs.List>
 							<Tabs.Content
 								value="prompt"


### PR DESCRIPTION
### **User description**
## Summary
Removed the feature flag `layoutV2` and its related UI element from the Image Generation Node Properties Panel.

## Changes
- Removed the import of `useFeatureFlag` from `@giselle-sdk/giselle-engine/react`
- Removed the `layoutV2` variable declaration that used the feature flag
- Removed the conditional tab trigger for "Input" that was only shown when `layoutV2` was false

## Testing
Verified that the Image Generation Node Properties Panel renders correctly without the "Input" tab and doesn't require the feature flag anymore.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `layoutV2` feature flag and related imports

- Remove conditional "Input" tab from image generation panel

- Simplify UI by removing feature flag dependency


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Feature Flag Import"] -- "removed" --> B["Simplified Component"]
  C["layoutV2 Variable"] -- "removed" --> B
  D["Conditional Input Tab"] -- "removed" --> B
  B --> E["Cleaner UI"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove feature flag and Input tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx

<li>Removed <code>useFeatureFlag</code> import from giselle-engine/react<br> <li> Removed <code>layoutV2</code> variable declaration and usage<br> <li> Removed conditional "Input" tab trigger from tabs list


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1482/files#diff-a45b1e18cc18aaa3a96fc447d8ae2e9138abb9f12b4da800373da10eb9194072">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The "Input" tab is now always visible in the properties panel, regardless of feature flag settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->