### PR TITLE
Fix duplicate/delete dialogs on apps list

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/components/searchable-agent-list.tsx
+++ b/apps/studio.giselles.ai/app/(main)/apps/components/searchable-agent-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Select } from "@giselle-internal/ui/select";
+import { formatTimestamp } from "@giselles-ai/lib/utils";
 import {
 	ArrowDownAZ,
 	ArrowUpAZ,
@@ -23,11 +24,11 @@ type ViewMode = "grid" | "list";
 
 function ListItem({ agent }: { agent: typeof dbAgents.$inferSelect }) {
 	return (
-		<Link
-			href={`/workspaces/${agent.workspaceId}`}
-			className="group flex items-center justify-between px-2 py-3 first:border-t-0 border-t-[0.5px] border-white/10"
-		>
-			<div className="flex items-center gap-3">
+		<div className="group flex items-center justify-between px-2 py-3 first:border-t-0 border-t-[0.5px] border-white/10">
+			<Link
+				href={`/workspaces/${agent.workspaceId}`}
+				className="flex flex-1 items-center gap-3"
+			>
 				{/* Icon */}
 				<div className="w-9 h-9 rounded-full bg-white/5 flex items-center justify-center flex-shrink-0 transition-all group-hover:bg-primary-100/20">
 					<svg
@@ -50,10 +51,10 @@ function ListItem({ agent }: { agent: typeof dbAgents.$inferSelect }) {
 						{agent.name || "Untitled"}
 					</p>
 					<p className="text-[12px] font-geist text-white-400">
-						Edited {agent.updatedAt.toLocaleDateString()}
+						Edited {formatTimestamp.toShortDate(agent.updatedAt.getTime())}
 					</p>
 				</div>
-			</div>
+			</Link>
 
 			{/* Action buttons */}
 			<div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -66,7 +67,7 @@ function ListItem({ agent }: { agent: typeof dbAgents.$inferSelect }) {
 					agentName={agent.name || "Untitled"}
 				/>
 			</div>
-		</Link>
+		</div>
 	);
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- prevent apps list duplicate/delete buttons from triggering workspace navigation
- align list timestamp formatting with shared utilities to keep hydration stable

## Related Issue
- closes #1775

## Changes
- restructure list item markup so action buttons sit outside the workspace link
- reuse formatTimestamp.toShortDate for list timestamps

## Testing
- Not run (not requested).

## Other Information
- None


___

### **PR Type**
Bug fix


___

### **Description**
- Fix duplicate/delete buttons not opening dialogs in apps list

- Restructure list item markup to separate action buttons from navigation link

- Standardize timestamp formatting using shared utility function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Link wrapper"] --> B["Restructured markup"]
  B --> C["Action buttons outside link"]
  C --> D["Dialogs work correctly"]
  E["Custom date format"] --> F["Shared utility"]
  F --> G["Consistent formatting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>searchable-agent-list.tsx</strong><dd><code>Restructure list item to fix action buttons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/apps/components/searchable-agent-list.tsx

<ul><li>Import <code>formatTimestamp</code> utility for consistent date formatting<br> <li> Restructure <code>ListItem</code> component markup to move action buttons outside <br>the navigation link<br> <li> Replace custom date formatting with <code>formatTimestamp.toShortDate()</code> <br>method<br> <li> Change wrapper from <code>Link</code> to <code>div</code> with <code>Link</code> only wrapping content area</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1835/files#diff-b7de194bf64d7d36cd5975bed5d7a92e316e5b217e3a5e4fc0248fe790cec490">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

