### PR TITLE
Remove layoutV2 flag and references

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -18,7 +18,6 @@ export default async function Layout({
 				sidemenu: true,
 				githubTools: true,
 				webSearchAction: false,
-				layoutV2: true,
 				layoutV3: true,
 				experimental_storage: true,
 				stage: true,

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -6,7 +6,6 @@ import { db, flowTriggers } from "@/drizzle";
 import {
 	experimental_storageFlag,
 	githubToolsFlag,
-	layoutV2Flag,
 	layoutV3Flag,
 	runV3Flag,
 	sidemenuFlag,
@@ -48,7 +47,6 @@ export default async function Layout({
 	const sidemenu = await sidemenuFlag();
 	const githubTools = await githubToolsFlag();
 	const webSearchAction = await webSearchActionFlag();
-	const layoutV2 = await layoutV2Flag();
 	const layoutV3 = await layoutV3Flag();
 	const experimental_storage = await experimental_storageFlag();
 	const stage = await stageFlag();
@@ -82,7 +80,6 @@ export default async function Layout({
 				sidemenu,
 				githubTools,
 				webSearchAction,
-				layoutV2,
 				layoutV3,
 				experimental_storage,
 				stage,

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -98,25 +98,6 @@ export const sidemenuFlag = flag<boolean>({
 	],
 });
 
-export const layoutV2Flag = flag<boolean>({
-	key: "layout-v2",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("LAYOUT_V2_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return true;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable Layout V2",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const layoutV3Flag = flag<boolean>({
 	key: "layout-v3",
 	async decide() {

--- a/packages/giselle-engine/src/react/feature-flags/context.ts
+++ b/packages/giselle-engine/src/react/feature-flags/context.ts
@@ -5,7 +5,6 @@ export interface FeatureFlagContextValue {
 	sidemenu: boolean;
 	githubTools: boolean;
 	webSearchAction: boolean;
-	layoutV2: boolean;
 	layoutV3: boolean;
 	experimental_storage: boolean;
 	stage: boolean;

--- a/packages/giselle-engine/src/react/workspace/provider.tsx
+++ b/packages/giselle-engine/src/react/workspace/provider.tsx
@@ -67,7 +67,6 @@ export function WorkspaceProvider({
 				sidemenu: featureFlag?.sidemenu ?? false,
 				githubTools: featureFlag?.githubTools ?? false,
 				webSearchAction: featureFlag?.webSearchAction ?? false,
-				layoutV2: featureFlag?.layoutV2 ?? false,
 				layoutV3: featureFlag?.layoutV3 ?? false,
 				experimental_storage: featureFlag?.experimental_storage ?? false,
 				stage: featureFlag?.stage ?? false,


### PR DESCRIPTION
### **User description**
## Summary
Remove the deprecated `layoutV2` feature flag as it's no longer needed since we've fully migrated to `layoutV3`.

## Changes
- Removed `layoutV2` flag from layout configurations in both playground and studio apps
- Deleted the `layoutV2Flag` function from the flags.ts file
- Removed `layoutV2` from the FeatureFlagContextValue interface
- Removed `layoutV2` from the default values in the WorkspaceProvider

## Testing
Verified that the application continues to function correctly with `layoutV3` flag, which has fully replaced the functionality of the removed flag.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove deprecated `layoutV2` feature flag and references

- Clean up flag configuration and context interfaces

- Update workspace providers to remove obsolete flag


___

### **Changes diagram**

```mermaid
flowchart LR
  A["layoutV2Flag function"] -- "deleted" --> B["flags.ts cleanup"]
  C["FeatureFlagContextValue interface"] -- "removed layoutV2" --> D["context.ts update"]
  E["WorkspaceProvider components"] -- "removed layoutV2 references" --> F["layout.tsx files"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Delete layoutV2Flag function definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<li>Deleted entire <code>layoutV2Flag</code> function definition<br> <li> Removed flag configuration with key "layout-v2"<br> <li> Cleaned up flag options and description


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1485/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>context.ts</strong><dd><code>Remove layoutV2 from context interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle-engine/src/react/feature-flags/context.ts

<li>Removed <code>layoutV2: boolean</code> property from FeatureFlagContextValue <br>interface


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1485/files#diff-2da1aaea74bbc63c346376d7bf8f13a87da0de230d65972484c7045209ac0b22">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Remove layoutV2 from playground layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/playground/app/workspaces/[workspaceId]/layout.tsx

<li>Removed <code>layoutV2: true</code> from featureFlag object in WorkspaceProvider


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1485/files#diff-4bcbefb23b47c4c61b927ade9b43dd978e216008f1c243a471a937c8c9a122ba">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Remove layoutV2 from studio layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx

<li>Removed <code>layoutV2Flag</code> import statement<br> <li> Deleted <code>layoutV2</code> variable assignment<br> <li> Removed <code>layoutV2</code> from featureFlag object


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1485/files#diff-15f3074fd9425f9c2957c436fb950d744614df0ac6ce51fd55cfaa5ff2bfb04e">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provider.tsx</strong><dd><code>Remove layoutV2 from workspace provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle-engine/src/react/workspace/provider.tsx

<li>Removed <code>layoutV2: featureFlag?.layoutV2 ?? false</code> from <br>FeatureFlagContext value


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1485/files#diff-6ece33222135c03b00c27f6f147ea7da610570f6704e126a5f701db930a69313">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `layoutV2` feature flag and all related references from the application. This flag is no longer available or used in any part of the workspace layouts or feature flag context. No other feature flags or user-facing functionality are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->