### PR TITLE
feat(language-model,langfuse): add embedding pricing tables and total-only cost reporting

### DIFF
--- a/packages/langfuse/src/trace-embedding.ts
+++ b/packages/langfuse/src/trace-embedding.ts
@@ -1,3 +1,4 @@
+import { calculateEmbeddingDisplayCost } from "@giselle-sdk/language-model";
 import type { EmbeddingMetrics } from "@giselle-sdk/rag";
 import { Langfuse } from "langfuse";
 
@@ -49,7 +50,11 @@ export async function traceEmbedding(args: {
 			],
 		});
 
-		// TODO: Calculate costs
+		const totalTokens = usage?.tokens ?? 0;
+		const cost = await calculateEmbeddingDisplayCost(provider, model, {
+			tokens: totalTokens,
+		});
+
 		trace.generation({
 			name: operation,
 			model: model,
@@ -57,8 +62,8 @@ export async function traceEmbedding(args: {
 			// output: args.metrics.embeddings,
 			usage: {
 				unit: "TOKENS",
-				totalTokens: usage?.tokens ?? 0,
-				totalCost: 0, // TODO: Calculate costs
+				totalTokens,
+				totalCost: cost.totalCostForDisplay,
 			},
 			startTime: startTime,
 			endTime: endTime,

--- a/packages/language-model/src/costs/embedding-costs.test.ts
+++ b/packages/language-model/src/costs/embedding-costs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { calculateEmbeddingDisplayCost } from "./index";
+
+describe("calculateEmbeddingDisplayCost", () => {
+	it("computes cost for OpenAI text-embedding-3-small", async () => {
+		const cost = await calculateEmbeddingDisplayCost(
+			"openai",
+			"text-embedding-3-small",
+			{ tokens: 1000 },
+		);
+		// $0.01 per 1M tokens => 1000 tokens = $0.00001
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.00001, 10);
+	});
+
+	it("computes cost for OpenAI text-embedding-3-large", async () => {
+		const cost = await calculateEmbeddingDisplayCost(
+			"openai",
+			"text-embedding-3-large",
+			{ tokens: 2000 },
+		);
+		// $0.065 per 1M tokens => 2000 tokens = $0.00013
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.00013, 10);
+	});
+
+	it("computes cost for Google gemini-embedding-001", async () => {
+		const cost = await calculateEmbeddingDisplayCost(
+			"google",
+			"gemini-embedding-001",
+			{ tokens: 1000 },
+		);
+		// $0.15 per 1M tokens => 1000 tokens = $0.00015
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.00015, 10);
+	});
+});

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -313,8 +313,8 @@ export function getValidPricing(
  * Embeddings charge per input token only (no output distinction)
  */
 type EmbeddingModelPrice = {
-  validFrom: string;
-  costPerMegaToken: number; // USD per 1,000,000 tokens
+	validFrom: string;
+	costPerMegaToken: number; // USD per 1,000,000 tokens
 };
 
 export type EmbeddingModelPriceTable = Record<

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -307,3 +307,73 @@ export function getValidPricing(
 
 	return validPrices[0];
 }
+
+/**
+ * Embedding model pricing
+ * Embeddings charge per input token only (no output distinction)
+ */
+type EmbeddingModelPrice = {
+  validFrom: string;
+  costPerMegaToken: number; // USD per 1,000,000 tokens
+};
+
+export type EmbeddingModelPriceTable = Record<
+	string,
+	{ prices: EmbeddingModelPrice[] }
+>;
+
+export function getValidEmbeddingPricing(
+	modelId: string,
+	priceTable: EmbeddingModelPriceTable,
+): EmbeddingModelPrice {
+	const modelPricing = priceTable[modelId];
+	if (!modelPricing) {
+		throw new Error(`No embedding pricing found for model ${modelId}`);
+	}
+
+	const now = new Date();
+	const validPrices = modelPricing.prices
+		.filter((price) => new Date(price.validFrom) <= now)
+		.sort(
+			(a, b) =>
+				new Date(b.validFrom).getTime() - new Date(a.validFrom).getTime(),
+		);
+
+	if (validPrices.length === 0) {
+		throw new Error(`No valid embedding pricing found for model ${modelId}`);
+	}
+
+	return validPrices[0];
+}
+
+// Embedding pricing tables (per 1M tokens)
+// validFrom is unified per request
+export const openAiEmbeddingPricing: EmbeddingModelPriceTable = {
+	"text-embedding-3-small": {
+		prices: [
+			{
+				validFrom: "2025-08-28T00:00:00Z",
+				costPerMegaToken: 0.01,
+			},
+		],
+	},
+	"text-embedding-3-large": {
+		prices: [
+			{
+				validFrom: "2025-08-28T00:00:00Z",
+				costPerMegaToken: 0.065,
+			},
+		],
+	},
+};
+
+export const googleEmbeddingPricing: EmbeddingModelPriceTable = {
+	"gemini-embedding-001": {
+		prices: [
+			{
+				validFrom: "2025-08-28T00:00:00Z",
+				costPerMegaToken: 0.15,
+			},
+		],
+	},
+};


### PR DESCRIPTION
### **User description**
Summary:
- Add an embedding-only pricing table and calculator that returns { totalCostForDisplay }.
- Align Langfuse embedding usage to totalTokens/totalCost only.

Changes:
- packages/language-model/src/costs/model-prices.ts:
  - Add EmbeddingModelPriceTable + getValidEmbeddingPricing
  - Prices (per 1M tokens, validFrom: 2025-08-28T00:00:00Z):
    - OpenAI: text-embedding-3-small 0.01, text-embedding-3-large 0.065
    - Google: gemini-embedding-001 0.15
- packages/language-model/src/costs/index.ts: add calculateEmbeddingDisplayCost returning { totalCostForDisplay }
- packages/langfuse/src/trace-embedding.ts: switch to totalTokens/totalCost usage shape
- packages/language-model/src/costs/embedding-costs.test.ts: add/update tests

Notes:
- Removed legacy ada-002 pricing (not supported).
- Intended to land after #1754  and before ingestion/query tracing PRs.


___

### **PR Type**
Enhancement


___

### **Description**
- Add embedding model pricing tables for OpenAI and Google

- Implement cost calculation for embedding operations

- Update Langfuse tracing to include embedding costs

- Add comprehensive test coverage for embedding pricing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Embedding Usage"] --> B["calculateEmbeddingDisplayCost"]
  B --> C["Price Tables"]
  C --> D["Cost Calculation"]
  D --> E["Langfuse Tracing"]
  F["OpenAI Pricing"] --> C
  G["Google Pricing"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Add embedding model pricing infrastructure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Add <code>EmbeddingModelPriceTable</code> type and <code>getValidEmbeddingPricing</code> <br>function<br> <li> Define pricing tables for OpenAI and Google embedding models<br> <li> Set prices per 1M tokens with validFrom date of 2025-08-28</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1755/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Implement embedding cost calculation function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/index.ts

<ul><li>Import embedding pricing functions and types<br> <li> Add <code>calculateEmbeddingDisplayCost</code> function for cost calculation<br> <li> Handle provider-specific pricing with error fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1755/files#diff-df9a3d559770f2a99e5d418a460d01e4e3a2cd75bcc922252ef012790816235e">+54/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>trace-embedding.ts</strong><dd><code>Integrate embedding cost calculation into tracing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/langfuse/src/trace-embedding.ts

<ul><li>Import <code>calculateEmbeddingDisplayCost</code> function<br> <li> Calculate actual costs using token usage and model pricing<br> <li> Update trace generation with real <code>totalCost</code> values</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1755/files#diff-759d9723bf8c7ca1e9ef57c0b33c45b2e2effb0aba2c8821bc441f62e499f6f0">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>embedding-costs.test.ts</strong><dd><code>Add embedding cost calculation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/embedding-costs.test.ts

<ul><li>Add comprehensive tests for OpenAI embedding models<br> <li> Test Google gemini-embedding-001 pricing calculation<br> <li> Verify cost calculations with precise decimal assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1755/files#diff-b292703e48ba7493aa3ffb70aa3cd9db04a08cb4828d5b76d7338281b204037f">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Embedding requests now show calculated costs in the UI for supported OpenAI and Google models.
  - Costs are computed automatically based on token usage for clearer spend visibility.

- Bug Fixes
  - Replaced placeholder embedding cost (0) with accurate pricing.
  - Ensured total token usage is correctly aggregated for cost calculation.

- Tests
  - Added test coverage validating embedding cost calculations across multiple providers and models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->