### PR TITLE
fix(error-handling): use AggregateError for better error detail expansion in Sentry

### DIFF
--- a/apps/studio.giselles.ai/lib/vector-stores/github/ingest/error-handling.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/ingest/error-handling.ts
@@ -21,7 +21,10 @@ export function handleIngestErrors<T extends BaseIngestParams>(
 		const errorMessage = `Failed to ingest ${result.failedDocuments} out of ${result.totalDocuments} ${documentType} documents for ${params.source.owner}/${params.source.repo}`;
 		console.error(errorMessage, result.errors);
 
-		const aggregatedError = new Error(errorMessage);
+		const aggregatedError = new AggregateError(
+			result.errors.map((e) => e.error),
+			errorMessage,
+		);
 		captureException(aggregatedError, {
 			extra: {
 				...params.source,
@@ -29,7 +32,7 @@ export function handleIngestErrors<T extends BaseIngestParams>(
 				totalDocuments: result.totalDocuments,
 				successfulDocuments: result.successfulDocuments,
 				failedDocuments: result.failedDocuments,
-				errors: result.errors,
+				failedDocumentKeys: result.errors.map((e) => e.document),
 			},
 		});
 	}


### PR DESCRIPTION
## Summary
- Replace simple Error with AggregateError in the ingest error handling to properly send individual error details to Sentry
- This allows Sentry to better display and track each failed document during the ingestion process

## Test plan
- [x] Run pnpm format
- [x] Run pnpm build-sdk
- [x] Run pnpm check-types (failed due to unrelated issues)
- [x] Run pnpm tidy
- [x] Run pnpm test

🤖 Generated with [Claude Code](https://claude.ai/code)