### PR TITLE
feat(trace): add workspace team handling for github-app origins

### DIFF
--- a/apps/studio.giselles.ai/lib/workspaces/get-workspace-team.ts
+++ b/apps/studio.giselles.ai/lib/workspaces/get-workspace-team.ts
@@ -1,0 +1,31 @@
+import type { WorkspaceId } from "@giselle-sdk/data-type";
+import { db } from "@/drizzle";
+
+export async function getWorkspaceTeam(workspaceId: WorkspaceId) {
+	// First, get the workspace and its team
+	const agent = await db.query.agents.findFirst({
+		where: (agents, { eq }) => eq(agents.workspaceId, workspaceId),
+		with: {
+			team: true,
+		},
+	});
+
+	if (!agent) {
+		throw new Error(`Workspace ${workspaceId} not found`);
+	}
+
+	// Then, check for active subscription
+	const activeSubscription = await db.query.subscriptions.findFirst({
+		where: (subscriptions, { eq, and }) =>
+			and(
+				eq(subscriptions.teamDbId, agent.team.dbId),
+				eq(subscriptions.status, "active"),
+			),
+	});
+
+	return {
+		...agent.team,
+		activeSubscriptionId: activeSubscription?.id || null,
+		subscription: activeSubscription || null,
+	};
+}

--- a/apps/studio.giselles.ai/services/teams/utils.ts
+++ b/apps/studio.giselles.ai/services/teams/utils.ts
@@ -1,7 +1,9 @@
 import { createId } from "@paralleldrive/cuid2";
 import type { CurrentTeam, TeamId } from "./types";
 
-export function isProPlan(team: CurrentTeam) {
+export function isProPlan(
+	team: Pick<CurrentTeam, "activeSubscriptionId" | "type">,
+) {
 	return team.activeSubscriptionId != null || team.type === "internal";
 }
 


### PR DESCRIPTION
### **User description**
Summary
- Add handling of teams for GitHub App origins

What changed
- Implemented workspace team handling logic for github-app event origins

Why
- Ensure proper team association when processing traces from GitHub App origins

Notes
- None


___

### **PR Type**
Enhancement


___

### **Description**
- Add workspace team handling for GitHub App origins

- Implement origin type switching in generation callbacks

- Create utility function to fetch workspace team data

- Update team type checking to support workspace teams


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub App Origin"] --> B["getWorkspaceTeam()"]
  B --> C["Workspace Team Data"]
  C --> D["Trace Generation"]
  E["Studio/Stage Origins"] --> F["fetchCurrentTeam()"]
  F --> G["Current Team Data"]
  G --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>giselle-engine.ts</strong><dd><code>Implement origin-based trace generation handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/giselle-engine.ts

<ul><li>Import <code>getWorkspaceTeam</code> utility function<br> <li> Replace single trace logic with origin type switching<br> <li> Add GitHub App specific handling using workspace team<br> <li> Maintain existing logic for studio/stage origins</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1684/files#diff-235b6c6d2e5711d3bbc50862c678e55f5d79296fc35007dab4dc963a82b5be63">+53/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get-workspace-team.ts</strong><dd><code>Add workspace team data fetching utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/lib/workspaces/get-workspace-team.ts

<ul><li>Create new utility to fetch workspace team data<br> <li> Query agents table to find workspace and associated team<br> <li> Include active subscription information in response<br> <li> Add error handling for missing workspaces</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1684/files#diff-56da97c2d3fd8f74341cd61adb4c191a6eafa56d9cab989c73e4a9cc360fb9f0">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Update team utility function signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/services/teams/utils.ts

<ul><li>Update <code>isProPlan</code> function signature to accept partial team type<br> <li> Make function more flexible for workspace team usage</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1684/files#diff-3d2311c9eeaf634c6e65adb075315d06d3f52662857f3632d9526d8a9d23853f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Correctly applies plan and team type when actions originate from GitHub App vs Studio/Stage.
  - Ensures accurate user/session tagging and subscription linkage in activity tracking.
  - Adds clearer errors when a workspace cannot be found.
- Refactor
  - Introduces origin-aware handling for generation completion to use the appropriate team and subscription context.
- Chores
  - Adds a workspace team retrieval helper used across flows.
  - Narrows a utility’s accepted input shape without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1685 
- <kbd>&nbsp;1&nbsp;</kbd> #1684 👈 
<!-- GitButler Footer Boundary Bottom -->

