### PR TITLE
feat: add script to purge stale Stripe subscriptions

### DIFF
--- a/apps/studio.giselles.ai/scripts/20250807-purge-stale-stripe-subscriptions.ts
+++ b/apps/studio.giselles.ai/scripts/20250807-purge-stale-stripe-subscriptions.ts
@@ -19,6 +19,13 @@ if (!process.env.STRIPE_SECRET_KEY) {
 	throw new Error("STRIPE_SECRET_KEY is not set in environment variables");
 }
 
+// Safety check: Prevent running in production
+if (process.env.STRIPE_SECRET_KEY.includes("sk_live_")) {
+	console.error("❌ ERROR: This script is for development/sandbox use only!");
+	console.error("Production environment detected. Aborting to prevent data loss.");
+	process.exit(1);
+}
+
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
 	apiVersion: "2025-07-30.basil",
 });

--- a/apps/studio.giselles.ai/scripts/20250807-purge-stale-stripe-subscriptions.ts
+++ b/apps/studio.giselles.ai/scripts/20250807-purge-stale-stripe-subscriptions.ts
@@ -1,0 +1,117 @@
+/**
+ * Script to purge stale Stripe subscriptions from the database
+ *
+ * This maintenance script identifies and removes subscription records from the database
+ * that no longer exist in Stripe (e.g., subscriptions that were deleted in Stripe Sandbox
+ * but still remain in the database).
+ *
+ * Usage:
+ *   cd apps/studio.giselles.ai
+ *   pnpm dlx tsx --env-file=.env.local scripts/20250807-purge-stale-stripe-subscriptions.ts
+ */
+
+import readline from "node:readline";
+import { inArray } from "drizzle-orm";
+import Stripe from "stripe";
+import { db, subscriptions } from "@/drizzle";
+
+if (!process.env.STRIPE_SECRET_KEY) {
+	throw new Error("STRIPE_SECRET_KEY is not set in environment variables");
+}
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+	apiVersion: "2025-07-30.basil",
+});
+
+// Add delay to avoid hitting Stripe API rate limits
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function checkSubscriptionExists(
+	subscriptionId: string,
+): Promise<boolean> {
+	try {
+		// Wait 100 ms before making the request
+		await delay(100);
+
+		// Try to fetch subscription data from Stripe
+		await stripe.subscriptions.retrieve(subscriptionId);
+		return true;
+	} catch (error: unknown) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			typeof (error as { code: unknown }).code === "string"
+		) {
+			const stripeError = error as { code: string };
+			if (stripeError.code === "resource_missing") {
+				return false;
+			}
+		}
+		// For other errors, assume subscription exists to be safe
+		console.error(`Error checking subscription ${subscriptionId}:`, error);
+		return true;
+	}
+}
+
+async function main() {
+	// Get all subscription IDs from database
+	const dbSubscriptions = await db.query.subscriptions.findMany();
+
+	console.log(`Found ${dbSubscriptions.length} subscriptions in database`);
+
+	const staleIds: string[] = [];
+
+	// Check each subscription against Stripe
+	for (const sub of dbSubscriptions) {
+		const exists = await checkSubscriptionExists(sub.id);
+		if (!exists) {
+			staleIds.push(sub.id);
+			console.log(
+				`Subscription ${sub.id} no longer exists in Stripe - marking for deletion`,
+			);
+		} else {
+			console.log(`Subscription ${sub.id} still exists in Stripe`);
+		}
+	}
+
+	if (staleIds.length === 0) {
+		console.log("No stale subscriptions found");
+		return;
+	}
+
+	console.log(`Found ${staleIds.length} stale subscriptions to delete:`);
+	console.log(staleIds);
+
+	// Confirm before deletion
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+
+	const answer = await new Promise<string>((resolve) => {
+		rl.question("Do you want to proceed with deletion? (yes/no): ", resolve);
+	});
+	rl.close();
+
+	if (answer.toLowerCase() !== "yes") {
+		console.log("Deletion cancelled");
+		return;
+	}
+
+	// Delete stale subscriptions from database
+	console.log("Deleting stale subscriptions from database...");
+
+	await db.delete(subscriptions).where(inArray(subscriptions.id, staleIds));
+
+	console.log(`Successfully deleted ${staleIds.length} stale subscriptions`);
+}
+
+main()
+	.catch((error) => {
+		console.error("Purge failed:", error);
+		process.exit(1);
+	})
+	.finally(() => {
+		process.exit(0);
+	});


### PR DESCRIPTION
## Background
- #1624 introduced `subscriptions.customer_id` column to store Stripe customer IDs
- #1630 aims to add a non-null constraint to this column
- However, some subscriptions in the database no longer exist in Stripe (deleted in Stripe Sandbox), preventing customer_id population
- This is a Sandbox-specific issue that doesn't affect Production

## Summary
- Add maintenance script to identify and remove subscriptions that no longer exist in Stripe
- Include safety check to prevent accidental execution in production environment
- Script requires manual confirmation before deletion

## How it works
1. Fetches all subscriptions from the database
2. Checks each subscription against Stripe API using `retrieve()`
3. Marks subscriptions returning `resource_missing` error for deletion
4. Shows deletion list and prompts for confirmation
5. Deletes stale subscriptions from database

## Usage
```bash
cd apps/studio.giselles.ai
pnpm dlx tsx --env-file=.env.local scripts/20250807-purge-stale-stripe-subscriptions.ts
```

## Safety
- Script automatically aborts if production Stripe key (sk_live_*) is detected
- This is intended only for development/sandbox environments

## Test plan
- [ ] Run script in development environment with test data
- [ ] Verify script correctly identifies stale subscriptions
- [ ] Confirm safety check prevents execution with production Stripe keys
- [ ] Test confirmation prompt works correctly
- [ ] After purging, verify customer_id can be populated for remaining subscriptions

🤖 Generated with [Claude Code](https://claude.ai/code)