### PR TITLE
Move workflow types from data-type to giselle/concepts/workflow

### DIFF
--- a/packages/data-type/src/index.ts
+++ b/packages/data-type/src/index.ts
@@ -3,5 +3,4 @@ export * from "./flow";
 export * from "./integrations";
 export * from "./node";
 export * from "./secret";
-export * from "./workflow";
 export * from "./workspace";

--- a/packages/giselle/src/concepts/workflow/index.ts
+++ b/packages/giselle/src/concepts/workflow/index.ts
@@ -1,4 +1,9 @@
-import { Connection, Node, NodeLike, OperationNode } from "@giselle-sdk/data-type";
+import {
+	Connection,
+	Node,
+	NodeLike,
+	OperationNode,
+} from "@giselle-sdk/data-type";
 import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
 

--- a/packages/giselle/src/concepts/workflow/index.ts
+++ b/packages/giselle/src/concepts/workflow/index.ts
@@ -1,7 +1,6 @@
+import { Connection, Node, NodeLike, OperationNode } from "@giselle-sdk/data-type";
 import { createIdGenerator } from "@giselle-sdk/utils";
 import { z } from "zod/v4";
-import { Connection } from "../connection";
-import { Node, NodeLike, OperationNode } from "../node";
 
 export const SequenceId = createIdGenerator("sq");
 export type SequenceId = z.infer<typeof SequenceId.schema>;

--- a/packages/giselle/src/engine/error.ts
+++ b/packages/giselle/src/engine/error.ts
@@ -1,4 +1,5 @@
-import type { WorkflowId, WorkspaceId } from "@giselle-sdk/data-type";
+import type { WorkspaceId } from "@giselle-sdk/data-type";
+import type { WorkflowId } from "../concepts/workflow";
 
 class BaseError extends Error {
 	constructor(message: string, options?: ErrorOptions) {

--- a/packages/giselle/src/engine/flows/build-workflow-from-trigger.ts
+++ b/packages/giselle/src/engine/flows/build-workflow-from-trigger.ts
@@ -1,9 +1,9 @@
 import type {
 	FlowTrigger,
 	FlowTriggerId,
-	Workflow,
 	Workspace,
 } from "@giselle-sdk/data-type";
+import type { Workflow } from "../../concepts/workflow";
 import type { GiselleEngineContext } from "../types";
 import { buildWorkflowFromNode } from "../utils/workflow/build-workflow-from-node";
 import { getWorkspace } from "../workspaces/utils";

--- a/packages/giselle/src/engine/index.ts
+++ b/packages/giselle/src/engine/index.ts
@@ -67,6 +67,7 @@ import {
 export * from "../concepts/act";
 export * from "../concepts/generation";
 export * from "../concepts/identifiers";
+export { Workflow, WorkflowId } from "../concepts/workflow";
 export type * from "./acts";
 export * from "./experimental_storage";
 export * from "./experimental_vector-store";

--- a/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.test.ts
+++ b/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.test.ts
@@ -1,10 +1,6 @@
-import {
-	isTriggerNode,
-	type NodeId,
-	Workspace,
-} from "@giselle-sdk/data-type";
-import type { Workflow } from "../../../concepts/workflow";
+import { isTriggerNode, type NodeId, Workspace } from "@giselle-sdk/data-type";
 import { beforeEach, describe, expect, it, test } from "vitest";
+import type { Workflow } from "../../../concepts/workflow";
 import { buildWorkflowFromNode } from "./build-workflow-from-node";
 import workspace1 from "./test/fixtures/workspace1.json";
 import workspace2 from "./test/fixtures/workspace2.json";

--- a/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.test.ts
+++ b/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.test.ts
@@ -1,9 +1,9 @@
 import {
 	isTriggerNode,
 	type NodeId,
-	type Workflow,
 	Workspace,
 } from "@giselle-sdk/data-type";
+import type { Workflow } from "../../../concepts/workflow";
 import { beforeEach, describe, expect, it, test } from "vitest";
 import { buildWorkflowFromNode } from "./build-workflow-from-node";
 import workspace1 from "./test/fixtures/workspace1.json";

--- a/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.ts
+++ b/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.ts
@@ -1,8 +1,8 @@
 import {
 	type NodeLike,
-	WorkflowId,
 	type Workspace,
 } from "@giselle-sdk/data-type";
+import { WorkflowId } from "../../../concepts/workflow";
 import { buildSequenceList } from "./helper";
 import { sliceGraphFromNode } from "./slice-graph-from-node";
 

--- a/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.ts
+++ b/packages/giselle/src/engine/utils/workflow/build-workflow-from-node.ts
@@ -1,7 +1,4 @@
-import {
-	type NodeLike,
-	type Workspace,
-} from "@giselle-sdk/data-type";
+import type { NodeLike, Workspace } from "@giselle-sdk/data-type";
 import { WorkflowId } from "../../../concepts/workflow";
 import { buildSequenceList } from "./helper";
 import { sliceGraphFromNode } from "./slice-graph-from-node";

--- a/packages/giselle/src/engine/utils/workflow/helper.test.ts
+++ b/packages/giselle/src/engine/utils/workflow/helper.test.ts
@@ -1,5 +1,6 @@
-import type { Connection, Node, WorkflowId } from "@giselle-sdk/data-type";
+import type { Connection, Node } from "@giselle-sdk/data-type";
 import { describe, expect, test } from "vitest";
+import type { WorkflowId } from "../../../concepts/workflow";
 import { buildSequenceList } from "./helper";
 
 // Sample data for tests based on provided workflow JSON

--- a/packages/giselle/src/engine/utils/workflow/helper.ts
+++ b/packages/giselle/src/engine/utils/workflow/helper.ts
@@ -4,11 +4,13 @@ import {
 	Node,
 	type NodeId,
 	type NodeLike,
+} from "@giselle-sdk/data-type";
+import {
 	type Sequence,
 	SequenceId,
 	type Step,
 	type WorkflowId,
-} from "@giselle-sdk/data-type";
+} from "../../../concepts/workflow";
 
 /**
  * Converts a directed graph into a sequence of sequences with steps based on topological sorting.


### PR DESCRIPTION
### **User description**
## Summary
Moved workflow-related types from `@giselle-sdk/data-type` to `@giselle/src/concepts/workflow` to better organize the codebase architecture.

## Changes
- Relocated `workflow/index.ts` from data-type package to giselle package
- Updated imports in affected files to reference the new location
- Removed workflow export from data-type package
- Re-exported Workflow and WorkflowId from the engine index file

## Testing
Existing tests have been updated to use the new import paths.


___

### **PR Type**
Enhancement


___

### **Description**
- Move workflow types from data-type to giselle/concepts/workflow

- Update imports across affected files

- Re-export Workflow and WorkflowId from engine index


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["@giselle-sdk/data-type"] -- "remove workflow export" --> B["data-type/index.ts"]
  C["giselle/concepts/workflow"] -- "update imports" --> D["workflow/index.ts"]
  E["engine files"] -- "update import paths" --> F["workflow types"]
  G["engine/index.ts"] -- "re-export" --> H["Workflow, WorkflowId"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated import paths for workflow-related types across multiple modules to improve organization and consistency.
  * Removed workflow exports from one module and added them to another for clearer separation.
  * No changes to application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->