### PR TITLE
feat: Add PR context to RAG query results for comment/diff chunks

### DIFF
--- a/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/pr-context-utils.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/pr-context-utils.ts
@@ -1,0 +1,83 @@
+import type { GitHubQueryContext } from "@giselle-sdk/giselle";
+import type { QueryResult } from "@giselle-sdk/rag";
+import { and, eq, inArray } from "drizzle-orm";
+import { db, githubRepositoryPullRequestEmbeddings } from "@/drizzle";
+import { resolveGitHubRepositoryIndex } from "../resolve-github-repository-index";
+import type { GitHubPullRequestMetadata } from "./schema";
+
+/**
+ * Fetches PR context (title and body) for the given PR numbers
+ */
+async function fetchPRContexts(
+	repositoryIndexDbId: number,
+	prNumbers: number[],
+): Promise<Map<number, { content: string }>> {
+	const prContexts = await db
+		.select({
+			prNumber: githubRepositoryPullRequestEmbeddings.prNumber,
+			content: githubRepositoryPullRequestEmbeddings.chunkContent,
+		})
+		.from(githubRepositoryPullRequestEmbeddings)
+		.where(
+			and(
+				eq(
+					githubRepositoryPullRequestEmbeddings.repositoryIndexDbId,
+					repositoryIndexDbId,
+				),
+				eq(githubRepositoryPullRequestEmbeddings.contentType, "title_body"),
+				inArray(githubRepositoryPullRequestEmbeddings.prNumber, prNumbers),
+			),
+		);
+
+	const prContextMap = new Map<number, { content: string }>();
+	for (const context of prContexts) {
+		prContextMap.set(context.prNumber, {
+			content: context.content,
+		});
+	}
+
+	return prContextMap;
+}
+
+/**
+ * Adds PR context to query results for comment/diff chunks
+ */
+export async function addPRContextToResults(
+	results: QueryResult<GitHubPullRequestMetadata>[],
+	context: GitHubQueryContext,
+): Promise<QueryResult<GitHubPullRequestMetadata>[]> {
+	// Find PR numbers that need context (comment/diff chunks)
+	const prNumbersNeedingContext: number[] = [
+		...new Set(
+			results
+				.filter((r) => r.metadata.contentType !== "title_body")
+				.map((r) => r.metadata.prNumber),
+		),
+	];
+
+	// If no PR contexts needed, return results as-is
+	if (prNumbersNeedingContext.length === 0) {
+		return results;
+	}
+
+	// Fetch PR contexts
+	const repositoryIndexDbId = await resolveGitHubRepositoryIndex(context);
+	const prContextMap = await fetchPRContexts(
+		repositoryIndexDbId,
+		prNumbersNeedingContext,
+	);
+
+	// Add PR context to results that need it
+	return results.map((result) => {
+		if (result.metadata.contentType !== "title_body") {
+			const context = prContextMap.get(result.metadata.prNumber);
+			if (context) {
+				return {
+					...result,
+					additional: { prContext: context.content },
+				};
+			}
+		}
+		return result;
+	});
+}

--- a/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/schema.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod/v4";
+
+/**
+ * Metadata schema for GitHub Pull Request embeddings
+ */
+export const gitHubPullRequestMetadataSchema = z.object({
+	prNumber: z.number(),
+	mergedAt: z.date(),
+	contentType: z.string(),
+	contentId: z.string(),
+});
+
+export type GitHubPullRequestMetadata = z.infer<
+	typeof gitHubPullRequestMetadataSchema
+>;

--- a/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/service.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/service.ts
@@ -1,21 +1,18 @@
 import { createPostgresQueryService } from "@giselle-sdk/rag";
 import { getTableName } from "drizzle-orm";
-import z from "zod/v4";
 import { githubRepositoryPullRequestEmbeddings } from "@/drizzle";
 import { createDatabaseConfig } from "../../database";
+import { addPRContextToResults } from "./pr-context-utils";
 import { resolveGitHubPullRequestEmbeddingFilter } from "./resolver";
