### PR TITLE
fix: Display avatar images on team members page

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/actions.ts
@@ -175,6 +175,7 @@ export async function getTeamMembers() {
 				userId: users.id,
 				email: users.email,
 				displayName: users.displayName,
+				avatarUrl: users.avatarUrl,
 				role: teamMemberships.role,
 			})
 			.from(users)

--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Avatar from "boring-avatars";
 import { Check, ChevronDown } from "lucide-react";
 import { useState } from "react";
 import {
@@ -20,12 +19,14 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { TeamRole } from "@/drizzle";
+import { AvatarImage } from "@/services/accounts/components/user-button/avatar-image";
 import { deleteTeamMember, updateTeamMemberRole } from "./actions";
 
 type TeamMemberListItemProps = {
 	userId: string;
 	displayName: string | null;
 	email: string | null;
+	avatarUrl: string | null;
 	role: TeamRole;
 	currentUserRole: TeamRole;
 	isProPlan: boolean;
@@ -36,6 +37,7 @@ export function TeamMemberListItem({
 	userId,
 	displayName,
 	email,
+	avatarUrl,
 	role: initialRole,
 	currentUserRole,
 	isProPlan,
@@ -108,11 +110,11 @@ export function TeamMemberListItem({
 			<div className="flex items-center justify-between gap-2 border-b-[0.5px] border-white/10 last:border-b-0">
 				<div className="flex gap-x-2 items-center">
 					<div className="flex-shrink-0">
-						<Avatar
-							name={email || userId}
-							variant="marble"
-							size={36}
-							colors={["#413e4a", "#73626e", "#b38184", "#f0b49e", "#f7e4be"]}
+						<AvatarImage
+							avatarUrl={avatarUrl}
+							width={36}
+							height={36}
+							alt={displayName || email || ""}
 						/>
 					</div>
 					<div className="flex flex-col gap-y-1 font-medium">

--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list.tsx
@@ -13,6 +13,7 @@ type TeamMembersListProps = {
 		userId: string;
 		displayName: string | null;
 		email: string | null;
+		avatarUrl: string | null;
 		role: TeamRole;
 	}[];
 	invitations: Invitation[];
@@ -39,6 +40,7 @@ export function TeamMembersList({
 					userId={member.userId}
 					displayName={member.displayName}
 					email={member.email}
+					avatarUrl={member.avatarUrl}
 					role={member.role}
 					currentUserRole={currentUserRole}
 					isProPlan={isProPlan}

--- a/apps/studio.giselles.ai/services/accounts/components/user-button/avatar-image.tsx
+++ b/apps/studio.giselles.ai/services/accounts/components/user-button/avatar-image.tsx
@@ -22,7 +22,7 @@ export function AvatarImage({
 			width={width}
 			height={height}
 			alt={alt}
-			className={cn("rounded-full object-cover w-full h-full", className)}
+			className={cn("rounded-full object-cover shrink-0", className)}
 			style={{ objectPosition: "center" }}
 		/>
 	) : (
@@ -32,7 +32,7 @@ export function AvatarImage({
 			width={width}
 			height={height}
 			colors={["#413e4a", "#73626e", "#b38184", "#f0b49e", "#f7e4be"]}
-			className={cn("w-full h-full", className)}
+			className={cn(className)}
 		/>
 	);
 }


### PR DESCRIPTION
## Summary
- Fixed avatar display issue on team members page by passing avatarUrl prop
- Updated AvatarImage component to properly respect width/height props
- Team members list now shows actual user avatars instead of placeholder avatars

## Test plan
- [x] Verify avatars display correctly on team members page
- [x] Check that width/height props work properly for AvatarImage component
- [x] Ensure fallback avatars (boring-avatars) still work when no avatarUrl is present

🤖 Generated with [Claude Code](https://claude.ai/code)