### PR TITLE
fix(flow): multi-image paste upload + duplicate handling

### DIFF
--- a/packages/giselle/src/react/flow/hooks/index.ts
+++ b/packages/giselle/src/react/flow/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from "./use-add-node";
 export * from "./use-connection";
 export * from "./use-copy-node";
+export * from "./use-file-uploads";
 export * from "./use-node-update";
 export * from "./use-properties-panel";
 export * from "./use-workflow-designer";

--- a/packages/giselle/src/react/flow/hooks/use-file-uploads.ts
+++ b/packages/giselle/src/react/flow/hooks/use-file-uploads.ts
@@ -1,0 +1,107 @@
+import {
+	createFailedFileData,
+	createUploadedFileData,
+	createUploadingFileData,
+	type FileId,
+	type FileNode,
+	type WorkspaceId,
+} from "@giselle-sdk/data-type";
+import { useCallback } from "react";
+import { APICallError } from "../../errors";
+import type { WorkspaceAction } from "./use-workspace-reducer";
+
+type UploadOptions = { onError?: (message: string) => void } | undefined;
+
+type FileUploadClient = {
+	uploadFile: (input: {
+		workspaceId: WorkspaceId;
+		file: File;
+		fileId: FileId;
+		fileName: string;
+		useExperimentalStorage: boolean;
+	}) => Promise<unknown>;
+};
+
+export function useFileUploads(args: {
+	dispatch: React.Dispatch<WorkspaceAction>;
+	client: FileUploadClient;
+	workspaceId: WorkspaceId;
+	useExperimentalStorage: boolean;
+}) {
+	const { dispatch, client, workspaceId, useExperimentalStorage } = args;
+
+	const uploadFile = useCallback(
+		async (files: File[], node: FileNode, options: UploadOptions) => {
+			// Track existing names and mark duplicates (exact match: name including extension)
+			const reservedNames = new Set<string>(
+				node.content.files.map((f) => f.name),
+			);
+			const preparedFiles = files.map((originalFile) => {
+				const name = originalFile.name;
+				const isDuplicate = reservedNames.has(name);
+				if (!isDuplicate) {
+					reservedNames.add(name);
+				}
+				return { file: originalFile, name, isDuplicate };
+			});
+
+			let fileContents = node.content.files;
+			for (const { file, name, isDuplicate } of preparedFiles) {
+				if (isDuplicate) {
+					options?.onError?.(`duplicate file name: ${name}`);
+					continue;
+				}
+				const uploadingFileData = createUploadingFileData({
+					name,
+					type: file.type,
+					size: file.size,
+				});
+				fileContents = [...fileContents, uploadingFileData];
+				dispatch({
+					type: "UPDATE_FILE_STATUS",
+					nodeId: node.id,
+					files: fileContents,
+				});
+				try {
+					await client.uploadFile({
+						workspaceId,
+						file,
+						fileId: uploadingFileData.id,
+						fileName: name,
+						useExperimentalStorage,
+					});
+					const uploadedFileData = createUploadedFileData(
+						uploadingFileData,
+						Date.now(),
+					);
+					fileContents = [
+						...fileContents.filter((f) => f.id !== uploadedFileData.id),
+						uploadedFileData,
+					];
+				} catch (error) {
+					if (APICallError.isInstance(error)) {
+						const message =
+							error.statusCode === 413 ? "filesize too large" : error.message;
+						options?.onError?.(message);
+						const failedFileData = createFailedFileData(
+							uploadingFileData,
+							message,
+						);
+						fileContents = [
+							...fileContents.filter((f) => f.id !== failedFileData.id),
+							failedFileData,
+						];
+					}
+				}
+				dispatch({
+					type: "UPDATE_FILE_STATUS",
+					nodeId: node.id,
+					files: fileContents,
+				});
+			}
+		},
+		[client, dispatch, useExperimentalStorage, workspaceId],
+	);
+
+	return { uploadFile } as const;
+}


### PR DESCRIPTION
# Fix: Multi-image paste uploads and duplicate handling

Fixes #1802

## Summary
- Ensure a single paste action uploads all images instead of only the last one.
- Update file list using reducer-based `UPDATE_FILE_STATUS` to avoid overwriting with stale node content.
- Treat exact name match (name + extension) as duplicate and skip with clear error: `duplicate file name: <name>`.
- Keep validation consistent between drag-and-drop and paste paths.
- Extract upload logic into `useFileUploads` hook for clarity and reuse.

## Changes
- `packages/giselle/src/react/flow/context.tsx`
  - Replace direct content merging with reducer updates.
  - Improve duplicate detection and error message.
  - Wire in custom hook for upload behavior.
- `packages/giselle/src/react/flow/hooks/use-file-uploads.ts` (new)
  - Handles batching, duplicate checks, step-wise UI updates, and API error handling.
- `packages/giselle/src/react/flow/hooks/index.ts`
  - Export `useFileUploads`.

## Rationale
Previously, multiple uploads in a single paste mutated files based on a captured `node.content`, causing only the last file to persist. Reducer-based updates ensure we always apply changes to the latest state. Duplicate handling prevents redundant files from consuming context with minimal user confusion.

## Validation
- Paste 3 images (e.g., gif/jpg/png with same base name): all 3 upload successfully.
- Paste 3 identical files: shows duplicate error per file and only the first is uploaded.
- Drag-and-drop and file selection follow the same behavior.
- Type-check: `pnpm -F @giselle-sdk/giselle check-types` (passed).

## Risks / Mitigations
- UI updates are now dispatched twice per file (uploading -> final). This improves UX and is batched by store save debounce.
- No change to storage keys (still `fileId`-based), safe for existing data.

## Follow-ups
- Add unit tests around duplicate policies and error handling.
- Consider an opt-in policy flag (error/rename/smart) if product needs evolve.
