### PR TITLE
feat(dialog): size prop to Dialog for responsive widths

### DIFF
--- a/internal-packages/ui/components/dialog.tsx
+++ b/internal-packages/ui/components/dialog.tsx
@@ -6,13 +6,20 @@ export const Dialog = DialogPrimitive.Root;
 export const DialogPortal = DialogPrimitive.Portal;
 export const DialogTrigger = DialogPrimitive.Trigger;
 
-export function DialogContent({ children }: PropsWithChildren) {
+export type DialogSize = "default" | "wide";
+export function DialogContent({
+	children,
+	size = "default",
+}: PropsWithChildren<{ size?: DialogSize }>) {
 	return (
 		<DialogPortal>
 			<DialogPrimitive.Overlay className="fixed inset-0 bg-black/60 z-50" />
 			<DialogPrimitive.Content
+				data-size={size}
 				className={clsx(
-					"fixed left-[50%] top-[50%] translate-y-[-50%] translate-x-[-50%] w-[500px] z-50 max-h-[75%] overflow-y-auto overflow-x-hidden outline-none",
+					"fixed left-[50%] top-[50%] translate-y-[-50%] translate-x-[-50%] z-50 overflow-y-auto overflow-x-hidden outline-none",
+					"data-[size=default]:w-[500px] data-[size=default]:max-h-[75%]",
+					"data-[size=wide]:w-[800px] data-[size=default]:max-h-[85%]",
 					"bg-(image:--glass-bg)",
 					"border border-glass-border/20 shadow-xl text-text",
 					"p-6 rounded-[12px]",


### PR DESCRIPTION
- Add `size` prop to Dialog to support responsive widths
- Implement responsive width handling based on `size` values
- Update Dialog types and documentation to include `size` prop

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1699 
- <kbd>&nbsp;1&nbsp;</kbd> #1698 👈 
<!-- GitButler Footer Boundary Bottom -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialogs now support selectable content sizes (default or wide) to better fit varying amounts of content.
* **Style**
  * Updated dialog dimensions for more responsive behavior, replacing fixed widths with size-aware layouts.
  * Increased default max-height to improve visibility of longer content without excessive scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->