### PR TITLE
refactor(showcase): use executable flow triggers and update navigation

### DIFF
--- a/apps/studio.giselles.ai/app/stage/showcase/showcase-client.tsx
+++ b/apps/studio.giselles.ai/app/stage/showcase/showcase-client.tsx
@@ -415,11 +415,7 @@ export function ShowcaseClient({
 													title="Run app"
 													onClick={(e) => {
 														e.stopPropagation();
-														if (app.workspaceId) {
-															router.push(
-																`/stage?workspaceId=${app.workspaceId}&teamId=${selectedTeamId}`,
-															);
-														}
+														router.push(`/stage?appId=${app.id}`);
 													}}
 												>
 													<Play className="h-3 w-3" />


### PR DESCRIPTION
- Replace direct agent queries with fetchFlowTriggers for consistency 
  with stage logic
- Filter and transform flow triggers to match App interface requirements
- Update Run app button to navigate using appId instead of workspaceId + teamId
- Maintain proper updatedAt timestamps by querying agents table
- Handle errors gracefully with fallback dates
