### PR TITLE
fix: ensure staged triggers appear in /stage page after app duplication

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/apps/actions.ts
@@ -1,11 +1,12 @@
 "use server";
 
-import type { WorkspaceId } from "@giselle-sdk/data-type";
+import type { WorkspaceId, TriggerNode } from "@giselle-sdk/data-type";
+import { isTriggerNode } from "@giselle-sdk/data-type";
 import type { AgentId } from "@giselles-ai/types";
 import { createId } from "@paralleldrive/cuid2";
 import { eq } from "drizzle-orm";
 import { giselleEngine } from "@/app/giselle-engine";
-import { agents, db, githubIntegrationSettings } from "@/drizzle";
+import { agents, db, flowTriggers, githubIntegrationSettings } from "@/drizzle";
 import { fetchCurrentUser } from "@/services/accounts";
 import { fetchCurrentTeam } from "@/services/teams";
 
@@ -70,6 +71,32 @@ export async function copyAgent(
 			creatorDbId: user.dbId,
 			workspaceId: workspace.id,
 		});
+
+		// Copy flowTrigger DB records for staged triggers
+		const configuredTriggerNodes = workspace.nodes.filter(
+			(node): node is TriggerNode =>
+				isTriggerNode(node) && node.content.state.status === "configured",
+		);
+
+		for (const node of configuredTriggerNodes) {
+			if (node.content.state.status === "configured") {
+				const flowTrigger = await giselleEngine.getTrigger({
+					flowTriggerId: node.content.state.flowTriggerId,
+				});
+				if (
+					flowTrigger &&
+					flowTrigger.configuration.provider === "manual" &&
+					flowTrigger.configuration.staged
+				) {
+					await db.insert(flowTriggers).values({
+						teamDbId: team.dbId,
+						sdkFlowTriggerId: node.content.state.flowTriggerId,
+						sdkWorkspaceId: workspace.id,
+						staged: true,
+					});
+				}
+			}
+		}
 
 		return { result: "success", workspaceId: workspace.id };
 	} catch (error) {


### PR DESCRIPTION
### **User description**
## Summary
I fixed app duplication for `/stage` page

## Related Issue
close https://github.com/giselles-ai/giselle/issues/1650

## Changes
When duplicating an app with staged manual triggers, the triggers were not appearing in the /stage page because:

1. FlowTrigger configurations were copied in SDK storage but not in the database
2. The /stage page relies on the flowTriggers database table to display triggers

This change:

- Copies FlowTrigger configurations with new IDs in copyWorkspace (SDK layer)
- Updates trigger nodes to reference the new FlowTrigger IDs
- Creates corresponding database records for staged triggers in copyAgent (app layer)
- Ensures staged manual triggers appear in /stage page after duplication

## Testing
1. Create app in `/apps` page
2. Duplicate an app
3. Check the duplicated app in `/stage` page

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fix staged triggers not appearing after app duplication

- Copy FlowTrigger configurations with new IDs in SDK layer

- Create database records for staged manual triggers

- Update trigger nodes to reference new FlowTrigger IDs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original App"] --> B["Duplicate App"]
  B --> C["Copy FlowTrigger configs"]
  C --> D["Update trigger node IDs"]
  D --> E["Create DB records"]
  E --> F["Staged triggers visible"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Create database records for staged triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/apps/actions.ts

<ul><li>Import <code>TriggerNode</code> and <code>isTriggerNode</code> types<br> <li> Add <code>flowTriggers</code> table import<br> <li> Filter configured trigger nodes after workspace copy<br> <li> Create database records for staged manual triggers</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1651/files#diff-91bf7f43202611af84b83a2ab7060e56adf19e9030ac1d45b60f853ebd4f1450">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>copy-workspace.ts</strong><dd><code>Copy FlowTrigger configurations in SDK layer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/workspaces/copy-workspace.ts

<ul><li>Import <code>FlowTriggerId</code> and trigger-related utilities<br> <li> Copy FlowTrigger configurations with new IDs<br> <li> Update trigger nodes to reference new FlowTrigger IDs<br> <li> Map old node IDs to new FlowTrigger IDs</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1651/files#diff-4e2ce0e8f103dec2af0cdcd57a0eb820d6cd8e8e89618553c28f19113e5abac4">+62/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copying an agent/workspace now also duplicates configured manual triggers and automatically links them into the new copy.
  * Trigger duplication runs in parallel for faster workspace copies.

* **Bug Fixes**
  * Copied workspaces now have trigger nodes correctly wired to new trigger IDs, preventing broken or missing trigger references.
  * Copy process reliability improved while preserving existing error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->