### PR TITLE
Move Act types from engine/acts/object to concepts/act directory

### DIFF
--- a/packages/giselle/src/engine/acts/create-act.ts
+++ b/packages/giselle/src/engine/acts/create-act.ts
@@ -18,7 +18,7 @@ import {
 	type Sequence,
 	SequenceId,
 	type Step,
-} from "./object";
+} from "../../concepts/act";
 import { actPath, workspaceActPath } from "./object/paths";
 
 export const CreateActInputs = z.object({

--- a/packages/giselle/src/engine/acts/create-act.ts
+++ b/packages/giselle/src/engine/acts/create-act.ts
@@ -2,6 +2,14 @@ import { NodeId, Workspace, WorkspaceId } from "@giselle-sdk/data-type";
 import { buildWorkflowFromNode } from "@giselle-sdk/workflow-utils";
 import { z } from "zod/v4";
 import {
+	type Act,
+	ActId,
+	ActIndexObject,
+	type Sequence,
+	SequenceId,
+	type Step,
+} from "../../concepts/act";
+import {
 	type CreatedGeneration,
 	GenerationContextInput,
 	GenerationOrigin,
@@ -11,14 +19,6 @@ import { setGeneration } from "../generations";
 import type { GiselleEngineContext } from "../types";
 import { addWorkspaceIndexItem } from "../utils/workspace-index";
 import { getWorkspace } from "../workspaces";
-import {
-	type Act,
-	ActId,
-	ActIndexObject,
-	type Sequence,
-	SequenceId,
-	type Step,
-} from "../../concepts/act";
 import { actPath, workspaceActPath } from "./object/paths";
 
 export const CreateActInputs = z.object({

--- a/packages/giselle/src/engine/acts/create-and-start-act.ts
+++ b/packages/giselle/src/engine/acts/create-and-start-act.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 import type { GiselleEngineContext } from "../types";
 import { CreateActInputs, createAct } from "./create-act";
-import type { Act } from "./object";
+import type { Act } from "../../concepts/act";
 import { type StartActCallbacks, StartActInputs, startAct } from "./start-act";
 
 interface CreateAndStartActCallbacks extends StartActCallbacks {

--- a/packages/giselle/src/engine/acts/create-and-start-act.ts
+++ b/packages/giselle/src/engine/acts/create-and-start-act.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
+import type { Act } from "../../concepts/act";
 import type { GiselleEngineContext } from "../types";
 import { CreateActInputs, createAct } from "./create-act";
-import type { Act } from "../../concepts/act";
 import { type StartActCallbacks, StartActInputs, startAct } from "./start-act";
 
 interface CreateAndStartActCallbacks extends StartActCallbacks {

--- a/packages/giselle/src/engine/acts/get-workspace-acts.ts
+++ b/packages/giselle/src/engine/acts/get-workspace-acts.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceId } from "@giselle-sdk/data-type";
 import type { GiselleEngineContext } from "../types";
 import { getWorkspaceIndex } from "../utils/workspace-index";
-import { Act, ActIndexObject } from "./object";
+import { Act, ActIndexObject } from "../../concepts/act";
 import { actPath, workspaceActPath } from "./object/paths";
 
 export async function getWorkspaceActs(args: {

--- a/packages/giselle/src/engine/acts/get-workspace-acts.ts
+++ b/packages/giselle/src/engine/acts/get-workspace-acts.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceId } from "@giselle-sdk/data-type";
+import { Act, ActIndexObject } from "../../concepts/act";
 import type { GiselleEngineContext } from "../types";
 import { getWorkspaceIndex } from "../utils/workspace-index";
-import { Act, ActIndexObject } from "../../concepts/act";
 import { actPath, workspaceActPath } from "./object/paths";
 
 export async function getWorkspaceActs(args: {

--- a/packages/giselle/src/engine/acts/index.ts
+++ b/packages/giselle/src/engine/acts/index.ts
@@ -2,6 +2,5 @@ export * from "./create-act";
 export * from "./create-and-start-act";
 export * from "./get-act";
 export * from "./get-workspace-acts";
-export * from "./object";
 export * from "./patch-act";
 export * from "./start-act";

--- a/packages/giselle/src/engine/acts/object/index.ts
+++ b/packages/giselle/src/engine/acts/object/index.ts
@@ -1,2 +1,0 @@
-// Re-export all Act-related types from concepts
-export * from "../../../concepts/act";

--- a/packages/giselle/src/engine/acts/object/patch-object.ts
+++ b/packages/giselle/src/engine/acts/object/patch-object.ts
@@ -1,4 +1,4 @@
-import type { Act } from ".";
+import type { Act } from "../../../concepts/act";
 
 type ActPath = DotPaths<Act>;
 

--- a/packages/giselle/src/engine/acts/object/paths.ts
+++ b/packages/giselle/src/engine/acts/object/paths.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceId } from "@giselle-sdk/data-type";
-import type { ActId } from "./index";
+import type { ActId } from "../../../concepts/identifiers";
 
 export function actPath(actId: ActId) {
 	return `acts/${actId}/act.json`;

--- a/packages/giselle/src/engine/acts/patch-act.ts
+++ b/packages/giselle/src/engine/acts/patch-act.ts
@@ -1,6 +1,6 @@
 import type { ActId } from "../../concepts/identifiers";
 import type { GiselleEngineContext } from "../types";
-import type { Act } from "./object";
+import type { Act } from "../../concepts/act";
 import {
 	type PatchDelta,
 	patchAct as patchActObject,

--- a/packages/giselle/src/engine/acts/patch-act.ts
+++ b/packages/giselle/src/engine/acts/patch-act.ts
@@ -1,6 +1,6 @@
+import type { Act } from "../../concepts/act";
 import type { ActId } from "../../concepts/identifiers";
 import type { GiselleEngineContext } from "../types";
-import type { Act } from "../../concepts/act";
 import {
 	type PatchDelta,
 	patchAct as patchActObject,

--- a/packages/giselle/src/engine/acts/start-act.ts
+++ b/packages/giselle/src/engine/acts/start-act.ts
@@ -13,7 +13,7 @@ import {
 import { executeAction } from "../operations";
 import { executeQuery } from "../operations/execute-query";
 import type { GiselleEngineContext } from "../types";
-import { Act, type Sequence } from "./object";
+import { Act, type Sequence } from "../../concepts/act";
 import { actPath } from "./object/paths";
 import { patchAct } from "./patch-act";
 

--- a/packages/giselle/src/engine/acts/start-act.ts
+++ b/packages/giselle/src/engine/acts/start-act.ts
@@ -1,5 +1,6 @@
 import { AISDKError } from "ai";
 import { z } from "zod/v4";
+import { Act, type Sequence } from "../../concepts/act";
 import { ActId } from "../../concepts/identifiers";
 import { resolveTrigger } from "../flows";
 import {
@@ -13,7 +14,6 @@ import {
 import { executeAction } from "../operations";
 import { executeQuery } from "../operations/execute-query";
 import type { GiselleEngineContext } from "../types";
-import { Act, type Sequence } from "../../concepts/act";
 import { actPath } from "./object/paths";
 import { patchAct } from "./patch-act";
 

--- a/packages/giselle/src/engine/index.ts
+++ b/packages/giselle/src/engine/index.ts
@@ -9,7 +9,6 @@ import type {
 	WorkspaceId,
 } from "@giselle-sdk/data-type";
 import {
-	ActId,
 	type CreateActInputs,
 	type CreateAndStartActInputs,
 	createAct,
@@ -37,7 +36,6 @@ import {
 import {
 	cancelGeneration,
 	type Generation,
-	GenerationId,
 	type GenerationOrigin,
 	generateImage,
 	generateText,
@@ -66,10 +64,10 @@ import {
 	updateWorkspace,
 } from "./workspaces";
 
+export * from "../concepts/act";
 export * from "../concepts/generation";
 export * from "../concepts/identifiers";
 export type * from "./acts";
-export * from "./acts/object";
 export * from "./experimental_storage";
 export * from "./experimental_vector-store";
 export * from "./integrations";
@@ -362,6 +360,7 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 export type GiselleEngine = ReturnType<typeof GiselleEngine>;
 
 // Re-export value constructors explicitly
+import { ActId, GenerationId } from "../concepts/identifiers";
 export { ActId, GenerationId };
 
 export * from "./error";

--- a/packages/giselle/src/http/router.ts
+++ b/packages/giselle/src/http/router.ts
@@ -9,13 +9,13 @@ import {
 	WorkspaceId,
 } from "@giselle-sdk/data-type";
 import { z } from "zod/v4";
+import { ActId } from "../concepts/identifiers";
 import type { GiselleEngine } from "../engine";
 import {
 	CreateActInputs,
 	CreateAndStartActInputs,
 	type PatchDelta,
 } from "../engine/acts";
-import { ActId } from "../concepts/identifiers";
 import { DataSourceProviderObject } from "../engine/data-source";
 import { ConfigureTriggerInput } from "../engine/flows";
 import {

--- a/packages/giselle/src/http/router.ts
+++ b/packages/giselle/src/http/router.ts
@@ -11,11 +11,11 @@ import {
 import { z } from "zod/v4";
 import type { GiselleEngine } from "../engine";
 import {
-	ActId,
 	CreateActInputs,
 	CreateAndStartActInputs,
 	type PatchDelta,
 } from "../engine/acts";
+import { ActId } from "../concepts/identifiers";
 import { DataSourceProviderObject } from "../engine/data-source";
 import { ConfigureTriggerInput } from "../engine/flows";
 import {


### PR DESCRIPTION
### **User description**
## Summary
Refactored Act-related imports by moving types from `engine/acts/object` to directly import from `concepts/act`. This eliminates the intermediate re-export layer, simplifying the import structure.

## Changes
- Removed the re-export file `packages/giselle/src/engine/acts/object/index.ts`
- Updated import paths across multiple files to import Act types directly from `concepts/act`
- Removed `object` export from `engine/acts/index.ts`
- Added direct export of Act types from the engine's main index file
- Reorganized identifier imports to use the proper source paths

## Testing
All import paths have been updated to maintain the same functionality while simplifying the import structure.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored Act type imports to use direct paths

- Removed intermediate re-export layer from engine/acts/object

- Updated import statements across multiple files

- Reorganized imports to group external and internal modules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["engine/acts/object/index.ts"] -- "removed re-export" --> B["concepts/act"]
  C["Multiple files"] -- "updated imports" --> B
  D["engine/index.ts"] -- "direct export" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal import paths for several types and identifiers to use centralized modules, improving consistency and maintainability.
  * Removed redundant re-exports and simplified export structure for act-related types.

* **Chores**
  * Cleaned up unused or duplicate modules related to act type re-exports. 

No user-facing features or functionality have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->