### PR TITLE
feat(giselle): add resumableGeneration flag through engine to UI and types

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -21,6 +21,7 @@ export default async function Layout({
 				stage: true,
 				multiEmbedding: false,
 				aiGateway: false,
+				resumableGeneration: false,
 			}}
 		>
 			{children}

--- a/apps/studio.giselles.ai/app/stage/(top)/actions.ts
+++ b/apps/studio.giselles.ai/app/stage/(top)/actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { after } from "next/server";
 import { giselleEngine } from "@/app/giselle-engine";
 import { acts as actsSchema, db } from "@/drizzle";
-import { aiGatewayFlag } from "@/flags";
+import { aiGatewayFlag, resumableGenerationFlag } from "@/flags";
 import { fetchCurrentUser } from "@/services/accounts";
 import type { PerformStagePayloads } from "./types";
 
@@ -41,11 +41,13 @@ export async function performStageAction(
 		});
 
 		const useAiGateway = await aiGatewayFlag();
+		const useResumableGeneration = await resumableGenerationFlag();
 
 		after(() =>
 			giselleEngine.startAct({
 				actId: act.id,
 				useAiGateway,
+				useResumableGeneration,
 			}),
 		);
 

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -8,6 +8,7 @@ import {
 	experimental_storageFlag,
 	layoutV3Flag,
 	multiEmbeddingFlag,
+	resumableGenerationFlag,
 	runV3Flag,
 	stageFlag,
 	webSearchActionFlag,
@@ -52,6 +53,8 @@ export default async function Layout({
 	const stage = await stageFlag();
 	const multiEmbedding = await multiEmbeddingFlag();
 	const aiGateway = await aiGatewayFlag();
+	const resumableGeneration = await resumableGenerationFlag();
+
 	// return children
 	return (
 		<WorkspaceProvider
@@ -86,6 +89,7 @@ export default async function Layout({
 				stage,
 				multiEmbedding,
 				aiGateway,
+				resumableGeneration,
 			}}
 			flowTrigger={{
 				callbacks: {

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -153,3 +153,22 @@ export const aiGatewayFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const resumableGenerationFlag = flag<boolean>({
+	key: "resumable-generation",
+	async decide() {
+		if (process.env.NODE_ENV === "development") {
+			return takeLocalEnv("RESUMABLE_GENERATION_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return edgeConfig === true || edgeConfig === "true";
+	},
+	description: "Enable resumable generation",
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});

--- a/packages/giselle/src/concepts/generation/index.ts
+++ b/packages/giselle/src/concepts/generation/index.ts
@@ -71,6 +71,7 @@ export const RunningGeneration = GenerationBase.extend({
 	queuedAt: z.number(),
 	startedAt: z.number(),
 	messages: z.array(Message),
+	resumePointer: z.string().optional(),
 });
 export type RunningGeneration = z.infer<typeof RunningGeneration>;
 
@@ -94,6 +95,7 @@ export const CompletedGeneration = GenerationBase.extend({
 	messages: z.array(Message),
 	outputs: z.array(GenerationOutput),
 	usage: GenerationUsage.optional(),
+	resumePointer: z.string().optional(),
 });
 export type CompletedGeneration = z.infer<typeof CompletedGeneration>;
 

--- a/packages/giselle/src/engine/acts/create-and-start-act.ts
+++ b/packages/giselle/src/engine/acts/create-and-start-act.ts
@@ -30,5 +30,6 @@ export async function createAndStartAct(
 		actId: act.id,
 		callbacks: args.callbacks,
 		useAiGateway: args.useAiGateway,
+		useResumableGeneration: args.useResumableGeneration,
 	});
 }

--- a/packages/giselle/src/engine/acts/start-act.ts
+++ b/packages/giselle/src/engine/acts/start-act.ts
@@ -38,6 +38,7 @@ async function executeStep(args: {
 		onFailed?: (generation: QueuedGeneration) => void | Promise<void>;
 	};
 	useAiGateway: boolean;
+	useResumableGeneration: boolean;
 }) {
 	try {
 		switch (args.generation.context.operationNode.content.type) {
@@ -51,7 +52,6 @@ async function executeStep(args: {
 				const generateTextStream = await generateText({
 					...args,
 					useExperimentalStorage: true,
-					useAiGateway: args.useAiGateway,
 				});
 
 				// Consume the stream to trigger completion callbacks and persist generation results
@@ -81,6 +81,7 @@ export const StartActInputs = z.object({
 	actId: ActId.schema,
 	callbacks: z.optional(z.custom<StartActCallbacks>()),
 	useAiGateway: z.boolean().default(false),
+	useResumableGeneration: z.boolean().default(false),
 });
 export type StartActInputs = z.infer<typeof StartActInputs>;
 
@@ -119,6 +120,7 @@ export async function startAct(
 					generation: queuedGeneration,
 					callbacks,
 					useAiGateway: args.useAiGateway,
+					useResumableGeneration: args.useResumableGeneration,
 				});
 			},
 			onSequenceStart: async (sequence) => {

--- a/packages/giselle/src/engine/generations/generate-text.ts
+++ b/packages/giselle/src/engine/generations/generate-text.ts
@@ -37,11 +37,13 @@ export function generateText(args: {
 	generation: QueuedGeneration;
 	useExperimentalStorage: boolean;
 	useAiGateway: boolean;
+	useResumableGeneration: boolean;
 }) {
 	return useGenerationExecutor({
 		context: args.context,
 		generation: args.generation,
 		useExperimentalStorage: args.useExperimentalStorage,
+		useResumableGeneration: args.useResumableGeneration,
 		execute: async ({
 			completeGeneration,
 			runningGeneration,

--- a/packages/giselle/src/engine/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/engine/generations/internal/use-generation-executor.ts
@@ -47,6 +47,7 @@ export async function useGenerationExecutor<T>(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
 	useExperimentalStorage?: boolean;
+	useResumableGeneration?: boolean;
 	signal?: AbortSignal;
 	execute: (utils: {
 		runningGeneration: RunningGeneration;

--- a/packages/giselle/src/engine/github/event-handlers.ts
+++ b/packages/giselle/src/engine/github/event-handlers.ts
@@ -491,6 +491,7 @@ export async function processEvent<TEventName extends WebhookEventName>(
 				},
 			},
 			useAiGateway: false,
+			useResumableGeneration: false,
 		});
 		const greeting = hasFlowError
 			? "Unexpected error on running flow"

--- a/packages/giselle/src/engine/index.ts
+++ b/packages/giselle/src/engine/index.ts
@@ -122,12 +122,14 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 			generation: QueuedGeneration,
 			useExperimentalStorage: boolean,
 			useAiGateway: boolean,
+			useResumableGeneration: boolean,
 		) => {
 			return await generateText({
 				context,
 				generation,
 				useExperimentalStorage,
 				useAiGateway,
+				useResumableGeneration,
 			});
 		},
 		getGeneration: async (

--- a/packages/giselle/src/http/router.ts
+++ b/packages/giselle/src/http/router.ts
@@ -84,12 +84,14 @@ export const createJsonRouters = {
 					generation: QueuedGeneration,
 					useExperimentalStorage: z.boolean(),
 					useAiGateway: z.boolean(),
+					useResumableGeneration: z.boolean(),
 				}),
 				handler: async ({ input }) => {
 					const stream = await giselleEngine.generateText(
 						input.generation,
 						input.useExperimentalStorage,
 						input.useAiGateway,
+						input.useResumableGeneration,
 					);
 					return createUIMessageStreamResponse({ stream });
 				},

--- a/packages/giselle/src/react/feature-flags/context.ts
+++ b/packages/giselle/src/react/feature-flags/context.ts
@@ -8,6 +8,7 @@ export interface FeatureFlagContextValue {
 	stage: boolean;
 	multiEmbedding: boolean;
 	aiGateway: boolean;
+	resumableGeneration: boolean;
 }
 export const FeatureFlagContext = createContext<
 	FeatureFlagContextValue | undefined

--- a/packages/giselle/src/react/generations/generation-runner.tsx
+++ b/packages/giselle/src/react/generations/generation-runner.tsx
@@ -68,7 +68,8 @@ function TextGenerationRunner({ generation }: { generation: Generation }) {
 }
 
 function CompletionRunner({ generation }: { generation: Generation }) {
-	const { experimental_storage, aiGateway } = useFeatureFlag();
+	const { experimental_storage, aiGateway, resumableGeneration } =
+		useFeatureFlag();
 	const {
 		generateTextApi,
 		updateGenerationStatusToRunning,
@@ -84,6 +85,7 @@ function CompletionRunner({ generation }: { generation: Generation }) {
 				generation,
 				useExperimentalStorage: experimental_storage,
 				useAiGateway: aiGateway,
+				useResumableGeneration: resumableGeneration,
 			},
 		}),
 		onFinish: async () => {

--- a/packages/giselle/src/react/workspace/provider.tsx
+++ b/packages/giselle/src/react/workspace/provider.tsx
@@ -70,6 +70,7 @@ export function WorkspaceProvider({
 				stage: featureFlag?.stage ?? false,
 				multiEmbedding: featureFlag?.multiEmbedding ?? false,
 				aiGateway: featureFlag?.aiGateway ?? false,
+				resumableGeneration: featureFlag?.resumableGeneration ?? false,
 			}}
 		>
 			<TelemetryProvider settings={telemetry}>


### PR DESCRIPTION
### **User description**
- Add resumableGeneration flag support through engine to UI and types
- Expose resumableGeneration in types used by UI
- Ensure engine forwards resumableGeneration to UI components


___

### **PR Type**
Enhancement


___

### **Description**
- Add resumableGeneration feature flag support throughout the system

- Extend generation types with resumePointer field

- Thread flag from UI through engine to execution layer

- Enable resumable text generation capability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["UI Components"] -- "resumableGeneration flag" --> Engine["Giselle Engine"]
  Engine -- "useResumableGeneration param" --> Executor["Generation Executor"]
  Types["Generation Types"] -- "resumePointer field" --> Running["Running Generation"]
  Types -- "resumePointer field" --> Completed["Completed Generation"]
  FeatureFlag["Feature Flag Context"] -- "resumableGeneration" --> UI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add resumePointer to generation types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/concepts/generation/index.ts

<ul><li>Add optional <code>resumePointer</code> field to RunningGeneration schema<br> <li> Add optional <code>resumePointer</code> field to CompletedGeneration schema</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-f45dd98c6d76cbb44bd17b27f6970c279065c20570433c368437946799c62780">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generate-text.ts</strong><dd><code>Add resumable generation parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/generate-text.ts

<ul><li>Add <code>useResumableGeneration</code> parameter to generateText function<br> <li> Pass flag through to useGenerationExecutor</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-5400b929dc7742af3e854d768fec81e158d4e91f51eada68eb9316aea079ef21">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-generation-executor.ts</strong><dd><code>Support resumable generation in executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/internal/use-generation-executor.ts

<ul><li>Add optional <code>useResumableGeneration</code> parameter to function signature</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-645da4ddaf278f6429309520143adef3cd2dc3f58b65f760c4e2b96202218c23">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Expose resumable generation in engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/index.ts

<ul><li>Add <code>useResumableGeneration</code> parameter to generateText method<br> <li> Forward parameter to internal generateText function</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-96a319ad87ae93d0a9bbf783a2f323c01833adf52dee5d3321684a26b7e1c74a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.ts</strong><dd><code>Add resumable generation to HTTP API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/http/router.ts

<ul><li>Add <code>useResumableGeneration</code> to input schema validation<br> <li> Pass parameter to engine generateText method</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-642a528890ac508b2bfeb93f61540c69062a6733f4ad3948cf70eefbbdb6bc07">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>context.ts</strong><dd><code>Add resumable generation feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/feature-flags/context.ts

<ul><li>Add <code>resumableGeneration</code> boolean field to FeatureFlagContextValue <br>interface</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-51e00df034c44dc1e5319c55d0effbebeb1358b9492f9c4f140b4caafe891bbe">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generation-runner.tsx</strong><dd><code>Use resumable generation flag in runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/generations/generation-runner.tsx

<ul><li>Extract <code>resumableGeneration</code> from useFeatureFlag hook<br> <li> Pass flag to chat transport body configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-176ab85fc92facda33ffaa5227d9e6f062abe67614f90723d845f2200f3ab5b8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provider.tsx</strong><dd><code>Provide resumable generation flag context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/provider.tsx

<ul><li>Add <code>resumableGeneration</code> field to feature flag context value<br> <li> Default to false when feature flag is undefined</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1760/files#diff-8a9be06df265f969925b0eaaa2a4817e372f5a9038025ba24b59438ce6c69744">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Resumable generation support via a new feature flag; UI surfaces propagate the flag so enabled requests can run in resumable mode.
  - Added an optional resume pointer on running and completed generations to allow continuing interrupted runs.

- API
  - Text-generation APIs and engine calls accept a new boolean option to opt into resumable generation; HTTP requests must include this flag when used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->