### PR TITLE
Fix Select component to use min-width for long options

### DIFF
--- a/apps/playground/app/ui/select/page.tsx
+++ b/apps/playground/app/ui/select/page.tsx
@@ -12,6 +12,7 @@ export default function () {
 						{ id: 1, name: "apple" },
 						{ id: 2, name: "banana" },
 						{ id: 3, name: "melon" },
+						{ id: 4, name: "long long long option" },
 					]}
 					renderOption={(option) => option.name}
 					placeholder="Select apple..."

--- a/internal-packages/ui/components/select.tsx
+++ b/internal-packages/ui/components/select.tsx
@@ -54,7 +54,7 @@ export function Select<T extends Identifiable>({
 				<SelectPrimitive.Content
 					position="popper"
 					sideOffset={4}
-					className={clsx("w-(--radix-select-trigger-width) z-50")}
+					className={clsx("min-w-(--radix-select-trigger-width) z-50")}
 				>
 					<PopoverContent>
 						<SelectPrimitive.Viewport>


### PR DESCRIPTION
### **User description**
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Select dropdown width to accommodate long options

- Change from fixed width to minimum width constraint

- Add test case with long option text


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Select Trigger"] -- "min-width constraint" --> B["Dropdown Content"]
  B -- "accommodates" --> C["Long Option Text"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add long option test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/playground/app/ui/select/page.tsx

<ul><li>Add test option with long text "long long long option"<br> <li> Verify Select component handles lengthy option names</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1554/files#diff-6f61edde4f1e313ba4b0d9ffb0a5c62a4a891e45b6a4fbe97d888b5bb261a51b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>select.tsx</strong><dd><code>Fix dropdown width constraint for long options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ui/components/select.tsx

<ul><li>Change dropdown width from <code>w-(--radix-select-trigger-width)</code> to <br><code>min-w-(--radix-select-trigger-width)</code><br> <li> Allow dropdown to expand beyond trigger width for long options</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1554/files#diff-334ea23b0b90f95f0a9aac273214bc85d86ed72c558c132c56cd9ddc8a0b3ba1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option labeled "long long long option" to the selection list.

* **Style**
  * Improved the dropdown menu styling so that its width can expand beyond the trigger element, enhancing usability for longer option names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->