### PR TITLE
Return early after error in executeStep to prevent further processing

### DIFF
--- a/packages/giselle/src/engine/acts/start-act.ts
+++ b/packages/giselle/src/engine/acts/start-act.ts
@@ -48,9 +48,11 @@ async function executeStep(args: {
 					...args,
 					useExperimentalStorage: true,
 				});
+				let errorOccurred = false;
 				await result.consumeStream({
 					onError: async (error) => {
 						if (AISDKError.isInstance(error)) {
+							errorOccurred = true;
 							const failedGeneration = {
 								...args.generation,
 								status: "failed",
@@ -76,6 +78,9 @@ async function executeStep(args: {
 						}
 					},
 				});
+				if (errorOccurred) {
+					return;
+				}
 				break;
 			}
 			case "trigger":


### PR DESCRIPTION
## Summary
Fix a bug in the start-act.ts file where execution would continue after an error occurred during stream consumption.

## Changes
- Added a flag `errorOccurred` to track when an error happens during stream consumption
- Added a return statement after stream consumption if an error occurred to prevent further execution

## Testing
Verified that execution properly stops when an error occurs during stream consumption.