### PR TITLE
Rename generation methods to include "Runner" suffix for clarity

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/node.tsx
@@ -142,7 +142,7 @@ export function NodeComponent({
 	connectedOutputIds?: OutputId[];
 }) {
 	const { updateNodeData, data } = useWorkflowDesigner();
-	const { stopGeneration, currentGeneration } = useNodeGenerations({
+	const { stopGenerationRunner, currentGeneration } = useNodeGenerations({
 		nodeId: node.id,
 		origin: { type: "workspace", id: data.id },
 	});
@@ -230,7 +230,7 @@ export function NodeComponent({
 								type="button"
 								onClick={(e) => {
 									e.stopPropagation();
-									stopGeneration();
+									stopGenerationRunner();
 								}}
 								className="ml-1 p-1 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors"
 							>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/index.tsx
@@ -17,7 +17,7 @@ import { useConnectedInputs } from "./lib";
 export function ActionNodePropertiesPanel({ node }: { node: ActionNode }) {
 	const { data, updateNodeData, setUiNodeState } = useWorkflowDesigner();
 	const { isValid, connectedInputs } = useConnectedInputs(node.id, node.inputs);
-	const { createAndStartGeneration } = useNodeGenerations({
+	const { createAndStartGenerationRunner } = useNodeGenerations({
 		nodeId: node.id,
 		origin: { type: "workspace", id: data.id },
 	});
@@ -32,7 +32,7 @@ export function ActionNodePropertiesPanel({ node }: { node: ActionNode }) {
 		setUiNodeState(node.id, {
 			showError: false,
 		});
-		createAndStartGeneration({
+		createAndStartGenerationRunner({
 			origin: {
 				type: "workspace",
 				id: data.id,
@@ -51,7 +51,7 @@ export function ActionNodePropertiesPanel({ node }: { node: ActionNode }) {
 		node,
 		data.id,
 		data.connections,
-		createAndStartGeneration,
+		createAndStartGenerationRunner,
 		connectedInputs,
 	]);
 	return (

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -33,7 +33,7 @@ export function ImageGenerationNodePropertiesPanel({
 }) {
 	const { data, updateNodeDataContent, updateNodeData, setUiNodeState } =
 		useWorkflowDesigner();
-	const { createAndStartGeneration, isGenerating, stopGeneration } =
+	const { createAndStartGenerationRunner, isGenerating, stopGenerationRunner } =
 		useNodeGenerations({
 			nodeId: node.id,
 			origin: { type: "workspace", id: data.id },
@@ -50,7 +50,7 @@ export function ImageGenerationNodePropertiesPanel({
 			return;
 		}
 
-		createAndStartGeneration({
+		createAndStartGenerationRunner({
 			origin: {
 				type: "workspace",
 				id: data.id,
@@ -68,7 +68,7 @@ export function ImageGenerationNodePropertiesPanel({
 		data.id,
 		data.connections,
 		node,
-		createAndStartGeneration,
+		createAndStartGenerationRunner,
 		usageLimitsReached,
 		error,
 	]);
@@ -90,7 +90,7 @@ export function ImageGenerationNodePropertiesPanel({
 						loading={isGenerating}
 						onClick={() => {
 							if (isGenerating) {
-								stopGeneration();
+								stopGenerationRunner();
 							} else {
 								generateText();
 							}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/index.tsx
@@ -26,7 +26,7 @@ import { useConnectedSources } from "./sources";
 
 export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 	const { data, updateNodeData } = useWorkflowDesigner();
-	const { createAndStartGeneration, isGenerating, stopGeneration } =
+	const { createAndStartGenerationRunner, isGenerating, stopGenerationRunner } =
 		useNodeGenerations({
 			nodeId: node.id,
 			origin: { type: "workspace", id: data.id },
@@ -47,7 +47,7 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 			error("Query is empty");
 			return;
 		}
-		createAndStartGeneration({
+		createAndStartGenerationRunner({
 			origin: {
 				type: "workspace",
 				id: data.id,
@@ -65,7 +65,7 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 		data.id,
 		data.connections,
 		node,
-		createAndStartGeneration,
+		createAndStartGenerationRunner,
 		error,
 		query,
 	]);
@@ -84,7 +84,7 @@ export function QueryNodePropertiesPanel({ node }: { node: QueryNode }) {
 						type="button"
 						onClick={() => {
 							if (isGenerating) {
-								stopGeneration();
+								stopGenerationRunner();
 							} else {
 								generate();
 							}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -43,7 +43,7 @@ export function TextGenerationNodePropertiesPanel({
 		setUiNodeState,
 		deleteConnection,
 	} = useWorkflowDesigner();
-	const { createAndStartGeneration, isGenerating, stopGeneration } =
+	const { createAndStartGenerationRunner, isGenerating, stopGenerationRunner } =
 		useNodeGenerations({
 			nodeId: node.id,
 			origin: { type: "workspace", id: data.id },
@@ -60,7 +60,7 @@ export function TextGenerationNodePropertiesPanel({
 			return;
 		}
 
-		createAndStartGeneration({
+		createAndStartGenerationRunner({
 			origin: {
 				type: "workspace",
 				id: data.id,
@@ -78,7 +78,7 @@ export function TextGenerationNodePropertiesPanel({
 		data.id,
 		data.connections,
 		node,
-		createAndStartGeneration,
+		createAndStartGenerationRunner,
 		usageLimitsReached,
 		error,
 	]);
@@ -122,7 +122,7 @@ export function TextGenerationNodePropertiesPanel({
 						disabled={disabled}
 						onClick={() => {
 							if (isGenerating) {
-								stopGeneration();
+								stopGenerationRunner();
 							} else {
 								generateText();
 							}

--- a/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/helpers.ts
+++ b/internal-packages/workflow-designer-ui/src/header/ui/trigger-input-dialog/helpers.ts
@@ -227,9 +227,9 @@ export function createGenerationsForFlow(
 	flow: NonNullable<ReturnType<typeof buildWorkflowFromNode>>,
 	inputs: FormInput[],
 	values: Record<string, string | number>,
-	createGeneration: ReturnType<
+	createGenerationRunner: ReturnType<
 		typeof useGenerationRunnerSystem
-	>["createGeneration"],
+	>["createGenerationRunner"],
 	workspaceId: WorkspaceId,
 ) {
 	const generations: Generation[] = [];
@@ -239,7 +239,7 @@ export function createGenerationsForFlow(
 				step.node.content.type === "trigger"
 					? toParameterItems(inputs, values)
 					: [];
-			const generation = createGeneration({
+			const generation = createGenerationRunner({
 				origin: { type: "workspace", id: workspaceId },
 				inputs:
 					parameterItems.length > 0

--- a/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
+++ b/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
@@ -13,8 +13,11 @@ import {
 import { useToasts } from "../ui/toast";
 
 export function useFlowController() {
-	const { createGenerationRunner, startGenerationRunner, stopGeneration } =
-		useGenerationRunnerSystem();
+	const {
+		createGenerationRunner,
+		startGenerationRunner,
+		stopGenerationRunner,
+	} = useGenerationRunnerSystem();
 	const { data } = useWorkflowDesigner();
 	const { info } = useToasts();
 	const client = useGiselleEngine();
@@ -26,10 +29,10 @@ export function useFlowController() {
 		cancelRef.current = true;
 		await Promise.all(
 			activeGenerationsRef.current.map((generation) =>
-				stopGeneration(generation.id),
+				stopGenerationRunner(generation.id),
 			),
 		);
-	}, [stopGeneration]);
+	}, [stopGenerationRunner]);
 
 	const patchRunAnnotations = useCallback(
 		async (actId: ActId, message: string) => {

--- a/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
+++ b/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
@@ -13,7 +13,7 @@ import {
 import { useToasts } from "../ui/toast";
 
 export function useFlowController() {
-	const { createGeneration, startGeneration, stopGeneration } =
+	const { createGenerationRunner, startGeneration, stopGeneration } =
 		useGenerationRunnerSystem();
 	const { data } = useWorkflowDesigner();
 	const { info } = useToasts();
@@ -155,7 +155,7 @@ export function useFlowController() {
 				flow,
 				inputs,
 				values,
-				createGeneration,
+				createGenerationRunner,
 				data.id,
 			);
 			activeGenerationsRef.current = generations;
@@ -200,7 +200,7 @@ export function useFlowController() {
 			await finalizeRun(act.id, hasFlowError, flowStartedAt);
 		},
 		[
-			createGeneration,
+			createGenerationRunner,
 			data.id,
 			info,
 			stopFlow,

--- a/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
+++ b/internal-packages/workflow-designer-ui/src/hooks/use-flow-controller.tsx
@@ -13,7 +13,7 @@ import {
 import { useToasts } from "../ui/toast";
 
 export function useFlowController() {
-	const { createGenerationRunner, startGeneration, stopGeneration } =
+	const { createGenerationRunner, startGenerationRunner, stopGeneration } =
 		useGenerationRunnerSystem();
 	const { data } = useWorkflowDesigner();
 	const { info } = useToasts();
@@ -59,7 +59,7 @@ export function useFlowController() {
 				return { duration: 0, hasError: false };
 			}
 			let hasError = false;
-			await startGeneration(generation.id, {
+			await startGenerationRunner(generation.id, {
 				onGenerationFailed: async (failedGeneration) => {
 					hasError = true;
 					await patchRunAnnotations(actId, failedGeneration.error.message);
@@ -67,7 +67,7 @@ export function useFlowController() {
 			});
 			return { duration: Date.now() - sequenceStartedAt, hasError };
 		},
-		[patchRunAnnotations, startGeneration],
+		[patchRunAnnotations, startGenerationRunner],
 	);
 
 	const executeSequence = useCallback(

--- a/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
+++ b/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
@@ -38,7 +38,7 @@ import {
 	waitAndGetGenerationRunning,
 } from "../helpers";
 
-type CreateGeneration = (
+type CreateGenerationRunner = (
 	generationContext: GenerationContext,
 ) => CreatedGeneration;
 
@@ -70,7 +70,7 @@ export interface FetchNodeGenerationsParams {
 
 interface GenerationRunnerSystemContextType {
 	generateTextApi: string;
-	createGeneration: CreateGeneration;
+	createGenerationRunner: CreateGenerationRunner;
 	startGeneration: StartGeneration;
 	createAndStartGeneration: CreateAndStartGeneration;
 	getGeneration: (generationId: GenerationId) => Generation | undefined;
@@ -221,7 +221,7 @@ export function GenerationRunnerSystemProvider({
 		},
 		[],
 	);
-	const createGeneration = useCallback<CreateGeneration>(
+	const createGenerationRunner = useCallback<CreateGenerationRunner>(
 		(generationContext) => {
 			const generationId = GenerationId.generate();
 			const createdGeneration = {
@@ -269,11 +269,11 @@ export function GenerationRunnerSystemProvider({
 
 	const createAndStartGeneration = useCallback<CreateAndStartGeneration>(
 		async (generationContext, options = {}) => {
-			const createdGeneration = createGeneration(generationContext);
+			const createdGeneration = createGenerationRunner(generationContext);
 			options?.onGenerationCreated?.(createdGeneration);
 			await startGeneration(createdGeneration.id, options);
 		},
-		[createGeneration, startGeneration],
+		[createGenerationRunner, startGeneration],
 	);
 	const getGeneration = useCallback(
 		(generationId: GenerationId) =>
@@ -409,7 +409,7 @@ export function GenerationRunnerSystemProvider({
 		<GenerationRunnerSystemContext.Provider
 			value={{
 				generateTextApi,
-				createGeneration,
+				createGenerationRunner,
 				startGeneration,
 				createAndStartGeneration,
 				getGeneration,

--- a/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
+++ b/packages/giselle-engine/src/react/generations/contexts/generation-runner-system.tsx
@@ -50,7 +50,7 @@ interface StartGenerationOptions {
 	onGenerationFailed?: (generation: FailedGeneration) => void | Promise<void>;
 	onUpdateMessages?: (generation: RunningGeneration) => void;
 }
-export type StartGeneration = (
+export type StartGenerationRunner = (
 	id: GenerationId,
 	options?: StartGenerationOptions,
 ) => Promise<void>;
@@ -71,7 +71,7 @@ export interface FetchNodeGenerationsParams {
 interface GenerationRunnerSystemContextType {
 	generateTextApi: string;
 	createGenerationRunner: CreateGenerationRunner;
-	startGeneration: StartGeneration;
+	startGenerationRunner: StartGenerationRunner;
 	createAndStartGeneration: CreateAndStartGeneration;
 	getGeneration: (generationId: GenerationId) => Generation | undefined;
 	generations: Generation[];
@@ -237,7 +237,7 @@ export function GenerationRunnerSystemProvider({
 		[],
 	);
 
-	const startGeneration = useCallback<StartGeneration>(
+	const startGenerationRunner = useCallback<StartGenerationRunner>(
 		async (id, options = {}) => {
 			const generation = generationListener.current[id];
 			if (!isCreatedGeneration(generation)) {
@@ -271,9 +271,9 @@ export function GenerationRunnerSystemProvider({
 		async (generationContext, options = {}) => {
 			const createdGeneration = createGenerationRunner(generationContext);
 			options?.onGenerationCreated?.(createdGeneration);
-			await startGeneration(createdGeneration.id, options);
+			await startGenerationRunner(createdGeneration.id, options);
 		},
-		[createGenerationRunner, startGeneration],
+		[createGenerationRunner, startGenerationRunner],
 	);
 	const getGeneration = useCallback(
 		(generationId: GenerationId) =>
@@ -410,7 +410,7 @@ export function GenerationRunnerSystemProvider({
 			value={{
 				generateTextApi,
 				createGenerationRunner,
-				startGeneration,
+				startGenerationRunner,
 				createAndStartGeneration,
 				getGeneration,
 				generations,

--- a/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
+++ b/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
@@ -24,7 +24,7 @@ export function useNodeGenerations({
 }) {
 	const {
 		generations: allGenerations,
-		createGeneration,
+		createGenerationRunner,
 		startGeneration,
 		createAndStartGeneration,
 		stopGeneration: stopGenerationSystem,
@@ -118,7 +118,7 @@ export function useNodeGenerations({
 
 	return {
 		generations,
-		createGeneration,
+		createGenerationRunner,
 		startGeneration,
 		createAndStartGeneration,
 		isGenerating,

--- a/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
+++ b/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
@@ -26,8 +26,8 @@ export function useNodeGenerations({
 		generations: allGenerations,
 		createGenerationRunner,
 		startGenerationRunner,
-		createAndStartGeneration,
-		stopGeneration: stopGenerationSystem,
+		createAndStartGenerationRunner,
+		stopGenerationRunner: stopGenerationSystem,
 		setGenerations,
 	} = useGenerationRunnerSystem();
 	const client = useGiselleEngine();
@@ -109,7 +109,7 @@ export function useNodeGenerations({
 		);
 	}, [generations]);
 
-	const stopGeneration = useCallback(() => {
+	const stopGenerationRunner = useCallback(() => {
 		const latestGeneration = generations[generations.length - 1];
 		if (latestGeneration !== undefined) {
 			stopGenerationSystem(latestGeneration.id);
@@ -120,9 +120,9 @@ export function useNodeGenerations({
 		generations,
 		createGenerationRunner,
 		startGenerationRunner,
-		createAndStartGeneration,
+		createAndStartGenerationRunner,
 		isGenerating,
 		currentGeneration,
-		stopGeneration,
+		stopGenerationRunner,
 	};
 }

--- a/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
+++ b/packages/giselle-engine/src/react/generations/hooks/use-node-generations.ts
@@ -25,7 +25,7 @@ export function useNodeGenerations({
 	const {
 		generations: allGenerations,
 		createGenerationRunner,
-		startGeneration,
+		startGenerationRunner,
 		createAndStartGeneration,
 		stopGeneration: stopGenerationSystem,
 		setGenerations,
@@ -119,7 +119,7 @@ export function useNodeGenerations({
 	return {
 		generations,
 		createGenerationRunner,
-		startGeneration,
+		startGenerationRunner,
 		createAndStartGeneration,
 		isGenerating,
 		currentGeneration,


### PR DESCRIPTION
### **User description**
## Summary
Renamed generation-related functions to improve clarity and consistency by adding "Runner" suffix to function names that interact with the generation runner system.

## Changes
- Renamed `stopGeneration` to `stopGenerationRunner`
- Renamed `createAndStartGeneration` to `createAndStartGenerationRunner`
- Renamed `createGeneration` to `createGenerationRunner`
- Renamed `startGeneration` to `startGenerationRunner`
- Updated all references to these functions across multiple components

## Testing
All components using these functions continue to work as expected with the renamed function calls.

## Other Information
This change improves code readability by making it clearer when functions are interacting with the generation runner system.


___

### **PR Type**
Enhancement


___

### **Description**
- Renamed generation methods to include "Runner" suffix

- Updated function calls across all components

- Improved code clarity and consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Methods"] --> B["Renamed Methods"]
  B --> C["Updated Components"]
  A --> D["createGeneration"]
  A --> E["startGeneration"]
  A --> F["stopGeneration"]
  A --> G["createAndStartGeneration"]
  D --> H["createGenerationRunner"]
  E --> I["startGenerationRunner"]
  F --> J["stopGenerationRunner"]
  G --> K["createAndStartGenerationRunner"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated naming of generation control functions and types across the workflow designer UI and engine to use the "Runner" suffix for consistency. No changes to user-facing functionality or workflows.
* **Chores**
  * Internal codebase improvements for clearer naming conventions related to generation processes. No impact on exported APIs or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->