### PR TITLE
feat(giselle): move workspace fetch app and wrap children with workflow provider

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -1,7 +1,11 @@
 import { WorkspaceId } from "@giselle-sdk/data-type";
-import { WorkspaceProvider } from "@giselle-sdk/giselle/react";
+import {
+	WorkflowDesignerProvider,
+	WorkspaceProvider,
+} from "@giselle-sdk/giselle/react";
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
+import { giselleEngine } from "@/app/giselle-engine";
 import { db, flowTriggers } from "@/drizzle";
 import {
 	aiGatewayFlag,
@@ -66,11 +70,11 @@ export default async function Layout({
 	const stage = await stageFlag();
 	const aiGateway = await aiGatewayFlag();
 	const resumableGeneration = await resumableGenerationFlag();
+	const data = await giselleEngine.getWorkspace(workspaceId, true);
 
 	// return children
 	return (
 		<WorkspaceProvider
-			workspaceId={workspaceId}
 			integration={{
 				value: {
 					github: gitHubIntegrationState,
@@ -128,7 +132,9 @@ export default async function Layout({
 				},
 			}}
 		>
-			{children}
+			<WorkflowDesignerProvider data={data}>
+				{children}
+			</WorkflowDesignerProvider>
 		</WorkspaceProvider>
 	);
 }

--- a/packages/giselle/src/react/workspace/provider.tsx
+++ b/packages/giselle/src/react/workspace/provider.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import type { Workspace, WorkspaceId } from "@giselle-sdk/data-type";
-import { type ReactNode, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import type { TelemetrySettings, UsageLimits } from "../../engine";
 import {
 	FeatureFlagContext,
 	type FeatureFlagContextValue,
 } from "../feature-flags";
-import { WorkflowDesignerProvider } from "../flow";
 import {
 	FlowTriggerContext,
 	type FlowTriggerContextValue,
@@ -19,7 +17,6 @@ import {
 } from "../integrations";
 import { TelemetryProvider } from "../telemetry";
 import { UsageLimitsProvider } from "../usage-limits";
-import { useGiselleEngine } from "../use-giselle-engine";
 import {
 	type VectorStoreContextValue,
 	VectorStoreProvider,
@@ -27,7 +24,6 @@ import {
 
 export function WorkspaceProvider({
 	children,
-	workspaceId,
 	integration,
 	usageLimits,
 	telemetry,
@@ -36,7 +32,6 @@ export function WorkspaceProvider({
 	flowTrigger,
 }: {
 	children: ReactNode;
-	workspaceId: WorkspaceId;
 	integration?: IntegrationProviderProps;
 	usageLimits?: UsageLimits;
 	telemetry?: TelemetrySettings;
@@ -44,22 +39,6 @@ export function WorkspaceProvider({
 	vectorStore?: VectorStoreContextValue;
 	flowTrigger?: FlowTriggerContextValue;
 }) {
-	const client = useGiselleEngine();
-
-	const [workspace, setWorkspace] = useState<Workspace | undefined>();
-	useEffect(() => {
-		client
-			.getWorkspace({
-				workspaceId,
-				useExperimentalStorage: featureFlag?.experimental_storage ?? false,
-			})
-			.then((workspace) => {
-				setWorkspace(workspace);
-			});
-	}, [workspaceId, client, featureFlag?.experimental_storage]);
-	if (workspace === undefined) {
-		return null;
-	}
 	return (
 		<FeatureFlagContext
 			value={{
@@ -77,11 +56,9 @@ export function WorkspaceProvider({
 					<UsageLimitsProvider limits={usageLimits}>
 						<IntegrationProvider {...integration}>
 							<VectorStoreProvider value={vectorStore}>
-								<WorkflowDesignerProvider data={workspace}>
-									<GenerationRunnerSystemProvider>
-										{children}
-									</GenerationRunnerSystemProvider>
-								</WorkflowDesignerProvider>
+								<GenerationRunnerSystemProvider>
+									{children}
+								</GenerationRunnerSystemProvider>
 							</VectorStoreProvider>
 						</IntegrationProvider>
 					</UsageLimitsProvider>


### PR DESCRIPTION
### **User description**
To make the implementation of WorkflowDesignerContext, which has issues with state management, replaceable, we removed it from the common Provider and made it possible to insert it as needed.


___

### **PR Type**
Enhancement


___

### **Description**
- Moved workspace data fetching from client to server-side

- Extracted WorkflowDesignerProvider from common WorkspaceProvider

- Enabled selective injection of WorkflowDesignerProvider as needed

- Improved state management architecture for workspace context


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WorkspaceProvider"] --> B["Server-side fetch"]
  B --> C["WorkflowDesignerProvider"]
  C --> D["Children components"]
  A --> E["Other providers"]
  E --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Move workspace fetch server-side and wrap with </code><br><code>WorkflowDesignerProvider</code></dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx

<ul><li>Added WorkflowDesignerProvider import and giselleEngine import<br> <li> Moved workspace data fetching to server-side using <br><code>giselleEngine.getWorkspace()</code><br> <li> Wrapped children with WorkflowDesignerProvider instead of including it <br>in WorkspaceProvider<br> <li> Removed <code>workspaceId</code> prop from WorkspaceProvider</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1794/files#diff-15f3074fd9425f9c2957c436fb950d744614df0ac6ce51fd55cfaa5ff2bfb04e">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provider.tsx</strong><dd><code>Extract WorkflowDesignerProvider and remove client-side workspace </code><br><code>fetching</code></dd></summary>
<hr>

packages/giselle/src/react/workspace/provider.tsx

<ul><li>Removed <code>workspaceId</code> parameter and workspace fetching logic<br> <li> Removed WorkflowDesignerProvider from provider chain<br> <li> Removed client-side state management for workspace data<br> <li> Simplified provider to focus on other context providers only</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1794/files#diff-8a9be06df265f969925b0eaaa2a4817e372f5a9038025ba24b59438ce6c69744">+4/-27</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Enhanced workflow designer experience on workspace pages with preloaded workspace data for smoother interactions.
* Bug Fixes
  * Resolved intermittent blank/loading states when opening workspaces.
* Refactor
  * Simplified workspace context management and removed the need to pass a workspace ID, improving initial load time and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->