### PR TITLE
feat(language-model): update Google model IDs for Vertex AI compatibility

### DIFF
--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -151,7 +151,7 @@ export const googleTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"gemini-2.5-flash-lite-preview-06-17": {
+	"gemini-2.5-flash-lite": {
 		prices: [
 			{
 				validFrom: "2025-06-18T02:00:00Z",

--- a/packages/language-model/src/google.test.ts
+++ b/packages/language-model/src/google.test.ts
@@ -10,9 +10,9 @@ describe("google llm", () => {
 			expect(GoogleLanguageModelId.parse("gemini-2.5-flash")).toBe(
 				"gemini-2.5-flash",
 			);
-			expect(
-				GoogleLanguageModelId.parse("gemini-2.5-flash-lite-preview-06-17"),
-			).toBe("gemini-2.5-flash-lite-preview-06-17");
+			expect(GoogleLanguageModelId.parse("gemini-2.5-flash-lite")).toBe(
+				"gemini-2.5-flash-lite",
+			);
 		});
 
 		it("should fallback gemini-2.5-pro-preview variants to gemini-2.5-pro", () => {
@@ -68,27 +68,30 @@ describe("google llm", () => {
 			);
 		});
 
-		it("should fallback all known gemini-2.5-flash-lite variants and any version to gemini-2.5-flash-lite-preview-06-17", () => {
-			expect(
-				GoogleLanguageModelId.parse("gemini-2.5-flash-lite-preview-06-17"),
-			).toBe("gemini-2.5-flash-lite-preview-06-17");
+		it("should fallback all known gemini-2.5-flash-lite variants and any version to gemini-2.5-flash-lite", () => {
+			expect(GoogleLanguageModelId.parse("gemini-2.5-flash-lite")).toBe(
+				"gemini-2.5-flash-lite",
+			);
 			expect(GoogleLanguageModelId.parse("gemini-2.0-flash-lite")).toBe(
-				"gemini-2.5-flash-lite-preview-06-17",
+				"gemini-2.5-flash-lite",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-1.5-flash-lite")).toBe(
-				"gemini-2.5-flash-lite-preview-06-17",
+				"gemini-2.5-flash-lite",
 			);
+			expect(
+				GoogleLanguageModelId.parse("gemini-2.5-flash-lite-preview-06-17"),
+			).toBe("gemini-2.5-flash-lite");
 		});
 
-		it("should fallback unknown or non-matching variants to gemini-2.5-flash-lite-preview-06-17", () => {
+		it("should fallback unknown or non-matching variants to gemini-2.5-flash-lite", () => {
 			expect(GoogleLanguageModelId.parse("gemini-unknown-model")).toBe(
-				"gemini-2.5-flash-lite-preview-06-17",
+				"gemini-2.5-flash-lite",
 			);
 			expect(GoogleLanguageModelId.parse("gemini-foo-bar")).toBe(
-				"gemini-2.5-flash-lite-preview-06-17",
+				"gemini-2.5-flash-lite",
 			);
 			expect(GoogleLanguageModelId.parse("random-model")).toBe(
-				"gemini-2.5-flash-lite-preview-06-17",
+				"gemini-2.5-flash-lite",
 			);
 		});
 	});

--- a/packages/language-model/src/google.ts
+++ b/packages/language-model/src/google.ts
@@ -19,25 +19,21 @@ const defaultConfigurations: GoogleLanguageModelConfigurations = {
 };
 
 export const GoogleLanguageModelId = z
-	.enum([
-		"gemini-2.5-pro",
-		"gemini-2.5-flash",
-		"gemini-2.5-flash-lite-preview-06-17",
-	])
+	.enum(["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"])
 	.catch((ctx) => {
 		if (typeof ctx.value !== "string") {
-			return "gemini-2.5-flash-lite-preview-06-17";
+			return "gemini-2.5-flash-lite";
 		}
 		if (/^gemini-\d+(?:\.\d+)?-pro/.test(ctx.value)) {
 			return "gemini-2.5-pro";
 		}
 		if (/^gemini-\d+(?:\.\d+)?-flash-lite/.test(ctx.value)) {
-			return "gemini-2.5-flash-lite-preview-06-17";
+			return "gemini-2.5-flash-lite";
 		}
 		if (/^gemini-\d+(?:\.\d+)?-flash/.test(ctx.value)) {
 			return "gemini-2.5-flash";
 		}
-		return "gemini-2.5-flash-lite-preview-06-17";
+		return "gemini-2.5-flash-lite";
 	});
 
 const GoogleLanguageModel = LanguageModelBase.extend({
@@ -71,9 +67,9 @@ const gemini25Flash: GoogleLanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-const gemini25FlashLitePreview: GoogleLanguageModel = {
+const gemini25FlashLite: GoogleLanguageModel = {
 	provider: "google",
-	id: "gemini-2.5-flash-lite-preview-06-17",
+	id: "gemini-2.5-flash-lite",
 	capabilities:
 		Capability.TextGeneration |
 		Capability.OptionalSearchGrounding |
@@ -82,7 +78,7 @@ const gemini25FlashLitePreview: GoogleLanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-export const models = [gemini25Pro, gemini25Flash, gemini25FlashLitePreview];
+export const models = [gemini25Pro, gemini25Flash, gemini25FlashLite];
 
 export const LanguageModel = GoogleLanguageModel;
 export type LanguageModel = GoogleLanguageModel;


### PR DESCRIPTION
### **User description**
## Summary
Update Google model IDs for Vertex AI compatibility.

## Related Issue
None.

## Changes
Replace gemini-2.5-flash-lite-preview-06-17 with gemini-2.5-flash-lite to align with Vertex AI stable model versions. Updated model configuration, pricing, and tests with fallback support for preview version.

- see: [Model versions and lifecycle  \|  Generative AI on Vertex AI  \|  Google Cloud](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions?hl=en#latest-stable)

## Testing
_via: https://github.com/giselles-ai/giselle/pull/1791#issuecomment-3243942630_

- [x] **Verify New Stable Model ID (`gemini-2.5-flash-lite`)**: Make a request to the language model service explicitly using the new model ID `gemini-2.5-flash-lite`. Expected Result: The request is successfully processed by Google's Vertex AI, and a valid response is returned. The cost calculation, if applicable, should use the pricing defined for `gemini-2.5-flash-lite`.
- [x] **Verify Fallback for Old Preview Model ID**: Make a request to the language model service using the old preview model ID `gemini-2.5-flash-lite-preview-06-17`. Expected Result: The system should automatically parse this as `gemini-2.5-flash-lite`. The request should be successfully processed by Vertex AI as if you had used the new stable ID.
- [x] **Verify Other Google Models are Unaffected**: Make separate requests using the other existing Google model IDs: `gemini-2.5-pro` and `gemini-2.5-flash`. Expected Result: Both requests should be processed successfully without any changes in behavior. This ensures that the updates to the fallback logic did not negatively impact other models.


## Other Information
This PR is a preliminary step to using the [Google Vertex Provider](https://ai-sdk.dev/providers/ai-sdk-providers/google-vertex) to support the [Vercel AI Gateway](https://vercel.com/ai-gateway).


___

### **PR Type**
Enhancement


___

### **Description**
- Update Google model ID from preview to stable version

- Maintain backward compatibility with fallback support

- Update pricing configuration and test cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gemini-2.5-flash-lite-preview-06-17"] -- "replace with" --> B["gemini-2.5-flash-lite"]
  B --> C["Vertex AI compatibility"]
  D["fallback logic"] --> B
  E["pricing config"] --> B
  F["test updates"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Update pricing model ID to stable version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Update model ID key from <code>gemini-2.5-flash-lite-preview-06-17</code> to <br><code>gemini-2.5-flash-lite</code><br> <li> Maintain existing pricing configuration structure</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1791/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google.test.ts</strong><dd><code>Update tests for stable model ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/google.test.ts

<ul><li>Update test cases to use stable model ID <code>gemini-2.5-flash-lite</code><br> <li> Add fallback test for preview version to stable version<br> <li> Update all test expectations to reference new stable model</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1791/files#diff-ae9898676b66011e8ce8b6144a551ab4eea474608a5d9473a76f7d136a813e91">+16/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google.ts</strong><dd><code>Replace preview model with stable version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/google.ts

<ul><li>Replace <code>gemini-2.5-flash-lite-preview-06-17</code> with <code>gemini-2.5-flash-lite</code> <br>in enum<br> <li> Update fallback logic to return stable model ID<br> <li> Rename model constant and update model configuration<br> <li> Maintain backward compatibility through fallback patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1791/files#diff-0bce79e94f5fbf67fc0fbd3c072e51e6e96635e0e59ff755774a03d551528811">+7/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Replaced the preview-named “Gemini 2.5 Flash Lite” variant with the stable “gemini-2.5-flash-lite” across the app, including defaults and validation.
  - All related inputs now normalize to “gemini-2.5-flash-lite”.

- Chores
  - Updated pricing mapping to use the stable “gemini-2.5-flash-lite” identifier; pricing values remain unchanged.

- Tests
  - Adjusted tests to reflect normalization to the stable “gemini-2.5-flash-lite” model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->