### PR TITLE
feat-unify-generation-error-tracing

### DIFF
--- a/packages/giselle/src/engine/generations/generate-text.ts
+++ b/packages/giselle/src/engine/generations/generate-text.ts
@@ -225,6 +225,11 @@ export function generateText(args: {
 
 					await setGeneration(failedGeneration);
 
+					await args.context.callbacks?.generationFailed?.({
+						generation: failedGeneration,
+						inputMessages: messages,
+					});
+
 					await Promise.all(
 						preparedToolSet.cleanupFunctions.map((cleanupFunction) =>
 							cleanupFunction(),

--- a/packages/giselle/src/engine/generations/generate-text.ts
+++ b/packages/giselle/src/engine/generations/generate-text.ts
@@ -201,57 +201,49 @@ export function generateText(args: {
 				args.useAiGateway,
 				args.context.aiGateway,
 			);
-			let isGenerationFailed = false;
+			let generationError: unknown | undefined;
 			const streamTextResult = streamText({
 				model,
 				providerOptions,
 				messages,
 				tools: preparedToolSet.toolSet,
-				onError: async ({ error }) => {
-					isGenerationFailed = true;
-					const errInfo = AISDKError.isInstance(error)
-						? { name: error.name, message: error.message }
-						: {
-								name: "UnknownError",
-								message: error instanceof Error ? error.message : String(error),
-							};
-
-					const failedGeneration = {
-						...runningGeneration,
-						status: "failed",
-						failedAt: Date.now(),
-						error: errInfo,
-					} satisfies FailedGeneration;
-
-					await setGeneration(failedGeneration);
-
-					await args.context.callbacks?.generationFailed?.({
-						generation: failedGeneration,
-						inputMessages: messages,
-					});
-
-					await Promise.all(
-						preparedToolSet.cleanupFunctions.map((cleanupFunction) =>
-							cleanupFunction(),
-						),
-					);
-				},
-				async onFinish() {
-					try {
-						await Promise.all(
-							preparedToolSet.cleanupFunctions.map((cleanupFunction) =>
-								cleanupFunction(),
-							),
-						);
-					} catch (error) {
-						console.error("Cleanup process failed:", error);
-					}
+				onError: ({ error }) => {
+					generationError = error;
 				},
 			});
 			return streamTextResult.toUIMessageStream({
 				sendReasoning: true,
 				onFinish: async ({ messages: generateMessages }) => {
-					if (isGenerationFailed) {
+					await Promise.all(
+						preparedToolSet.cleanupFunctions.map((cleanupFunction) =>
+							cleanupFunction(),
+						),
+					);
+					if (generationError) {
+						const errInfo = AISDKError.isInstance(generationError)
+							? { name: generationError.name, message: generationError.message }
+							: {
+									name: "UnknownError",
+									message:
+										generationError instanceof Error
+											? generationError.message
+											: String(generationError),
+								};
+
+						const failedGeneration = {
+							...runningGeneration,
+							status: "failed",
+							failedAt: Date.now(),
+							error: errInfo,
+						} satisfies FailedGeneration;
+
+						await Promise.all([
+							setGeneration(failedGeneration),
+							args.context.callbacks?.generationFailed?.({
+								generation: failedGeneration,
+								inputMessages: messages,
+							}),
+						]);
 						return;
 					}
 					const generationOutputs: GenerationOutput[] = [];

--- a/packages/giselle/src/engine/types.ts
+++ b/packages/giselle/src/engine/types.ts
@@ -16,6 +16,7 @@ import type { GiselleStorage } from "./experimental_storage";
 import type { VectorStore } from "./experimental_vector-store/types/interface";
 import type {
 	CompletedGeneration,
+	FailedGeneration,
 	OutputFileBlob,
 	RunningGeneration,
 } from "./generations";
@@ -31,6 +32,14 @@ export interface GenerationCompleteCallbackFunctionArgs {
 }
 type GenerationCompleteCallbackFunction = (
 	args: GenerationCompleteCallbackFunctionArgs,
+) => void | Promise<void>;
+
+export interface GenerationFailedCallbackFunctionArgs {
+	generation: FailedGeneration;
+	inputMessages: ModelMessage[];
+}
+export type GenerationFailedCallbackFunction = (
+	args: GenerationFailedCallbackFunctionArgs,
 ) => void | Promise<void>;
 
 export interface EmbeddingCompleteCallbackFunctionArgs {
@@ -64,6 +73,7 @@ export interface GiselleEngineContext {
 	};
 	callbacks?: {
 		generationComplete?: GenerationCompleteCallbackFunction;
+		generationFailed?: GenerationFailedCallbackFunction;
 		flowTriggerUpdate?: (flowTrigger: FlowTrigger) => Promise<void>;
 		embeddingComplete?: EmbeddingCompleteCallbackFunction;
 	};
@@ -148,6 +158,7 @@ export interface GiselleEngineConfig {
 	};
 	callbacks?: {
 		generationComplete?: GenerationCompleteCallbackFunction;
+		generationFailed?: GenerationFailedCallbackFunction;
 		flowTriggerUpdate?: (flowTrigger: FlowTrigger) => Promise<void>;
 		embeddingComplete?: EmbeddingCompleteCallbackFunction;
 	};

--- a/packages/langfuse/src/trace-generation.ts
+++ b/packages/langfuse/src/trace-generation.ts
@@ -6,7 +6,11 @@ import {
 	isTextGenerationNode,
 	type TextGenerationNode,
 } from "@giselle-sdk/data-type";
-import type { CompletedGeneration, OutputFileBlob } from "@giselle-sdk/giselle";
+import type {
+	CompletedGeneration,
+	FailedGeneration,
+	OutputFileBlob,
+} from "@giselle-sdk/giselle";
 import { calculateDisplayCost } from "@giselle-sdk/language-model";
 import type { DataContent, ModelMessage } from "ai";
 import { type ApiMediaContentType, Langfuse, LangfuseMedia } from "langfuse";
@@ -156,12 +160,12 @@ function extractMetadata(
 }
 
 export async function traceGeneration(args: {
-	generation: CompletedGeneration;
+	generation: CompletedGeneration | FailedGeneration;
 	inputMessages: ModelMessage[];
 	userId?: string;
 	metadata?: Record<string, unknown>;
 	tags?: string[];
-	outputFileBlobs: OutputFileBlob[];
+	outputFileBlobs?: OutputFileBlob[];
 	sessionId?: string;
 }) {
 	try {
@@ -203,6 +207,35 @@ export async function traceGeneration(args: {
 		};
 
 		const { llm } = operationNode.content;
+
+		const generationName = isTextGenerationNode(operationNode)
+			? "generateText"
+			: isImageGenerationNode(operationNode)
+				? "generateImage"
+				: undefined;
+
+		if (args.generation.status === "failed") {
+			trace.update({
+				tags,
+				metadata,
+			});
+
+			console.log(`errorM: ${args.generation.error.message}`);
+			trace.generation({
+				name: generationName,
+				model: llm.id,
+				modelParameters: llm.configurations,
+				input: langfuseInput,
+				startTime: new Date(args.generation.startedAt),
+				endTime: new Date(args.generation.failedAt),
+				metadata,
+				level: "ERROR",
+				statusMessage: args.generation.error.message,
+			});
+			await langfuse.flushAsync();
+			return;
+		}
+
 		// Handle text generation telemetry
 		if (isTextGenerationNode(operationNode)) {
 			const usage = args.generation.usage ?? {
@@ -224,7 +257,7 @@ export async function traceGeneration(args: {
 			});
 
 			trace.generation({
-				name: "generateText",
+				name: generationName,
 				model: llm.id,
 				modelParameters: llm.configurations,
 				input: langfuseInput,
@@ -241,13 +274,14 @@ export async function traceGeneration(args: {
 				startTime: new Date(args.generation.startedAt),
 				endTime: new Date(args.generation.completedAt),
 				metadata,
+				level: "DEFAULT",
 			});
 		}
 
 		// Handle image generation telemetry
 		if (isImageGenerationNode(operationNode)) {
 			// Convert output files to Langfuse media references
-			const mediaReferences = args.outputFileBlobs.map(
+			const mediaReferences = (args.outputFileBlobs ?? []).map(
 				(file) =>
 					new LangfuseMedia({
 						contentType: file.contentType as ApiMediaContentType,
@@ -263,7 +297,7 @@ export async function traceGeneration(args: {
 				});
 
 				trace.generation({
-					name: "generateImage",
+					name: generationName,
 					model: llm.id,
 					modelParameters: llm.configurations,
 					input: langfuseInput,

--- a/packages/langfuse/src/trace-generation.ts
+++ b/packages/langfuse/src/trace-generation.ts
@@ -220,7 +220,6 @@ export async function traceGeneration(args: {
 				metadata,
 			});
 
-			console.log(`errorM: ${args.generation.error.message}`);
 			trace.generation({
 				name: generationName,
 				model: llm.id,


### PR DESCRIPTION
### **User description**
- Add aFailed callback and invoke it on failures
- Unify handling, cleanup, tracing for failed generation runs
- Extract generation trace logic into a shared handler (handleGenerationTrace) to deduplicate and centralize tracing logic
- Remove debug log that leaked error messages during generation


___

### **PR Type**
Enhancement


___

### **Description**
- Add `generationFailed` callback for error handling

- Unify generation tracing logic across success/failure cases

- Extract shared trace handler to reduce code duplication

- Fix error message leaking in debug logs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generation Process"] --> B["Success/Failure"]
  B --> C["handleGenerationTrace"]
  C --> D["traceGenerationForTeam"]
  D --> E["Langfuse Tracing"]
  F["generationComplete callback"] --> C
  G["generationFailed callback"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>giselle-engine.ts</strong><dd><code>Add failed generation callback and unified tracing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/giselle-engine.ts

<ul><li>Add <code>FailedGeneration</code> type import and support<br> <li> Create <code>handleGenerationTrace</code> function to unify tracing logic<br> <li> Add <code>generationFailed</code> callback to engine configuration<br> <li> Update <code>traceGenerationForTeam</code> to handle failed generations</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1778/files#diff-235b6c6d2e5711d3bbc50862c678e55f5d79296fc35007dab4dc963a82b5be63">+65/-48</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generate-text.ts</strong><dd><code>Refactor error handling in text generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/generate-text.ts

<ul><li>Move error handling from <code>onError</code> to <code>onFinish</code> callback<br> <li> Add cleanup function calls for both success and failure cases<br> <li> Invoke <code>generationFailed</code> callback when generation fails<br> <li> Consolidate error processing logic</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1778/files#diff-5400b929dc7742af3e854d768fec81e158d4e91f51eada68eb9316aea079ef21">+33/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add failed generation callback types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/types.ts

<ul><li>Add <code>GenerationFailedCallbackFunctionArgs</code> interface<br> <li> Add <code>GenerationFailedCallbackFunction</code> type definition<br> <li> Include <code>generationFailed</code> callback in engine context and config</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1778/files#diff-c0d6a1af4548e95f47f51c05c6860243de8642f174043c3120d42dd6e5c53680">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>trace-generation.ts</strong><dd><code>Add failed generation support to tracing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/langfuse/src/trace-generation.ts

<ul><li>Support <code>FailedGeneration</code> type in trace function<br> <li> Make <code>outputFileBlobs</code> parameter optional<br> <li> Add error-specific tracing with status message and error level<br> <li> Handle failed generations with appropriate metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1778/files#diff-5e47fc185717113a19b0d5a6b464dac3afcf299c8d0dce99f844591b4b8def39">+39/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Failed generations are now captured and reported with clear status and timing.
  - Analytics/tracing includes failed runs, improving visibility across text and image generations.
- Improvements
  - More consistent post-run handling reduces edge-case inconsistencies between success and failure paths.
  - Analytics naming is standardized for easier monitoring and reporting.
- Bug Fixes
  - Prevented errors when image outputs are missing, improving stability.
  - Reduced risk of state mismatches by deferring failure processing until completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->