### PR TITLE
Use Google Generative AI key variable

### DIFF
--- a/packages/rag/src/ingest/pipeline.ts
+++ b/packages/rag/src/ingest/pipeline.ts
@@ -86,7 +86,9 @@ export function createPipeline<
 
 	const apiKey =
 		process.env[
-			profile.provider === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY"
+			profile.provider === "openai"
+				? "OPENAI_API_KEY"
+				: "GOOGLE_GENERATIVE_AI_API_KEY"
 		];
 	if (!apiKey) {
 		throw new ConfigurationError(

--- a/packages/rag/src/query-service/postgres/index.ts
+++ b/packages/rag/src/query-service/postgres/index.ts
@@ -129,7 +129,9 @@ export function createPostgresQueryService<
 
 			const apiKey =
 				process.env[
-					profile.provider === "openai" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY"
+					profile.provider === "openai"
+						? "OPENAI_API_KEY"
+						: "GOOGLE_GENERATIVE_AI_API_KEY"
 				];
 			if (!apiKey) {
 				throw new ConfigurationError(


### PR DESCRIPTION
## Summary
- use `GOOGLE_GENERATIVE_AI_API_KEY` for Google embedder selection in ingest pipeline
- use `GOOGLE_GENERATIVE_AI_API_KEY` for Google embedder in Postgres query service

## Testing
- `pnpm biome check --write packages/rag/src/ingest/pipeline.ts packages/rag/src/query-service/postgres/index.ts`
- `pnpm turbo build --filter '@giselle-sdk/*' --filter giselle-sdk --cache=local:rw` *(fails: No package found with name 'giselle-sdk')*
- `pnpm turbo check-types --cache=local:rw` *(fails: Cannot find module './assets/02.gif' or its corresponding type declarations)*
- `pnpm turbo format --cache=local:rw`
- `pnpm turbo test --cache=local:rw`

------
https://chatgpt.com/codex/tasks/task_e_68a6cbb014c88328bc5130315fc4a74c