### PR TITLE
Remove GenerationType and related type definitions

### DIFF
--- a/packages/data-type/src/generation/index.ts
+++ b/packages/data-type/src/generation/index.ts
@@ -14,15 +14,6 @@ export * from "./output";
 export const GenerationId = createIdGenerator("gnr");
 export type GenerationId = z.infer<typeof GenerationId.schema>;
 
-export const GenerationTypeWorkspace = z.literal("workspace");
-export type GenerationTypeWorkspace = z.infer<typeof GenerationTypeWorkspace>;
-export const GenerationTypeRun = z.literal("run");
-export type GenerationTypeRun = z.infer<typeof GenerationTypeRun>;
-export const GenerationType = z.union([
-	GenerationTypeWorkspace,
-	GenerationTypeRun,
-]);
-export type GenerationType = z.infer<typeof GenerationType>;
 export const Message = z.custom<AISdkMessage>();
 export type Message = z.infer<typeof Message>;
 


### PR DESCRIPTION
## Summary
Removed unused `GenerationType` related constants and types from the generation module.

## Changes
- Removed `GenerationTypeWorkspace` constant and type
- Removed `GenerationTypeRun` constant and type
- Removed `GenerationType` union constant and type

## Testing
Verified that these types were not referenced elsewhere in the codebase.

## Other Information
This change helps clean up unused code in the data-type package, reducing maintenance overhead and improving code clarity.