### PR TITLE
refactor-run-button-logic

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
@@ -81,36 +81,23 @@ export function RunButton() {
 				index,
 			}),
 		);
-		if (triggerNodeItems.length === 0) {
-			return [
-				{
-					groupId: "operationNodes",
-					groupLabel: "Node Group",
-					items: operationNodeItems,
-				},
-			];
-		}
-		if (operationNodeItems.length === 0) {
-			return [
-				{
-					groupId: "triggerNodes",
-					groupLabel: "Trigger Nodes",
-					items: triggerNodeItems,
-				},
-			];
-		}
-		return [
-			{
+
+		const groups = [];
+		if (triggerNodeItems.length > 0) {
+			groups.push({
 				groupId: "triggerNodes",
 				groupLabel: "Trigger Nodes",
 				items: triggerNodeItems,
-			},
-			{
+			});
+		}
+		if (operationNodeItems.length > 0) {
+			groups.push({
 				groupId: "operationNodes",
 				groupLabel: "Node Group",
 				items: operationNodeItems,
-			},
-		];
+			});
+		}
+		return groups;
 	}, [nodeGroups]);
 
 	const { info } = useToasts();

--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
@@ -59,33 +59,56 @@ export function RunButton() {
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 	const nodeGroups = useNodeGroups();
 	const startingNodes = useMemo(() => {
+		const triggerNodeItems = nodeGroups.triggerNodeGroups.map(
+			(triggerNodeGroup) => ({
+				type: "triggerNode",
+				value: triggerNodeGroup.node.id,
+				label: triggerNodeGroup.node.name ?? defaultName(triggerNodeGroup.node),
+				node: triggerNodeGroup.node,
+				nodeIds: triggerNodeGroup.nodeGroup.nodeIds,
+				connectionIds: triggerNodeGroup.nodeGroup.connectionIds,
+				index: undefined,
+			}),
+		);
+		const operationNodeItems = nodeGroups.operationNodeGroups.map(
+			(operationNodeGroup, index) => ({
+				type: "nodeGroup",
+				value: `operation-node-index-${index}`,
+				label: `Group ${index + 1}`,
+				node: undefined,
+				nodeIds: operationNodeGroup.nodeIds,
+				connectionIds: operationNodeGroup.connectionIds,
+				index,
+			}),
+		);
+		if (triggerNodeItems.length === 0) {
+			return [
+				{
+					groupId: "operationNodes",
+					groupLabel: "Node Group",
+					items: operationNodeItems,
+				},
+			];
+		}
+		if (operationNodeItems.length === 0) {
+			return [
+				{
+					groupId: "triggerNodes",
+					groupLabel: "Trigger Nodes",
+					items: triggerNodeItems,
+				},
+			];
+		}
 		return [
 			{
 				groupId: "triggerNodes",
 				groupLabel: "Trigger Nodes",
-				items: nodeGroups.triggerNodeGroups.map((triggerNodeGroup) => ({
-					type: "triggerNode",
-					value: triggerNodeGroup.node.id,
-					label:
-						triggerNodeGroup.node.name ?? defaultName(triggerNodeGroup.node),
-					node: triggerNodeGroup.node,
-					nodeIds: triggerNodeGroup.nodeGroup.nodeIds,
-					connectionIds: triggerNodeGroup.nodeGroup.connectionIds,
-					index: undefined,
-				})),
+				items: triggerNodeItems,
 			},
 			{
 				groupId: "operationNodes",
 				groupLabel: "Node Group",
-				items: nodeGroups.operationNodeGroups.map((nodeGroup, index) => ({
-					type: "nodeGroup",
-					value: `operation-node-index-${index}`,
-					label: `Group ${index + 1}`,
-					node: undefined,
-					nodeIds: nodeGroup.nodeIds,
-					connectionIds: nodeGroup.connectionIds,
-					index,
-				})),
+				items: operationNodeItems,
 			},
 		];
 	}, [nodeGroups]);


### PR DESCRIPTION
### **User description**
### Description

- Memoize and simplify startingNodes grouping logic
- Simplify node group rendering logic to avoid redundant checks
- Refactor run logic to support single and grouped runs with dialogs and dropdowns
- Extract run logic into a dedicated hook for better maintainability


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor run button logic to support single and grouped runs

- Extract run logic into dedicated hook for better maintainability

- Simplify node group rendering and memoize grouping logic

- Add type definitions for run items and menu items


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RunButton"] --> B["Single Trigger"]
  A --> C["Single Node Group"]
  A --> D["Multiple Runs Dropdown"]
  B --> E["SingleTriggerRunButton"]
  C --> F["SingleNodeGroupRunButton"]
  D --> G["MultipleRunsDropdown"]
  E --> H["useRunAct hook"]
  F --> H
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-button.tsx</strong><dd><code>Complete refactor of run button architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx

<ul><li>Added comprehensive type definitions for run items and menu items<br> <li> Extracted <code>useRunAct</code> hook for centralized run logic<br> <li> Split main component into specialized sub-components for different <br>scenarios<br> <li> Simplified and memoized node grouping logic with cleaner data <br>structures<br> <li> Refactored dropdown rendering to use typed menu items</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1580/files#diff-8a9745738738ef2c3b8f9ac4e66ea3a2abdefa3e5b53e53845092b4165130db6">+211/-75</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved run button experience with clearer options for running workflows, including separate buttons for single trigger nodes, single node groups, and a dropdown menu for multiple options.
  * Enhanced UI feedback with dialogs for input overrides and better highlighting of nodes.

* **Refactor**
  * Streamlined and modularized the run button functionality for easier navigation and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1583 
- <kbd>&nbsp;1&nbsp;</kbd> #1580 👈 
<!-- GitButler Footer Boundary Bottom -->

