### PR TITLE
refactor-simplify-useNodeGenerations-hook

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/action-node-properties-panel/generation-panel.tsx
@@ -1,30 +1,16 @@
 import type { ActionNode } from "@giselle-sdk/data-type";
-import type { Generation } from "@giselle-sdk/giselle";
 import {
 	useNodeGenerations,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle/react";
 import clsx from "clsx/lite";
-import { useEffect, useState } from "react";
 
 export function GenerationPanel({ node }: { node: ActionNode }) {
 	const { data } = useWorkflowDesigner();
-	const { generations } = useNodeGenerations({
+	const { currentGeneration } = useNodeGenerations({
 		nodeId: node.id,
 		origin: { type: "studio", workspaceId: data.id },
 	});
-	const [currentGeneration, setCurrentGeneration] = useState<
-		Generation | undefined
-	>();
-
-	useEffect(() => {
-		if (generations.length === 0) {
-			setCurrentGeneration(undefined);
-		} else {
-			const latestGeneration = generations[generations.length - 1];
-			setCurrentGeneration(latestGeneration);
-		}
-	}, [generations]);
 
 	if (currentGeneration === undefined) {
 		return null;

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
@@ -1,11 +1,10 @@
 import type { ImageGenerationNode } from "@giselle-sdk/data-type";
-import type { Generation } from "@giselle-sdk/giselle";
 import {
 	useNodeGenerations,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle/react";
 import clsx from "clsx/lite";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { StackBlicksIcon } from "../../../icons";
 import { EmptyState } from "../../../ui/empty-state";
 import { GenerationView } from "../../../ui/generation-view";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
@@ -65,22 +65,10 @@ export function GenerationPanel({
 	onClickGenerateButton?: () => void;
 }) {
 	const { data } = useWorkflowDesigner();
-	const { generations } = useNodeGenerations({
+	const { currentGeneration } = useNodeGenerations({
 		nodeId: node.id,
 		origin: { type: "studio", workspaceId: data.id },
 	});
-	const [currentGeneration, setCurrentGeneration] = useState<
-		Generation | undefined
-	>();
-
-	useEffect(() => {
-		if (generations.length === 0) {
-			setCurrentGeneration(undefined);
-		} else {
-			const latestGeneration = generations[generations.length - 1];
-			setCurrentGeneration(latestGeneration);
-		}
-	}, [generations]);
 
 	const handleGenerate = useCallback(() => {
 		if (onClickGenerateButton) {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/generation-panel.tsx
@@ -61,22 +61,10 @@ export function GenerationPanel({
 	onClickGenerateButton?: () => void;
 }) {
 	const { data } = useWorkflowDesigner();
-	const { generations } = useNodeGenerations({
+	const { currentGeneration } = useNodeGenerations({
 		nodeId: node.id,
 		origin: { type: "studio", workspaceId: data.id },
 	});
-	const [currentGeneration, setCurrentGeneration] = useState<
-		Generation | undefined
-	>();
-
-	useEffect(() => {
-		if (generations.length === 0) {
-			setCurrentGeneration(undefined);
-		} else {
-			const latestGeneration = generations[generations.length - 1];
-			setCurrentGeneration(latestGeneration);
-		}
-	}, [generations]);
 
 	const handleGenerate = useCallback(() => {
 		if (onClickGenerateButton) {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/generation-panel.tsx
@@ -1,11 +1,10 @@
 import type { QueryNode } from "@giselle-sdk/data-type";
-import type { Generation } from "@giselle-sdk/giselle";
 import {
 	useNodeGenerations,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle/react";
 import clsx from "clsx/lite";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { StackBlicksIcon } from "../../../icons";
 import { EmptyState } from "../../../ui/empty-state";
 import { QueryResultView } from "../../../ui/query-result-view";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
@@ -6,7 +6,7 @@ import {
 } from "@giselle-sdk/giselle/react";
 import clsx from "clsx/lite";
 import { ArrowDownIcon, ArrowUpIcon, TimerIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { StackBlicksIcon } from "../../../icons";
 import ClipboardButton from "../../../ui/clipboard-button";
 import { EmptyState } from "../../../ui/empty-state";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
@@ -106,22 +106,10 @@ export function GenerationPanel({
 	onClickGenerateButton?: () => void;
 }) {
 	const { data } = useWorkflowDesigner();
-	const { generations } = useNodeGenerations({
+	const { currentGeneration } = useNodeGenerations({
 		nodeId: node.id,
 		origin: { type: "studio", workspaceId: data.id },
 	});
-	const [currentGeneration, setCurrentGeneration] = useState<
-		Generation | undefined
-	>();
-
-	useEffect(() => {
-		if (generations.length === 0) {
-			setCurrentGeneration(undefined);
-		} else {
-			const latestGeneration = generations[generations.length - 1];
-			setCurrentGeneration(latestGeneration);
-		}
-	}, [generations]);
 
 	const handleGenerate = useCallback(() => {
 		if (onClickGenerateButton) {


### PR DESCRIPTION
### Description

- Simplified `useNodeGenerations` hook by removing state and effects.
- Unified generation filtering and sorting logic within the hook.
- Removed unused `useEffect` and `useState` imports from generation panels.