### PR TITLE
fix(giselle): add stop condition to limit generation steps in text generation

### DIFF
--- a/packages/giselle/src/engine/generations/generate-text.ts
+++ b/packages/giselle/src/engine/generations/generate-text.ts
@@ -13,7 +13,7 @@ import {
 	hasCapability,
 	languageModels,
 } from "@giselle-sdk/language-model";
-import { AISDKError, streamText } from "ai";
+import { AISDKError, stepCountIs, streamText } from "ai";
 import type {
 	FailedGeneration,
 	GenerationOutput,
@@ -208,6 +208,7 @@ export function generateText(args: {
 						),
 					);
 				},
+				stopWhen: stepCountIs(Object.keys(preparedToolSet.toolSet).length + 1),
 				async onFinish(event) {
 					const generatedTextOutput =
 						generationContext.operationNode.outputs.find(


### PR DESCRIPTION
### **User description**
### Description

- Added a stop condition to limit the number of generation steps in text generation within Giselle.


___

### **PR Type**
Bug fix


___

### **Description**
- Added stop condition to prevent infinite generation loops

- Limits generation steps based on available tools count


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Text Generation"] --> B["Tool Set Preparation"]
  B --> C["Step Count Calculation"]
  C --> D["Stop Condition Applied"]
  D --> E["Generation Completion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-text.ts</strong><dd><code>Add generation step limit with stop condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/generate-text.ts

<ul><li>Imported <code>stepCountIs</code> function from ai SDK<br> <li> Added <code>stopWhen</code> parameter with step count limit<br> <li> Limit based on number of tools plus one</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1632/files#diff-5400b929dc7742af3e854d768fec81e158d4e91f51eada68eb9316aea079ef21">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text generation behavior by adjusting stopping conditions based on the number of available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->