### PR TITLE
fix: Validate non-empty prompt before text/image generation

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/lib/validate-prompt.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/lib/validate-prompt.ts
@@ -1,0 +1,12 @@
+import {
+	isJsonContent,
+	jsonContentToText,
+} from "@giselle-sdk/text-editor-utils";
+
+export function isPromptEmpty(prompt: string | undefined) {
+	const text = isJsonContent(prompt)
+		? jsonContentToText(JSON.parse(prompt))
+		: prompt;
+	const noWhitespaceText = text?.replace(/[\s\u3000]+/g, "");
+	return !noWhitespaceText;
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -100,7 +100,7 @@ export function ImageGenerationNodePropertiesPanel({
 			return;
 		}
 		if (isPromptEmpty(node.content.prompt)) {
-			error(`Please enter a prompt for node: ${node.name || node.id}`);
+			error("Please fill in the prompt to run.");
 			return;
 		}
 

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -24,6 +24,7 @@ import { Button } from "../../../ui/button";
 import { UsageLimitWarning } from "../../../ui/usage-limit-warning";
 import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { useModelEligibility } from "../../lib/use-model-eligibility";
+import { isPromptEmpty } from "../../lib/validate-prompt";
 import {
 	PropertiesPanelContent,
 	PropertiesPanelHeader,
@@ -135,7 +136,7 @@ export function ImageGenerationNodePropertiesPanel({
 				action={
 					<Button
 						type="button"
-						disabled={usageLimitsReached}
+						disabled={usageLimitsReached || isPromptEmpty(node.content.prompt)}
 						loading={isGenerating}
 						onClick={() => {
 							if (isGenerating) {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx
@@ -99,6 +99,10 @@ export function ImageGenerationNodePropertiesPanel({
 			error("Please upgrade your plan to continue using this feature.");
 			return;
 		}
+		if (isPromptEmpty(node.content.prompt)) {
+			error(`Please enter a prompt for node: ${node.name || node.id}`);
+			return;
+		}
 
 		createAndStartGenerationRunner({
 			origin: {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -60,7 +60,7 @@ export function TextGenerationNodePropertiesPanel({
 			return;
 		}
 		if (isPromptEmpty(node.content.prompt)) {
-			error(`Please enter a prompt for node: ${node.name || node.id}`);
+			error("Please fill in the prompt to run.");
 			return;
 		}
 

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -59,6 +59,10 @@ export function TextGenerationNodePropertiesPanel({
 			error("Please upgrade your plan to continue using this feature.");
 			return;
 		}
+		if (isPromptEmpty(node.content.prompt)) {
+			error(`Please enter a prompt for node: ${node.name || node.id}`);
+			return;
+		}
 
 		createAndStartGenerationRunner({
 			origin: {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx
@@ -4,10 +4,6 @@ import {
 	useNodeGenerations,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle/react";
-import {
-	isJsonContent,
-	jsonContentToText,
-} from "@giselle-sdk/text-editor-utils";
 import { CommandIcon, CornerDownLeft } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
@@ -15,6 +11,7 @@ import { useUsageLimitsReached } from "../../../hooks/usage-limits";
 import { Button } from "../../../ui/button";
 import { UsageLimitWarning } from "../../../ui/usage-limit-warning";
 import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
+import { isPromptEmpty } from "../../lib/validate-prompt";
 import {
 	PropertiesPanelContent,
 	PropertiesPanelHeader,
@@ -86,13 +83,6 @@ export function TextGenerationNodePropertiesPanel({
 		error,
 	]);
 
-	const jsonOrText = node.content.prompt;
-	const text = isJsonContent(jsonOrText)
-		? jsonContentToText(JSON.parse(jsonOrText))
-		: jsonOrText;
-	const noWhitespaceText = text?.replace(/[\s\u3000]+/g, "");
-	const disabled = usageLimitsReached || !noWhitespaceText;
-
 	return (
 		<PropertiesPanelRoot>
 			{usageLimitsReached && <UsageLimitWarning />}
@@ -107,7 +97,7 @@ export function TextGenerationNodePropertiesPanel({
 					<Button
 						loading={isGenerating}
 						type="button"
-						disabled={disabled}
+						disabled={usageLimitsReached || isPromptEmpty(node.content.prompt)}
 						onClick={() => {
 							if (isGenerating) {
 								stopGenerationRunner();

--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
@@ -18,14 +18,11 @@ import {
 	useNodeGroups,
 	useWorkflowDesigner,
 } from "@giselle-sdk/giselle/react";
-import {
-	isJsonContent,
-	jsonContentToText,
-} from "@giselle-sdk/text-editor-utils";
 import clsx from "clsx/lite";
 import { PlayIcon, UngroupIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { NodeIcon } from "../../../icons/node";
+import { isPromptEmpty } from "../../lib/validate-prompt";
 import { TriggerInputDialog } from "./trigger-input-dialog";
 
 type RunItem = {
@@ -95,13 +92,7 @@ function useRunAct() {
 		for (const nodeId of item.nodeIds) {
 			const node = data.nodes.find((n) => n.id === nodeId);
 			if (node && (isTextGenerationNode(node) || isImageGenerationNode(node))) {
-				const jsonOrText = node.content.prompt;
-				const text = isJsonContent(jsonOrText)
-					? jsonContentToText(JSON.parse(jsonOrText))
-					: jsonOrText;
-				const noWhitespaceText = text?.replace(/[\s\u3000]+/g, "");
-
-				if (!noWhitespaceText) {
+				if (isPromptEmpty(node.content.prompt)) {
 					error(`Please enter a prompt for node: ${node.name || node.id}`);
 					return;
 				}

--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
@@ -93,7 +93,7 @@ function useRunAct() {
 			const node = data.nodes.find((n) => n.id === nodeId);
 			if (node && (isTextGenerationNode(node) || isImageGenerationNode(node))) {
 				if (isPromptEmpty(node.content.prompt)) {
-					error(`Please enter a prompt for node: ${node.name || node.id}`);
+					error("Please fill in the prompt to run.");
 					return;
 				}
 			}


### PR DESCRIPTION
### **User description**
## Summary
Add frontend validation for empty prompts in Text Generator and Image Generator nodes to prevent 500 errors and stuck execution.

## Related Issue
Fixes #1819

## Changes
  - Added empty prompt validation to `run-button.tsx` for both Text Generator and Image Generator nodes
  - Show error messages with node names when prompts are empty
  - Prevent backend execution to avoid 500 errors
  - Created shared isPromptEmpty utility function in editor/lib/validate-prompt.ts
  - Disable Generate button if prompt is empty in image-generation-node-properties-panel
## Testing
  1. Add a text generation node or image generation node to the workflow
  2. Leave the prompt field empty (no text entered)
  3. Click the "Run" button in the workflow toolbar
  4. Verify that an error toast appears with message "Please enter a prompt for node: [node name]"
  5. Confirm that no backend error occurs
  6. Verify that workflow execution does not start (no stuck execution state)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add frontend validation for empty prompts in text/image generation nodes

- Prevent 500 errors and stuck execution states

- Disable generate buttons when prompts are empty

- Create shared prompt validation utility function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Empty Prompt Input"] --> B["Validation Check"]
  B --> C["Show Error Message"]
  B --> D["Disable Generate Button"]
  C --> E["Prevent Backend Execution"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate-prompt.ts</strong><dd><code>Add shared prompt validation utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/lib/validate-prompt.ts

<ul><li>Create new utility function <code>isPromptEmpty</code><br> <li> Handle both JSON and plain text prompt formats<br> <li> Remove whitespace and unicode spaces for validation</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1848/files#diff-9da341165ce3fe95634c435da1df3c706561cf0fa474eea19da1a19426d0c3f5">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Disable image generation button for empty prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/index.tsx

<ul><li>Import <code>isPromptEmpty</code> validation function<br> <li> Disable Generate button when prompt is empty<br> <li> Add prompt validation to existing usage limits check</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1848/files#diff-a45b1e18cc18aaa3a96fc447d8ae2e9138abb9f12b4da800373da10eb9194072">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Refactor text generation prompt validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx

<ul><li>Replace inline prompt validation with shared utility<br> <li> Remove duplicate validation logic<br> <li> Use <code>isPromptEmpty</code> function for button disable state</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1848/files#diff-b1f2287bb552bf4b22b33e8ad29c9c365a3e751e24ee9b8f29eb16687aba37d6">+2/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run-button.tsx</strong><dd><code>Add run-time prompt validation checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx

<ul><li>Add pre-execution validation for text/image generation nodes<br> <li> Show error toast when empty prompts detected<br> <li> Prevent workflow execution with empty prompts<br> <li> Import node type checking functions</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1848/files#diff-8a9745738738ef2c3b8f9ac4e66ea3a2abdefa3e5b53e53845092b4165130db6">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Prevents starting runs when any text or image generation node has an empty prompt; shows an error if input is missing.
  - Generate buttons on text and image nodes are disabled when prompts are empty.
  - Prompts containing only whitespace (including full-width spaces) or empty JSON content are treated as empty for consistent validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->