### PR TITLE
Remove custom maxSize limit for Image File Node

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -21,7 +21,6 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 	image: {
 		accept: ["image/png", "image/jpeg", "image/gif", "image/svg"],
 		label: "Image",
-		maxSize: 1024 * 1024,
 	},
 };
 


### PR DESCRIPTION
### **User description**
## Summary
Removes the 1MB maxSize restriction for image files, allowing them to use the default 4.5MB limit like PDF and text files.

## Related Issue
None.

## Testing
_via: https://github.com/giselles-ai/giselle/pull/1784#issuecomment-3241113367_


- [x] **[Image File Node - Happy Path]**: Verify successful upload of an image file between 1MB and 4.5MB.
- [x] **[Image File Node - Happy Path]**: Verify successful upload of an image file close to the 4.5MB limit.
- [x] **[Image File Node - Regression]**: Verify successful upload of a small image file (under 1MB).
- [x] **[Image File Node - Failure Path]**: Verify that uploading an image file larger than 4.5MB results in a validation error.
- [x] **[Image File Node - Failure Path]**: Verify that attempting to upload a non-image file (e.g., `.zip`) is rejected.

___

### **PR Type**
Enhancement


___

### **Description**
- Remove 1MB size limit for image files

- Allow images to use default 4.5MB limit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Image File Config"] -- "Remove maxSize: 1MB" --> B["Default 4.5MB Limit"]
  C["PDF Files"] -- "Already uses" --> B
  D["Text Files"] -- "Already uses" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove image file size restriction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx

<ul><li>Remove <code>maxSize: 1024 * 1024</code> property from image file type <br>configuration<br> <li> Allow image files to inherit the default file size limit</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1784/files#diff-85261abdafa38434822dbd9a6e5e130e69eea838ac626a44ab3232f724b10aa3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Removed the 1 MB size limit for image uploads in the file properties panel, allowing larger images to be used.
  * Image type acceptance remains unchanged; only the size restriction was lifted.
  * Other file categories are unaffected, preserving existing behaviors.
  * Improves flexibility for workflows requiring high-resolution images without impacting non-image files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->