### PR TITLE
fix: restore GitHub tool results display after AI SDK v5 migration

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -46,6 +46,13 @@ export function GenerationView({ generation }: { generation: Generation }) {
 		<>
 			{generation.status === "completed" &&
 				generation.outputs.map((output) => {
+					if (output.type === "generated-text") {
+						return (
+							<div key={output.outputId} className="markdown-renderer">
+								<MemoizedMarkdown content={output.content} />
+							</div>
+						);
+					}
 					if (output.type !== "generated-image") {
 						return null;
 					}
@@ -130,6 +137,7 @@ export function GenerationView({ generation }: { generation: Generation }) {
 										<MemoizedMarkdown content={part.text} />
 									</div>
 								);
+
 							default: {
 								console.warn("unsupport part type");
 								return null;

--- a/packages/giselle/src/engine/generations/generate-text.ts
+++ b/packages/giselle/src/engine/generations/generate-text.ts
@@ -281,14 +281,12 @@ export function generateText(args: {
 							}
 						}
 
-						// Only push output if there's content (either text or tool results)
-						if (contentWithToolResults) {
-							generationOutputs.push({
-								type: "generated-text",
-								content: contentWithToolResults,
-								outputId: generatedTextOutput.id,
-							});
-						}
+						// Always push generated-text output to maintain UI consistency
+						generationOutputs.push({
+							type: "generated-text",
+							content: contentWithToolResults,
+							outputId: generatedTextOutput.id,
+						});
 					}
 
 					const reasoningOutput = generationContext.operationNode.outputs.find(


### PR DESCRIPTION
### **User description**
close https://github.com/giselles-ai/giselle/issues/1628

## Summary
Restore GitHub tool results display after AI SDK v5 migration

<img width="600" alt="image" src="https://github.com/user-attachments/assets/1dda0a7b-ac0f-4135-b374-ff6387ab1be2" />

## Changes
- Aggregate tool results from AI SDK v5's new step.content structure
- Extract tool-call and tool-result pairs from DefaultStepResult
- Format tool results as Markdown and append to generated text output
- Display generated-text outputs in frontend GenerationView component
- Add TypeScript type assertions for tool result property access

The AI SDK v5 migration changed how tool invocations are represented. Tool results now appear in step.content array with tool-call and tool-result types. This fix ensures tool execution results are visible in the Text Generator Node's Results section as they were before the migration.

Fixes issue where GitHub tool results were not displayed after PR #1597

## Testing
1. Use `getFileContents` github tool in generator node.

## Other Information
I was able to fix it with a PR, but I don't think the code base is good.
It might be better to create a new PR using this as a reference.


___

### **PR Type**
Bug fix


___

### **Description**
- Restore GitHub tool results display after AI SDK v5 migration

- Extract tool-call and tool-result pairs from new step.content structure

- Format tool results as Markdown with input/output sections

- Display generated-text outputs in frontend GenerationView component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AI SDK v5 step.content"] --> B["Extract tool-call/tool-result pairs"]
  B --> C["Format as Markdown"]
  C --> D["Append to generated text"]
  D --> E["Display in GenerationView"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-text.ts</strong><dd><code>Extract and format tool results from AI SDK v5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/generate-text.ts

<ul><li>Extract tool results from AI SDK v5's new <code>step.content</code> structure<br> <li> Format tool results as Markdown with input/output sections<br> <li> Append tool results to generated text content<br> <li> Add fallback support for old tool structure</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1631/files#diff-5400b929dc7742af3e854d768fec81e158d4e91f51eada68eb9316aea079ef21">+75/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generation-view.tsx</strong><dd><code>Add generated-text output rendering support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/generation-view.tsx

<ul><li>Add rendering support for <code>generated-text</code> output type<br> <li> Display generated text content using MemoizedMarkdown component<br> <li> Ensure tool results are visible in the UI</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1631/files#diff-7e1e868389c8152e3a617fb188f0955cc9d4c3bd4cb5c9f367b57db2de1f0a40">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying "generated-text" outputs with detailed tool invocation results in the generation view.
* **Style**
  * Improved formatting in message display for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->