### PR TITLE
Allow gho_ GitHub tokens

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
@@ -25,12 +25,15 @@ import {
 
 const secretTags = ["github-access-token"];
 
-// GitHub Personal Access Token validation
+// GitHub token validation
 function isValidGitHubPAT(token: string): boolean {
-	// GitHub PAT formats (personal access tokens only):
+	// GitHub token formats:
 	// Classic PAT: ghp_ followed by 36 alphanumeric characters (total 40 chars)
 	// Fine-grained PAT: github_pat_ followed by 82 alphanumeric characters (total 93 chars)
-	return /^(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{82})$/.test(token);
+	// OAuth token: gho_ followed by 36 alphanumeric characters (total 40 chars)
+	return /^(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{82}|gho_[a-zA-Z0-9]{36})$/.test(
+		token,
+	);
 }
 
 export function GitHubToolConfigurationDialog({
@@ -108,7 +111,7 @@ function GitHubToolConnectionDialog({
 
 		if (value && !isValidGitHubPAT(value)) {
 			setTokenError(
-				"Invalid token format. GitHub Personal Access Tokens should start with ghp_ (classic) or github_pat_ (fine-grained)",
+				"Invalid token format. GitHub tokens should start with ghp_ (classic), github_pat_ (fine-grained), or gho_ (OAuth)",
 			);
 		} else {
 			setTokenError(null);


### PR DESCRIPTION
### **User description**
## Summary
- permit GitHub OAuth tokens beginning with `gho_`
- adjust validation messaging for supported token prefixes

## Testing
- `pnpm -F @giselle-internal/workflow-designer-ui test --run`


------
https://chatgpt.com/codex/tasks/task_e_68942e6caf4c832fabbd54d6d1cf8508


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for GitHub OAuth tokens with `gho_` prefix

- Update token validation regex and error messages

- Expand GitHub token format compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Token Validation"] --> B["Updated Regex Pattern"]
  B --> C["Support gho_ OAuth Tokens"]
  B --> D["Updated Error Messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.tsx</strong><dd><code>Expand GitHub token validation for OAuth support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx

<ul><li>Updated <code>isValidGitHubPAT</code> function to accept <code>gho_</code> OAuth tokens<br> <li> Modified regex pattern to include OAuth token format validation<br> <li> Updated error message to mention all supported token types<br> <li> Renamed function comments from PAT-specific to general GitHub tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1634/files#diff-122425196c8136251eb216cd110a334c4894b71bbf455312bb9920599703d1dc">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub token validation to support OAuth tokens with the "gho_" prefix.
  * Updated error messages to reflect the acceptance of OAuth token formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->