### PR TITLE
feat(nav): set default open sequences in accordion based on act data

### DIFF
--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/ui/nav.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/ui/nav.tsx
@@ -28,7 +28,7 @@ function SequenceBlock({ children }: React.PropsWithChildren) {
 export function Nav({ act }: NavProps) {
 	const pathname = usePathname();
 	return (
-		<Accordion.Root type="multiple" className="flex flex-col gap-[8px]">
+		<Accordion.Root type="multiple" className="flex flex-col gap-[8px]" defaultValue={act.sequences.map((sequence) =>sequence.id)}>
 			{act.sequences.map((sequence, index) => (
 				<Accordion.Item key={sequence.id} value={sequence.id}>
 					<Accordion.Header asChild>

--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/ui/nav.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/ui/nav.tsx
@@ -28,7 +28,11 @@ function SequenceBlock({ children }: React.PropsWithChildren) {
 export function Nav({ act }: NavProps) {
 	const pathname = usePathname();
 	return (
-		<Accordion.Root type="multiple" className="flex flex-col gap-[8px]" defaultValue={act.sequences.map((sequence) =>sequence.id)}>
+		<Accordion.Root
+			type="multiple"
+			className="flex flex-col gap-[8px]"
+			defaultValue={act.sequences.map((sequence) => sequence.id)}
+		>
 			{act.sequences.map((sequence, index) => (
 				<Accordion.Item key={sequence.id} value={sequence.id}>
 					<Accordion.Header asChild>


### PR DESCRIPTION
### **User description**
### Description

- Set default open sequences in the accordion component based on act data.


___

### **PR Type**
Enhancement


___

### **Description**
- Set default open state for accordion sequences

- Map all sequence IDs to defaultValue prop


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Act Data"] --> B["Sequence IDs"] --> C["Accordion DefaultValue"] --> D["All Sequences Open"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nav.tsx</strong><dd><code>Configure accordion default open sequences</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/stage/acts/[actId]/ui/nav.tsx

<ul><li>Added <code>defaultValue</code> prop to Accordion.Root component<br> <li> Maps all sequence IDs from act data to set default open state</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1602/files#diff-ec04d12492ed4597c43ed281ee43fd40d99924e933d3637bf790a7c3650f8441">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * All accordion items in the navigation are now expanded by default, allowing users to view all sequences immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->