### PR TITLE
fix(workflow-designer-ui): remove Query node's dynamic input when disconnecting Vector Store

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -60,7 +60,8 @@ function getDataSourceDisplayInfo(input: ConnectedSource): {
 }
 
 export function QueryPanel({ node }: { node: QueryNode }) {
-	const { updateNodeDataContent, deleteConnection } = useWorkflowDesigner();
+	const { updateNodeDataContent, deleteConnection, updateNodeData } =
+		useWorkflowDesigner();
 	const { all: connectedInputs } = useConnectedSources(node);
 	const connectedDatasourceInputs = useMemo(
 		() =>
@@ -131,9 +132,17 @@ export function QueryPanel({ node }: { node: QueryNode }) {
 											</div>
 											<button
 												type="button"
-												onClick={() =>
-													deleteConnection(dataSource.connection.id)
-												}
+												onClick={() => {
+													// Remove the connection between Vector Store and this Query node
+													deleteConnection(dataSource.connection.id);
+													// Also remove the dynamically created input associated with this connection
+													updateNodeData(node, {
+														inputs: node.inputs.filter(
+															(input) =>
+																input.id !== dataSource.connection.inputId,
+														),
+													});
+												}}
 												className="ml-1 p-0.5 rounded transition-colors"
 												style={{
 													color: "rgba(131, 157, 195, 0.7)",


### PR DESCRIPTION
### **User description**
Summary:
When removing a Vector Store connection from a Query node in the properties panel, the dynamically created input on the Query node wasn't being cleaned up. This left a stale input visible and caused inconsistent node state.

Change:
On delete, also update the node's data to filter out the input associated with the removed connection.

Affected area:
internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx

Behavior:
Removing a Vector Store connection now also removes the corresponding dynamic input from the Query node, keeping the UI and graph state in sync.

Risk:
Low — change is scoped to the specific delete action in QueryPanel.

Checks:
Ran pnpm format, build-sdk, check-types, tidy, and test. All passed locally.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix stale dynamic input cleanup in Query node

- Remove Vector Store connection and associated input

- Maintain UI and graph state consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Vector Store Connection"] -- "delete" --> B["Query Node"]
  B -- "remove connection" --> C["Connection Deleted"]
  B -- "filter inputs" --> D["Dynamic Input Removed"]
  C --> E["Consistent State"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query-panel.tsx</strong><dd><code>Enhanced Vector Store connection deletion with input cleanup</code></dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx

<ul><li>Added <code>updateNodeData</code> hook import<br> <li> Enhanced delete button click handler to remove dynamic input<br> <li> Filter out input associated with deleted connection<br> <li> Added comments explaining the cleanup process</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1765/files#diff-2f277cc52b1175885fefa342e968f15baeb98b0ab10803c97192777b2cbfd05e">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Removing a data source connection in the Query panel now also removes its associated input field. This prevents orphaned fields, keeps connections and inputs in sync, and reduces confusion. The removal flow is more reliable and results in a cleaner, more consistent editing experience when configuring queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->