### PR TITLE
Add Docs links to GitHub tool checkboxes

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx
@@ -421,10 +421,14 @@ function GitHubToolConfigurationDialogInternal({
 											</p>
 										</div>
 										<a
-											href={`https://docs.giselles.ai/glossary/github-tools#${tool.toLowerCase()}`}
+											href={`https://docs.giselles.ai/glossary/github-tools#${encodeURIComponent(
+												tool.toLowerCase(),
+											)}`}
 											target="_blank"
 											rel="noopener"
+											aria-label={`Open docs for ${tool}`}
 											className="flex items-center gap-[4px] text-[13px] text-text-muted hover:bg-ghost-element-hover transition-colors px-[4px] rounded-[2px] ml-2"
+											onMouseDown={(e) => e.stopPropagation()}
 											onClick={(e) => e.stopPropagation()}
 										>
 											<span>Docs</span>


### PR DESCRIPTION
### **User description**
## Summary
Add Docs links to GitHub tool checkboxes.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/bab7d4fd-e5fa-4617-b711-75c44d7612e3" />

## Related Issue
None

## Changes
- Add external documentation links next to each GitHub tool checkbox
- Links point to https://docs.giselles.ai/glossary/github-tools#{toolName.toLowerCase()}
- Open in new tab without rel="noreferrer" as requested
- Include click handler to prevent checkbox toggle when clicking link

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add documentation links to GitHub tool checkboxes

- Links open in new tab with lowercase URL format

- Prevent checkbox toggle when clicking documentation links

- Improve user experience with external documentation access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Tool Checkbox"] --> B["Add Docs Link"]
  B --> C["External Documentation"]
  B --> D["Prevent Toggle on Click"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.tsx</strong><dd><code>Add documentation links to tool checkboxes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tools/tool-provider/github.tsx

<ul><li>Restructure checkbox layout with flex container<br> <li> Add external documentation links next to each tool<br> <li> Implement click handler to prevent checkbox toggle<br> <li> Style links with hover effects and external icon</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1678/files#diff-122425196c8136251eb216cd110a334c4894b71bbf455312bb9920599703d1dc">+26/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline "Docs" link next to each GitHub tool option that opens in a new tab with an external-link indicator.

* **Style**
  * Redesigned tool rows to separate checkbox, tool name, and actions for a cleaner, more accessible layout.
  * Checkbox visual indicator behavior improved for clearer selection state.

* **Bug Fixes**
  * Clicking the Docs link no longer toggles the associated checkbox; initial checked state handling made safer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->