### PR TITLE
feat: add document-preprocessor package for PDF text and image extraction

### DIFF
--- a/packages/document-preprocessor/README.md
+++ b/packages/document-preprocessor/README.md
@@ -1,0 +1,99 @@
+# @giselle-sdk/document-preprocessor
+
+Utilities for turning raw document binaries into clean text and image payloads ready for RAG ingestion. The initial focus is on PDF support, but the APIs are designed to extend to future formats (PowerPoint, Excel, Word, …).
+
+## Features
+
+- Password-aware PDF parsing via [`@hyzyla/pdfium`](https://www.npmjs.com/package/@hyzyla/pdfium)
+- Normalised text extraction with whitespace cleanup and hyphen repair
+- Page-by-page PNG rendering using [`pngjs`](https://www.npmjs.com/package/pngjs)
+- Abort signal propagation so long-running conversions can be cancelled
+- Strongly-typed results that surface per-page metadata for downstream chunking
+
+## Installation
+
+This package is published inside the monorepo under the `@giselle-sdk/*` namespace. It relies on optional native bindings shipped with PDFium, so make sure your runtime matches the supported Node.js versions (>=18).
+
+## Usage
+
+### Extract text from a PDF
+
+```ts
+import { readFile, writeFile } from "node:fs/promises";
+import { extractPdfText } from "@giselle-sdk/document-preprocessor";
+
+const binary = await readFile("./contract.pdf");
+const { totalPages, pages } = await extractPdfText(binary, {
+  password: process.env.PDF_PASSWORD,
+  maxPages: 10,
+});
+
+for (const page of pages) {
+  console.log(`# Page ${page.pageNumber}`);
+  console.log(page.text);
+}
+```
+
+### Render PDF pages to PNG
+
+```ts
+import { readFile } from "node:fs/promises";
+import { renderPdfPageImages } from "@giselle-sdk/document-preprocessor";
+
+const binary = await readFile("./whitepaper.pdf");
+const { pages } = await renderPdfPageImages(binary, {
+  targetDpi: 150,
+  maxPages: 5,
+  renderFormFields: true,
+});
+
+for (const page of pages) {
+  await writeFile(`./page-${page.pageNumber}.png`, page.png);
+}
+```
+
+### Aborting long-running work
+
+All public APIs accept an optional `AbortSignal` to cancel ongoing work, which is useful for user-driven ingestion flows.
+
+```ts
+const abortController = new AbortController();
+setTimeout(() => abortController.abort("timeout"), 5_000);
+
+await extractPdfText(data, { signal: abortController.signal });
+```
+
+## API surface
+
+| Function | Description |
+| --- | --- |
+| `extractPdfText(input, options?)` | Returns normalised text content for each page. |
+| `renderPdfPageImages(input, options?)` | Produces PNG buffers (RGB + alpha) per page at the requested DPI. |
+
+Relevant option objects are exported from `./types` for downstream reuse.
+
+## Roadmap
+
+- Additional loaders for Office formats (PowerPoint, Excel, Word)
+- Configurable image sampling heuristics (e.g. skip dense-text pages)
+- Shared preprocessing utilities for chunk scheduling and modality tagging
+
+## Development
+
+```bash
+pnpm -F @giselle-sdk/document-preprocessor test
+pnpm -F @giselle-sdk/document-preprocessor check-types
+pnpm -F @giselle-sdk/document-preprocessor build
+```
+
+Run Biome formatting after changes:
+
+```bash
+pnpm biome check --write packages/document-preprocessor
+```
+
+## Security Considerations
+
+- **PDFium is sandboxed**: The PDFium engine is executed in a sandboxed environment to mitigate risks from malicious PDF files. However, always keep dependencies up to date and monitor for security advisories.
+- **Password-protected PDFs**: Be cautious when processing password-protected or encrypted PDFs. The package may not fully support all encryption schemes, and handling such files could expose sensitive data if not managed securely.
+- **File size and processing time limits**: To prevent denial-of-service attacks or resource exhaustion, enforce reasonable limits on input file size and processing time when using this package in production environments.

--- a/packages/document-preprocessor/package.json
+++ b/packages/document-preprocessor/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@giselle-sdk/document-preprocessor",
+	"version": "0.1.0",
+	"description": "Document preprocessing utilities for text and image extraction",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "tsup",
+		"check-types": "tsc --noEmit",
+		"dev": "tsup --watch",
+		"test": "vitest run",
+		"format": "biome check --write ."
+	},
+	"dependencies": {
+		"@hyzyla/pdfium": "catalog:",
+		"pngjs": "catalog:"
+	},
+	"devDependencies": {
+		"@giselle/giselle-sdk-tsconfig": "workspace:^",
+		"@types/node": "catalog:",
+		"@types/pngjs": "catalog:",
+		"tsup": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"keywords": [
+		"pdf",
+		"preprocessing",
+		"rag"
+	],
+	"license": "MIT"
+}

--- a/packages/document-preprocessor/src/global.d.ts
+++ b/packages/document-preprocessor/src/global.d.ts
@@ -1,0 +1,5 @@
+declare interface ImageData {
+	readonly data: Uint8ClampedArray;
+	readonly width: number;
+	readonly height: number;
+}

--- a/packages/document-preprocessor/src/index.ts
+++ b/packages/document-preprocessor/src/index.ts
@@ -1,0 +1,10 @@
+export { extractPdfText, renderPdfPageImages } from "./pdf.js";
+export type {
+	BinaryDataInput,
+	PdfImagePage,
+	PdfImageRenderOptions,
+	PdfImageRenderResult,
+	PdfTextExtractionOptions,
+	PdfTextExtractionResult,
+	PdfTextPage,
+} from "./types.js";

--- a/packages/document-preprocessor/src/internal/__tests__/binary.test.ts
+++ b/packages/document-preprocessor/src/internal/__tests__/binary.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { toUint8Array } from "../binary.js";
+
+describe("toUint8Array", () => {
+	it("returns the same Uint8Array instance", () => {
+		const data = new Uint8Array([1, 2, 3]);
+		expect(toUint8Array(data)).toBe(data);
+	});
+
+	it("copies ArrayBufferView with offset", () => {
+		const buffer = new Uint8Array([0, 1, 2, 3]).buffer;
+		const view = new DataView(buffer, 1, 2);
+		const result = toUint8Array(view);
+		expect(Array.from(result)).toEqual([1, 2]);
+	});
+
+	it("wraps ArrayBuffer", () => {
+		const buffer = new Uint8Array([5, 6, 7]).buffer;
+		const result = toUint8Array(buffer);
+		expect(Array.from(result)).toEqual([5, 6, 7]);
+	});
+});

--- a/packages/document-preprocessor/src/internal/__tests__/text-normalizer.test.ts
+++ b/packages/document-preprocessor/src/internal/__tests__/text-normalizer.test.ts
@@ -1,0 +1,40 @@
+it("returns empty string for empty input", () => {
+	expect(normalizeExtractedText("")).toBe("");
+});
+
+it("handles complex mixed content edge cases", () => {
+	const input = "Hello\u200B\r\n\r\nWorld-\nTest  \tmultiple   spaces\n\n\n";
+	const result = normalizeExtractedText(input);
+	expect(result).toBe("Hello\n\nWorldTest multiple spaces");
+});
+
+it("preserves and normalizes unicode (NFKC)", () => {
+	const input = "café";
+	const result = normalizeExtractedText(input);
+	// If the function normalizes to NFKC, this will pass for both composed and decomposed forms
+	expect(result).toBe("café");
+});
+
+import { describe, expect, it } from "vitest";
+
+import { normalizeExtractedText } from "../text-normalizer.js";
+
+describe("normalizeExtractedText", () => {
+	it("removes zero width characters and normalizes whitespace", () => {
+		const input = "Hello\u200B World\n\n\nThis  is\t\ttext";
+		const result = normalizeExtractedText(input);
+		expect(result).toBe("Hello World\n\nThis is text");
+	});
+
+	it("merges hyphenated line breaks", () => {
+		const input = "Hyphen-\nated word";
+		const result = normalizeExtractedText(input);
+		expect(result).toBe("Hyphenated word");
+	});
+
+	it("returns empty string for whitespace-only input", () => {
+		const input = "  \n\t";
+		const result = normalizeExtractedText(input);
+		expect(result).toBe("");
+	});
+});

--- a/packages/document-preprocessor/src/internal/abort.ts
+++ b/packages/document-preprocessor/src/internal/abort.ts
@@ -1,0 +1,17 @@
+export function assertNotAborted(signal?: AbortSignal): void {
+	if (!signal) {
+		return;
+	}
+	if (typeof signal.throwIfAborted === "function") {
+		signal.throwIfAborted();
+		return;
+	}
+	if (signal.aborted) {
+		const reason =
+			signal.reason instanceof Error
+				? signal.reason
+				: new Error("Operation aborted");
+		reason.name = "AbortError";
+		throw reason;
+	}
+}

--- a/packages/document-preprocessor/src/internal/binary.ts
+++ b/packages/document-preprocessor/src/internal/binary.ts
@@ -1,0 +1,11 @@
+import type { BinaryDataInput } from "../types.js";
+
+export function toUint8Array(input: BinaryDataInput): Uint8Array {
+	if (input instanceof Uint8Array) {
+		return input;
+	}
+	if (ArrayBuffer.isView(input)) {
+		return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+	}
+	return new Uint8Array(input);
+}

--- a/packages/document-preprocessor/src/internal/pdfium.ts
+++ b/packages/document-preprocessor/src/internal/pdfium.ts
@@ -1,0 +1,52 @@
+import { Buffer } from "node:buffer";
+
+import { type PDFiumDocument, PDFiumLibrary } from "@hyzyla/pdfium";
+import { PDFIUM_WASM_BASE64 } from "@hyzyla/pdfium/dist/pdfium.wasm.base64-B4io7kt4.js";
+
+import { assertNotAborted } from "./abort.js";
+
+let pdfiumLibraryPromise: Promise<PDFiumLibrary> | null = null;
+
+let _pdfiumWasmBinary: ArrayBuffer | null = null;
+function getPdfiumWasmBinary(): ArrayBuffer {
+	if (_pdfiumWasmBinary === null) {
+		_pdfiumWasmBinary = decodeBase64ToArrayBuffer(PDFIUM_WASM_BASE64);
+	}
+	return _pdfiumWasmBinary;
+}
+
+function createPdfiumLibrary(): Promise<PDFiumLibrary> {
+	return PDFiumLibrary.init({ wasmBinary: getPdfiumWasmBinary() });
+}
+
+export function getPdfiumLibrary(): Promise<PDFiumLibrary> {
+	if (pdfiumLibraryPromise === null) {
+		pdfiumLibraryPromise = createPdfiumLibrary();
+	}
+	return pdfiumLibraryPromise;
+}
+
+function decodeBase64ToArrayBuffer(base64: string): ArrayBuffer {
+	const buffer = Buffer.from(base64, "base64");
+	return buffer.buffer.slice(
+		buffer.byteOffset,
+		buffer.byteOffset + buffer.byteLength,
+	);
+}
+
+export async function withPdfDocument<T>(
+	data: Uint8Array,
+	options: { password?: string; signal?: AbortSignal },
+	handler: (document: PDFiumDocument) => Promise<T> | T,
+): Promise<T> {
+	assertNotAborted(options.signal);
+	const library = await getPdfiumLibrary();
+	assertNotAborted(options.signal);
+	const document = await library.loadDocument(data, options.password);
+	try {
+		assertNotAborted(options.signal);
+		return await handler(document);
+	} finally {
+		document.destroy();
+	}
+}

--- a/packages/document-preprocessor/src/internal/text-normalizer.ts
+++ b/packages/document-preprocessor/src/internal/text-normalizer.ts
@@ -1,0 +1,28 @@
+const ZERO_WIDTH_CHARACTERS = /\u200B|\u200C|\u200D|\uFEFF/gu;
+const HARD_HYPHEN_BREAK = /-\n(?=[\p{L}\p{N}])/gu;
+const MULTI_SPACE = /[ \t\f\v]+/g;
+const TRAILING_WHITESPACE = /[ \t\f\v]+$/gm;
+const MULTI_LINE_BREAKS = /\n{3,}/g;
+
+export function normalizeExtractedText(raw: string): string {
+	if (raw.length === 0) {
+		return "";
+	}
+	const normalisedLineEndings = raw.replace(/\r\n?/g, "\n");
+	const withoutZeroWidth = normalisedLineEndings.replace(
+		ZERO_WIDTH_CHARACTERS,
+		"",
+	);
+	const withoutHyphenBreaks = withoutZeroWidth.replace(HARD_HYPHEN_BREAK, "");
+	const collapsedSpaces = withoutHyphenBreaks
+		.replace(TRAILING_WHITESPACE, "")
+		.replace(MULTI_SPACE, " ")
+		.replace(/ ?\n ?/g, "\n")
+		.replace(MULTI_LINE_BREAKS, "\n\n");
+	const trimmedLines = collapsedSpaces
+		.split("\n")
+		.map((line) => line.trimEnd())
+		.join("\n")
+		.trim();
+	return trimmedLines.normalize("NFKC");
+}

--- a/packages/document-preprocessor/src/pdf.ts
+++ b/packages/document-preprocessor/src/pdf.ts
@@ -1,0 +1,134 @@
+import { Buffer } from "node:buffer";
+
+import { PNG } from "pngjs";
+
+import { assertNotAborted } from "./internal/abort.js";
+import { toUint8Array } from "./internal/binary.js";
+import { withPdfDocument } from "./internal/pdfium.js";
+import { normalizeExtractedText } from "./internal/text-normalizer.js";
+import type {
+	BinaryDataInput,
+	PdfImagePage,
+	PdfImageRenderOptions,
+	PdfImageRenderResult,
+	PdfTextExtractionOptions,
+	PdfTextExtractionResult,
+	PdfTextPage,
+} from "./types.js";
+
+const POINTS_PER_INCH = 72;
+const DEFAULT_TARGET_DPI = 144;
+
+export async function extractPdfText(
+	input: BinaryDataInput,
+	options: PdfTextExtractionOptions = {},
+): Promise<PdfTextExtractionResult> {
+	const bytes = toUint8Array(input);
+	const { password, maxPages, signal } = options;
+
+	return await withPdfDocument(
+		bytes,
+		{ password, signal },
+		(document): PdfTextExtractionResult => {
+			const totalPages = document.getPageCount();
+			const limit = calculatePageLimit(totalPages, maxPages);
+			const pages: PdfTextPage[] = [];
+
+			for (let index = 0; index < limit; index += 1) {
+				assertNotAborted(signal);
+				const page = document.getPage(index);
+				const rawText = page.getText();
+				const text = normalizeExtractedText(rawText);
+				pages.push({
+					pageNumber: page.number + 1,
+					text,
+				});
+			}
+
+			return { totalPages, pages };
+		},
+	);
+}
+
+export async function renderPdfPageImages(
+	input: BinaryDataInput,
+	options: PdfImageRenderOptions = {},
+): Promise<PdfImageRenderResult> {
+	const bytes = toUint8Array(input);
+	const { password, maxPages, signal } = options;
+	const targetDpi = options.targetDpi ?? DEFAULT_TARGET_DPI;
+	const scale = Math.max(targetDpi / POINTS_PER_INCH, 0.1);
+
+	return await withPdfDocument(
+		bytes,
+		{ password, signal },
+		async (document): Promise<PdfImageRenderResult> => {
+			const totalPages = document.getPageCount();
+			const limit = calculatePageLimit(totalPages, maxPages);
+			const pages: PdfImagePage[] = [];
+
+			for (let index = 0; index < limit; index += 1) {
+				assertNotAborted(signal);
+				const page = document.getPage(index);
+				const renderResult = await page.render({
+					scale,
+					renderFormFields: options.renderFormFields ?? true,
+					render: async ({ data, width, height }) => {
+						return await encodeRgbaToPng(
+							new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+							width,
+							height,
+						);
+					},
+				});
+
+				pages.push({
+					pageNumber: page.number + 1,
+					width: renderResult.width,
+					height: renderResult.height,
+					png: renderResult.data,
+				});
+			}
+
+			return { totalPages, pages };
+		},
+	);
+}
+
+async function encodeRgbaToPng(
+	rgba: Uint8Array,
+	width: number,
+	height: number,
+): Promise<Uint8Array> {
+	const png = new PNG({
+		width,
+		height,
+		inputHasAlpha: true,
+		colorType: 6,
+	});
+	png.data.set(rgba);
+	const chunks: Buffer[] = [];
+	await new Promise<void>((resolve, reject) => {
+		png
+			.pack()
+			.on("data", (chunk: Buffer) => {
+				chunks.push(chunk);
+			})
+			.once("end", () => {
+				resolve();
+			})
+			.once("error", (error) => {
+				reject(error);
+			});
+	});
+	const buffer = Buffer.concat(chunks);
+	// Return a Uint8Array view over the Buffer's memory without copying
+	return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+}
+
+function calculatePageLimit(totalPages: number, maxPages?: number): number {
+	if (!maxPages || maxPages <= 0) {
+		return totalPages;
+	}
+	return Math.min(totalPages, maxPages);
+}

--- a/packages/document-preprocessor/src/types.ts
+++ b/packages/document-preprocessor/src/types.ts
@@ -1,0 +1,43 @@
+import type { Buffer } from "node:buffer";
+
+export type BinaryDataInput =
+	| ArrayBuffer
+	| ArrayBufferView
+	| Uint8Array
+	| Buffer;
+
+export interface PdfTextPage {
+	pageNumber: number;
+	text: string;
+}
+
+export interface PdfTextExtractionOptions {
+	password?: string;
+	maxPages?: number;
+	signal?: AbortSignal;
+}
+
+export interface PdfTextExtractionResult {
+	totalPages: number;
+	pages: PdfTextPage[];
+}
+
+export interface PdfImagePage {
+	pageNumber: number;
+	width: number;
+	height: number;
+	png: Uint8Array;
+}
+
+export interface PdfImageRenderOptions {
+	password?: string;
+	targetDpi?: number;
+	maxPages?: number;
+	signal?: AbortSignal;
+	renderFormFields?: boolean;
+}
+
+export interface PdfImageRenderResult {
+	totalPages: number;
+	pages: PdfImagePage[];
+}

--- a/packages/document-preprocessor/src/types/pdfium-base64.d.ts
+++ b/packages/document-preprocessor/src/types/pdfium-base64.d.ts
@@ -1,0 +1,3 @@
+declare module "@hyzyla/pdfium/dist/pdfium.wasm.base64-B4io7kt4.js" {
+	export const PDFIUM_WASM_BASE64: string;
+}

--- a/packages/document-preprocessor/tsconfig.json
+++ b/packages/document-preprocessor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@giselle/giselle-sdk-tsconfig/node-library.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/document-preprocessor/tsup.config.ts
+++ b/packages/document-preprocessor/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: ["cjs", "esm"],
+	dts: true,
+	clean: true,
+	sourcemap: true,
+	target: "node18",
+	external: ["@hyzyla/pdfium", "pngjs"],
+});

--- a/packages/document-preprocessor/turbo.json
+++ b/packages/document-preprocessor/turbo.json
@@ -1,0 +1,9 @@
+{
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["**/dist/**"]
+		},
+		"test": {}
+	}
+}

--- a/packages/document-preprocessor/vitest.config.mts
+++ b/packages/document-preprocessor/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		globals: true,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     '@biomejs/biome':
       specifier: 2.0.6
       version: 2.0.6
+    '@hyzyla/pdfium':
+      specifier: 2.1.9
+      version: 2.1.9
     '@next/env':
       specifier: 15.5.2
       version: 15.5.2
@@ -102,6 +105,9 @@ catalogs:
     '@types/pluralize':
       specifier: 0.0.33
       version: 0.0.33
+    '@types/pngjs':
+      specifier: 6.0.5
+      version: 6.0.5
     '@types/react':
       specifier: 19.1.10
       version: 19.1.10
@@ -186,6 +192,9 @@ catalogs:
     pluralize:
       specifier: 8.0.0
       version: 8.0.0
+    pngjs:
+      specifier: 7.0.0
+      version: 7.0.0
     postcss:
       specifier: 8.5.5
       version: 8.5.5
@@ -808,6 +817,34 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(happy-dom@17.6.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.7.0)
+
+  packages/document-preprocessor:
+    dependencies:
+      '@hyzyla/pdfium':
+        specifier: 'catalog:'
+        version: 2.1.9
+      pngjs:
+        specifier: 'catalog:'
+        version: 7.0.0
+    devDependencies:
+      '@giselle/giselle-sdk-tsconfig':
+        specifier: workspace:^
+        version: link:../../tools/tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.14.0
+      '@types/pngjs':
+        specifier: 'catalog:'
+        version: 6.0.5
+      tsup:
+        specifier: 'catalog:'
+        version: 8.3.5(jiti@2.4.2)(postcss@8.5.6)(typescript@5.7.3)(yaml@2.7.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.7.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.14.0)(happy-dom@17.6.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.7.0)
 
   packages/flow:
     dependencies:
@@ -2203,6 +2240,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hyzyla/pdfium@2.1.9':
+    resolution: {integrity: sha512-c2T59buVQjjsqkuxjcUMQqy+M8CssAnK856ZBnzcy2KOauHSgJUOZIcsrXUR0poIh4RK9FYKD7PbyqjodooxUg==}
+
   '@icons-pack/react-simple-icons@10.0.0':
     resolution: {integrity: sha512-oU0PVDx9sbNQjRxJN555dsHbRApYN+aBq/O9+wo3JgNkEfvBMgAEtsSGtXWWXQsLAxJcYiFOCzBWege/Xj/JFQ==}
     peerDependencies:
@@ -2355,9 +2395,6 @@ packages:
 
   '@jridgewell/source-map@0.3.11':
     resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
-
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -4789,9 +4826,6 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -4851,6 +4885,9 @@ packages:
 
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@types/react-dom@19.1.7':
     resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
@@ -6975,6 +7012,10 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -7441,6 +7482,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -9425,6 +9467,8 @@ snapshots:
       protobufjs: 7.4.0
       yargs: 17.7.2
 
+  '@hyzyla/pdfium@2.1.9': {}
+
   '@icons-pack/react-simple-icons@10.0.0(react@19.1.1)':
     dependencies:
       react: 19.1.1
@@ -9536,7 +9580,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -9548,14 +9592,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
 
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.30':
     dependencies:
@@ -11277,18 +11319,18 @@ snapshots:
       '@rollup/pluginutils': 5.1.4(rollup@4.35.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.4.4(picomatch@4.0.2)
+      fdir: 6.4.4(picomatch@4.0.3)
       is-reference: 1.2.1
       magic-string: 0.30.17
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.35.0
 
   '@rollup/pluginutils@5.1.4(rollup@4.35.0)':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.35.0
 
@@ -12287,8 +12329,6 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
-  '@types/estree@1.0.7': {}
-
   '@types/estree@1.0.8': {}
 
   '@types/fast-levenshtein@0.0.4': {}
@@ -12357,6 +12397,10 @@ snapshots:
   '@types/phoenix@1.6.6': {}
 
   '@types/pluralize@0.0.33': {}
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 24.3.0
 
   '@types/react-dom@19.1.7(@types/react@19.1.10)':
     dependencies:
@@ -13232,9 +13276,9 @@ snapshots:
     dependencies:
       walk-up-path: 4.0.0
 
-  fdir@6.4.4(picomatch@4.0.2):
+  fdir@6.4.4(picomatch@4.0.3):
     optionalDependencies:
-      picomatch: 4.0.2
+      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -13669,7 +13713,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   is-stream@2.0.1: {}
 
@@ -13911,11 +13955,11 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.8:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-it@14.1.0:
     dependencies:
@@ -14633,6 +14677,8 @@ snapshots:
       fsevents: 2.3.2
 
   pluralize@8.0.0: {}
+
+  pngjs@7.0.0: {}
 
   postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.7.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,9 +83,12 @@ catalog:
   "@types/pg": 8.11.13
   pgvector: 0.2.1
   swr: 2.2.5
+  "@hyzyla/pdfium": 2.1.9
+  pngjs: 7.0.0
   defuddle: 0.6.4
   "fast-levenshtein": 3.0.0
   "@types/fast-levenshtein": 0.0.4
+  "@types/pngjs": 6.0.5
   "happy-dom": 17.6.1
   jsdom: 26.1.0
   tar: 7.4.3


### PR DESCRIPTION
## Summary
- Add new `@giselle-sdk/document-preprocessor` package for extracting text and images from PDF documents
- Implement PDF processing capabilities optimized for RAG (Retrieval-Augmented Generation) applications
- Support both text extraction and PNG image rendering from PDF files

## Related Issue
part of #1827 

## Changes
- **PDF text extraction** with automatic normalization (whitespace cleanup, hyphen repair)
- **PDF to PNG conversion** with configurable DPI settings
- **Password-protected PDF support** for encrypted documents
- **Abort signal support** for cancelling long-running operations
- **Base64 WASM bundling** for PDFium to ensure Vercel compatibility
- **Server-side optimized** using pngjs for Node.js environments
- **Comprehensive unit tests** for internal utilities
- **Full TypeScript support** with type definitions

 ### Technical details
- Uses `@hyzyla/pdfium` with base64-encoded WASM for PDF processing
- Uses `pngjs` for PNG encoding (Node.js compatible)
- Implements text normalization including:
  - Zero-width character removal
  - Hyphenated line break merging
  - Unicode NFKC normalization
  - Whitespace normalization

## Testing
- Unit tests for binary utilities, text normalizer
- Manual testing with real PDF files confirmed working

```typescript
// Text extraction
const { pages } = await extractPdfText(pdfBuffer, {
  maxPages: 10,
  password: 'optional'
});

// Image rendering
const { pages } = await renderPdfPageImages(pdfBuffer, {
  targetDpi: 144,
  maxPages: 5
});
```

## Other Information
- Add support for other document formats (PowerPoint, Excel, Word)
- Add chunk scheduling utilities for RAG pipelines
