### PR TITLE
Fix GPT-5 reasoning item error by removing step count limit

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
@@ -1,5 +1,9 @@
 import type { TextGenerationNode } from "@giselle-sdk/data-type";
-import type { CompletedGeneration, Generation } from "@giselle-sdk/giselle";
+import type {
+	CompletedGeneration,
+	FailedGeneration,
+	Generation,
+} from "@giselle-sdk/giselle";
 import {
 	useNodeGenerations,
 	useWorkflowDesigner,
@@ -98,6 +102,17 @@ function getGenerationTextContent(generation: Generation): string {
 		.join("\n");
 }
 
+// Helper function to extract error content from a failed generation
+function getGenerationErrorContent(generation: Generation): string {
+	if (generation.status === "failed") {
+		const failedGeneration = generation as FailedGeneration;
+		const error = failedGeneration.error;
+		return `${error.name}: ${error.message}`;
+	}
+
+	return "";
+}
+
 export function GenerationPanel({
 	node,
 	onClickGenerateButton,
@@ -177,6 +192,13 @@ export function GenerationPanel({
 					<ClipboardButton
 						text={getGenerationTextContent(currentGeneration)}
 						tooltip="Copy to clipboard"
+						className="text-black-400 hover:text-black-300"
+					/>
+				)}
+				{currentGeneration.status === "failed" && (
+					<ClipboardButton
+						text={getGenerationErrorContent(currentGeneration)}
+						tooltip="Copy error to clipboard"
 						className="text-black-400 hover:text-black-300"
 					/>
 				)}

--- a/packages/giselle/src/engine/generations/generate-text.ts
+++ b/packages/giselle/src/engine/generations/generate-text.ts
@@ -14,7 +14,7 @@ import {
 	hasCapability,
 	languageModels,
 } from "@giselle-sdk/language-model";
-import { AISDKError, stepCountIs, streamText } from "ai";
+import { AISDKError, streamText } from "ai";
 import type {
 	FailedGeneration,
 	GenerationOutput,
@@ -224,7 +224,6 @@ export function generateText(args: {
 						),
 					);
 				},
-				stopWhen: stepCountIs(Object.keys(preparedToolSet.toolSet).length + 1),
 				async onFinish() {
 					try {
 						await Promise.all(


### PR DESCRIPTION
## Summary
This PR fixes an error that frequently occurs with GPT-5 series models where reasoning items are provided without their required following items. The issue was caused by the step count limit interrupting the generation process before all required items could be produced.


<img width="1398" height="672" alt="スクリーンショット 2025-08-28 12 44 48" src="https://github.com/user-attachments/assets/852f7be9-86b3-4f89-95ea-2634661be4b2" />

## Related Issue
N/A

## Changes
- Removed `stopWhen: stepCountIs(Object.keys(preparedToolSet.toolSet).length + 1)` parameter from `streamText` function call
- Removed unused `stepCountIs` import from the `ai` package
- Modified `packages/giselle/src/engine/generations/generate-text.ts`

## Testing
- Test with GPT-5 series models to ensure the "AI_APICallError: Item '...' of type 'reasoning' was provided without its required following item" error no longer occurs
- Verify that reasoning steps are followed by their required items
- Confirm that text generation completes successfully without premature termination

## Other Information
The GPT-5 series models include reasoning steps in their responses, which require subsequent items to be valid. The previous step count limit was interrupting the generation process mid-flow, causing incomplete reasoning chains. By removing this artificial limit, the models can now complete their full reasoning process and provide all required items.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove step count limit from text generation

- Fix GPT-5 reasoning item error

- Allow complete reasoning chain execution

- Remove unused import from ai package


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Text Generation"] -- "Remove limit" --> B["Unlimited Steps"]
  B -- "Complete" --> C["Full Reasoning Chain"]
  C -- "Fix" --> D["GPT-5 Error Resolved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-text.ts</strong><dd><code>Remove step count limit from text generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/generate-text.ts

<ul><li>Remove <code>stopWhen: stepCountIs()</code> parameter from <code>streamText</code> call<br> <li> Remove unused <code>stepCountIs</code> import from ai package<br> <li> Allow text generation to continue without artificial step limits</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1762/files#diff-5400b929dc7742af3e854d768fec81e158d4e91f51eada68eb9316aea079ef21">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

