### PR TITLE
fix(run-button): hide run button when no runnable items exist

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
@@ -312,6 +312,11 @@ export function RunButton() {
 
 	const totalRuns = triggerRuns.length + nodeGroupRuns.length;
 
+	// No runnable items
+	if (totalRuns === 0) {
+		return null;
+	}
+
 	// Single trigger node
 	if (totalRuns === 1 && triggerRuns.length === 1) {
 		return <SingleTriggerRunButton triggerRun={triggerRuns[0]} />;


### PR DESCRIPTION
### **User description**
### Description

- Hide the run button when there are no runnable items available.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1583 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1580 
<!-- GitButler Footer Boundary Bottom -->


___

### **PR Type**
Bug fix


___

### **Description**
- Hide run button when no runnable items exist


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check totalRuns"] --> B{"totalRuns === 0?"}
  B -->|Yes| C["Return null (hide button)"]
  B -->|No| D["Show appropriate run button"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-button.tsx</strong><dd><code>Add conditional rendering for empty runnable items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx

<ul><li>Added early return condition to hide button when totalRuns is 0<br> <li> Prevents rendering run button when no runnable items exist</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1583/files#diff-8a9745738738ef2c3b8f9ac4e66ea3a2abdefa3e5b53e53845092b4165130db6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The run button is now hidden when there are no runnable items available, ensuring the UI does not display unnecessary controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->