### PR TITLE
Add onBeforeDelete to V2 editor

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -10,6 +10,7 @@ import {
 	type Connection,
 	type Edge,
 	type IsValidConnection,
+	type OnBeforeDelete,
 	ReactFlow,
 	useReactFlow,
 	useUpdateNodeInternals,
@@ -179,6 +180,14 @@ function V2NodeCanvas() {
 		[data.nodes, data.connections, deleteConnection, updateNodeData],
 	);
 
+	const handleBeforeDelete: OnBeforeDelete<
+		GiselleWorkflowDesignerNode,
+		ConnectorType
+	> = () =>
+		Promise.resolve(
+			window.confirm("Are you sure you want to delete the selected item(s)?"),
+		);
+
 	const isValidConnection: IsValidConnection<ConnectorType> = (connection) => {
 		if (
 			!connection.sourceHandle ||
@@ -208,6 +217,7 @@ function V2NodeCanvas() {
 			defaultViewport={data.ui.viewport}
 			onConnect={handleConnect}
 			onEdgesDelete={handleEdgesDelete}
+			onBeforeDelete={handleBeforeDelete}
 			isValidConnection={isValidConnection}
 			panOnScroll={true}
 			zoomOnScroll={false}


### PR DESCRIPTION
### **User description**
https://github.com/user-attachments/assets/b1e890d2-7e55-4d00-b481-2f2ace5569bc


## Summary
- implement `onBeforeDelete` for the ReactFlow canvas in workflow-designer-ui
- confirm deletion using `window.confirm`

## Testing
- `turbo test --cache=local:rw`


------
https://chatgpt.com/codex/tasks/task_e_68887341ef54832fb6b5f4db7676d88c


___

### **PR Type**
Enhancement


___

### **Description**
- Add deletion confirmation dialog to ReactFlow canvas

- Implement `onBeforeDelete` handler with `window.confirm`

- Enhance user experience with deletion safety check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User initiates delete"] --> B["onBeforeDelete handler"] --> C["window.confirm dialog"] --> D["Confirm/Cancel deletion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>v2-container.tsx</strong><dd><code>Add deletion confirmation to ReactFlow canvas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx

<ul><li>Import <code>OnBeforeDelete</code> type from ReactFlow<br> <li> Add <code>handleBeforeDelete</code> function with confirmation dialog<br> <li> Connect handler to ReactFlow <code>onBeforeDelete</code> prop</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1569/files#diff-2d75399629db36d10f858317710b1faa4d19f16f00bfefc8956ce8deeea5d460">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when attempting to delete items, ensuring users are prompted before nodes or edges are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->