### PR TITLE
Fix invite links on preview deployments

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/invitation.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/invitation.ts
@@ -132,10 +132,20 @@ export async function sendInvitationEmail(invitation: Invitation) {
 }
 
 function buildJoinLink(token: string) {
-	const baseUrl =
-		process.env.NEXT_PUBLIC_SITE_URL || "https://studio.giselles.ai";
+	const explicitBaseUrl = process.env.NEXT_PUBLIC_SITE_URL;
+	if (explicitBaseUrl) {
+		return new URL(`/join/${token}`, explicitBaseUrl).toString();
+	}
 
-	return `${baseUrl}/join/${token}`;
+	const vercelUrl = process.env.VERCEL_URL;
+	if (vercelUrl) {
+		const normalizedBaseUrl = `https://${vercelUrl}`;
+		return new URL(`/join/${token}`, normalizedBaseUrl).toString();
+	}
+
+	throw new Error(
+		"Missing NEXT_PUBLIC_SITE_URL or VERCEL_URL environment variables for invitation links",
+	);
 }
 
 export async function listInvitations(): Promise<Invitation[]> {


### PR DESCRIPTION
### **User description**
## Summary
- Ensure team invitations use environment-provided base URLs before falling back to the Vercel deployment domain.
- Improve preview QA by preventing invites from pointing at the production `studio.giselles.ai` domain.

## Related Issue
- Found while QA'ing https://github.com/giselles-ai/giselle/pull/1842

## Changes
- Read `NEXT_PUBLIC_SITE_URL` or `VERCEL_URL` to compose the invitation join link.
- Throw an explicit error if neither env var is available so misconfigurations surface early.

## Testing
- Manual: generated an invitation in preview and confirmed the join URL targets the preview domain.

## Other Information
- Update Supabase Allowed Redirect URLs if new domains are introduced.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix invite links to use deployment-specific URLs instead of hardcoded production domain

- Add fallback logic for `VERCEL_URL` when `NEXT_PUBLIC_SITE_URL` unavailable

- Throw explicit error when neither environment variable is configured


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check NEXT_PUBLIC_SITE_URL"] --> B{"URL exists?"}
  B -->|Yes| C["Use explicit base URL"]
  B -->|No| D["Check VERCEL_URL"]
  D --> E{"VERCEL_URL exists?"}
  E -->|Yes| F["Use Vercel deployment URL"]
  E -->|No| G["Throw configuration error"]
  C --> H["Generate invite link"]
  F --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>invitation.ts</strong><dd><code>Environment-based invite link URL resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/invitation.ts

<ul><li>Replace hardcoded production URL with environment-based URL resolution<br> <li> Add fallback to <code>VERCEL_URL</code> when <code>NEXT_PUBLIC_SITE_URL</code> is not set<br> <li> Implement error handling for missing environment variables<br> <li> Use proper URL constructor for link generation</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1847/files#diff-64541e227ed84f64d57be9d9c2bd61e9d44aee84bd5db7ac15b1f64659d04e90">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team invitation links now consistently use the correct site domain, resolving cases where invites could point to an incorrect or non-production URL.
  * Improved URL construction to prevent malformed links in invitations, increasing reliability when sharing or joining teams.
  * Clearer behavior when configuration is incomplete, reducing the likelihood of users receiving broken invite links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->