### PR TITLE
feat: add Redis env vars and broaden Google env pattern in turbo config

### DIFF
--- a/packages/github-tool/turbo.json
+++ b/packages/github-tool/turbo.json
@@ -10,6 +10,7 @@
 				"GITHUB_*",
 				"LANGFUSE_*",
 				"POSTGRES_*",
+				"REDIS_*",
 				"SIGNOZ_*",
 				"STRIPE_*",
 				"SMTP_*",
@@ -21,7 +22,7 @@
 				"SAMPLE_APP_WORKSPACE_IDS",
 				"INNGEST_*",
 				"OTEL_*",
-				"GOOGLE_OAUTH_CLIENT_*",
+				"GOOGLE_*",
 				"WAITUNTIL_OFFSET_MILLIS",
 				"EDGE_CONFIG"
 			]

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
 				"GITHUB_*",
 				"LANGFUSE_*",
 				"POSTGRES_*",
+				"REDIS_*",
 				"SIGNOZ_*",
 				"STRIPE_*",
 				"SMTP_*",
@@ -19,7 +20,7 @@
 				"SAMPLE_APP_WORKSPACE_IDS",
 				"INNGEST_*",
 				"OTEL_*",
-				"GOOGLE_OAUTH_CLIENT_*",
+				"GOOGLE_*",
 				"WAITUNTIL_OFFSET_MILLIS",
 				"EDGE_CONFIG"
 			],


### PR DESCRIPTION

## Summary
- Add REDIS_* to environment variable patterns
- Change GOOGLE_OAUTH_CLIENT_* to GOOGLE_* for broader Google service support

## Related Issue
None.

## Changes

The changes add support for Redis environment variables and expand the Google environment variable pattern from OAuth-specific to all Google services.

Warning messages in vercel build logs:

```
Warning - the following environment variables are set on your Vercel project, but missing from "turbo.json". These variables WILL NOT be available to your application and may cause your build to fail. Learn more at https://turbo.build/repo/docs/platform-environment-variables
```

## Testing


## Other Information
https://turbo.build/repo/docs/platform-environment-variables