### PR TITLE
feat(studio): add Vercel feature flag for document vector store

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -172,3 +172,24 @@ export const newEditorFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+// Enable document vector store ingest (PDF text and image)
+// Dev: set DOC_VECTOR_STORE_FLAG=true
+export const docVectorStoreFlag = flag<boolean>({
+	key: "doc-vector-store",
+	async decide() {
+		if (process.env.NODE_ENV === "development") {
+			return takeLocalEnv("DOC_VECTOR_STORE_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return edgeConfig === true || edgeConfig === "true";
+	},
+	description: "Enable document vector store ingest",
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});


### PR DESCRIPTION
### **User description**
## Summary
Add Vercel feature flag for document vector store.

## Related Issue
part of https://github.com/giselles-ai/giselle/issues/1827

## Changes
- Introduce docVectorStoreFlag in apps/studio.giselles.ai/flags.ts
- Flag key: doc-vector-store (Edge Config: flag__doc-vector-store)
- Local override via DOC_VECTOR_STORE_FLAG=true

## Testing
- Check it on vercel flags


___

### **PR Type**
Enhancement


___

### **Description**
- Add Vercel feature flag for document vector store

- Enable PDF text and image ingestion control

- Support local development override via environment variable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Feature Flag"] --> B["Document Vector Store"]
  A --> C["PDF Text Ingestion"]
  A --> D["PDF Image Ingestion"]
  E["Environment Variable"] --> A
  F["Edge Config"] --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Add document vector store feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Add <code>docVectorStoreFlag</code> boolean flag with key "doc-vector-store"<br> <li> Implement development environment override via <code>DOC_VECTOR_STORE_FLAG</code><br> <li> Configure Edge Config integration with <code>flag__doc-vector-store</code><br> <li> Add flag description and enable/disable options</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1828/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds a toggle to enable or disable document vector-store ingestion for PDFs (text and images).
  * Defaults to off; the state is controlled by environment configuration.
  * Presents user-facing options labeled “disable” and “Enable.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->