### PR TITLE
fix: generate unique IDs for sample workspace elements

### DIFF
--- a/packages/giselle/src/engine/workspaces/create-sample-workspace.ts
+++ b/packages/giselle/src/engine/workspaces/create-sample-workspace.ts
@@ -110,7 +110,7 @@ async function createSampleWorkspaceFromTemplate(args: {
 			let updatedPrompt = node.content.prompt;
 			// Replace old node IDs with new ones in prompt content
 			for (const [oldId, newId] of idMap.entries()) {
-				updatedPrompt = updatedPrompt.replace(new RegExp(oldId, "g"), newId);
+				updatedPrompt = updatedPrompt.replaceAll(oldId, newId);
 			}
 			return {
 				...node,

--- a/packages/giselle/src/engine/workspaces/create-sample-workspace.ts
+++ b/packages/giselle/src/engine/workspaces/create-sample-workspace.ts
@@ -98,21 +98,40 @@ async function createSampleWorkspaceFromTemplate(args: {
 		newNodeState[NodeId.parse(newNodeId)] = nodeState;
 	}
 	const newWorkspaceId = WorkspaceId.generate();
+
+	// Update prompt content with new IDs if present
+	const updatedNodes = newNodes.map((node) => {
+		if (
+			node.type === "operation" &&
+			node.content.type === "textGeneration" &&
+			node.content.prompt &&
+			typeof node.content.prompt === "string"
+		) {
+			let updatedPrompt = node.content.prompt;
+			// Replace old node IDs with new ones in prompt content
+			for (const [oldId, newId] of idMap.entries()) {
+				updatedPrompt = updatedPrompt.replace(new RegExp(oldId, "g"), newId);
+			}
+			return {
+				...node,
+				content: {
+					...node.content,
+					prompt: updatedPrompt,
+				},
+			};
+		}
+		return node;
+	});
+
 	const newWorkspace = {
 		...templateWorkspace,
 		id: newWorkspaceId,
-		//
-		// I wanted to re-assign new IDs to all copied Nodes, Inputs, Outputs, and Connections.
-		// However, doing so would require updating the information embedded in the prompt,
-		// which would be a bit complicated. So, for now, I'm leaving the IDs as they are.
-		// Since the workspace ID is different, each element can still be uniquely identified.
-		// Also, nothing is globally identified based on the node or input ID, so it shouldn't cause any problems.
-		//
-		// schemaVersion: templateWorkspace.schemaVersion,
-		// nodes: newNodes,
-		// connections: newConnections,
-		// editingWorkflows: workflows,
-		// ui: newUi,
+		nodes: updatedNodes,
+		connections: newConnections,
+		ui: {
+			...templateWorkspace.ui,
+			nodeState: newNodeState,
+		},
 	} satisfies Workspace;
 	await Promise.all([
 		setWorkspace({


### PR DESCRIPTION
### **User description**
## Summary
I fixed generate unique IDs for sample workspace elements.

## Related Issue
None

## Changes
Previously, sample workspaces copied from templates reused the same node, input, output, and connection IDs across all users, causing execution results to be shared between different users' workspaces.

This change:
- Generates new unique IDs for all workspace elements (nodes, inputs, outputs, connections)
- Updates ID references within text generation node prompts to use the new IDs
- Uses proper node state mapping with new IDs

## Testing
1. Signup
2. Run the sample app
3. Check the Node Result of the app from which the sample app was copied

## Other Information

Resolves execution result sharing issue between users.


___

### **PR Type**
Bug fix


___

### **Description**
- Generate unique IDs for workspace elements (nodes, inputs, outputs, connections)

- Update prompt content to reference new IDs

- Fix execution result sharing between users

- Replace old ID mapping with proper implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Template Workspace"] --> B["Generate New IDs"]
  B --> C["Update Prompt Content"]
  C --> D["Map Node States"]
  D --> E["Create Unique Workspace"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-sample-workspace.ts</strong><dd><code>Implement unique ID generation for workspace elements</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/workspaces/create-sample-workspace.ts

<ul><li>Implement ID mapping for all workspace elements<br> <li> Add prompt content updating with new IDs using regex replacement<br> <li> Remove commented code and use proper node/connection assignments<br> <li> Fix node state mapping with new unique IDs</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1708/files#diff-886451ef85853becff4efcae1c8d2e781256f077843960b8411f6482cc987b5f">+31/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures sample workspaces correctly rewrite prompts in text-generation operation nodes when node IDs are remapped, preventing broken references after creation or duplication.
  * Applies prompt updates only to operation nodes with string prompts; other node types remain unchanged.
  * Uses regenerated node IDs and connections consistently so UI state aligns with nodes.

* **Refactor**
  * Streamlined workspace construction to assemble nodes, connections, and UI from updated IDs for more reliable initialization without public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->