### PR TITLE
fix: copy FlowTrigger configurations in createSampleWorkspaces

### DIFF
--- a/packages/giselle/src/engine/workspaces/create-sample-workspace.ts
+++ b/packages/giselle/src/engine/workspaces/create-sample-workspace.ts
@@ -104,14 +104,9 @@ async function createSampleWorkspaceFromTemplate(args: {
 	const newWorkspaceId = WorkspaceId.generate();
 
 	// Copy FlowTrigger configurations for configured trigger nodes
-	const configuredTriggerNodes = newNodes.filter(
-		(node): node is TriggerNode =>
-			isTriggerNode(node) && node.content.state.status === "configured",
-	);
-
 	const flowTriggerCopies = await Promise.all(
-		configuredTriggerNodes.map(async (node) => {
-			if (node.content.state.status !== "configured") {
+		newNodes.map(async (node) => {
+			if (!isTriggerNode(node) || node.content.state.status !== "configured") {
 				return null;
 			}
 			const oldFlowTriggerId = node.content.state.flowTriggerId;


### PR DESCRIPTION
### **User description**
## Summary
Ensures Manual Trigger Node stage settings are properly copied when creating sample workspaces, mirroring the fix from PR #1651.

## Related Issue
None.

## Changes
- Add FlowTrigger copying logic for configured trigger nodes
- Update trigger nodes to reference new FlowTrigger IDs
- Ensure staged manual triggers work in sample workspaces
- Mirror approach from PR #1651 copyWorkspace implementation

## Testing
1. Signup
2. Verify that the sample app is available on the `/stage` page


___

### **PR Type**
Bug fix


___

### **Description**
- Copy FlowTrigger configurations for configured trigger nodes

- Update trigger nodes to reference new FlowTrigger IDs

- Ensure staged manual triggers work in sample workspaces

- Mirror approach from PR #1651 copyWorkspace implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Workspace"] --> B["Filter Configured Triggers"]
  B --> C["Copy FlowTrigger Data"]
  C --> D["Generate New FlowTrigger IDs"]
  D --> E["Update Trigger Node References"]
  E --> F["New Sample Workspace"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-sample-workspace.ts</strong><dd><code>Add FlowTrigger configuration copying logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/workspaces/create-sample-workspace.ts

<ul><li>Add FlowTrigger copying logic for configured trigger nodes<br> <li> Import required types and utility functions<br> <li> Update trigger nodes with new FlowTrigger IDs<br> <li> Ensure proper FlowTrigger configuration in sample workspaces</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1727/files#diff-886451ef85853becff4efcae1c8d2e781256f077843960b8411f6482cc987b5f">+62/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sample workspaces now include independent copies of trigger configurations so trigger nodes work immediately.
  * Node references and text-generation prompts are remapped to new IDs to keep workspace consistency.
  * Account initialization now persists "staged" manual triggers for configured trigger nodes so staged triggers are tracked upon setup.

* **Other**
  * No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->