### PR TITLE
refactor(giselle): remove unused telemetry from image generation

### DIFF
--- a/packages/giselle/src/engine/generations/generate-image.ts
+++ b/packages/giselle/src/engine/generations/generate-image.ts
@@ -21,7 +21,6 @@ import {
 } from "../../concepts/generation";
 import type { GiselleEngineContext } from "../types";
 import { useGenerationExecutor } from "./internal/use-generation-executor";
-import type { TelemetrySettings } from "./types";
 import {
 	buildMessageObject,
 	detectImageType,
@@ -31,7 +30,6 @@ import {
 export function generateImage(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
-	telemetry?: TelemetrySettings;
 	useExperimentalStorage: boolean;
 	signal?: AbortSignal;
 }) {

--- a/packages/giselle/src/engine/generations/types.ts
+++ b/packages/giselle/src/engine/generations/types.ts
@@ -1,8 +1,4 @@
-import type { TelemetrySettings as AI_TelemetrySettings, ToolSet } from "ai";
-
-export interface TelemetrySettings {
-	metadata?: AI_TelemetrySettings["metadata"];
-}
+import type { ToolSet } from "ai";
 
 export type PreparedToolSet = {
 	toolSet: ToolSet;

--- a/packages/giselle/src/engine/index.ts
+++ b/packages/giselle/src/engine/index.ts
@@ -44,7 +44,6 @@ import {
 	getNodeGenerations,
 	type QueuedGeneration,
 	setGeneration,
-	type TelemetrySettings,
 } from "./generations";
 import { flushGenerationIndexQueue } from "./generations/internal/act-generation-index-queue";
 import {
@@ -210,14 +209,12 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		generateImage: async (
 			generation: QueuedGeneration,
 			useExperimentalStorage: boolean,
-			telemetry?: TelemetrySettings,
 			signal?: AbortSignal,
 		) => {
 			return await generateImage({
 				context,
 				generation,
 				useExperimentalStorage,
-				telemetry,
 				signal,
 			});
 		},

--- a/packages/giselle/src/http/router.ts
+++ b/packages/giselle/src/http/router.ts
@@ -25,7 +25,6 @@ import {
 	GenerationId,
 	GenerationOrigin,
 	QueuedGeneration,
-	type TelemetrySettings,
 } from "../engine/generations";
 import { JsonResponse } from "../utils";
 import { createHandler, withUsageLimitErrorHandler } from "./create-handler";
@@ -180,13 +179,11 @@ export const createJsonRouters = {
 				input: z.object({
 					generation: QueuedGeneration,
 					useExperimentalStorage: z.boolean(),
-					telemetry: z.custom<TelemetrySettings>().optional(),
 				}),
 				handler: async ({ input, signal }) => {
 					await giselleEngine.generateImage(
 						input.generation,
 						input.useExperimentalStorage,
-						input.telemetry,
 						signal,
 					);
 					return new Response(null, { status: 204 });

--- a/packages/giselle/src/react/generations/generation-runner.tsx
+++ b/packages/giselle/src/react/generations/generation-runner.tsx
@@ -8,7 +8,6 @@ import {
 	isQueuedGeneration,
 } from "../../concepts/generation";
 import { useFeatureFlag } from "../feature-flags";
-import { useTelemetry } from "../telemetry";
 import { useGiselleEngine } from "../use-giselle-engine";
 import { useGenerationRunnerSystem } from "./contexts/generation-runner-system";
 
@@ -124,7 +123,6 @@ function ImageGenerationRunner({ generation }: { generation: Generation }) {
 	} = useGenerationRunnerSystem();
 	const { experimental_storage } = useFeatureFlag();
 	const client = useGiselleEngine();
-	const telemetry = useTelemetry();
 	const abortControllerRef = useRef<AbortController | null>(null);
 
 	const stop = useCallback(() => {
@@ -155,7 +153,6 @@ function ImageGenerationRunner({ generation }: { generation: Generation }) {
 					await client.generateImage(
 						{
 							generation,
-							telemetry,
 							useExperimentalStorage: experimental_storage,
 						},
 						{ signal: abortController.signal },


### PR DESCRIPTION
### **User description**
This PR removes unused telemetry plumbing from the image generation path.

Changes

- Remove TelemetrySettings type and parameter from generation types
- Drop telemetry from engine API, HTTP router, and React runner
- No behavioral impact; fields were unused


___

### **PR Type**
Other


___

### **Description**
- Remove unused `TelemetrySettings` type and parameters

- Clean up telemetry plumbing from image generation

- Strip telemetry from engine API and HTTP router

- Remove telemetry usage from React runner component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TelemetrySettings type"] -- "removed from" --> B["Generation types"]
  C["Engine API"] -- "telemetry parameter removed" --> D["generateImage function"]
  E["HTTP router"] -- "telemetry input removed" --> F["Image generation endpoint"]
  G["React runner"] -- "telemetry hook removed" --> H["ImageGenerationRunner"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-image.ts</strong><dd><code>Remove telemetry parameter from image generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/generate-image.ts

<ul><li>Remove <code>TelemetrySettings</code> import<br> <li> Drop <code>telemetry</code> parameter from <code>generateImage</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1759/files#diff-61de51aa8915a3133418e86b44e65270da1d21e0e25c20888a5a13bd16b77413">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Remove TelemetrySettings type definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/types.ts

<ul><li>Delete <code>TelemetrySettings</code> interface definition<br> <li> Remove <code>AI_TelemetrySettings</code> import<br> <li> Keep only <code>ToolSet</code> import</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1759/files#diff-30cf8ceaf047ab960bc69f85a7861427b09d58b91f4092dad77e29cbc0385333">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Remove telemetry from engine API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/index.ts

<ul><li>Remove <code>TelemetrySettings</code> import<br> <li> Drop <code>telemetry</code> parameter from <code>generateImage</code> method<br> <li> Update function signature and call</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1759/files#diff-96a319ad87ae93d0a9bbf783a2f323c01833adf52dee5d3321684a26b7e1c74a">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.ts</strong><dd><code>Remove telemetry from HTTP router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/http/router.ts

<ul><li>Remove <code>TelemetrySettings</code> import<br> <li> Drop <code>telemetry</code> field from input schema<br> <li> Remove telemetry parameter from handler call</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1759/files#diff-642a528890ac508b2bfeb93f61540c69062a6733f4ad3948cf70eefbbdb6bc07">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generation-runner.tsx</strong><dd><code>Remove telemetry from React runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/generations/generation-runner.tsx

<ul><li>Remove <code>useTelemetry</code> hook import and usage<br> <li> Drop telemetry parameter from <code>generateImage</code> call</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1759/files#diff-176ab85fc92facda33ffaa5227d9e6f062abe67614f90723d845f2200f3ab5b8">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified image generation API by removing the telemetry parameter across engine, HTTP endpoint input, and React runner. Existing behavior remains unchanged.
- New Features
  - Added a PreparedToolSet type to support bundling tools with associated cleanup functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->