### PR TITLE
chore: remove unused GitHub code scanning alert tools

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
@@ -294,14 +294,7 @@ const githubToolCatalog = [
 	},
 	{
 		label: "Code Management",
-		tools: [
-			"createBranch",
-			"createOrUpdateFile",
-			"getCommit",
-			"listCommits",
-			"listCodeScanningAlerts",
-			"getCodeScanningAlert",
-		],
+		tools: ["createBranch", "createOrUpdateFile", "getCommit", "listCommits"],
 	},
 	{
 		label: "Search",

--- a/packages/github-tool/src/tools.ts
+++ b/packages/github-tool/src/tools.ts
@@ -330,29 +330,6 @@ export function githubTools(octokit: Octokit) {
 				return response.data;
 			},
 		}),
-		getCodeScanningAlert: tool({
-			description:
-				"Get details of a specific code scanning alert in a GitHub repository.",
-			inputSchema: z.object({
-				alertNumber: z.number().describe("The number of the alert."),
-				owner: z.string().describe("The owner of the repository."),
-				repo: z.string().describe("The name of the repository."),
-			}),
-			execute: async (params) => {
-				const { alertNumber, owner, repo } = params;
-
-				const response = await octokit.request(
-					"GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}",
-					{
-						owner,
-						repo,
-						alert_number: alertNumber,
-					},
-				);
-
-				return response.data;
-			},
-		}),
 		getCommit: tool({
 			description: "Get details for a commit from a GitHub repository",
 			inputSchema: z.object({
@@ -628,49 +605,6 @@ export function githubTools(octokit: Octokit) {
 						repo,
 						page,
 						per_page: perPage,
-					},
-				);
-
-				return response.data;
-			},
-		}),
-		listCodeScanningAlerts: tool({
-			description: "List code scanning alerts in a GitHub repository.",
-			inputSchema: z.object({
-				owner: z.string().describe("The owner of the repository."),
-				ref: z
-					.string()
-					.describe("The Git reference for the results you want to list.")
-					.optional(),
-				repo: z.string().describe("The name of the repository."),
-				severity: z
-					.enum([
-						"critical",
-						"high",
-						"medium",
-						"low",
-						"warning",
-						"note",
-						"error",
-					])
-					.optional(),
-				state: z.enum(["open", "dismissed", "fixed"]).optional(),
-				toolName: z
-					.string()
-					.describe("The name of the tool used for code scanning.")
-					.optional(),
-			}),
-			execute: async (params) => {
-				const { owner, ref, repo, severity, state } = params;
-
-				const response = await octokit.request(
-					"GET /repos/{owner}/{repo}/code-scanning/alerts",
-					{
-						owner,
-						repo,
-						ref,
-						severity,
-						state,
 					},
 				);
 


### PR DESCRIPTION
### **User description**
## Summary
Remove unused GitHub code scanning alert tools.

## Changes
Remove listCodeScanningAlerts and getCodeScanningAlert functions from the GitHub tools as they are not being used in the codebase.

## Testing
1. Place a generator node
2. Use GitHub Tools
3. Check removed `listCodeScanningAlerts` and `getCodeScanningAlert` tools

## Other Information


___

### **PR Type**
Other


___

### **Description**
- Remove unused GitHub code scanning alert tools

- Clean up tool catalog references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Tools"] --> B["Remove getCodeScanningAlert"]
  A --> C["Remove listCodeScanningAlerts"]
  D["Tool Catalog"] --> E["Update Code Management section"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tools.ts</strong><dd><code>Remove code scanning alert tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/tools.ts

<ul><li>Remove <code>getCodeScanningAlert</code> tool function and its implementation<br> <li> Remove <code>listCodeScanningAlerts</code> tool function and its implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1645/files#diff-ab66c02e5fde02391b87c3272ec687c015b73608a1f444143d55d758aff2fb65">+0/-66</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.tsx</strong><dd><code>Update GitHub tool catalog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx

<ul><li>Remove <code>listCodeScanningAlerts</code> and <code>getCodeScanningAlert</code> from Code <br>Management tools array</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1645/files#diff-122425196c8136251eb216cd110a334c4894b71bbf455312bb9920599703d1dc">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed Code Scanning Alerts actions from the GitHub toolset (list alerts, get alert). These options no longer appear in the workflow designer or tool catalog.
  * Other GitHub actions (commits, branches, files) remain available and unchanged.
  * If previously configured, selections of the removed actions will no longer be selectable and must be replaced with supported actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->