### PR TITLE
fix: correct drizzle snapshot index syntax to prevent unnecessary recreations

### DIFF
--- a/apps/studio.giselles.ai/drizzle/schema.ts
+++ b/apps/studio.giselles.ai/drizzle/schema.ts
@@ -400,18 +400,10 @@ export const githubRepositoryEmbeddings = pgTable(
 		),
 		// Partial HNSW indexes for different dimensions with casting
 		index("github_repository_embeddings_embedding_1536_idx")
-			.using(
-				"hnsw",
-				sql`(${table.embedding}::vector(1536))`,
-				sql`vector_cosine_ops`,
-			)
+			.using("hnsw", sql`${table.embedding}::vector(1536) vector_cosine_ops`)
 			.where(sql`${table.embeddingDimensions} = 1536`),
 		index("github_repository_embeddings_embedding_3072_idx")
-			.using(
-				"hnsw",
-				sql`(${table.embedding}::halfvec(3072))`,
-				sql`halfvec_cosine_ops`,
-			)
+			.using("hnsw", sql`${table.embedding}::halfvec(3072) halfvec_cosine_ops`)
 			.where(sql`${table.embeddingDimensions} = 3072`),
 	],
 );
@@ -463,18 +455,10 @@ export const githubRepositoryPullRequestEmbeddings = pgTable(
 		),
 		// Partial HNSW indexes for different dimensions with casting
 		index("gh_pr_embeddings_embedding_1536_idx")
-			.using(
-				"hnsw",
-				sql`(${table.embedding}::vector(1536))`,
-				sql`vector_cosine_ops`,
-			)
+			.using("hnsw", sql`${table.embedding}::vector(1536) vector_cosine_ops`)
 			.where(sql`${table.embeddingDimensions} = 1536`),
 		index("gh_pr_embeddings_embedding_3072_idx")
-			.using(
-				"hnsw",
-				sql`(${table.embedding}::halfvec(3072))`,
-				sql`halfvec_cosine_ops`,
-			)
+			.using("hnsw", sql`${table.embedding}::halfvec(3072) halfvec_cosine_ops`)
 			.where(sql`${table.embeddingDimensions} = 3072`),
 		foreignKey({
 			columns: [table.repositoryIndexDbId],

--- a/apps/studio.giselles.ai/migrations/meta/0045_snapshot.json
+++ b/apps/studio.giselles.ai/migrations/meta/0045_snapshot.json
@@ -955,11 +955,10 @@
 					"name": "github_repository_embeddings_embedding_1536_idx",
 					"columns": [
 						{
-							"expression": "embedding",
-							"isExpression": false,
+							"expression": "\"embedding\"::vector(1536) vector_cosine_ops",
 							"asc": true,
-							"nulls": "last",
-							"opclass": "vector_cosine_ops"
+							"isExpression": true,
+							"nulls": "last"
 						}
 					],
 					"isUnique": false,
@@ -972,11 +971,10 @@
 					"name": "github_repository_embeddings_embedding_3072_idx",
 					"columns": [
 						{
-							"expression": "embedding",
-							"isExpression": false,
+							"expression": "\"embedding\"::halfvec(3072) halfvec_cosine_ops",
 							"asc": true,
-							"nulls": "last",
-							"opclass": "vector_cosine_ops"
+							"isExpression": true,
+							"nulls": "last"
 						}
 					],
 					"isUnique": false,
@@ -1243,11 +1241,10 @@
 					"name": "gh_pr_embeddings_embedding_1536_idx",
 					"columns": [
 						{
-							"expression": "embedding",
-							"isExpression": false,
+							"expression": "\"embedding\"::vector(1536) vector_cosine_ops",
 							"asc": true,
-							"nulls": "last",
-							"opclass": "vector_cosine_ops"
+							"isExpression": true,
+							"nulls": "last"
 						}
 					],
 					"isUnique": false,
@@ -1260,11 +1257,10 @@
 					"name": "gh_pr_embeddings_embedding_3072_idx",
 					"columns": [
 						{
-							"expression": "embedding",
-							"isExpression": false,
+							"expression": "\"embedding\"::halfvec(3072) halfvec_cosine_ops",
 							"asc": true,
-							"nulls": "last",
-							"opclass": "vector_cosine_ops"
+							"isExpression": true,
+							"nulls": "last"
 						}
 					],
 					"isUnique": false,


### PR DESCRIPTION
## Summary
- Fixed index definitions in drizzle schema and snapshot files to use the correct syntax
- Prevents drizzle-kit from unnecessarily dropping and recreating indexes in future migrations

## Background
During a previous migration (https://github.com/giselles-ai/giselle/pull/1656) , the SQL was manually modified after running `drizzle-kit generate`, which caused the snapshot to record incorrect index definitions. This would have caused drizzle-kit to attempt to drop and recreate these indexes unnecessarily in future migrations.

## Changes
- Updated index definitions in `drizzle/schema.ts` to use the correct inline syntax
- Corrected the corresponding snapshot entries in `migrations/meta/0045_snapshot.json`
- Changed from separate parameters to inline SQL expressions for HNSW index definitions

## Test plan
- [x] Run `drizzle-kit generate` and verify no unnecessary index changes are generated

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated vector indexes for repository and pull request embeddings to expression-based HNSW definitions for 1536 and 3072 dimensions, improving similarity search performance and stability without changing query behavior.
- Chores
  - Synced migration metadata to reflect the new index expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->