### PR TITLE
fix(filter): default to "all" filter instead of "history" to align

### DIFF
--- a/apps/studio.giselles.ai/app/stage/(top)/hooks/use-filter-state.ts
+++ b/apps/studio.giselles.ai/app/stage/(top)/hooks/use-filter-state.ts
@@ -25,7 +25,7 @@ export function useFilterState({ teamOptions }: UseFilterStateProps) {
 	// State
 	const [selectedTeamId, setSelectedTeamId] = useState<TeamId>(defaultTeamId);
 	const [selectedFilter, setSelectedFilter] = useState<FilterType>(
-		urlFilter || "history",
+		urlFilter || "all",
 	);
 
 	// Navigation handlers


### PR DESCRIPTION
### **User description**
- Change default filter from "history" to "all" to align behavior across components/functions.


___

### **PR Type**
Bug fix


___

### **Description**
- Change default filter from "history" to "all"

- Align filter behavior across components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Default Filter"] -- "changed from" --> B["history"]
  A -- "changed to" --> C["all"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-filter-state.ts</strong><dd><code>Change default filter from history to all</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/stage/(top)/hooks/use-filter-state.ts

<ul><li>Updated default filter value from "history" to "all"<br> <li> Modified <code>useState</code> initialization for <code>selectedFilter</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1810/files#diff-344039311fc87b8c1ff553f60d2b3af90a007afa3c320874b30aa4057d9652de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The default filter in the stage view now initializes to “All” when no filter is specified in the URL, showing all items on first load. This improves the initial experience for direct visits and shared links without a filter parameter. Existing navigation, selection behavior, and URL updates remain unchanged after the initial load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->