### PR TITLE
feat(gis): accept both experimental and standard github webhook route

### DIFF
--- a/packages/giselle/src/next/next-giselle-engine.ts
+++ b/packages/giselle/src/next/next-giselle-engine.ts
@@ -134,7 +134,10 @@ export function createHttpHandler({
 			});
 		}
 		/** Experimental implementation for handling webhooks with GiselleEngine */
-		if (routerPath === "experimental_github-webhook") {
+		if (
+			routerPath === "experimental_github-webhook" ||
+			routerPath === "github-webhook"
+		) {
 			try {
 				await verifyRequestAsGitHubWebook({
 					secret: config.integrationConfigs?.github?.authV2.webhookSecret ?? "",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Accept both experimental and standard GitHub webhook routes

- Expand webhook handler to support dual route paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] --> B["Route Check"]
  B --> C["experimental_github-webhook OR github-webhook"]
  C --> D["GitHub Webhook Handler"]
  D --> E["Verify GitHub Webhook"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next-giselle-engine.ts</strong><dd><code>Expand webhook route handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/next/next-giselle-engine.ts

<ul><li>Modified route condition to accept both experimental and standard <br>webhook paths<br> <li> Added OR condition for <code>github-webhook</code> alongside existing <br><code>experimental_github-webhook</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1640/files#diff-5226483ce6c21ed6f8aac31a651a6740b887a477cf8b03043c926ea119ba797a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a standard GitHub webhook endpoint alongside the existing experimental one. Both routes are now accepted and handled identically, improving compatibility and easing migrations without requiring configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->