### PR TITLE
fix: allow workspace access for all user's teams

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -16,7 +16,11 @@ import { getGitHubRepositoryIndexes } from "@/lib/vector-stores/github";
 import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
 import { fetchCurrentUser } from "@/services/accounts";
-import { fetchCurrentTeam, isProPlan } from "@/services/teams";
+import {
+	checkUserTeamMembership,
+	fetchCurrentTeam,
+	isProPlan,
+} from "@/services/teams";
 
 export default async function Layout({
 	params,
@@ -38,7 +42,13 @@ export default async function Layout({
 	const currentUser = await fetchCurrentUser();
 
 	const currentTeam = await fetchCurrentTeam();
-	if (currentTeam.dbId !== agent.teamDbId) {
+
+	// Check if user is a member of the workspace's team
+	const isUserMemberOfWorkspaceTeam = await checkUserTeamMembership(
+		currentUser.dbId,
+		agent.teamDbId,
+	);
+	if (!isUserMemberOfWorkspaceTeam) {
 		return notFound();
 	}
 	const usageLimits = await getUsageLimitsForTeam(currentTeam);

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -37,8 +37,6 @@ export default async function Layout({
 	if (agent === undefined) {
 		return notFound();
 	}
-	const gitHubIntegrationState = await getGitHubIntegrationState(agent.dbId);
-
 	const currentUser = await fetchCurrentUser();
 
 	// Check if user is a member of the workspace's team before other operations
@@ -49,6 +47,8 @@ export default async function Layout({
 	if (!isUserMemberOfWorkspaceTeam) {
 		return notFound();
 	}
+
+	const gitHubIntegrationState = await getGitHubIntegrationState(agent.dbId);
 
 	const workspaceTeam = await fetchWorkspaceTeam(agent.teamDbId);
 	if (!workspaceTeam) {

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -17,8 +17,8 @@ import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
 import { fetchCurrentUser } from "@/services/accounts";
 import {
-	checkUserTeamMembership,
 	fetchWorkspaceTeam,
+	isMemberOfTeam,
 	isProPlan,
 } from "@/services/teams";
 
@@ -40,7 +40,7 @@ export default async function Layout({
 	const currentUser = await fetchCurrentUser();
 
 	// Check if user is a member of the workspace's team before other operations
-	const isUserMemberOfWorkspaceTeam = await checkUserTeamMembership(
+	const isUserMemberOfWorkspaceTeam = await isMemberOfTeam(
 		currentUser.dbId,
 		agent.teamDbId,
 	);

--- a/apps/studio.giselles.ai/services/teams/check-user-team-membership.ts
+++ b/apps/studio.giselles.ai/services/teams/check-user-team-membership.ts
@@ -1,0 +1,23 @@
+import { and, eq } from "drizzle-orm";
+import { db, teamMemberships } from "@/drizzle";
+
+/**
+ * Checks if the specified user is a member of the specified team
+ */
+export async function checkUserTeamMembership(
+	userDbId: number,
+	teamDbId: number,
+): Promise<boolean> {
+	const membership = await db
+		.select({ teamDbId: teamMemberships.teamDbId })
+		.from(teamMemberships)
+		.where(
+			and(
+				eq(teamMemberships.userDbId, userDbId),
+				eq(teamMemberships.teamDbId, teamDbId),
+			),
+		)
+		.limit(1);
+
+	return membership.length > 0;
+}

--- a/apps/studio.giselles.ai/services/teams/fetch-workspace-team.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-workspace-team.ts
@@ -1,0 +1,36 @@
+import { and, eq } from "drizzle-orm";
+import { db, subscriptions, teams } from "@/drizzle";
+import type { CurrentTeam } from "@/services/teams";
+
+/**
+ * Fetch the team that owns the workspace by its database ID
+ */
+export async function fetchWorkspaceTeam(
+	workspaceTeamDbId: number,
+): Promise<CurrentTeam | null> {
+	const teamResult = await db
+		.select({
+			id: teams.id,
+			dbId: teams.dbId,
+			name: teams.name,
+			avatarUrl: teams.avatarUrl,
+			type: teams.type,
+			activeSubscriptionId: subscriptions.id,
+		})
+		.from(teams)
+		.leftJoin(
+			subscriptions,
+			and(
+				eq(subscriptions.teamDbId, teams.dbId),
+				eq(subscriptions.status, "active"),
+			),
+		)
+		.where(eq(teams.dbId, workspaceTeamDbId))
+		.limit(1);
+
+	if (teamResult.length === 0) {
+		return null;
+	}
+
+	return teamResult[0];
+}

--- a/apps/studio.giselles.ai/services/teams/index.ts
+++ b/apps/studio.giselles.ai/services/teams/index.ts
@@ -1,3 +1,4 @@
+export { checkUserTeamMembership } from "./check-user-team-membership";
 export { fetchCurrentTeam } from "./fetch-current-team";
 export { fetchUserTeams } from "./fetch-user-teams";
 export { setCurrentTeam } from "./set-current-team";

--- a/apps/studio.giselles.ai/services/teams/index.ts
+++ b/apps/studio.giselles.ai/services/teams/index.ts
@@ -1,7 +1,7 @@
-export { checkUserTeamMembership } from "./check-user-team-membership";
 export { fetchCurrentTeam } from "./fetch-current-team";
 export { fetchUserTeams } from "./fetch-user-teams";
 export { fetchWorkspaceTeam } from "./fetch-workspace-team";
+export { isMemberOfTeam } from "./is-member-of-team";
 export { setCurrentTeam } from "./set-current-team";
 export * from "./types";
 export { isProPlan } from "./utils";

--- a/apps/studio.giselles.ai/services/teams/index.ts
+++ b/apps/studio.giselles.ai/services/teams/index.ts
@@ -1,6 +1,7 @@
 export { checkUserTeamMembership } from "./check-user-team-membership";
 export { fetchCurrentTeam } from "./fetch-current-team";
 export { fetchUserTeams } from "./fetch-user-teams";
+export { fetchWorkspaceTeam } from "./fetch-workspace-team";
 export { setCurrentTeam } from "./set-current-team";
 export * from "./types";
 export { isProPlan } from "./utils";

--- a/apps/studio.giselles.ai/services/teams/is-member-of-team.ts
+++ b/apps/studio.giselles.ai/services/teams/is-member-of-team.ts
@@ -4,7 +4,7 @@ import { db, teamMemberships } from "@/drizzle";
 /**
  * Checks if the specified user is a member of the specified team
  */
-export async function checkUserTeamMembership(
+export async function isMemberOfTeam(
 	userDbId: number,
 	teamDbId: number,
 ): Promise<boolean> {


### PR DESCRIPTION
### **User description**
## Summary
Replace strict current team matching with user team membership check to allow access to workspaces from any team the user belongs to. Previously users would get 404 when accessing workspaces from teams they're members of but not currently active in.

## Related Issue
None

## Testing
_via: https://github.com/giselles-ai/giselle/pull/1781#issuecomment-3240806925_

- [x] **[Workspace Access] Verify direct access to a workspace from a non-active team**: Navigate to a workspace URL belonging to Team B while Team A is active. Ensure the workspace loads correctly.
- [x] **[Workspace Context] Verify correct team context displayed for non-active team workspace**: While viewing Workspace B (owned by Team B) with Team A active, check that all team-specific information (e.g., plan, repo list) reflects Team B's data.
- [x] **[Workspace Access] Verify access to workspace from the active team (Regression)**: Switch active team to Team B and access Workspace B. Ensure it loads as expected.
- [x] **[Workspace Access] Verify denial of access to a workspace from an unassociated team**: Attempt to access a workspace belonging to Team C, which the user is not a member of. Confirm a 404 error is displayed.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix workspace access for all user's teams

- Replace current team check with team membership validation

- Add new services for team membership and workspace team fetching

- Refactor layout to use workspace team instead of current team


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Request"] --> B["Check Team Membership"]
  B --> C["Fetch Workspace Team"]
  C --> D["Allow Access"]
  B --> E["Deny Access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check-user-team-membership.ts</strong><dd><code>Add user team membership validation service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/services/teams/check-user-team-membership.ts

<ul><li>Add new service to check if user is member of specific team<br> <li> Query team memberships table with user and team database IDs<br> <li> Return boolean indicating membership status</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1781/files#diff-fe33de8e2a5a367fec74a2f11ee2fab0354fe241007e89c84041d94802603cee">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fetch-workspace-team.ts</strong><dd><code>Add workspace team fetching service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/services/teams/fetch-workspace-team.ts

<ul><li>Add service to fetch team that owns workspace by ID<br> <li> Join teams with active subscriptions data<br> <li> Return team details or null if not found</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1781/files#diff-232c4efa5eb46cedbe24512a6dad85cb59061130cde5e5ee8420617bdcb41595">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export new team services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/services/teams/index.ts

<ul><li>Export new <code>checkUserTeamMembership</code> function<br> <li> Export new <code>fetchWorkspaceTeam</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1781/files#diff-37ac268787f6033d980924a15a11a34919e5f7bbe61b61d7488c6852d11b2319">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Refactor workspace access control logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx

<ul><li>Replace current team check with user team membership validation<br> <li> Use workspace team instead of current team for operations<br> <li> Update imports to include new team services<br> <li> Refactor team-related logic throughout component</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1781/files#diff-15f3074fd9425f9c2957c436fb950d744614df0ac6ce51fd55cfaa5ff2bfb04e">+23/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Enforces workspace access based on membership, preventing access to non-member workspaces.
  - Ensures plan, usage limits, and repository indexes reflect the active workspace.
  - Reduces errors by resolving workspace context before loading integrations.

- Refactor
  - Simplifies workspace data flow to a single, consistent source of truth.

- Chores
  - Aligns telemetry and identifiers with the active workspace.
  - Ensures background flow triggers target the correct workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->