+import { gitHubPullRequestMetadataSchema } from "./schema";
 
 /**
- * Pre-configured GitHub Pull Request query service instance
+ * GitHub Pull Request query service with additional context
  */
 export const gitHubPullRequestQueryService = createPostgresQueryService({
 	database: createDatabaseConfig(),
 	tableName: getTableName(githubRepositoryPullRequestEmbeddings),
-	metadataSchema: z.object({
-		prNumber: z.number(),
-		mergedAt: z.date(),
-		contentType: z.string(),
-		contentId: z.string(),
-	}),
+	metadataSchema: gitHubPullRequestMetadataSchema,
 	contextToFilter: resolveGitHubPullRequestEmbeddingFilter,
+	additionalResolver: addPRContextToResults,
 });

--- a/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
@@ -1,8 +1,48 @@
 import type { Generation } from "@giselle-sdk/giselle";
 import clsx from "clsx/lite";
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
-import { useState } from "react";
+import {
+	ChevronDownIcon,
+	ChevronRightIcon,
+	GitPullRequestIcon,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { z } from "zod/v4";
 import { GitHubIcon, WilliIcon } from "../icons";
+
+const VectorStoreQueryResultRecord = z.object({
+	chunkContent: z.string(),
+	chunkIndex: z.number(),
+	score: z.number(),
+	metadata: z.record(z.string(), z.string()),
+	additional: z.record(z.string(), z.unknown()).optional(),
+});
+
+const GitHubVectorStoreSource = z.object({
+	provider: z.literal("github"),
+	state: z.discriminatedUnion("status", [
+		z.object({
+			status: z.literal("configured"),
+			owner: z.string(),
+			repo: z.string(),
+			contentType: z.enum(["blob", "pull_request"]),
+		}),
+		z.object({
+			status: z.literal("unconfigured"),
+		}),
+	]),
+});
+
+const VectorStoreQueryResult = z.object({
+	type: z.literal("vector-store"),
+	source: GitHubVectorStoreSource,
+	records: z.array(VectorStoreQueryResultRecord),
+});
+
+type QueryResultData = z.infer<typeof VectorStoreQueryResult>;
+
+const gitHubPRContextSchema = z.object({
+	prContext: z.string().optional(),
+});
 
 function Spinner() {
 	return (
@@ -88,25 +128,102 @@ function ContentPreview({
 	);
 }
 
-type QueryResultRecord = {
-	chunkContent: string;
-	chunkIndex: number;
-	score: number;
+function PRContextDisplay({
+	metadata,
+	additional,
+}: {
 	metadata: Record<string, string>;
-};
+	additional?: Record<string, unknown>;
+}) {
+	const [isExpanded, setIsExpanded] = useState(false);
 
-type QueryResultData = {
-	type: string;
-	source?: {
-		provider: string;
-		state: {
-			status: string;
-			owner?: string;
-			repo?: string;
+	const additionalPRContext = additional
+		? gitHubPRContextSchema.safeParse(additional).data
+		: null;
+
+	const prNumber = metadata.prNumber;
+	const contentType = metadata.contentType;
+	// Check both metadata and additional for prContext
+	const prContextContent = additionalPRContext?.prContext;
+
+	const parsedContext = useMemo(() => {
+		if (!prContextContent) {
+			return { title: "", body: null };
+		}
+		const [title, ...bodyParts] = prContextContent.split("\n\n");
+		return {
+			title: title || "",
+			body: bodyParts.length > 0 ? bodyParts.join("\n\n") : null,
 		};
-	};
-	records?: QueryResultRecord[];
-};
+	}, [prContextContent]);
+
+	if (!prNumber || !prContextContent) {
+		return null;
+	}
+
+	const contentTypeLabel =
+		contentType === "comment"
+			? "Comment"
+			: contentType === "diff"
+				? "Diff"
+				: contentType === "title_body"
+					? "Title & Body"
+					: "Unknown";
+
+	return (
+		<div className="mt-[8px] p-[8px] bg-blue-500/10 rounded-[6px] border border-blue-500/20">
+			<div className="flex items-start gap-[8px]">
+				<GitPullRequestIcon className="w-[14px] h-[14px] text-blue-400 flex-shrink-0 mt-[2px]" />
+				<div className="flex-1 space-y-[4px]">
+					<div className="flex items-center gap-[6px] flex-wrap">
+						<span className="text-[11px] font-medium text-blue-400">
+							PR #{prNumber}
+						</span>
+						<span className="text-[11px] text-white-500">•</span>
+						<span className="text-[11px] text-white-600">
+							{contentTypeLabel}
+						</span>
+					</div>
+
+					{parsedContext.title && (
+						<p className="text-[12px] font-medium text-white-800 leading-snug">
+							{parsedContext.title}
+						</p>
+					)}
+
+					{parsedContext.body && (
+						<div>
+							<button
+								type="button"
+								onClick={() => setIsExpanded(!isExpanded)}
+								className="flex items-center gap-[4px] text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
+							>
+								{isExpanded ? (
+									<>
+										<ChevronDownIcon className="w-[12px] h-[12px]" />
+										Hide PR description
+									</>
+								) : (
+									<>
+										<ChevronRightIcon className="w-[12px] h-[12px]" />
+										Show PR description
+									</>
+								)}
+							</button>
+							{isExpanded && (
+								<div className="mt-[6px] p-[8px] bg-black-900/30 rounded-[4px]">
+									<pre className="text-[11px] text-white-700 whitespace-pre-wrap font-mono leading-relaxed">
+										{parsedContext.body}
+									</pre>
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
 
 type DataSourceDisplayInfo = {
 	line1: string;
@@ -117,34 +234,19 @@ function getDataSourceDisplayInfo(
 	result: QueryResultData,
 ): DataSourceDisplayInfo {
 	if (
-		result.source?.provider === "github" &&
-		result.source.state.status === "configured" &&
-		result.source.state.owner &&
-		result.source.state.repo
+		result.source.provider === "github" &&
+		result.source.state.status === "configured"
 	) {
 		return {
 			line1: `${result.source.state.owner}/${result.source.state.repo}`,
-			line2: "Code",
-		};
-	}
-	if (
-		result.source?.provider === "githubPullRequest" &&
-		result.source.state.status === "configured" &&
-		result.source.state.owner &&
-		result.source.state.repo
-	) {
-		return {
-			line1: `${result.source.state.owner}/${result.source.state.repo}`,
-			line2: "Pull Requests",
-		};
-	}
-	if (result.source?.provider) {
-		return {
-			line1: `${result.source.provider} vector store`,
+			line2:
+				result.source.state.contentType === "pull_request"
+					? "Pull Requests"
+					: "Code",
 		};
 	}
 	return {
-		line1: "Unknown source",
+		line1: "GitHub vector store",
 	};
 }
 
@@ -159,9 +261,7 @@ function DataSourceTab({
 }) {
 	const displayInfo = getDataSourceDisplayInfo(result);
 	const recordCount = result.records?.length || 0;
-	const isGitHub =
-		result.source?.provider === "github" ||
-		result.source?.provider === "githubPullRequest";
+	const isGitHub = result.source?.provider === "github";
 
 	return (
 		<button
@@ -253,6 +353,11 @@ function QueryResultCard({ result }: { result: QueryResultData }) {
 						onToggle={() => toggleRecord(recordIndex)}
 					/>
 
+					<PRContextDisplay
+						metadata={record.metadata}
+						additional={record.additional}
+					/>
+
 					{Object.keys(record.metadata).length > 0 && (
 						<details className="text-[11px] text-white-500">
 							<summary className="cursor-pointer hover:text-white-400">
@@ -328,7 +433,7 @@ export function QueryResultView({ generation }: { generation: Generation }) {
 				<div className="flex gap-[0px] flex-nowrap">
 					{queryResults.map((result, index) => (
 						<DataSourceTab
-							key={`datasource-${index}-${result.source?.provider || "unknown"}-${result.source?.state?.owner || ""}-${result.source?.state?.repo || ""}`}
+							key={`datasource-${index}-github-${result.source.state.status === "configured" ? `${result.source.state.owner}-${result.source.state.repo}` : "unconfigured"}`}
 							result={result}
 							isActive={activeTabIndex === index}
 							onClick={() => setActiveTabIndex(index)}
@@ -351,11 +456,15 @@ function getGenerationQueryResult(generation: Generation): QueryResultData[] {
 		(output) => output.type === "query-result",
 	);
 
-	// Flatten all query results from all outputs
 	const allResults: QueryResultData[] = [];
 	for (const output of queryResultOutputs) {
 		if (output.type === "query-result") {
-			allResults.push(...output.content);
+			for (const item of output.content) {
+				const parsed = VectorStoreQueryResult.safeParse(item);
+				if (parsed.success) {
+					allResults.push(parsed.data);
+				}
+			}
 		}
 	}
 

--- a/packages/giselle/src/concepts/generation/output.ts
+++ b/packages/giselle/src/concepts/generation/output.ts
@@ -61,6 +61,7 @@ const VectorStoreQueryResultRecord = z.object({
 	chunkIndex: z.number(),
 	score: z.number(),
 	metadata: z.record(z.string(), z.string()),
+	additional: z.record(z.string(), z.unknown()).optional(),
 });
 const VectorStoreQueryResult = z.object({
 	type: z.literal("vector-store"),

--- a/packages/giselle/src/engine/generations/utils.ts
+++ b/packages/giselle/src/engine/generations/utils.ts
@@ -779,6 +779,23 @@ export function queryResultToText(
 					recordSections.push(`*Source: ${metadataEntries}*`);
 				}
 
+				// Include additional data if present
+				if (record.additional && Object.keys(record.additional).length > 0) {
+					for (const [key, value] of Object.entries(record.additional)) {
+						if (typeof value === "string") {
+							if (value.includes("\n") || value.includes("#")) {
+								recordSections.push(`#### Additional: ${key}\n${value}`);
+							} else {
+								recordSections.push(`*${key}:* ${value}`);
+							}
+						} else {
+							recordSections.push(
+								`*${key}:* ${typeof value === "object" ? JSON.stringify(value) : value}`,
+							);
+						}
+					}
+				}
+
 				sections.push(recordSections.join("\n\n"));
 			}
 		}

--- a/packages/giselle/src/engine/operations/execute-query.ts
+++ b/packages/giselle/src/engine/operations/execute-query.ts
@@ -373,7 +373,6 @@ async function queryVectorStore(
 										String(v),
 									]),
 								),
-								additional: undefined,
 							})),
 						};
 					}

--- a/packages/giselle/src/engine/operations/execute-query.ts
+++ b/packages/giselle/src/engine/operations/execute-query.ts
@@ -343,6 +343,7 @@ async function queryVectorStore(
 											String(v),
 										]),
 									),
+									additional: result.additional,
 								})),
 							};
 						}
@@ -372,6 +373,7 @@ async function queryVectorStore(
 										String(v),
 									]),
 								),
+								additional: undefined,
 							})),
 						};
 					}

