### PR TITLE
ci: add 10 minute timeout to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0


### PR DESCRIPTION
### **User description**
## Summary
Add 10 minute timeout to e2e workflow.

## Related Issue
https://github.com/giselles-ai/giselle/actions/runs/17287998910/job/49068799485#step:9:18

## Changes
I've tried explicitly setting the timeout period.

## Testing
Run e2e in GitHub Actions.


___

### **PR Type**
Other


___

### **Description**
- Add 10-minute timeout to e2e workflow job


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["E2E Workflow"] --> B["Add timeout-minutes: 10"] --> C["Prevent hanging jobs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e.yml</strong><dd><code>Add timeout configuration to e2e job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e.yml

- Add `timeout-minutes: 10` to e2e job configuration


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1764/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Implemented a maximum runtime for the end-to-end test job in continuous integration to prevent stalled runs and improve pipeline reliability.
- Tests
  - End-to-end job now terminates after 10 minutes if still running, ensuring timely feedback without altering existing test steps or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->