### PR TITLE
fix(github-tool): handle repository not found errors in pull request ingest

### DIFF
--- a/packages/github-tool/src/document-loaders/pull-requests/fetchers.ts
+++ b/packages/github-tool/src/document-loaders/pull-requests/fetchers.ts
@@ -1,3 +1,4 @@
+import { DocumentLoaderError } from "@giselle-sdk/rag";
 import type { Octokit } from "@octokit/core";
 import type { Client } from "urql";
 import { executeRestRequest } from "../utils";
@@ -88,7 +89,21 @@ export async function fetchPullRequestsMetadata(
 	});
 
 	if (result.error) {
-		throw new Error(`GraphQL error: ${result.error.message}`);
+		throw DocumentLoaderError.fetchError(
+			"github",
+			"fetching pull requests metadata",
+			result.error,
+			{ owner: ctx.owner, repo: ctx.repo },
+		);
+	}
+
+	// Check if repository exists
+	if (result.data?.repository === null) {
+		throw DocumentLoaderError.notFound(
+			`${ctx.owner}/${ctx.repo}`,
+			new Error("Repository not found or no access"),
+			{ source: "github", resourceType: "Repository" },
+		);
 	}
 
 	const pullRequests = result.data?.repository?.pullRequests;
@@ -141,7 +156,21 @@ export async function fetchPullRequestDetails(
 	});
 
 	if (result.error) {
-		throw new Error(`GraphQL error: ${result.error.message}`);
+		throw DocumentLoaderError.fetchError(
+			"github",
+			"fetching pull request details",
+			result.error,
+			{ owner: ctx.owner, repo: ctx.repo, prNumber },
+		);
+	}
+
+	// Check if repository exists
+	if (result.data?.repository === null) {
+		throw DocumentLoaderError.notFound(
+			`${ctx.owner}/${ctx.repo}`,
+			new Error("Repository not found or no access"),
+			{ source: "github", resourceType: "Repository" },
+		);
 	}
 
 	const pr = result.data?.repository?.pullRequest;


### PR DESCRIPTION
### **User description**
## Summary
- Fixed error handling in pull request document loader to return correct error codes
- Repository not found now returns `DOCUMENT_NOT_FOUND` instead of `INVALID_OPERATION`
- Aligned pull request ingest error handling with blob ingest behavior

## Problem
When pull request ingest encounters a non-existent repository, it was returning:
- Error code: `INVALID_OPERATION` 
- retry_after: Set to a date value

This differs from blob ingest which correctly returns:
- Error code: `DOCUMENT_NOT_FOUND`
- retry_after: `null`

## Solution
Updated the GraphQL error handling in `fetchPullRequestsMetadata` and `fetchPullRequestDetails`:
- Check if `result.data?.repository === null` to detect missing repositories
- Throw `DocumentLoaderError.notFound()` for missing repos
- Use `DocumentLoaderError.fetchError()` for other GraphQL errors

This approach avoids additional API calls by using the GraphQL response structure to determine if the repository exists.

## Test plan
- [x] Run `pnpm format` - No formatting changes needed
- [x] Run `pnpm build-sdk` - Build successful
- [x] Run `pnpm check-types` - Existing unrelated errors only
- [x] Run `pnpm tidy` - No unused files/dependencies
- [x] Run `pnpm test` - All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed error handling for repository not found in pull request ingest

- Aligned error codes with blob ingest behavior

- Added proper GraphQL error handling using DocumentLoaderError

- Repository not found now returns DOCUMENT_NOT_FOUND instead of INVALID_OPERATION


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GraphQL Query"] --> B["Check result.error"]
  B --> C["Check repository === null"]
  C --> D["DocumentLoaderError.notFound()"]
  B --> E["DocumentLoaderError.fetchError()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fetchers.ts</strong><dd><code>Enhanced error handling for repository not found</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/document-loaders/pull-requests/fetchers.ts

<ul><li>Added DocumentLoaderError import for proper error handling<br> <li> Enhanced fetchPullRequestsMetadata with repository existence check<br> <li> Enhanced fetchPullRequestDetails with repository existence check<br> <li> Replaced generic Error throws with DocumentLoaderError methods</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1726/files#diff-67bef32c11ac0c6d00b8cd8f51ed5a36c5b30a792823b0ad833e04f5f3467944">+31/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when fetching GitHub pull request metadata and details.
  - Clearer, actionable errors when a repository is missing or access is denied.
  - Consistent error messages and context instead of generic failures, reducing ambiguity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->