--- a/packages/rag/src/query-service/types.ts
+++ b/packages/rag/src/query-service/types.ts
@@ -7,6 +7,7 @@ export interface QueryResult<
 	chunk: Chunk;
 	similarity: number;
 	metadata: TMetadata;
+	additional?: Record<string, unknown>;
 }
 
 export interface QueryService<


### PR DESCRIPTION
### **User description**
## Summary

This PR enhances the RAG (Retrieval-Augmented Generation) system to include Pull Request context (title and body) when returning comment or diff chunks from PR searches. This provides better context for downstream consumers like TextGenerationNode.

## Problem

When searching GitHub PRs, comment and diff chunks were returned without the PR title/body context, making it difficult to understand which PR they belong to.

## Solution

- Added an optional `additional` field to QueryResult interface for arbitrary enrichment data
- Implemented an `additionalResolver` pattern in postgres QueryService for post-processing results  
- Created PR context enricher that fetches PR title/body for comment/diff chunks
- Ensured additional data flows through to TextGenerationNode

## Changes

### RAG Package Enhancement
- Added optional `additional?: Record<string, unknown>` field to QueryResult
- Added `additionalResolver` parameter to createPostgresQueryService for result enrichment
- Maintains backward compatibility with existing query services

### PR Context Enrichment  
- Efficiently batch-fetches PR contexts for comment/diff chunks
- Stores PR content in the additional field
- Only enriches when needed (skips title_body chunks)

