### PR TITLE
Fix: Manual Trigger title not preserved when saving parameters

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/manual-trigger/manual-trigger-properties-panel.tsx
@@ -116,7 +116,7 @@ export function ManualTriggerPropertiesPanel({ node }: { node: TriggerNode }) {
 						},
 					},
 					outputs,
-					name: "Manual Trigger",
+					name: node.name,
 				});
 			});
 		},


### PR DESCRIPTION
## Summary
- Fixed an issue where custom node titles for Manual Trigger nodes were being overwritten when saving parameters
- Changed hardcoded `"Manual Trigger"` to use the current node name (`node.name`)

## Problem
When users edited the title of a Manual Trigger node and then saved parameters, the custom title would be reset to "Manual Trigger". This was due to the node name being hardcoded in the `updateNodeData` call.

## Solution
Modified the `updateNodeData` call to preserve the existing node name by using `node.name` instead of the hardcoded string.

## Test plan
1. Add a Manual Trigger node to a workflow
2. Click on the node title and change it (e.g., to "User Registration Form")
3. Click on the node to open the properties panel
4. Add parameters (e.g., name, email)
5. Click "Save Configuration"
6. Verify that the custom title is preserved and not reset to "Manual Trigger"

Fixes #1114