### PR TITLE
chore: update pnpm to v10.16.0 and add minimum release age protection

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -4,7 +4,7 @@
 	"engines": {
 		"node": "22.x"
 	},
-	"packageManager": "pnpm@10.6.5",
+	"packageManager": "pnpm@10.16.0",
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack",

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -17,7 +17,7 @@
 		"test:e2e": "playwright test",
 		"check-types": "tsc --noEmit"
 	},
-	"packageManager": "pnpm@10.0.0",
+	"packageManager": "pnpm@10.16.0",
 	"dependencies": {
 		"@aws-sdk/client-s3": "catalog:",
 		"@giselle-internal/ui": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"turbo": "2.4.2",
 		"typescript": "catalog:"
 	},
-	"packageManager": "pnpm@10.2.1",
+	"packageManager": "pnpm@10.16.0",
 	"engines": {
 		"node": ">=22"
 	},

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - internal-packages/*
   - packages/*
   - tools/*
+minimumReleaseAge: 1440
 catalog:
   "@biomejs/biome": 2.0.6
   typescript: 5.7.3

--- a/tools/storage-migration/package.json
+++ b/tools/storage-migration/package.json
@@ -15,7 +15,7 @@
 		"@supabase/supabase-js": "catalog:",
 		"@vercel/blob": "0.27.3"
 	},
-	"packageManager": "pnpm@10.2.1",
+	"packageManager": "pnpm@10.16.0",
 	"engines": {
 		"node": ">=22"
 	}


### PR DESCRIPTION
## Summary
Update pnpm to v10.16.0 and add minimum release age protection

## Related Issue
None.

## Changes
- Updated pnpm package manager from various versions (10.0.0, 10.2.1, 10.6.5) to v10.16.0 across all package.json files
for consistency
- Added `minimumReleaseAge: 1440` to pnpm-workspace.yaml to prevent installing packages released less than 24 hours ago
- This improves security and stability by avoiding potentially problematic new releases


## Testing
pnpm i

## Other Information
- [Release pnpm 10\.16 · pnpm/pnpm](https://github.com/pnpm/pnpm/releases/tag/v10.16.0)
- [minimumReleaseAge​ - Settings \(pnpm\-workspace\.yaml\) \| pnpm](https://pnpm.io/settings#minimumreleaseage)
