### PR TITLE
feat: add support for claude-opus-4-1-20250805 model

### DIFF
--- a/packages/language-model/src/anthropic.test.ts
+++ b/packages/language-model/src/anthropic.test.ts
@@ -4,6 +4,9 @@ import { AnthropicLanguageModelId } from "./anthropic";
 describe("anthropic llm", () => {
 	describe("AnthropicLanguageModelId", () => {
 		it("should parse valid enum values successfully", () => {
+			expect(AnthropicLanguageModelId.parse("claude-opus-4-1-20250805")).toBe(
+				"claude-opus-4-1-20250805",
+			);
 			expect(AnthropicLanguageModelId.parse("claude-4-opus-20250514")).toBe(
 				"claude-4-opus-20250514",
 			);
@@ -18,7 +21,13 @@ describe("anthropic llm", () => {
 			);
 		});
 
-		it("should fallback claude-opus-4-* to claude-4-opus-20250514", () => {
+		it("should fallback claude-opus-4-1-* to claude-opus-4-1-20250805", () => {
+			expect(AnthropicLanguageModelId.parse("claude-opus-4-1-foo")).toBe(
+				"claude-opus-4-1-20250805",
+			);
+		});
+
+		it("should fallback claude-4-opus-4-* to claude-4-opus-20250514", () => {
 			expect(AnthropicLanguageModelId.parse("claude-4-opus-4-foo")).toBe(
 				"claude-4-opus-20250514",
 			);

--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -20,6 +20,7 @@ const defaultConfigurations: AnthropicLanguageModelConfigurations = {
 
 export const AnthropicLanguageModelId = z
 	.enum([
+		"claude-opus-4-1-20250805",
 		"claude-4-opus-20250514",
 		"claude-4-sonnet-20250514",
 		"claude-3-7-sonnet-20250219",
@@ -30,6 +31,9 @@ export const AnthropicLanguageModelId = z
 			return "claude-3-5-haiku-20241022";
 		}
 		const v = ctx.value;
+		if (/^claude-opus-4-1-/.test(v)) {
+			return "claude-opus-4-1-20250805";
+		}
 		if (/^claude-4-opus-4-/.test(v)) {
 			return "claude-4-opus-20250514";
 		}
@@ -111,7 +115,20 @@ const claude35Haiku: AnthropicLanguageModel = {
 	configurations: defaultConfigurations,
 };
 
+const claude41Opus: AnthropicLanguageModel = {
+	provider: "anthropic",
+	id: "claude-opus-4-1-20250805",
+	capabilities:
+		Capability.TextGeneration |
+		Capability.PdfFileInput |
+		Capability.Reasoning |
+		Capability.ImageFileInput,
+	tier: Tier.enum.pro,
+	configurations: defaultConfigurations,
+};
+
 export const models = [
+	claude41Opus,
 	claude40Opus,
 	claude40Sonnet,
 	claude37Sonnet,

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -112,6 +112,21 @@ export const openAiTokenPricing: ModelPriceTable = {
 
 export const anthropicTokenPricing: ModelPriceTable = {
 	// https://www.anthropic.com/pricing
+	"claude-opus-4-1-20250805": {
+		prices: [
+			{
+				validFrom: "2025-08-06T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 15.0,
+					},
+					output: {
+						costPerMegaToken: 75.0,
+					},
+				},
+			},
+		],
+	},
 	"claude-4-opus-20250514": {
 		prices: [
 			{


### PR DESCRIPTION
### **User description**
## Summary
Add support for claude-opus-4-1-20250805 model.

## Changes
- Add claude-opus-4-1-20250805 to AnthropicLanguageModelId enum
- Add regex pattern fallback for claude-opus-4-1-* variants
- Create model configuration with same capabilities as Opus 4.0
- Add test cases for new model and its fallback behavior
- Model pricing was already configured in model-prices.ts

## Testing
1. Place a `claude-opus-4-1-20250805` node
2. Run it

## Other Information
- [Claude Opus 4\.1 \\ Anthropic](https://www.anthropic.com/news/claude-opus-4-1)
- [Pricing \\ Anthropic](https://www.anthropic.com/pricing#api)


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for new `claude-opus-4-1-20250805` model

- Implement regex fallback pattern for `claude-opus-4-1-*` variants

- Configure model with same capabilities as Opus 4.0

- Add comprehensive test coverage for new model


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New Model ID"] --> B["Enum Addition"]
  B --> C["Fallback Pattern"]
  C --> D["Model Configuration"]
  D --> E["Test Coverage"]
  E --> F["Pricing Setup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>anthropic.ts</strong><dd><code>Add new Claude Opus 4.1 model support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/anthropic.ts

<ul><li>Add <code>claude-opus-4-1-20250805</code> to enum<br> <li> Add regex fallback for <code>claude-opus-4-1-*</code> pattern<br> <li> Create model configuration with reasoning capabilities<br> <li> Export new model in models array</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1636/files#diff-818c98cd1d89138649fe8f8c94d74cc511c448d8b18b0cd602051978bf0bc59b">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>anthropic.test.ts</strong><dd><code>Add test coverage for new model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/anthropic.test.ts

<ul><li>Add test for valid <code>claude-opus-4-1-20250805</code> parsing<br> <li> Add test for <code>claude-opus-4-1-*</code> fallback behavior<br> <li> Update existing fallback test description</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1636/files#diff-31f3d68aac5b1b4f417c339174b564fa75bd6a55ab082b145fe45ed07da24886">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Configure pricing for Claude Opus 4.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Add pricing configuration for <code>claude-opus-4-1-20250805</code><br> <li> Set input cost at $15.0 per mega token<br> <li> Set output cost at $75.0 per mega token</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1636/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new Anthropic language model variant "claude-opus-4-1-20250805".
  * Updated model selection to recognize and map model IDs matching "claude-opus-4-1-*".
* **Bug Fixes**
  * Improved fallback handling for unrecognized model IDs to ensure correct model selection.
* **Chores**
  * Updated pricing information to include rates for "claude-opus-4-1-20250805".
* **Tests**
  * Expanded test coverage for the new model variant and refined fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->