### PR TITLE
feat(studio): add Pull Request content type management to Vector Stores

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import { after } from "next/server";
 import {
 	db,
+	type GitHubRepositoryContentType,
 	githubRepositoryContentStatus,
 	githubRepositoryIndex,
 } from "@/drizzle";
@@ -28,6 +29,10 @@ export async function registerRepositoryIndex(
 	owner: string,
 	repo: string,
 	installationId: number,
+	contentTypes?: {
+		contentType: GitHubRepositoryContentType;
+		enabled: boolean;
+	}[],
 ): Promise<ActionResult> {
 	try {
 		const team = await fetchCurrentTeam();
@@ -97,12 +102,42 @@ export async function registerRepositoryIndex(
 			})
 			.returning({ dbId: githubRepositoryIndex.dbId });
 
-		await db.insert(githubRepositoryContentStatus).values({
-			repositoryIndexDbId: newRepository.dbId,
-			contentType: "blob",
-			enabled: true,
-			status: "idle",
-		});
+		// Default content types if not provided
+		const defaultContentTypes: {
+			contentType: GitHubRepositoryContentType;
+			enabled: boolean;
+		}[] = [
+			{ contentType: "blob", enabled: true },
+			{ contentType: "pull_request", enabled: true },
+		];
+
+		const contentTypesToCreate = contentTypes || defaultContentTypes;
+
+		// Ensure blob is always enabled
+		const hasBlobEnabled = contentTypesToCreate.some(
+			(ct) => ct.contentType === "blob" && ct.enabled,
+		);
+		if (!hasBlobEnabled) {
+			// Force blob to be enabled
+			const blobIndex = contentTypesToCreate.findIndex(
+				(ct) => ct.contentType === "blob",
+			);
+			if (blobIndex >= 0) {
+				contentTypesToCreate[blobIndex].enabled = true;
+			} else {
+				contentTypesToCreate.push({ contentType: "blob", enabled: true });
+			}
+		}
+
+		// Create content status records
+		for (const contentType of contentTypesToCreate) {
+			await db.insert(githubRepositoryContentStatus).values({
+				repositoryIndexDbId: newRepository.dbId,
+				contentType: contentType.contentType,
+				enabled: contentType.enabled,
+				status: "idle",
+			});
+		}
 
 		revalidatePath("/settings/team/vector-stores");
 		return { success: true };
@@ -376,4 +411,109 @@ function executeManualIngest(repositoryData: RepositoryWithStatuses): void {
 	after(async () => {
 		await processRepository(repositoryData);
 	});
+}
+
+/**
+ * Update content type configurations for a repository
+ */
+export async function updateRepositoryContentTypes(
+	repositoryIndexId: string,
+	contentTypes: {
+		contentType: GitHubRepositoryContentType;
+		enabled: boolean;
+	}[],
+): Promise<ActionResult> {
+	try {
+		const team = await fetchCurrentTeam();
+
+		// Verify the repository belongs to the team
+		const [repository] = await db
+			.select({ dbId: githubRepositoryIndex.dbId })
+			.from(githubRepositoryIndex)
+			.where(
+				and(
+					eq(
+						githubRepositoryIndex.id,
+						repositoryIndexId as GitHubRepositoryIndexId,
+					),
+					eq(githubRepositoryIndex.teamDbId, team.dbId),
+				),
+			)
+			.limit(1);
+
+		if (!repository) {
+			return {
+				success: false,
+				error: "Repository not found",
+			};
+		}
+
+		// Validate that code (blob) is always enabled
+		const blobConfig = contentTypes.find((ct) => ct.contentType === "blob");
+		if (blobConfig && !blobConfig.enabled) {
+			return {
+				success: false,
+				error: "Code content type must remain enabled",
+			};
+		}
+
+		// Update or create content status records
+		for (const contentType of contentTypes) {
+			const existing = await db
+				.select()
+				.from(githubRepositoryContentStatus)
+				.where(
+					and(
+						eq(
+							githubRepositoryContentStatus.repositoryIndexDbId,
+							repository.dbId,
+						),
+						eq(
+							githubRepositoryContentStatus.contentType,
+							contentType.contentType,
+						),
+					),
+				)
+				.limit(1);
+
+			if (existing.length > 0) {
+				// Update existing record
+				await db
+					.update(githubRepositoryContentStatus)
+					.set({
+						enabled: contentType.enabled,
+						updatedAt: new Date(),
+					})
+					.where(
+						and(
+							eq(
+								githubRepositoryContentStatus.repositoryIndexDbId,
+								repository.dbId,
+							),
+							eq(
+								githubRepositoryContentStatus.contentType,
+								contentType.contentType,
+							),
+						),
+					);
+			} else {
+				// Create new record
+				await db.insert(githubRepositoryContentStatus).values({
+					repositoryIndexDbId: repository.dbId,
+					contentType: contentType.contentType,
+					enabled: contentType.enabled,
+					status: "idle",
+				});
+			}
+		}
+
+		revalidatePath("/settings/team/vector-stores");
+		return { success: true };
+	} catch (error) {
+		console.error("Error updating repository content types:", error);
+		return {
+			success: false,
+			error: "Failed to update content types",
+		};
+	}
 }

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
@@ -103,7 +103,7 @@ export function ConfigureSourcesDialog({
 						<ContentTypeToggle
 							icon={GitPullRequest}
 							label="Pull Requests"
-							description="Ingest pull request content and discussions"
+							description="Ingest merged pull request content and discussions"
 							enabled={config.pullRequests.enabled}
 							onToggle={(enabled) =>
 								setConfig({ ...config, pullRequests: { enabled } })

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { Code, GitPullRequest } from "lucide-react";
+import { useState, useTransition } from "react";
+import type {
+	GitHubRepositoryContentType,
+	githubRepositoryContentStatus,
+} from "@/drizzle";
+import type { RepositoryWithStatuses } from "@/lib/vector-stores/github";
+import {
+	GlassDialogBody,
+	GlassDialogContent,
+	GlassDialogFooter,
+	GlassDialogHeader,
+} from "../components/glass-dialog-content";
+
+type ConfigureSourcesDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	repositoryData: RepositoryWithStatuses;
+	updateRepositoryContentTypesAction: (
+		repositoryIndexId: string,
+		contentTypes: {
+			contentType: GitHubRepositoryContentType;
+			enabled: boolean;
+		}[],
+	) => Promise<{ success: boolean; error?: string }>;
+};
+
+export function ConfigureSourcesDialog({
+	open,
+	onOpenChange,
+	repositoryData,
+	updateRepositoryContentTypesAction,
+}: ConfigureSourcesDialogProps) {
+	const { repositoryIndex, contentStatuses } = repositoryData;
+	const [isPending, startTransition] = useTransition();
+	const [error, setError] = useState("");
+
+	// Initialize state with current status
+	const blobStatus = contentStatuses.find((cs) => cs.contentType === "blob");
+	const pullRequestStatus = contentStatuses.find(
+		(cs) => cs.contentType === "pull_request",
+	);
+
+	const [config, setConfig] = useState({
+		code: { enabled: blobStatus?.enabled ?? true },
+		pullRequests: { enabled: pullRequestStatus?.enabled ?? false },
+	});
+
+	const handleSave = () => {
+		setError("");
+		startTransition(async () => {
+			const contentTypes: {
+				contentType: GitHubRepositoryContentType;
+				enabled: boolean;
+			}[] = [
+				{ contentType: "blob", enabled: config.code.enabled },
+				{ contentType: "pull_request", enabled: config.pullRequests.enabled },
+			];
+
+			const result = await updateRepositoryContentTypesAction(
+				repositoryIndex.id,
+				contentTypes,
+			);
+
+			if (result.success) {
+				onOpenChange(false);
+			} else {
+				setError(result.error || "Failed to update configuration");
+			}
+		});
+	};
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<GlassDialogContent
+				onEscapeKeyDown={() => onOpenChange(false)}
+				onPointerDownOutside={() => onOpenChange(false)}
+			>
+				<GlassDialogHeader
+					title="Configure Sources"
+					description={`Select which content types to ingest for ${repositoryIndex.owner}/${repositoryIndex.repo}`}
+					onClose={() => onOpenChange(false)}
+				/>
+				<GlassDialogBody>
+					<div className="space-y-6">
+						{/* Code Configuration */}
+						<ContentTypeToggle
+							icon={Code}
+							label="Code"
+							description="Ingest source code files from the repository"
+							enabled={config.code.enabled}
+							onToggle={(enabled) =>
+								setConfig({ ...config, code: { enabled } })
+							}
+							disabled={true} // Code is mandatory
+							status={blobStatus}
+						/>
+
+						{/* Pull Requests Configuration */}
+						<ContentTypeToggle
+							icon={GitPullRequest}
+							label="Pull Requests"
+							description="Ingest pull request content and discussions"
+							enabled={config.pullRequests.enabled}
+							onToggle={(enabled) =>
+								setConfig({ ...config, pullRequests: { enabled } })
+							}
+							status={pullRequestStatus}
+						/>
+					</div>
+
+					{error && <div className="mt-4 text-sm text-error-500">{error}</div>}
+				</GlassDialogBody>
+				<GlassDialogFooter
+					onCancel={() => onOpenChange(false)}
+					onConfirm={handleSave}
+					confirmLabel="Save Changes"
+					isPending={isPending}
+				/>
+			</GlassDialogContent>
+		</Dialog.Root>
+	);
+}
+
+type ContentTypeToggleProps = {
+	icon: React.ElementType;
+	label: string;
+	description: string;
+	enabled: boolean;
+	onToggle: (enabled: boolean) => void;
+	disabled?: boolean;
+	status?: typeof githubRepositoryContentStatus.$inferSelect;
+};
+
+function ContentTypeToggle({
+	icon: Icon,
+	label,
+	description,
+	enabled,
+	onToggle,
+	disabled,
+	status,
+}: ContentTypeToggleProps) {
+	return (
+		<div className="bg-black-700/50 rounded-lg p-4">
+			<div className="flex items-center justify-between mb-3">
+				<div className="flex items-center gap-2">
+					<Icon size={18} className="text-gray-400" />
+					<span className="text-white font-medium">{label}</span>
+				</div>
+				<label className="relative inline-flex items-center cursor-pointer">
+					<input
+						type="checkbox"
+						checked={enabled}
+						onChange={(e) => onToggle(e.target.checked)}
+						disabled={disabled}
+						className="sr-only"
+					/>
+					<div
+						className={`w-11 h-6 rounded-full transition-colors ${
+							enabled ? "bg-blue-600" : "bg-gray-600"
+						} ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+					>
+						<div
+							className={`absolute w-4 h-4 bg-white rounded-full top-1 transition-transform ${
+								enabled ? "translate-x-6" : "translate-x-1"
+							}`}
+						/>
+					</div>
+				</label>
+			</div>
+			<p className="text-sm text-gray-400">{description}</p>
+			{disabled && (
+				<p className="text-xs text-gray-500 mt-1">
+					(Required - cannot be disabled)
+				</p>
+			)}
+			{status && status.status === "running" && (
+				<p className="text-xs text-blue-400 mt-2">Currently syncing...</p>
+			)}
+		</div>
+	);
+}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
@@ -17,7 +17,7 @@ import {
 
 type ConfigureSourcesDialogProps = {
 	open: boolean;
-	onOpenChange: (open: boolean) => void;
+	setOpen: (open: boolean) => void;
 	repositoryData: RepositoryWithStatuses;
 	updateRepositoryContentTypesAction: (
 		repositoryIndexId: string,
@@ -30,7 +30,7 @@ type ConfigureSourcesDialogProps = {
 
 export function ConfigureSourcesDialog({
 	open,
-	onOpenChange,
+	setOpen,
 	repositoryData,
 	updateRepositoryContentTypesAction,
 }: ConfigureSourcesDialogProps) {
@@ -66,7 +66,7 @@ export function ConfigureSourcesDialog({
 			);
 
 			if (result.success) {
-				onOpenChange(false);
+				setOpen(false);
 			} else {
 				setError(result.error || "Failed to update configuration");
 			}
@@ -74,15 +74,15 @@ export function ConfigureSourcesDialog({
 	};
 
 	return (
-		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+		<Dialog.Root open={open} onOpenChange={setOpen}>
 			<GlassDialogContent
-				onEscapeKeyDown={() => onOpenChange(false)}
-				onPointerDownOutside={() => onOpenChange(false)}
+				onEscapeKeyDown={() => setOpen(false)}
+				onPointerDownOutside={() => setOpen(false)}
 			>
 				<GlassDialogHeader
 					title="Configure Sources"
 					description={`Select which content types to ingest for ${repositoryIndex.owner}/${repositoryIndex.repo}`}
-					onClose={() => onOpenChange(false)}
+					onClose={() => setOpen(false)}
 				/>
 				<GlassDialogBody>
 					<div className="space-y-6">
@@ -115,7 +115,7 @@ export function ConfigureSourcesDialog({
 					{error && <div className="mt-4 text-sm text-error-500">{error}</div>}
 				</GlassDialogBody>
 				<GlassDialogFooter
-					onCancel={() => onOpenChange(false)}
+					onCancel={() => setOpen(false)}
 					onConfirm={handleSave}
 					confirmLabel="Save Changes"
 					isPending={isPending}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from "lucide-react";
+import { pullRequestVectorStoreFlag } from "@/flags";
 import { getGitHubIdentityState } from "@/services/accounts";
 import {
 	deleteRepositoryIndex,
@@ -37,10 +38,12 @@ export default async function TeamVectorStorePage() {
 		return <GitHubAppInstallRequiredCard />;
 	}
 
-	const [installationsWithRepos, repositoryIndexes] = await Promise.all([
-		getInstallationsWithRepos(),
-		getGitHubRepositoryIndexes(),
-	]);
+	const [installationsWithRepos, repositoryIndexes, isPullRequestEnabled] =
+		await Promise.all([
+			getInstallationsWithRepos(),
+			getGitHubRepositoryIndexes(),
+			pullRequestVectorStoreFlag(),
+		]);
 
 	return (
 		<div className="flex flex-col gap-[24px]">
@@ -66,6 +69,7 @@ export default async function TeamVectorStorePage() {
 					<RepositoryRegistrationDialog
 						installationsWithRepos={installationsWithRepos}
 						registerRepositoryIndexAction={registerRepositoryIndex}
+						isPullRequestEnabled={isPullRequestEnabled}
 					/>
 				</div>
 			</div>
@@ -75,6 +79,7 @@ export default async function TeamVectorStorePage() {
 				deleteRepositoryIndexAction={deleteRepositoryIndex}
 				triggerManualIngestAction={triggerManualIngest}
 				updateRepositoryContentTypesAction={updateRepositoryContentTypes}
+				isPullRequestEnabled={isPullRequestEnabled}
 			/>
 		</div>
 	);

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
@@ -4,6 +4,7 @@ import {
 	deleteRepositoryIndex,
 	registerRepositoryIndex,
 	triggerManualIngest,
+	updateRepositoryContentTypes,
 } from "./actions";
 import { getGitHubRepositoryIndexes, getInstallationsWithRepos } from "./data";
 import { RepositoryList } from "./repository-list";
@@ -73,6 +74,7 @@ export default async function TeamVectorStorePage() {
 				repositories={repositoryIndexes}
 				deleteRepositoryIndexAction={deleteRepositoryIndex}
 				triggerManualIngestAction={triggerManualIngest}
+				updateRepositoryContentTypesAction={updateRepositoryContentTypes}
 			/>
 		</div>
 	);

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item-blob-only.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item-blob-only.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { MoreVertical, RefreshCw, Trash } from "lucide-react";
+import { useState, useTransition } from "react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { GitHubRepositoryIndexStatus } from "@/drizzle";
+import { cn } from "@/lib/utils";
+import type { RepositoryWithStatuses } from "@/lib/vector-stores/github";
+import { getContentStatusMetadata } from "@/lib/vector-stores/github/types";
+import type { GitHubRepositoryIndexId } from "@/packages/types";
+import {
+	GlassDialogContent,
+	GlassDialogFooter,
+	GlassDialogHeader,
+} from "../components/glass-dialog-content";
+import { DiagnosticModal } from "./diagnostic-modal";
+import { getErrorMessage } from "./error-messages";
+import type { DocumentLoaderErrorCode } from "./types";
+
+type RepositoryItemBlobOnlyProps = {
+	repositoryData: RepositoryWithStatuses;
+	deleteRepositoryIndexAction: (
+		indexId: GitHubRepositoryIndexId,
+	) => Promise<void>;
+	triggerManualIngestAction: (
+		indexId: GitHubRepositoryIndexId,
+	) => Promise<{ success: boolean; error?: string }>;
+};
+
+export function RepositoryItemBlobOnly({
+	repositoryData,
+	deleteRepositoryIndexAction,
+	triggerManualIngestAction,
+}: RepositoryItemBlobOnlyProps) {
+	const { repositoryIndex, contentStatuses } = repositoryData;
+	const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+	const [showDiagnosticModal, setShowDiagnosticModal] = useState(false);
+	const [isPending, startTransition] = useTransition();
+	const [isIngesting, startIngestTransition] = useTransition();
+
+	const handleDelete = () => {
+		startTransition(async () => {
+			try {
+				await deleteRepositoryIndexAction(repositoryIndex.id);
+				setShowDeleteDialog(false);
+			} catch (error) {
+				console.error(error);
+			}
+		});
+	};
+
+	const handleManualIngest = () => {
+		startIngestTransition(async () => {
+			try {
+				const result = await triggerManualIngestAction(repositoryIndex.id);
+				if (!result.success) {
+					console.error("Failed to trigger manual ingest:", result.error);
+				}
+			} catch (error) {
+				console.error("Error triggering manual ingest:", error);
+			}
+		});
+	};
+
+	// Get the blob status
+	const blobStatus = contentStatuses.find((cs) => cs.contentType === "blob");
+
+	if (!blobStatus) {
+		throw new Error(
+			`Repository ${repositoryIndex.dbId} missing blob content status`,
+		);
+	}
+
+	// Parse metadata
+	const parsedMetadata = getContentStatusMetadata(blobStatus.metadata, "blob");
+
+	// Check if manual ingest is allowed
+	const now = new Date();
+	const canManuallyIngest =
+		blobStatus.status === "idle" ||
+		blobStatus.status === "completed" ||
+		(blobStatus.status === "failed" &&
+			blobStatus.retryAfter &&
+			new Date(blobStatus.retryAfter) <= now);
+
+	return (
+		<div
+			className={cn(
+				"group relative rounded-[12px] overflow-hidden px-[24px] py-[16px] w-full bg-white/[0.02] backdrop-blur-[8px] border-[0.5px] border-white/8 shadow-[inset_0_1px_1px_rgba(255,255,255,0.4),inset_0_-1px_1px_rgba(255,255,255,0.2)] before:content-[''] before:absolute before:inset-0 before:bg-white before:opacity-[0.02] before:rounded-[inherit] before:pointer-events-none hover:border-white/12 transition-colors duration-200",
+			)}
+		>
+			<div className="flex items-center justify-between gap-4">
+				<div className="flex flex-col gap-1">
+					<a
+						href={`https://github.com/${repositoryIndex.owner}/${repositoryIndex.repo}`}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="text-[#1663F3] font-medium text-[16px] leading-[22.4px] font-geist hover:text-[#0f4cd1] transition-colors duration-200"
+					>
+						{repositoryIndex.owner}/{repositoryIndex.repo}
+					</a>
+
+					<span className="text-black-400 font-medium text-[12px] leading-[20.4px] font-geist">
+						Updated {getRelativeTimeString(repositoryIndex.updatedAt)}
+					</span>
+				</div>
+				<div className="flex items-center gap-3">
+					<div className="flex flex-col items-end gap-1">
+						<StatusBadge
+							status={isIngesting ? "running" : blobStatus.status}
+							onVerify={
+								blobStatus.status === "failed" &&
+								blobStatus.errorCode === "DOCUMENT_NOT_FOUND"
+									? () => setShowDiagnosticModal(true)
+									: undefined
+							}
+						/>
+						{parsedMetadata?.lastIngestedCommitSha && (
+							<span className="text-black-400 font-medium text-[12px] leading-[20.4px] font-geist">
+								Last Ingested:{" "}
+								{parsedMetadata.lastIngestedCommitSha.substring(0, 7)}
+							</span>
+						)}
+						{blobStatus.status === "failed" && blobStatus.errorCode && (
+							<span className="text-red-400 font-medium text-[12px] leading-[20.4px] font-geist">
+								{getErrorMessage(
+									blobStatus.errorCode as DocumentLoaderErrorCode,
+								)}
+								{blobStatus.retryAfter &&
+									` Retrying in ${formatRetryTime(blobStatus.retryAfter)}.`}
+							</span>
+						)}
+					</div>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<button
+								type="button"
+								className="transition-opacity duration-200 p-2 text-white/60 hover:text-white/80 hover:bg-white/5 rounded-md disabled:opacity-50"
+								disabled={isPending || isIngesting}
+							>
+								<MoreVertical className="h-4 w-4" />
+							</button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent
+							align="end"
+							className="w-[160px] bg-black-850 border-[0.5px] border-black-400 rounded-[8px]"
+						>
+							<DropdownMenuItem
+								onClick={handleManualIngest}
+								disabled={!canManuallyIngest || isIngesting}
+								className="flex items-center px-3 py-2 text-[14px] leading-[16px] text-white-400 hover:bg-white/5 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+							>
+								<RefreshCw className="h-4 w-4 mr-2" />
+								Ingest Now
+							</DropdownMenuItem>
+							<DropdownMenuSeparator className="my-1 h-px bg-white/10" />
+							<Dialog.Root
+								open={showDeleteDialog}
+								onOpenChange={setShowDeleteDialog}
+							>
+								<Dialog.Trigger asChild>
+									<DropdownMenuItem
+										onClick={() => setShowDeleteDialog(true)}
+										className="flex items-center px-3 py-2 text-[14px] leading-[16px] text-error-900 hover:bg-error-900/20 rounded-md"
+									>
+										<Trash className="h-4 w-4 mr-2" />
+										Delete
+									</DropdownMenuItem>
+								</Dialog.Trigger>
+							</Dialog.Root>
+						</DropdownMenuContent>
+					</DropdownMenu>
+					<Dialog.Root
+						open={showDeleteDialog}
+						onOpenChange={setShowDeleteDialog}
+					>
+						<GlassDialogContent variant="destructive">
+							<GlassDialogHeader
+								title="Delete Repository"
+								description={`This action cannot be undone. This will permanently delete the repository "${repositoryIndex.owner}/${repositoryIndex.repo}" from your Vector Stores.`}
+								onClose={() => setShowDeleteDialog(false)}
+								variant="destructive"
+							/>
+							<GlassDialogFooter
+								onCancel={() => setShowDeleteDialog(false)}
+								onConfirm={handleDelete}
+								confirmLabel="Delete"
+								isPending={isPending}
+								variant="destructive"
+							/>
+						</GlassDialogContent>
+					</Dialog.Root>
+				</div>
+			</div>
+
+			<DiagnosticModal
+				repositoryData={repositoryData}
+				open={showDiagnosticModal}
+				setOpen={setShowDiagnosticModal}
+				onComplete={() => {
+					// Refresh will happen via revalidatePath in the action
+				}}
+				onDelete={() => handleDelete()}
+			/>
+		</div>
+	);
+}
+
+function getRelativeTimeString(date: Date): string {
+	const now = new Date();
+	const diffInMs = now.getTime() - date.getTime();
+	const diffInSeconds = Math.floor(diffInMs / 1000);
+	const diffInMinutes = Math.floor(diffInSeconds / 60);
+	const diffInHours = Math.floor(diffInMinutes / 60);
+	const diffInDays = Math.floor(diffInHours / 24);
+
+	if (diffInDays > 7) {
+		return date.toLocaleDateString("en-US");
+	}
+	if (diffInDays >= 1) {
+		return diffInDays === 1 ? "yesterday" : `${diffInDays} days ago`;
+	}
+	if (diffInHours >= 1) {
+		return diffInHours === 1 ? "1 hour ago" : `${diffInHours} hours ago`;
+	}
+	if (diffInMinutes >= 1) {
+		return diffInMinutes === 1
+			? "1 minute ago"
+			: `${diffInMinutes} minutes ago`;
+	}
+	return "just now";
+}
+
+const STATUS_CONFIG = {
+	idle: { dotColor: "bg-[#B8E8F4]", label: "Idle" },
+	running: { dotColor: "bg-[#39FF7F] animate-custom-pulse", label: "Running" },
+	completed: { dotColor: "bg-[#39FF7F]", label: "Ready" },
+	failed: { dotColor: "bg-[#FF3D71]", label: "Error" },
+} as const;
+
+function StatusBadge({
+	status,
+	onVerify,
+}: {
+	status: GitHubRepositoryIndexStatus;
+	onVerify?: () => void;
+}) {
+	const config = STATUS_CONFIG[status] ?? {
+		dotColor: "bg-gray-500",
+		label: "unknown",
+	};
+
+	const badgeContent = (
+		<>
+			<div className={`w-2 h-2 rounded-full ${config.dotColor} shrink-0`} />
+			<span className="text-black-400 text-[12px] leading-[14px] font-medium font-geist flex-1 text-center ml-1.5">
+				{config.label}
+			</span>
+			{status === "failed" && onVerify && (
+				<>
+					<span className="text-black-400 text-[12px] mx-1">•</span>
+					<span className="text-[#1663F3] text-[12px] leading-[14px] font-medium font-geist">
+						Check
+					</span>
+					<span className="text-[#1663F3] text-[10px] ml-0.5">↗</span>
+				</>
+			)}
+		</>
+	);
+
+	if (onVerify) {
+		return (
+			<button
+				type="button"
+				onClick={onVerify}
+				className="flex items-center px-2 py-1 rounded-full border border-white/20 w-auto hover:bg-white/5 transition-colors duration-200"
+			>
+				{badgeContent}
+			</button>
+		);
+	}
+
+	return (
+		<div className="flex items-center px-2 py-1 rounded-full border border-white/20 w-[80px]">
+			{badgeContent}
+		</div>
+	);
+}
+
+function formatRetryTime(retryAfter: Date): string {
+	const now = new Date();
+	const diffMs = retryAfter.getTime() - now.getTime();
+
+	if (diffMs <= 0) {
+		return "now";
+	}
+
+	const diffSeconds = Math.floor(diffMs / 1000);
+	const diffMinutes = Math.floor(diffSeconds / 60);
+	const diffHours = Math.floor(diffMinutes / 60);
+
+	if (diffHours > 0) {
+		return `${diffHours} hour${diffHours > 1 ? "s" : ""}`;
+	}
+	if (diffMinutes > 0) {
+		return `${diffMinutes} minute${diffMinutes > 1 ? "s" : ""}`;
+	}
+	return `${diffSeconds} second${diffSeconds > 1 ? "s" : ""}`;
+}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
@@ -199,13 +199,11 @@ export function RepositoryItem({
 					)}
 
 					{/* Pull Requests Section */}
-					{pullRequestStatus && (
-						<ContentTypeSection
-							contentType="pull_request"
-							status={pullRequestStatus}
-							isIngesting={isIngesting}
-						/>
-					)}
+					<ContentTypeSection
+						contentType="pull_request"
+						status={pullRequestStatus}
+						isIngesting={isIngesting}
+					/>
 				</div>
 			</div>
 
@@ -353,7 +351,7 @@ function formatRetryTime(retryAfter: Date): string {
 // Content Type Section Component
 type ContentTypeSectionProps = {
 	contentType: GitHubRepositoryContentType;
-	status: typeof githubRepositoryContentStatus.$inferSelect;
+	status?: typeof githubRepositoryContentStatus.$inferSelect;
 	isIngesting: boolean;
 	onVerify?: () => void;
 };
@@ -364,6 +362,35 @@ function ContentTypeSection({
 	isIngesting,
 	onVerify,
 }: ContentTypeSectionProps) {
+	// Handle case where status doesn't exist (e.g., pull_request not yet configured)
+	if (!status) {
+		const contentConfig = {
+			blob: { icon: Code, label: "Code" },
+			pull_request: { icon: GitPullRequest, label: "Pull Requests" },
+		};
+		const config = contentConfig[contentType];
+		const Icon = config.icon;
+
+		return (
+			<div className="bg-black-700/50 rounded-lg p-3 opacity-50">
+				<div className="flex items-center justify-between mb-1">
+					<div className="flex items-center gap-2 text-sm font-medium text-gray-300">
+						<Icon size={16} />
+						<span>{config.label}</span>
+					</div>
+					<div className="flex items-center gap-2">
+						<span className="bg-gray-600 text-gray-300 px-2 py-0.5 rounded text-xs">
+							Disabled
+						</span>
+					</div>
+				</div>
+				<div className="text-xs text-gray-500">
+					<span>Not configured</span>
+				</div>
+			</div>
+		);
+	}
+
 	const {
 		enabled,
 		status: syncStatus,

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
@@ -184,19 +184,17 @@ export function RepositoryItem({
 				{/* Content Type Sections */}
 				<div className="space-y-3">
 					{/* Code Section */}
-					{blobStatus && (
-						<ContentTypeSection
-							contentType="blob"
-							status={blobStatus}
-							isIngesting={isIngesting}
-							onVerify={
-								blobStatus.status === "failed" &&
-								blobStatus.errorCode === "DOCUMENT_NOT_FOUND"
-									? () => setShowDiagnosticModal(true)
-									: undefined
-							}
-						/>
-					)}
+					<ContentTypeSection
+						contentType="blob"
+						status={blobStatus}
+						isIngesting={isIngesting}
+						onVerify={
+							blobStatus?.status === "failed" &&
+							blobStatus?.errorCode === "DOCUMENT_NOT_FOUND"
+								? () => setShowDiagnosticModal(true)
+								: undefined
+						}
+					/>
 
 					{/* Pull Requests Section */}
 					<ContentTypeSection

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
@@ -230,7 +230,7 @@ export function RepositoryItem({
 
 			<ConfigureSourcesDialog
 				open={showConfigureDialog}
-				onOpenChange={setShowConfigureDialog}
+				setOpen={setShowConfigureDialog}
 				repositoryData={repositoryData}
 				updateRepositoryContentTypesAction={updateRepositoryContentTypesAction}
 			/>

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { MoreVertical, RefreshCw, Trash } from "lucide-react";
+import {
+	Code,
+	GitPullRequest,
+	MoreVertical,
+	RefreshCw,
+	Settings,
+	Trash,
+} from "lucide-react";
 import { useState, useTransition } from "react";
 import {
 	DropdownMenu,
@@ -10,7 +17,11 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { GitHubRepositoryIndexStatus } from "@/drizzle";
+import type {
+	GitHubRepositoryContentType,
+	GitHubRepositoryIndexStatus,
+	githubRepositoryContentStatus,
+} from "@/drizzle";
 import { cn } from "@/lib/utils";
 import type { RepositoryWithStatuses } from "@/lib/vector-stores/github";
 import { getContentStatusMetadata } from "@/lib/vector-stores/github/types";
@@ -20,6 +31,7 @@ import {
 	GlassDialogFooter,
 	GlassDialogHeader,
 } from "../components/glass-dialog-content";
+import { ConfigureSourcesDialog } from "./configure-sources-dialog";
 import { DiagnosticModal } from "./diagnostic-modal";
 import { getErrorMessage } from "./error-messages";
 import type { DocumentLoaderErrorCode } from "./types";
@@ -32,15 +44,24 @@ type RepositoryItemProps = {
 	triggerManualIngestAction: (
 		indexId: GitHubRepositoryIndexId,
 	) => Promise<{ success: boolean; error?: string }>;
+	updateRepositoryContentTypesAction: (
+		repositoryIndexId: string,
+		contentTypes: {
+			contentType: GitHubRepositoryContentType;
+			enabled: boolean;
+		}[],
+	) => Promise<{ success: boolean; error?: string }>;
 };
 
 export function RepositoryItem({
 	repositoryData,
 	deleteRepositoryIndexAction,
 	triggerManualIngestAction,
+	updateRepositoryContentTypesAction,
 }: RepositoryItemProps) {
 	const { repositoryIndex, contentStatuses } = repositoryData;
 	const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+	const [showConfigureDialog, setShowConfigureDialog] = useState(false);
 	const [showDiagnosticModal, setShowDiagnosticModal] = useState(false);
 	const [isPending, startTransition] = useTransition();
 	const [isIngesting, startIngestTransition] = useTransition();
@@ -69,8 +90,11 @@ export function RepositoryItem({
 		});
 	};
 
-	// Get the blob status
+	// Get content statuses
 	const blobStatus = contentStatuses.find((cs) => cs.contentType === "blob");
+	const pullRequestStatus = contentStatuses.find(
+		(cs) => cs.contentType === "pull_request",
+	);
 
 	if (!blobStatus) {
 		throw new Error(
@@ -78,26 +102,27 @@ export function RepositoryItem({
 		);
 	}
 
-	// Parse metadata
-	const parsedMetadata = getContentStatusMetadata(blobStatus.metadata, "blob");
-
-	// Check if manual ingest is allowed
+	// Check if manual ingest is allowed for any enabled content type
 	const now = new Date();
-	const canManuallyIngest =
-		blobStatus.status === "idle" ||
-		blobStatus.status === "completed" ||
-		(blobStatus.status === "failed" &&
-			blobStatus.retryAfter &&
-			new Date(blobStatus.retryAfter) <= now);
+	const canManuallyIngest = contentStatuses.some((cs) => {
+		if (!cs.enabled) return false;
+		return (
+			cs.status === "idle" ||
+			cs.status === "completed" ||
+			(cs.status === "failed" &&
+				cs.retryAfter &&
+				new Date(cs.retryAfter) <= now)
+		);
+	});
 
 	return (
 		<div
 			className={cn(
-				"group relative rounded-[12px] overflow-hidden px-[24px] py-[16px] w-full bg-white/[0.02] backdrop-blur-[8px] border-[0.5px] border-white/8 shadow-[inset_0_1px_1px_rgba(255,255,255,0.4),inset_0_-1px_1px_rgba(255,255,255,0.2)] before:content-[''] before:absolute before:inset-0 before:bg-white before:opacity-[0.02] before:rounded-[inherit] before:pointer-events-none hover:border-white/12 transition-colors duration-200",
+				"group relative rounded-[12px] overflow-hidden w-full bg-white/[0.02] backdrop-blur-[8px] border-[0.5px] border-white/8 shadow-[inset_0_1px_1px_rgba(255,255,255,0.4),inset_0_-1px_1px_rgba(255,255,255,0.2)] before:content-[''] before:absolute before:inset-0 before:bg-white before:opacity-[0.02] before:rounded-[inherit] before:pointer-events-none hover:border-white/12 transition-colors duration-200",
 			)}
 		>
-			<div className="flex items-center justify-between gap-4">
-				<div className="flex flex-col gap-1">
+			<div className="px-[24px] py-[16px]">
+				<div className="flex items-center justify-between gap-4 mb-4">
 					<a
 						href={`https://github.com/${repositoryIndex.owner}/${repositoryIndex.repo}`}
 						target="_blank"
@@ -106,15 +131,64 @@ export function RepositoryItem({
 					>
 						{repositoryIndex.owner}/{repositoryIndex.repo}
 					</a>
-
-					<span className="text-black-400 font-medium text-[12px] leading-[20.4px] font-geist">
-						Updated {getRelativeTimeString(repositoryIndex.updatedAt)}
-					</span>
+					<div className="flex items-center gap-2">
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<button
+									type="button"
+									className="transition-opacity duration-200 p-2 text-white/60 hover:text-white/80 hover:bg-white/5 rounded-md disabled:opacity-50"
+									disabled={isPending || isIngesting}
+								>
+									<MoreVertical className="h-4 w-4" />
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="end"
+								className="w-[180px] bg-black-850 border-[0.5px] border-black-400 rounded-[8px]"
+							>
+								<DropdownMenuItem
+									onClick={handleManualIngest}
+									disabled={!canManuallyIngest || isIngesting}
+									className="flex items-center px-3 py-2 text-[14px] leading-[16px] text-white-400 hover:bg-white/5 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+								>
+									<RefreshCw className="h-4 w-4 mr-2" />
+									Ingest Now
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									onClick={() => setShowConfigureDialog(true)}
+									className="flex items-center px-3 py-2 text-[14px] leading-[16px] text-white-400 hover:bg-white/5 rounded-md"
+								>
+									<Settings className="h-4 w-4 mr-2" />
+									Configure Sources
+								</DropdownMenuItem>
+								<DropdownMenuSeparator className="my-1 h-px bg-white/10" />
+								<Dialog.Root
+									open={showDeleteDialog}
+									onOpenChange={setShowDeleteDialog}
+								>
+									<Dialog.Trigger asChild>
+										<DropdownMenuItem
+											onClick={() => setShowDeleteDialog(true)}
+											className="flex items-center px-3 py-2 text-[14px] leading-[16px] text-error-900 hover:bg-error-900/20 rounded-md"
+										>
+											<Trash className="h-4 w-4 mr-2" />
+											Delete
+										</DropdownMenuItem>
+									</Dialog.Trigger>
+								</Dialog.Root>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
 				</div>
-				<div className="flex items-center gap-3">
-					<div className="flex flex-col items-end gap-1">
-						<StatusBadge
-							status={isIngesting ? "running" : blobStatus.status}
+
+				{/* Content Type Sections */}
+				<div className="space-y-3">
+					{/* Code Section */}
+					{blobStatus && (
+						<ContentTypeSection
+							contentType="blob"
+							status={blobStatus}
+							isIngesting={isIngesting}
 							onVerify={
 								blobStatus.status === "failed" &&
 								blobStatus.errorCode === "DOCUMENT_NOT_FOUND"
@@ -122,83 +196,45 @@ export function RepositoryItem({
 									: undefined
 							}
 						/>
-						{parsedMetadata?.lastIngestedCommitSha && (
-							<span className="text-black-400 font-medium text-[12px] leading-[20.4px] font-geist">
-								Last Ingested:{" "}
-								{parsedMetadata.lastIngestedCommitSha.substring(0, 7)}
-							</span>
-						)}
-						{blobStatus.status === "failed" && blobStatus.errorCode && (
-							<span className="text-red-400 font-medium text-[12px] leading-[20.4px] font-geist">
-								{getErrorMessage(
-									blobStatus.errorCode as DocumentLoaderErrorCode,
-								)}
-								{blobStatus.retryAfter &&
-									` Retrying in ${formatRetryTime(blobStatus.retryAfter)}.`}
-							</span>
-						)}
-					</div>
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<button
-								type="button"
-								className="transition-opacity duration-200 p-2 text-white/60 hover:text-white/80 hover:bg-white/5 rounded-md disabled:opacity-50"
-								disabled={isPending || isIngesting}
-							>
-								<MoreVertical className="h-4 w-4" />
-							</button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent
-							align="end"
-							className="w-[160px] bg-black-850 border-[0.5px] border-black-400 rounded-[8px]"
-						>
-							<DropdownMenuItem
-								onClick={handleManualIngest}
-								disabled={!canManuallyIngest || isIngesting}
-								className="flex items-center px-3 py-2 text-[14px] leading-[16px] text-white-400 hover:bg-white/5 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
-							>
-								<RefreshCw className="h-4 w-4 mr-2" />
-								Ingest Now
-							</DropdownMenuItem>
-							<DropdownMenuSeparator className="my-1 h-px bg-white/10" />
-							<Dialog.Root
-								open={showDeleteDialog}
-								onOpenChange={setShowDeleteDialog}
-							>
-								<Dialog.Trigger asChild>
-									<DropdownMenuItem
-										onClick={() => setShowDeleteDialog(true)}
-										className="flex items-center px-3 py-2 text-[14px] leading-[16px] text-error-900 hover:bg-error-900/20 rounded-md"
-									>
-										<Trash className="h-4 w-4 mr-2" />
-										Delete
-									</DropdownMenuItem>
-								</Dialog.Trigger>
-							</Dialog.Root>
-						</DropdownMenuContent>
-					</DropdownMenu>
-					<Dialog.Root
-						open={showDeleteDialog}
-						onOpenChange={setShowDeleteDialog}
-					>
-						<GlassDialogContent variant="destructive">
-							<GlassDialogHeader
-								title="Delete Repository"
-								description={`This action cannot be undone. This will permanently delete the repository "${repositoryIndex.owner}/${repositoryIndex.repo}" from your Vector Stores.`}
-								onClose={() => setShowDeleteDialog(false)}
-								variant="destructive"
-							/>
-							<GlassDialogFooter
-								onCancel={() => setShowDeleteDialog(false)}
-								onConfirm={handleDelete}
-								confirmLabel="Delete"
-								isPending={isPending}
-								variant="destructive"
-							/>
-						</GlassDialogContent>
-					</Dialog.Root>
+					)}
+
+					{/* Pull Requests Section */}
+					{pullRequestStatus && (
+						<ContentTypeSection
+							contentType="pull_request"
+							status={pullRequestStatus}
+							isIngesting={isIngesting}
+						/>
+					)}
 				</div>
 			</div>
+
+			{/* Dialogs */}
+			<Dialog.Root open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+				<GlassDialogContent variant="destructive">
+					<GlassDialogHeader
+						title="Delete Repository"
+						description={`This action cannot be undone. This will permanently delete the repository "${repositoryIndex.owner}/${repositoryIndex.repo}" from your Vector Stores.`}
+						onClose={() => setShowDeleteDialog(false)}
+						variant="destructive"
+					/>
+					<GlassDialogFooter
+						onCancel={() => setShowDeleteDialog(false)}
+						onConfirm={handleDelete}
+						confirmLabel="Delete"
+						isPending={isPending}
+						variant="destructive"
+					/>
+				</GlassDialogContent>
+			</Dialog.Root>
+
+			<ConfigureSourcesDialog
+				open={showConfigureDialog}
+				onOpenChange={setShowConfigureDialog}
+				repositoryData={repositoryData}
+				updateRepositoryContentTypesAction={updateRepositoryContentTypesAction}
+			/>
+
 			<DiagnosticModal
 				repositoryData={repositoryData}
 				open={showDiagnosticModal}
@@ -312,4 +348,103 @@ function formatRetryTime(retryAfter: Date): string {
 		return `${diffMinutes} minute${diffMinutes > 1 ? "s" : ""}`;
 	}
 	return `${diffSeconds} second${diffSeconds > 1 ? "s" : ""}`;
+}
+
+// Content Type Section Component
+type ContentTypeSectionProps = {
+	contentType: GitHubRepositoryContentType;
+	status: typeof githubRepositoryContentStatus.$inferSelect;
+	isIngesting: boolean;
+	onVerify?: () => void;
+};
+
+function ContentTypeSection({
+	contentType,
+	status,
+	isIngesting,
+	onVerify,
+}: ContentTypeSectionProps) {
+	const {
+		enabled,
+		status: syncStatus,
+		lastSyncedAt,
+		metadata,
+		errorCode,
+		retryAfter,
+	} = status;
+
+	// Parse metadata based on content type
+	const parsedMetadata = getContentStatusMetadata(metadata, contentType);
+
+	// Content type config
+	const contentConfig = {
+		blob: {
+			icon: Code,
+			label: "Code",
+			metadataLabel:
+				parsedMetadata && "lastIngestedCommitSha" in parsedMetadata
+					? `Commit: ${parsedMetadata.lastIngestedCommitSha?.substring(0, 7) || "none"}`
+					: null,
+		},
+		pull_request: {
+			icon: GitPullRequest,
+			label: "Pull Requests",
+			metadataLabel:
+				parsedMetadata && "lastIngestedPrNumber" in parsedMetadata
+					? `PR: #${parsedMetadata.lastIngestedPrNumber || "none"}`
+					: null,
+		},
+	};
+
+	const config = contentConfig[contentType];
+	const Icon = config.icon;
+
+	// Determine display status
+	const displayStatus = isIngesting && enabled ? "running" : syncStatus;
+
+	return (
+		<div className="bg-black-700/50 rounded-lg p-3">
+			<div className="flex items-center justify-between mb-1">
+				<div className="flex items-center gap-2 text-sm font-medium text-gray-300">
+					<Icon size={16} />
+					<span>{config.label}</span>
+				</div>
+				<div className="flex items-center gap-2">
+					{enabled ? (
+						<span className="bg-green-700 text-white px-2 py-0.5 rounded text-xs">
+							Enabled
+						</span>
+					) : (
+						<span className="bg-gray-600 text-gray-300 px-2 py-0.5 rounded text-xs">
+							Disabled
+						</span>
+					)}
+					{enabled && (
+						<StatusBadge
+							status={displayStatus}
+							onVerify={
+								syncStatus === "failed" && onVerify ? onVerify : undefined
+							}
+						/>
+					)}
+				</div>
+			</div>
+			{enabled && (
+				<div className="text-xs text-gray-500 flex justify-between">
+					{lastSyncedAt ? (
+						<span>Last sync: {getRelativeTimeString(lastSyncedAt)}</span>
+					) : (
+						<span>Never synced</span>
+					)}
+					{config.metadataLabel && <span>{config.metadataLabel}</span>}
+				</div>
+			)}
+			{enabled && syncStatus === "failed" && errorCode && (
+				<div className="text-xs text-red-400 mt-1">
+					{getErrorMessage(errorCode as DocumentLoaderErrorCode)}
+					{retryAfter && ` • Retry in ${formatRetryTime(retryAfter)}`}
+				</div>
+			)}
+		</div>
+	);
 }

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-list.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-list.tsx
@@ -3,6 +3,7 @@ import type { GitHubRepositoryContentType } from "@/drizzle";
 import type { RepositoryWithStatuses } from "@/lib/vector-stores/github";
 import type { GitHubRepositoryIndexId } from "@/packages/types";
 import { RepositoryItem } from "./repository-item";
+import { RepositoryItemBlobOnly } from "./repository-item-blob-only";
 
 type RepositoryListProps = {
 	repositories: RepositoryWithStatuses[];
@@ -19,6 +20,7 @@ type RepositoryListProps = {
 			enabled: boolean;
 		}[],
 	) => Promise<{ success: boolean; error?: string }>;
+	isPullRequestEnabled: boolean;
 };
 
 export function RepositoryList({
@@ -26,6 +28,7 @@ export function RepositoryList({
 	deleteRepositoryIndexAction,
 	triggerManualIngestAction,
 	updateRepositoryContentTypesAction,
+	isPullRequestEnabled,
 }: RepositoryListProps) {
 	return (
 		<div className="flex flex-col gap-y-[16px]">
@@ -44,17 +47,26 @@ export function RepositoryList({
 
 				{repositories.length > 0 ? (
 					<div className="space-y-4">
-						{repositories.map((repo) => (
-							<RepositoryItem
-								key={repo.repositoryIndex.id}
-								repositoryData={repo}
-								deleteRepositoryIndexAction={deleteRepositoryIndexAction}
-								triggerManualIngestAction={triggerManualIngestAction}
-								updateRepositoryContentTypesAction={
-									updateRepositoryContentTypesAction
-								}
-							/>
-						))}
+						{repositories.map((repo) =>
+							isPullRequestEnabled ? (
+								<RepositoryItem
+									key={repo.repositoryIndex.id}
+									repositoryData={repo}
+									deleteRepositoryIndexAction={deleteRepositoryIndexAction}
+									triggerManualIngestAction={triggerManualIngestAction}
+									updateRepositoryContentTypesAction={
+										updateRepositoryContentTypesAction
+									}
+								/>
+							) : (
+								<RepositoryItemBlobOnly
+									key={repo.repositoryIndex.id}
+									repositoryData={repo}
+									deleteRepositoryIndexAction={deleteRepositoryIndexAction}
+									triggerManualIngestAction={triggerManualIngestAction}
+								/>
+							),
+						)}
 					</div>
 				) : (
 					<EmptyRepositoryCard />

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-list.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-list.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@/components/ui/card";
+import type { GitHubRepositoryContentType } from "@/drizzle";
 import type { RepositoryWithStatuses } from "@/lib/vector-stores/github";
 import type { GitHubRepositoryIndexId } from "@/packages/types";
 import { RepositoryItem } from "./repository-item";
@@ -11,12 +12,20 @@ type RepositoryListProps = {
 	triggerManualIngestAction: (
 		indexId: GitHubRepositoryIndexId,
 	) => Promise<{ success: boolean; error?: string }>;
+	updateRepositoryContentTypesAction: (
+		repositoryIndexId: string,
+		contentTypes: {
+			contentType: GitHubRepositoryContentType;
+			enabled: boolean;
+		}[],
+	) => Promise<{ success: boolean; error?: string }>;
 };
 
 export function RepositoryList({
 	repositories,
 	deleteRepositoryIndexAction,
 	triggerManualIngestAction,
+	updateRepositoryContentTypesAction,
 }: RepositoryListProps) {
 	return (
 		<div className="flex flex-col gap-y-[16px]">
@@ -41,6 +50,9 @@ export function RepositoryList({
 								repositoryData={repo}
 								deleteRepositoryIndexAction={deleteRepositoryIndexAction}
 								triggerManualIngestAction={triggerManualIngestAction}
+								updateRepositoryContentTypesAction={
+									updateRepositoryContentTypesAction
+								}
 							/>
 						))}
 					</div>

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-registration-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-registration-dialog.tsx
@@ -278,7 +278,7 @@ export function RepositoryRegistrationDialog({
 								<ContentTypeToggle
 									icon={GitPullRequest}
 									label="Pull Requests"
-									description="Ingest pull request content and discussions"
+									description="Ingest merged pull request content and discussions"
 									enabled={contentConfig.pullRequests.enabled}
 									onToggle={(enabled) =>
 										setContentConfig({

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-registration-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-registration-dialog.tsx
@@ -29,11 +29,13 @@ type RepositoryRegistrationDialogProps = {
 			enabled: boolean;
 		}[],
 	) => Promise<ActionResult>;
+	isPullRequestEnabled: boolean;
 };
 
 export function RepositoryRegistrationDialog({
 	installationsWithRepos,
 	registerRepositoryIndexAction,
+	isPullRequestEnabled,
 }: RepositoryRegistrationDialogProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [ownerId, setOwnerId] = useState<string>("");
@@ -81,13 +83,15 @@ export function RepositoryRegistrationDialog({
 			const contentTypes: {
 				contentType: GitHubRepositoryContentType;
 				enabled: boolean;
-			}[] = [
-				{ contentType: "blob", enabled: contentConfig.code.enabled },
-				{
-					contentType: "pull_request",
-					enabled: contentConfig.pullRequests.enabled,
-				},
-			];
+			}[] = isPullRequestEnabled
+				? [
+						{ contentType: "blob", enabled: contentConfig.code.enabled },
+						{
+							contentType: "pull_request",
+							enabled: contentConfig.pullRequests.enabled,
+						},
+					]
+				: [{ contentType: "blob", enabled: true }];
 
 			const result = await registerRepositoryIndexAction(
 				owner,
@@ -256,39 +260,41 @@ export function RepositoryRegistrationDialog({
 						</div>
 
 						{/* Sources to Ingest Section */}
-						<div className="flex flex-col gap-y-2">
-							<div className="text-white-400 text-[14px] leading-[16.8px] font-sans">
-								Sources to Ingest
-							</div>
+						{isPullRequestEnabled && (
+							<div className="flex flex-col gap-y-2">
+								<div className="text-white-400 text-[14px] leading-[16.8px] font-sans">
+									Sources to Ingest
+								</div>
 
-							<div className="space-y-3">
-								{/* Code Configuration */}
-								<ContentTypeToggle
-									icon={Code}
-									label="Code"
-									description="Ingest source code files from the repository"
-									enabled={contentConfig.code.enabled}
-									onToggle={(enabled) =>
-										setContentConfig({ ...contentConfig, code: { enabled } })
-									}
-									disabled={true} // Code is mandatory
-								/>
+								<div className="space-y-3">
+									{/* Code Configuration */}
+									<ContentTypeToggle
+										icon={Code}
+										label="Code"
+										description="Ingest source code files from the repository"
+										enabled={contentConfig.code.enabled}
+										onToggle={(enabled) =>
+											setContentConfig({ ...contentConfig, code: { enabled } })
+										}
+										disabled={true} // Code is mandatory
+									/>
 
-								{/* Pull Requests Configuration */}
-								<ContentTypeToggle
-									icon={GitPullRequest}
-									label="Pull Requests"
-									description="Ingest merged pull request content and discussions"
-									enabled={contentConfig.pullRequests.enabled}
-									onToggle={(enabled) =>
-										setContentConfig({
-											...contentConfig,
-											pullRequests: { enabled },
-										})
-									}
-								/>
+									{/* Pull Requests Configuration */}
+									<ContentTypeToggle
+										icon={GitPullRequest}
+										label="Pull Requests"
+										description="Ingest merged pull request content and discussions"
+										enabled={contentConfig.pullRequests.enabled}
+										onToggle={(enabled) =>
+											setContentConfig({
+												...contentConfig,
+												pullRequests: { enabled },
+											})
+										}
+									/>
+								</div>
 							</div>
-						</div>
+						)}
 
 						{error && (
 							<div className="mt-1 text-sm text-error-500">{error}</div>

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -115,3 +115,22 @@ export const stageFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const pullRequestVectorStoreFlag = flag<boolean>({
+	key: "pull-request-vector-store",
+	async decide() {
+		if (process.env.NODE_ENV === "development") {
+			return takeLocalEnv("PULL_REQUEST_VECTOR_STORE_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return edgeConfig === true || edgeConfig === "true";
+	},
+	description: "Enable Pull Request Vector Store",
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});

--- a/apps/studio.giselles.ai/lib/vector-stores/github/ingest/process-repository.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/ingest/process-repository.ts
@@ -83,6 +83,10 @@ export async function processRepository(
 	);
 
 	for (const contentStatus of contentStatuses) {
+		if (!contentStatus.enabled) {
+			continue;
+		}
+
 		try {
 			await updateContentStatus(
 				repositoryIndex.dbId,


### PR DESCRIPTION
### **User description**
## Summary
- Display separate status sections for Code and Pull Requests in repository items
- Add Configure Sources dialog to enable/disable content types per repository  
- Enhance repository registration with content type selection
- **Implement `pullRequestVectorStoreFlag` feature flag to control Pull Request functionality**

## Details
This PR adds Pull Request content type management to the Vector Stores page, leveraging the existing `githubRepositoryContentStatus` table structure.

### Feature Flag Implementation
- **Flag Name**: `pullRequestVectorStoreFlag` (default: `false`)
- **When disabled (default)**: Shows only Code ingestion functionality using the original UI
- **When enabled**: Shows full Pull Request management features
- **Configuration**: 
  - Development: Set `PULL_REQUEST_VECTOR_STORE_FLAG=true` environment variable
  - Production: Can be controlled via Vercel Edge Config

### Features
- **Repository Item UI**: Shows separate sections for Code and Pull Requests with their individual statuses, metadata, and error states
- **Configure Sources Dialog**: Allows users to enable/disable content types (Code is mandatory)
- **Enhanced Registration**: Content type selection during repository registration
- **Server Actions**: New `updateRepositoryContentTypes` action and updated `registerRepositoryIndex` to support multiple content types
- **Backward Compatibility**: When feature flag is disabled, uses the original blob-only implementation

### Implementation Notes
- Code content type is always enabled and cannot be disabled (enforced at both UI and server levels)
- Maintains backward compatibility with existing data
- Follows existing design patterns and styling
- Feature flag allows gradual rollout of Pull Request functionality

## Test plan
- [x] With flag disabled: Verify only Code functionality is available (default behavior)
- [x] With flag enabled: Register a new repository and verify both Code and Pull Requests are enabled by default
- [x] With flag enabled: Use Configure Sources to disable Pull Requests and verify only Code is synced
- [x] Verify Code toggle is disabled in both registration and configuration dialogs
- [x] Check that error states and retry timing are displayed correctly
- [x] Ensure existing repositories continue to work without issues

## Screenshots

<img width="1125" height="820" alt="スクリーンショット 2025-07-28 13 21 03" src="https://github.com/user-attachments/assets/1e80228b-e225-4a95-81b3-a75271eedb05" />
<img width="529" height="632" alt="スクリーンショット 2025-07-28 13 21 08" src="https://github.com/user-attachments/assets/54e4e7f2-bd28-4e09-8c75-c606633b6c41" />
<img width="539" height="447" alt="スクリーンショット 2025-07-28 13 21 13" src="https://github.com/user-attachments/assets/95366542-9004-4358-8f35-b2578f9403b7" />

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add Pull Request content type management to Vector Stores

- Implement `pullRequestVectorStoreFlag` feature flag for gradual rollout

- Create Configure Sources dialog for content type selection

- Enhance repository registration with content type options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Feature Flag"] --> B["Repository Registration"]
  A --> C["Repository List"]
  B --> D["Content Type Selection"]
  C --> E["Configure Sources Dialog"]
  E --> F["Update Content Types"]
  D --> G["Server Actions"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>actions.ts</strong><dd><code>Add content type management server actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-c366d76c09210ba11343bfdbd3731fb7db9d49fbaf5d73dc015cbd229d4615f4">+119/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>process-repository.ts</strong><dd><code>Skip disabled content types during processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-52c8f00b7da8cb2853b276e2c98c9fcc6c9e7f40ab0c7bd5a3f5d98fdc17b971">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configure-sources-dialog.tsx</strong><dd><code>Create Configure Sources dialog component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-2b78e726ece9177c256c7b9bf64ca0895ac2168eef8f206e172511bf1d11dbab">+186/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Add feature flag integration to main page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-b908a559ffdf9bdc6e5d7cddcc845c0acf4d9a0e43c9c83cae6e52b850e77f69">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repository-item-blob-only.tsx</strong><dd><code>Create blob-only repository item component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-d2214211e1bd7cc245b7daafbbf3cc7e59e395f89f59790b5e853f66e4fec7cc">+316/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>repository-item.tsx</strong><dd><code>Enhance repository item with content type sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-7081ecafde073350a2fc722beae87dd986b2f8d55ca73cd48ffdfe62908296c6">+261/-99</a></td>

</tr>

<tr>
  <td><strong>repository-list.tsx</strong><dd><code>Add conditional rendering based on feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-f1b0f6f5a9809b2352b023dc80065f4f0272efa464a6f3e82d0f9c673823d6a4">+32/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>repository-registration-dialog.tsx</strong><dd><code>Add content type selection to registration dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-a7790a1af8eb6fba297a85df8b215b78877265241f0f0feb3e4a3756f9a62497">+122/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>flags.ts</strong><dd><code>Add pullRequestVectorStoreFlag feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1530/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring which GitHub content types (Code and Pull Requests) are ingested for each repository.
  * Introduced a dialog to manage content source settings per repository.
  * Enhanced repository registration to allow selection of content types to ingest.
  * Added feature flag to enable or disable Pull Request ingestion.

* **Improvements**
  * Repository list and item views now adapt based on enabled content types and feature flags.
  * Manual ingestion and status monitoring now support multiple content types.
  * UI and controls for repository management are more modular and user-friendly.

* **Bug Fixes**
  * Ingestion processes now correctly skip disabled content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->