### PR TITLE
fix(studio): enforce max avatar image size limit

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
@@ -95,7 +95,7 @@ export function ProfileEditModal({
 			return;
 		}
 
-		if (file.size > IMAGE_CONSTRAINTS.maxSize) {
+		if (file.size >= IMAGE_CONSTRAINTS.maxSize) {
 			setAvatarError(
 				`Please select an image under ${IMAGE_CONSTRAINTS.maxSize / (1024 * 1024)}MB in size`,
 			);

--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-profile-edit-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-profile-edit-modal.tsx
@@ -104,7 +104,7 @@ export function TeamProfileEditModal({
 			return;
 		}
 
-		if (file.size > IMAGE_CONSTRAINTS.maxSize) {
+		if (file.size >= IMAGE_CONSTRAINTS.maxSize) {
 			setProfileImageError(
 				`Please select an image under ${IMAGE_CONSTRAINTS.maxSize / (1024 * 1024)}MB in size`,
 			);

--- a/apps/studio.giselles.ai/app/(main)/settings/utils/avatar-upload.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/utils/avatar-upload.ts
@@ -32,7 +32,7 @@ export function validateImageFile(file: File): {
 				"Invalid file format. Please upload a JPG, PNG, GIF, or WebP image.",
 		};
 	}
-	if (file.size > IMAGE_CONSTRAINTS.maxSize) {
+	if (file.size >= IMAGE_CONSTRAINTS.maxSize) {
 		return {
 			valid: false,
 			error: `File size exceeds ${IMAGE_CONSTRAINTS.maxSize / (1024 * 1024)}MB limit`,


### PR DESCRIPTION
Summary
- Reject files with size >= `IMAGE_CONSTRAINTS.maxSize` to correctly enforce the limit.
- Applies to both Profile and Team image upload modals.
- Keeps error messages and validation consistent.

Changes
- apps/studio.giselles.ai/app/(main)/settings/utils/avatar-upload.ts
- apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx
- apps/studio.giselles.ai/app/(main)/settings/team/team-profile-edit-modal.tsx

Validation
- Formatting: Biome clean
- Type check: passed (`pnpm turbo check-types`)
- Tests: packages pass; studio app shows sandbox-specific EPERM worker termination unrelated to this change

Notes
- No UI changes; only validation boundary tightened from `>` to `>=`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile and team profile picture uploads now consistently enforce the maximum image size: images at the size limit are rejected with the standard error to prevent oversized uploads.
  * Standardized image size validation across upload flows for more predictable behavior and clearer error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->