### PR TITLE
feat(studio): add sidebar navigation for vector stores

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/page.tsx
@@ -4,6 +4,7 @@ import { Card } from "@/components/ui/card";
 import { docVectorStoreFlag } from "@/flags";
 import { createDocumentVectorStore } from "../actions";
 import { DocumentVectorStoreCreateDialog } from "../document-store-create-dialog";
+import { VectorStoresNavigationLayout } from "../navigation-layout";
 
 export default async function DocumentVectorStorePage() {
 	const enabled = await docVectorStoreFlag();
@@ -37,26 +38,27 @@ export default async function DocumentVectorStorePage() {
 					/>
 				</div>
 			</div>
-
-			<div className="flex flex-col gap-y-[16px]">
-				<Card className="rounded-[8px] bg-transparent p-6 border-0">
-					<div className="flex items-center mb-4">
-						<div>
-							<h4 className="text-white-400 font-medium text-[18px] leading-[21.6px] font-sans">
-								Document Vector Stores
-							</h4>
-							<p className="text-black-400 text-[14px] leading-[20.4px] font-geist mt-1">
-								Create and manage Vector Stores for your documents. PDF
-								ingestion and search will be available here.
-							</p>
+			<VectorStoresNavigationLayout isEnabled={enabled}>
+				<div className="flex flex-col gap-y-[16px]">
+					<Card className="rounded-[8px] bg-transparent p-6 border-0">
+						<div className="flex items-center mb-4">
+							<div>
+								<h4 className="text-white-400 font-medium text-[18px] leading-[21.6px] font-sans">
+									Document Vector Stores
+								</h4>
+								<p className="text-black-400 text-[14px] leading-[20.4px] font-geist mt-1">
+									Create and manage Vector Stores for your documents. PDF
+									ingestion and search will be available here.
+								</p>
+							</div>
 						</div>
-					</div>
-					<div className="text-black-300 text-center py-16 bg-black-300/10 rounded-lg">
-						<div>No document vector stores yet.</div>
-						<div>Use the "New Vector Store" button to create one.</div>
-					</div>
-				</Card>
-			</div>
+						<div className="text-black-300 text-center py-16 bg-black-300/10 rounded-lg">
+							<div>No document vector stores yet.</div>
+							<div>Use the "New Vector Store" button to create one.</div>
+						</div>
+					</Card>
+				</div>
+			</VectorStoresNavigationLayout>
 		</div>
 	);
 }

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/navigation-layout.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/navigation-layout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+import { VectorStoresSidebarMenu } from "./sidebar-menu";
+
+type VectorStoresNavigationLayoutProps = {
+	children: ReactNode;
+	isEnabled: boolean;
+};
+
+export function VectorStoresNavigationLayout({
+	children,
+	isEnabled,
+}: VectorStoresNavigationLayoutProps) {
+	if (!isEnabled) {
+		return <>{children}</>;
+	}
+
+	return (
+		<div className="flex min-h-full">
+			<div className="border-r border-black-70/50 pr-6">
+				<div className="sticky top-[64px]">
+					<VectorStoresSidebarMenu />
+				</div>
+			</div>
+			<div className="flex-1 pl-[24px]">{children}</div>
+		</div>
+	);
+}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from "lucide-react";
+import { docVectorStoreFlag } from "@/flags";
 import { getGitHubIdentityState } from "@/services/accounts";
 import {
 	deleteRepositoryIndex,
@@ -7,6 +8,7 @@ import {
 	updateRepositoryIndex,
 } from "./actions";
 import { getGitHubRepositoryIndexes, getInstallationsWithRepos } from "./data";
+import { VectorStoresNavigationLayout } from "./navigation-layout";
 import { RepositoryList } from "./repository-list";
 import { RepositoryRegistrationDialog } from "./repository-registration-dialog";
 import {
@@ -37,10 +39,12 @@ export default async function TeamVectorStorePage() {
 		return <GitHubAppInstallRequiredCard />;
 	}
 
-	const [installationsWithRepos, repositoryIndexes] = await Promise.all([
-		getInstallationsWithRepos(),
-		getGitHubRepositoryIndexes(),
-	]);
+	const [installationsWithRepos, repositoryIndexes, isDocVectorStoreEnabled] =
+		await Promise.all([
+			getInstallationsWithRepos(),
+			getGitHubRepositoryIndexes(),
+			docVectorStoreFlag(),
+		]);
 
 	return (
 		<div className="flex flex-col gap-[24px]">
@@ -69,13 +73,14 @@ export default async function TeamVectorStorePage() {
 					/>
 				</div>
 			</div>
-
-			<RepositoryList
-				repositories={repositoryIndexes}
-				deleteRepositoryIndexAction={deleteRepositoryIndex}
-				triggerManualIngestAction={triggerManualIngest}
-				updateRepositoryIndexAction={updateRepositoryIndex}
-			/>
+			<VectorStoresNavigationLayout isEnabled={isDocVectorStoreEnabled}>
+				<RepositoryList
+					repositories={repositoryIndexes}
+					deleteRepositoryIndexAction={deleteRepositoryIndex}
+					triggerManualIngestAction={triggerManualIngest}
+					updateRepositoryIndexAction={updateRepositoryIndex}
+				/>
+			</VectorStoresNavigationLayout>
 		</div>
 	);
 }

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/sidebar-menu.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/sidebar-menu.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+const links = [
+	{ href: "/settings/team/vector-stores/document", label: "Document" },
+	{ href: "/settings/team/vector-stores", label: "GitHub" },
+];
+
+export function VectorStoresSidebarMenu() {
+	const pathname = usePathname();
+	const documentHref = "/settings/team/vector-stores/document";
+	const githubHref = "/settings/team/vector-stores";
+	const isDocumentPath =
+		pathname === documentHref || pathname.startsWith(`${documentHref}/`);
+	const activeHref = isDocumentPath ? documentHref : githubHref;
+
+	return (
+		<div className="w-[200px] min-h-full flex flex-col">
+			<div className="flex flex-col space-y-2">
+				{links.map((link) => {
+					const isActive = link.href === activeHref;
+					return (
+						<Link
+							key={link.href}
+							href={link.href}
+							aria-label={`${link.label} vector stores`}
+							className={cn(
+								"text-[16px] font-sans font-medium rounded-lg px-4 py-1 hover:bg-white/5",
+								{
+									"text-white-400": isActive,
+									"text-black-70": !isActive,
+								},
+							)}
+						>
+							{link.label}
+						</Link>
+					);
+				})}
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
### **User description**
## Summary
Add sidebar navigation for vector stores.


https://github.com/user-attachments/assets/1bd52fa9-7588-4c7c-b314-e1a559075b0c


## Related Issue
part of #1827 

## Changes
- Add VectorStoresNavigationLayout wrapper component
- Create sidebar menu with Document and GitHub tabs
- Apply navigation layout to both vector store pages
- Show navigation only when document vector store flag is enabled

## Testing
https://github.com/giselles-ai/giselle/pull/1838#issuecomment-3300869635

## Other Information
This layout is a temporary implementation. We plan to ask for further refinements to improve the UX later.


___

### **PR Type**
Enhancement


___

### **Description**
- Add sidebar navigation layout for vector stores

- Create Document and GitHub tabs in sidebar menu

- Apply navigation wrapper to both vector store pages

- Show navigation only when document vector store flag enabled


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VectorStoresNavigationLayout"] --> B["VectorStoresSidebarMenu"]
  A --> C["Document Page"]
  A --> D["GitHub Page"]
  B --> E["Document Tab"]
  B --> F["GitHub Tab"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation-layout.tsx</strong><dd><code>Add navigation layout wrapper component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/navigation-layout.tsx

<ul><li>Create new wrapper component for vector stores navigation<br> <li> Conditionally render sidebar based on <code>isEnabled</code> flag<br> <li> Apply sticky positioning and layout styling</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1838/files#diff-ad1128df27e2eca85846b020e97549f10d331623bc506efb172ab5978d94f096">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sidebar-menu.tsx</strong><dd><code>Create sidebar menu with navigation tabs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/sidebar-menu.tsx

<ul><li>Create sidebar menu with Document and GitHub navigation links<br> <li> Implement active state detection based on current pathname<br> <li> Apply conditional styling for active/inactive states</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1838/files#diff-0d646882a6ba0f7ea94bf64c8826cc0fa0311438ec7648309635a5ebb4aa36a4">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Apply navigation layout to document page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/page.tsx

<ul><li>Wrap page content with <code>VectorStoresNavigationLayout</code><br> <li> Pass <code>enabled</code> flag to control navigation visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1838/files#diff-11cf517716dafb6bd905a6cc42179170ee2bd297018410c4f6fbd7cb45e7dfc0">+21/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Apply navigation layout to GitHub page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/page.tsx

<ul><li>Import and check document vector store flag<br> <li> Wrap repository list with <code>VectorStoresNavigationLayout</code><br> <li> Pass flag state to control navigation rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1838/files#diff-b908a559ffdf9bdc6e5d7cddcc845c0acf4d9a0e43c9c83cae6e52b850e77f69">+16/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a two‑column layout for Vector Stores settings with a sticky sidebar and main content area.
  * Added a sidebar menu with navigation links for “Document” and “GitHub,” including active state highlighting.
  * Repository list and Document Vector Stores content now display within the new layout for a more consistent experience.
  * Layout activates only when the relevant feature flag is enabled; otherwise, the existing single-column view remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->