### PR TITLE
Replace "Create pull request" heading with act name and filter out trigger nodes

### DIFF
--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/layout.tsx
@@ -36,7 +36,7 @@ export default async function ({
 				</div>
 
 				<div className="mb-[24px]">
-          <h2>{act.name}</h2>
+					<h2>{act.name}</h2>
 					{/* <div className="flex bg-secondary rounded-md p-1 text-sm">
 							<button className="flex-1 text-muted-foreground py-1 px-2 rounded">
 								Steps
@@ -62,23 +62,26 @@ export default async function ({
 					<Nav
 						act={{
 							...act,
-							sequences: act.sequences.map((sequence) => ({
-								...sequence,
-								steps: sequence.steps
-									.map((step) => {
-										const generation = generations.find(
-											(generation) => generation.id === step.generationId,
-										);
-										if (generation === undefined) {
-											return null;
-										}
-										return {
-											...step,
-											generation,
-										};
-									})
-									.filter((step) => step !== null),
-							})),
+							sequences: act.sequences
+							// Skip the first sequence as it's always a Trigger node and doesn't need to be displayed
+								.filter((_, index) => index > 0)
+								.map((sequence) => ({
+									...sequence,
+									steps: sequence.steps
+										.map((step) => {
+											const generation = generations.find(
+												(generation) => generation.id === step.generationId,
+											);
+											if (generation === undefined) {
+												return null;
+											}
+											return {
+												...step,
+												generation,
+											};
+										})
+										.filter((step) => step !== null),
+								})),
 						}}
 					/>
 				</div>

--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/layout.tsx
@@ -36,7 +36,7 @@ export default async function ({
 				</div>
 
 				<div className="mb-[24px]">
-					<h2>Create pull request</h2>
+          <h2>{act.name}</h2>
 					{/* <div className="flex bg-secondary rounded-md p-1 text-sm">
 							<button className="flex-1 text-muted-foreground py-1 px-2 rounded">
 								Steps


### PR DESCRIPTION
## Summary
Updated the act layout to display the act name as the heading instead of "Create pull request" and filtered out the first sequence from the navigation as it's always a Trigger node that doesn't need to be displayed.

## Changes
- Changed the heading from "Create pull request" to display the act's name
- Added filtering to skip the first sequence in the act's sequences array
- Added a comment explaining why the first sequence is filtered out

## Testing
Verify that the act name appears correctly in the heading and that the Trigger node no longer appears in the navigation.