### Engine Enhancement
- Updated execute-query.ts to map the additional field from QueryService results
- Enhanced queryResultToText to generically format additional field data
- Avoids hardcoding app-specific field names in the engine

### UI Enhancement
- Updated QueryResultView to handle and display additional field data
- Shows PR context for comment/diff chunks with expandable details
- Uses contentType for differentiation instead of provider

## Technical Details

- Type-safe implementation throughout
- Follows project's "Less is more" philosophy
- Clean separation between generic RAG functionality and app-specific logic
- Generic handling of additional fields in the engine

## Testing

- All existing tests pass
- Type checking passes
- No unused exports or files

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add PR context enrichment to RAG query results

- Implement generic additional field handling in QueryResult interface

- Create PR context utilities for batch fetching PR titles/bodies

- Update UI to display PR context for comment/diff chunks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["QueryResult Interface"] -- "add optional additional field" --> B["Enhanced QueryResult"]
  C["PostgresQueryService"] -- "add additionalResolver" --> D["Context Enrichment"]
  D -- "fetch PR titles/bodies" --> E["PR Context Utils"]
  B -- "flow through engine" --> F["UI Display"]
  E -- "enrich comment/diff chunks" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>pr-context-utils.ts</strong><dd><code>Create PR context enrichment utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-40e55a289fba93316b3a2e6ca02adb52d957f05aec1c28e826e1e4a22deef401">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.ts</strong><dd><code>Add GitHub PR metadata schema definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-e2d56f9145948106f0fd46f8004b79b2a6072a46d3189d0b120ae564d5eb2cfb">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service.ts</strong><dd><code>Integrate PR context enrichment into query service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-c86046e757f296ac137c7b29447c116d6211e98c54b4d8a42af7e564a25d5485">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>output.ts</strong><dd><code>Add optional additional field to query result schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-2957bccfa00e0e485e16a1553fb460bee82b02bb7ad2009edca8670818c7461e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.ts</strong><dd><code>Add generic additional field formatting in queryResultToText</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-ed92cccb2a5eb342158781935ad097db185fc40227b941cf9a1e9e48816aa6e0">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>execute-query.ts</strong><dd><code>Map additional field from QueryService to output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-3bf5dcda800337e54a682f2ee73b5489afc86e4d14597c65c390587d77982d9f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Add additionalResolver parameter to postgres query service</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-9ae84bd50fb275c4c066b2b1c26651804763a6d893a85bcdb2718a6c6f9010d7">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add optional additional field to QueryResult interface</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-f5854dc5cf6b3d867a54826a9752c286e4aa6d601927bcae9daa04c65c17ca97">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>query-result-view.tsx</strong><dd><code>Display PR context from additional field in UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1617/files#diff-56aa5eec75df28631c61366f27fef8da65e7f0101929fdb5cb1c6c9fcead897c">+130/-51</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub pull request query results now display enriched context, including PR titles and descriptions, directly within the UI.
  * Added expandable/collapsible PR context sections to query result cards for improved readability.

* **Improvements**
  * Unified and clarified GitHub data source labeling and display in the query results interface.
  * Enhanced type safety and validation for GitHub pull request metadata throughout the application.

* **Bug Fixes**
  * Improved handling of additional metadata in query results to support flexible, extensible data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->