### PR TITLE
Settings: Allow saving only when the form is valid

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-profile-edit-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-profile-edit-modal.tsx
@@ -53,8 +53,25 @@ export function TeamProfileEditModal({
 	const [error, setError] = useState<string>("");
 	const [profileImageError, setProfileImageError] = useState<string>("");
 	const [isLoading, setIsLoading] = useState(false);
-	const hasChanges =
-		selectedProfileImageFile !== null || teamName !== initialTeamName;
+
+	// Derived validity state (simple consts)
+	const trimmedTeamName = teamName.trim();
+	const trimmedInitialTeamName = initialTeamName.trim();
+	const isTeamNameChanged = trimmedTeamName !== trimmedInitialTeamName;
+	let isTeamNameValid = true;
+	if (isTeamNameChanged) {
+		try {
+			parse(TeamNameSchema, trimmedTeamName);
+			isTeamNameValid = true;
+		} catch {
+			isTeamNameValid = false;
+		}
+	}
+	const isProfileImageValid = profileImageError === "";
+	const isFormSubmittable =
+		(selectedProfileImageFile !== null || isTeamNameChanged) &&
+		isTeamNameValid &&
+		isProfileImageValid;
 
 	// Reset when the modal opens/closes
 	useEffect(() => {
@@ -143,9 +160,9 @@ export function TeamProfileEditModal({
 			setError("");
 			setProfileImageError("");
 
-			// Trim team name for validation and comparison
-			const trimmedName = teamName.trim();
-			const trimmedInitialName = initialTeamName.trim();
+			// Use memoized, trimmed values for validation and comparison
+			const trimmedName = trimmedTeamName;
+			const trimmedInitialName = trimmedInitialTeamName;
 
 			// Validate team name if changed
 			if (trimmedName !== trimmedInitialName) {
@@ -405,7 +422,7 @@ export function TeamProfileEditModal({
 										</button>
 										<button
 											type="button"
-											disabled={!hasChanges || isLoading}
+											disabled={!isFormSubmittable || isLoading}
 											onClick={handleSave}
 											className="flex-1 rounded-lg px-4 py-2 text-white/80 transition-all duration-200 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
 											style={{


### PR DESCRIPTION
### **User description**
Summary

- Improve the profile and team settings modals so the Save action is available only when the form has real changes and passes validation.
- Provide clear disabled states for Save to communicate when submission is not possible.

Scope

- Applies to user profile and team profile edit modals to ensure consistent, predictable form behavior.

User Impact

- Prevents accidental submissions with incomplete or invalid inputs.
- Clarifies readiness to save through clear button states.

Implementation Notes (brief)

- Align Save gating logic across both modals (change detected + valid inputs).
- Add visual disabled styles for the Save button.

Validation

- Save is enabled only with valid, meaningful changes; disabled otherwise.
- Error states block submission until resolved.

Risk

- Low; UI-only gating. Server-side behavior unchanged.


___

### **PR Type**
Enhancement


___

### **Description**
- Enable Save button only when form inputs are valid and changed

- Add trim-aware validation for display name and team name fields

- Improve disabled button styling with opacity and cursor changes

- Implement consistent validation logic across profile and team modals


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Form Input"] --> B["Trim & Validate"]
  B --> C["Check Changes"]
  C --> D["Enable/Disable Save"]
  D --> E["Visual Feedback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>profile-edit-modal.tsx</strong><dd><code>Enhanced profile modal validation and save logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/components/profile-edit-modal.tsx

<ul><li>Replace simple change detection with comprehensive validation logic<br> <li> Add trim-aware display name validation using schema parsing<br> <li> Update Save button to use <code>isFormSubmittable</code> instead of <code>hasChanges</code><br> <li> Enhance disabled button styling with opacity and cursor properties</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1766/files#diff-2e6b7897852898f1b34f0ca4eb52d79f3c02d067feaa62d50d3c6cd2a8d02b6b">+27/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>team-profile-edit-modal.tsx</strong><dd><code>Enhanced team profile modal validation and save logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/team-profile-edit-modal.tsx

<ul><li>Implement trim-aware team name validation with schema parsing<br> <li> Replace basic change detection with comprehensive form validation<br> <li> Update Save button to use <code>isFormSubmittable</code> for proper gating<br> <li> Add consistent disabled button styling matching profile modal</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1766/files#diff-43eb0e374ba4327947c8c6ba6620783fb6cf9e41f6faf9b1ba65917e01737043">+23/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Save button now enables only when a name or avatar change is made and all inputs are valid.
  - Names are trimmed to prevent whitespace-only changes and ensure saved names are clean.
  - Improved validation and clearer error messages for display/team names and profile images.
  - Prevents submission when avatar/profile image is invalid.
  - Consistent disabled state styling for the Save button during loading or invalid states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->