### PR TITLE
feat: disable tag input, add, and remove when disabled prop is

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/basic-tag-input.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/basic-tag-input.tsx
@@ -88,6 +88,8 @@ export function BasicTagInput({
 
 	// Tag removal process
 	const removeTag = (index: number) => {
+		// Prevent removal when component is disabled
+		if (disabled) return;
 		const newTags = tags.filter((_, i) => i !== index);
 		setTags(newTags);
 
@@ -139,12 +141,15 @@ export function BasicTagInput({
 							<button
 								type="button"
 								onClick={() => removeTag(index)}
+								disabled={disabled}
+								aria-disabled={disabled}
 								style={{
 									padding: "0 0 0 2px",
 									color: "var(--black-400, #505D7B)",
 									backgroundColor: "transparent",
 									border: "none",
-									cursor: "pointer",
+									cursor: disabled ? "not-allowed" : "pointer",
+									opacity: disabled ? 0.5 : 1,
 									fontFamily: "var(--font-geist), system-ui, sans-serif",
 								}}
 							>


### PR DESCRIPTION
### **User description**
Summary
- Disable tag input, prevent adding tags, and prevent removing tags when the component's disabled prop is true.

What changed
- Tag input field becomes non-interactive when disabled.
- Add/tag creation actions are blocked while disabled.
- Tag removal actions (e.g., delete buttons) are disabled when the prop is set.

Notes
- Behavioral change only applies when the disabled prop is true.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1699 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1698 
<!-- GitButler Footer Boundary Bottom -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add `disabled` prop to BasicTagInput component

- Disable input field when component is disabled

- Block tag addition and removal actions when disabled

- Update button styling to reflect disabled state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["disabled prop"] --> B["Input field disabled"]
  A --> C["Add button disabled"]
  A --> D["Remove actions blocked"]
  B --> E["Non-interactive UI"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>basic-tag-input.tsx</strong><dd><code>Add disabled prop with input/button controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/basic-tag-input.tsx

<ul><li>Add optional <code>disabled</code> boolean prop to component interface<br> <li> Disable input field when <code>disabled</code> or <code>isMaxReached</code> is true<br> <li> Disable add button when input is empty, max reached, or disabled<br> <li> Update button cursor and opacity styling for disabled state</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1699/files#diff-ea59e981b80ac5270ca75d99eac7b3d54bd82a71bd471cd75674e21b83b81938">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now disable the tag input to prevent edits. When disabled, adding and removing tags is blocked, and the input field and controls are non-interactive by default.
  * The input and Add button automatically disable when the maximum tag limit is reached.

* **Style**
  * Disabled state is clearly indicated: buttons and inputs appear dimmed and show a not-allowed cursor, with controls reflecting their disabled status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->