### PR TITLE
refactor(flow): unify remove flow with Zustand store and add type-safe guard

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-file-node.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-file-node.ts
@@ -1,22 +1,10 @@
 import { useToasts } from "@giselle-internal/ui/toast";
-import type {
-	FileData,
-	FileNode,
-	UploadedFileData,
-} from "@giselle-sdk/data-type";
+import type { FileData, FileNode } from "@giselle-sdk/data-type";
 import { useWorkflowDesigner } from "@giselle-sdk/giselle/react";
 import { useCallback } from "react";
 
-function isUploadedFile(f: FileData): f is UploadedFileData {
-	return f.status === "uploaded";
-}
-
 export function useFileNode(node: FileNode) {
-	const {
-		updateNodeDataContent,
-		uploadFile,
-		removeFile: removeFileInternal,
-	} = useWorkflowDesigner();
+	const { uploadFile, removeFile: _removeFile } = useWorkflowDesigner();
 	const { error } = useToasts();
 	const addFiles = useCallback(
 		async (files: File[]) => {
@@ -30,16 +18,8 @@ export function useFileNode(node: FileNode) {
 	);
 
 	const removeFile = useCallback(
-		async (file: FileData) => {
-			if (isUploadedFile(file)) {
-				await removeFileInternal(file);
-				return;
-			}
-			updateNodeDataContent(node, {
-				files: node.content.files.filter((f) => f.id !== file.id),
-			});
-		},
-		[node, updateNodeDataContent, removeFileInternal],
+		async (file: FileData) => await _removeFile(file),
+		[_removeFile],
 	);
 
 	return {

--- a/packages/giselle/src/react/flow/context.tsx
+++ b/packages/giselle/src/react/flow/context.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import {
+	type FileData,
 	type Node,
 	NodeId,
 	type NodeLike,
 	type NodeUIState,
 	type ShortcutScope,
-	type UploadedFileData,
 	type Viewport,
 	type Workspace,
 } from "@giselle-sdk/data-type";
@@ -148,12 +148,14 @@ export function WorkflowDesignerProvider({
 	});
 
 	const removeFile = useCallback(
-		async (uploadedFile: UploadedFileData) => {
-			await client.removeFile({
-				workspaceId: data.id,
-				fileId: uploadedFile.id,
-				useExperimentalStorage: experimental_storage,
-			});
+		async (file: FileData) => {
+			if (file.status === "uploaded") {
+				await client.removeFile({
+					workspaceId: data.id,
+					fileId: file.id,
+					useExperimentalStorage: experimental_storage,
+				});
+			}
 			dispatch({ type: "NO_OP" });
 		},
 		[client, data.id, dispatch, experimental_storage],

--- a/packages/giselle/src/react/flow/types.ts
+++ b/packages/giselle/src/react/flow/types.ts
@@ -1,4 +1,5 @@
 import type {
+	FileData,
 	FileNode,
 	InputId,
 	Node,
@@ -8,7 +9,6 @@ import type {
 	NodeUIState,
 	OutputId,
 	ShortcutScope,
-	UploadedFileData,
 	Viewport,
 	Workspace,
 } from "@giselle-sdk/data-type";
@@ -52,7 +52,7 @@ export interface WorkflowDesignerContextValue {
 		node: FileNode,
 		options?: { onError?: (message: string) => void },
 	) => Promise<void>;
-	removeFile: (uploadedFile: UploadedFileData) => Promise<void>;
+	removeFile: (file: FileData) => Promise<void>;
 	llmProviders: LanguageModelProvider[];
 	isLoading: boolean;
 	isSupportedConnection: (

--- a/packages/giselle/src/react/flow/zustand-bridge-provider.tsx
+++ b/packages/giselle/src/react/flow/zustand-bridge-provider.tsx
@@ -1,4 +1,4 @@
-import type { UploadedFileData, Workspace } from "@giselle-sdk/data-type";
+import type { FileData, Workspace } from "@giselle-sdk/data-type";
 import { useEffect, useMemo } from "react";
 import { useFeatureFlag } from "../feature-flags";
 import { useGiselleEngine } from "../use-giselle-engine";
@@ -109,8 +109,8 @@ export function ZustandBridgeProvider({
 					node,
 					options,
 				),
-			removeFile: (uploadedFile: UploadedFileData) =>
-				state.removeFile(client, data.id, experimental_storage, uploadedFile),
+			removeFile: (file: FileData) =>
+				state.removeFile(client, data.id, experimental_storage, file),
 			llmProviders: state.llmProviders,
 			isLoading: state.isLoading,
 			setUiViewport: state.setUiViewport,


### PR DESCRIPTION
### **User description**
# Refactor: Unify file removal flow (Zustand store)

## Summary
- Unify the file removal responsibility on the store (Zustand) to avoid UI/store races.
- UI no longer performs optimistic removal for uploaded files; it delegates to the provider/store.
- Store removes from storage in all cases and only updates UI state if the parent node still exists.

## Changes
- UI (internal-packages/workflow-designer-ui/.../use-file-node.ts)
  - Add a type guard to detect `UploadedFileData` and delegate removal to the provider.
  - For non-uploaded files (uploading/failed), update the local list only.
- Store (packages/giselle/src/react/flow/hooks/file-slice.ts)
  - Always call `client.removeFile` (storage) even if the file was already pruned from UI.
  - If parent node is present, update the node's `files` list by filtering the removed file.

## Rationale
Previously, when the UI removed the file first, the store could not find the parent node anymore and logged an error. Delegating the source of truth to the store (and making the UI behavior conditional) prevents this class of race conditions while keeping UX consistent.

## Validation
- Remove an uploaded file from the list: no console error, entry disappears.
- Remove during uploading/failed: entry disappears locally without storage call.

## Notes
- This PR is intentionally small and focused. If desired, we can further simplify by always delegating removal (including non-uploaded) to the store in a follow-up.


___

### **PR Type**
Enhancement


___

### **Description**
- Unified file removal flow through Zustand store

- Added type-safe handling for different file statuses

- Eliminated UI/store race conditions during file deletion

- Simplified API by accepting `FileData` instead of `UploadedFileData`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["UI Component"] -- "delegates removal" --> Store["Zustand Store"]
  Store -- "uploaded files" --> Storage["Remove from Storage"]
  Store -- "all files" --> State["Update UI State"]
  Storage --> State
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-file-node.ts</strong><dd><code>Delegate file removal to provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/use-file-node.ts

<ul><li>Removed optimistic UI deletion logic<br> <li> Simplified <code>removeFile</code> to delegate directly to provider<br> <li> Eliminated local state manipulation and type casting</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1823/files#diff-b51b9ef445312b45b6d2e4d428e5b2bbd4e8571961f5b7825da8a42cc51316ad">+4/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>file-slice.ts</strong><dd><code>Enhanced file removal with status-based logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/flow/hooks/file-slice.ts

<ul><li>Changed <code>removeFile</code> parameter from <code>UploadedFileData</code> to <code>FileData</code><br> <li> Added conditional storage removal based on file status<br> <li> Improved error handling by checking parent node existence<br> <li> Always update UI state when parent node is present</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1823/files#diff-35be425057c8d7a8e9a8c8156e0fc36c1747e2cd74a572769ada17ed1513653a">+14/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Updated type definitions for file removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/flow/types.ts

<ul><li>Updated <code>removeFile</code> method signature to accept <code>FileData</code><br> <li> Replaced <code>UploadedFileData</code> import with <code>FileData</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1823/files#diff-e1056eb8e8d0fe673578247176139324e842401f58efd22af5eae5b63ed23813">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>context.tsx</strong><dd><code>Enhanced context file removal logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/flow/context.tsx

<ul><li>Modified <code>removeFile</code> to handle all file types<br> <li> Added status check for uploaded files before storage removal<br> <li> Updated parameter type from <code>UploadedFileData</code> to <code>FileData</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1823/files#diff-8d822b5eac70a6830d87a1054cc01ec824e9f8344b66350e40533475273189a3">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zustand-bridge-provider.tsx</strong><dd><code>Updated bridge provider file removal interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/flow/zustand-bridge-provider.tsx

<ul><li>Updated <code>removeFile</code> method signature to use <code>FileData</code><br> <li> Changed import from <code>UploadedFileData</code> to <code>FileData</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1823/files#diff-b21d6945bf76aecc2caf7e22aa01eae460f40d8a27efc69d2e5be849209abc0f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

