### PR TITLE
feat(rag,giselle,studio): Flagged pointer-based hydration to reduce pgvector transfer

### DIFF
--- a/apps/studio.giselles.ai/app/giselle-engine.ts
+++ b/apps/studio.giselles.ai/app/giselle-engine.ts
@@ -16,7 +16,9 @@ import { openaiVectorStore } from "@giselle-sdk/vector-store-adapters";
 import type { ModelMessage, ProviderMetadata } from "ai";
 import { after } from "next/server";
 import { createStorage } from "unstorage";
+import { ragPointerHydrationFlag } from "@/flags";
 import { waitForLangfuseFlush } from "@/instrumentation.node";
+import { installationIdForRepository } from "@/lib/vector-stores/github/query/installation-resolver";
 import { getWorkspaceTeam } from "@/lib/workspaces/get-workspace-team";
 import { fetchUsageLimits } from "@/packages/lib/fetch-usage-limits";
 import { onConsumeAgentTime } from "@/packages/lib/on-consume-agent-time";
@@ -196,9 +198,15 @@ export const giselleEngine = NextGiselleEngine({
 		},
 	},
 	vault,
+	featureFlags: {
+		ragPointerHydration: ragPointerHydrationFlag,
+	},
 	vectorStoreQueryServices: {
 		github: gitHubQueryService,
 		githubPullRequest: gitHubPullRequestQueryService,
+		githubInstallations: {
+			installationIdForRepository,
+		},
 	},
 	callbacks: {
 		generationComplete: (args) => {

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -172,3 +172,23 @@ export const resumableGenerationFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+// Enable pointer-based retrieval with engine-side hydration (no rerank, no re-chunk)
+export const ragPointerHydrationFlag = flag<boolean>({
+	key: "rag-pointer-hydration",
+	async decide() {
+		if (process.env.NODE_ENV === "development") {
+			return takeLocalEnv("RAG_POINTER_HYDRATION_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return edgeConfig === true || edgeConfig === "true";
+	},
+	description: "Enable pointer-based retrieval + engine hydration",
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});

--- a/apps/studio.giselles.ai/lib/vector-stores/github/query/blobs/service.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/query/blobs/service.ts
@@ -2,6 +2,7 @@ import { createPostgresQueryService } from "@giselle-sdk/rag";
 import { getTableName } from "drizzle-orm";
 import z from "zod/v4";
 import { githubRepositoryEmbeddings } from "@/drizzle";
+import { ragPointerHydrationFlag } from "@/flags";
 import { createDatabaseConfig } from "../../database";
 import { resolveGitHubEmbeddingFilter } from "./resolver";
 
@@ -17,4 +18,6 @@ export const gitHubQueryService = createPostgresQueryService({
 	}),
 	contextToFilter: resolveGitHubEmbeddingFilter,
 	contextToEmbeddingProfileId: (context) => context.embeddingProfileId,
+	// Omit chunk content from DB when pointer hydration is enabled
+	omitChunkContent: async () => await ragPointerHydrationFlag(),
 });

--- a/apps/studio.giselles.ai/lib/vector-stores/github/query/installation-resolver.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/query/installation-resolver.ts
@@ -1,0 +1,36 @@
+import type { WorkspaceId } from "@giselle-sdk/data-type";
+import { and, eq } from "drizzle-orm";
+import { agents, db, githubRepositoryIndex, teams } from "@/drizzle";
+
+/**
+ * Resolve GitHub App installationId for a repository within a workspace context.
+ */
+export async function installationIdForRepository(args: {
+	workspaceId: WorkspaceId;
+	owner: string;
+	repo: string;
+}): Promise<number | undefined> {
+	const { workspaceId, owner, repo } = args;
+
+	const teamRecords = await db
+		.select({ dbId: teams.dbId })
+		.from(teams)
+		.innerJoin(agents, eq(agents.teamDbId, teams.dbId))
+		.where(eq(agents.workspaceId, workspaceId))
+		.limit(1);
+	if (teamRecords.length === 0) return undefined;
+	const teamDbId = teamRecords[0].dbId;
+
+	const repoRows = await db
+		.select({ installationId: githubRepositoryIndex.installationId })
+		.from(githubRepositoryIndex)
+		.where(
+			and(
+				eq(githubRepositoryIndex.teamDbId, teamDbId),
+				eq(githubRepositoryIndex.owner, owner),
+				eq(githubRepositoryIndex.repo, repo),
+			),
+		)
+		.limit(1);
+	return repoRows[0]?.installationId ?? undefined;
+}

--- a/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/service.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/github/query/pull-requests/service.ts
@@ -1,6 +1,7 @@
 import { createPostgresQueryService } from "@giselle-sdk/rag";
 import { getTableName } from "drizzle-orm";
 import { githubRepositoryPullRequestEmbeddings } from "@/drizzle";
+import { ragPointerHydrationFlag } from "@/flags";
 import { createDatabaseConfig } from "../../database";
 import { addPRContextToResults } from "./pr-context-utils";
 import { resolveGitHubPullRequestEmbeddingFilter } from "./resolver";
@@ -16,4 +17,6 @@ export const gitHubPullRequestQueryService = createPostgresQueryService({
 	contextToFilter: resolveGitHubPullRequestEmbeddingFilter,
 	contextToEmbeddingProfileId: (context) => context.embeddingProfileId,
 	additionalResolver: addPRContextToResults,
+	// Omit chunk content from DB when pointer hydration is enabled
+	omitChunkContent: async () => await ragPointerHydrationFlag(),
 });

--- a/packages/giselle/src/engine/types.ts
+++ b/packages/giselle/src/engine/types.ts
@@ -57,9 +57,19 @@ export interface GiselleEngineContext {
 		metadata?: TelemetrySettings["metadata"];
 	};
 	vault: Vault;
+	featureFlags?: {
+		ragPointerHydration: () => Promise<boolean>;
+	};
 	vectorStoreQueryServices?: {
 		github?: GitHubVectorStoreQueryService<Record<string, unknown>>;
 		githubPullRequest?: GitHubVectorStoreQueryService<Record<string, unknown>>;
+		githubInstallations?: {
+			installationIdForRepository: (args: {
+				owner: string;
+				repo: string;
+				workspaceId: WorkspaceId;
+			}) => Promise<number | undefined>;
+		};
 	};
 	callbacks?: {
 		generationComplete?: GenerationCompleteCallbackFunction;
@@ -140,9 +150,19 @@ export interface GiselleEngineConfig {
 	};
 	fetchUsageLimitsFn?: FetchUsageLimitsFn;
 	vault: Vault;
+	featureFlags?: {
+		ragPointerHydration: () => Promise<boolean>;
+	};
 	vectorStoreQueryServices?: {
 		github?: GitHubVectorStoreQueryService<Record<string, unknown>>;
 		githubPullRequest?: GitHubVectorStoreQueryService<Record<string, unknown>>;
+		githubInstallations?: {
+			installationIdForRepository: (args: {
+				owner: string;
+				repo: string;
+				workspaceId: WorkspaceId;
+			}) => Promise<number | undefined>;
+		};
 	};
 	callbacks?: {
 		generationComplete?: GenerationCompleteCallbackFunction;


### PR DESCRIPTION
Purpose
- Current pgvector queries send full chunk content DB→App, incurring high transfer cost. Switch to late retrieval so the DB only returns IDs + minimal metadata, and hydrate content only when needed to reduce DB egress.
- This PR targets cost reduction only. Latency may increase.

Change (Overview)
- Add feature flag rag-pointer-hydration (default OFF).
- When ON, the DB omits chunk content; the engine hydrates only the top M (= maxResults) results (no re-chunk, no rerank).
- GitHub hydration uses authV2 with a per-repository installationId resolver.

Benefits
- Cost reduction: removes full-text transfer DB→App.
- Backward compatible: engine fills chunkContent post-hydration so UI/LLM behavior stays unchanged.
- Tunable: can later adjust M, concurrency, and max size caps.

Trade-offs / Risks
- Latency: N+1 external fetches can increase end-to-end time.
- Preconditions: hydration requires a repository installationId; missing entries error when the flag is ON.
- Operational sensitivity: more exposure to rate limits/transient failures; monitoring and retries matter.

Out of Scope (this PR)
- No rerank or re-chunk; advanced metrics and concurrency/size limits can follow.
- Not moving hydration to the UI (full late materialization) yet.
