### PR TITLE
fix(layout): avoid redundant await by returning act directly and pass it to Sidebar

### DIFF
--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/layout.tsx
@@ -14,7 +14,7 @@ export default async function ({
 	params: Promise<{ actId: ActId }>;
 }>) {
 	const { actId } = await params;
-	const act = await giselleEngine.getAct({ actId });
+	const act = giselleEngine.getAct({ actId });
 	const { appName, teamName, triggerParameters } = await fetchActMetadata(act);
 
 	return (
@@ -23,7 +23,7 @@ export default async function ({
 			<div className="w-full md:w-auto md:h-screen md:overflow-y-auto">
 				<Suspense fallback={<NavSkelton />}>
 					<Sidebar
-						act={Promise.resolve(act)}
+						act={act}
 						appName={appName}
 						teamName={teamName}
 						triggerParameters={triggerParameters}


### PR DESCRIPTION
- Return `` directly instead of awaiting it redundantly.
- Pass the returned `act` to `Sidebar` to avoid duplicate awaiting and streamline flow.