### PR TITLE
Chore/colors foundation v1

### DIFF
--- a/apps/studio.giselles.ai/app/stage/(top)/page.tsx
+++ b/apps/studio.giselles.ai/app/stage/(top)/page.tsx
@@ -94,8 +94,8 @@ export default async function StagePage({
 											key={act.id}
 											className="hover:bg-white/5 transition-colors duration-200 cursor-pointer"
 										>
-											<Link href={act.link} className="contents">
-												<TableCell className="text-center w-6">
+											<TableCell className="text-center w-6">
+												<Link href={act.link} className="contents">
 													<div className="flex justify-center">
 														{act.status === "inProgress" && (
 															<StatusBadge
@@ -126,8 +126,10 @@ export default async function StagePage({
 															/>
 														)}
 													</div>
-												</TableCell>
-												<TableCell className="min-w-[240px]">
+												</Link>
+											</TableCell>
+											<TableCell className="min-w-[240px]">
+												<Link href={act.link} className="contents">
 													<div className="flex flex-col">
 														<span className="truncate">
 															{act.workspaceName}
@@ -137,11 +139,13 @@ export default async function StagePage({
 															{act.teamName}
 														</span>
 													</div>
-												</TableCell>
-												<TableCell className="text-right w-4">
+												</Link>
+											</TableCell>
+											<TableCell className="text-right w-4">
+												<Link href={act.link} className="contents">
 													<div className="flex justify-end">{">"}</div>
-												</TableCell>
-											</Link>
+												</Link>
+											</TableCell>
 										</TableRow>
 									);
 								})}

--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
-	"name": "giselle-project",
-	"version": "0.1.0",
-	"private": true,
-	"scripts": {
-		"build": "turbo build",
-		"build-sdk": "turbo build --filter '@giselle-sdk/*'",
-		"build-data-type": "turbo build --filter '@giselle-sdk/data-type'",
-		"check-types": "turbo check-types",
-		"format": "biome check --write .",
-		"clean": "turbo clean",
-		"dev": "turbo dev --filter playground",
-		"dev:studio.giselles.ai": "NODE_NO_WARNINGS=1 turbo dev --filter studio.giselles.ai",
-		"changeset": "changeset",
-		"version": "changeset version",
-		"test": "turbo test",
-		"tidy": "knip --no-config-hints",
-		"strip-workspace": "pnpm -F strip-workspace strip-workspace",
-		"prevd": "pnpm i && pnpm build-sdk",
-		"vd": "vercel dev"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "catalog:",
-		"@changesets/cli": "^2.28.1",
-		"@types/node": "catalog:",
-		"knip": "^5.61.3",
-		"turbo": "2.4.2",
-		"typescript": "catalog:"
-	},
-	"packageManager": "pnpm@10.16.0",
-	"engines": {
-		"node": ">=22"
-	},
-	"pnpm": {
-		"overrides": {
-			"vite": "7.1.3"
-		}
-	}
+  "name": "giselle-project",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "turbo build",
+    "build-sdk": "turbo build --filter '@giselle-sdk/*'",
+    "build-data-type": "turbo build --filter '@giselle-sdk/data-type'",
+    "check-types": "turbo check-types",
+    "format": "biome check --write .",
+    "clean": "turbo clean",
+    "dev": "turbo dev --filter playground",
+    "dev:studio.giselles.ai": "NODE_NO_WARNINGS=1 turbo dev --filter studio.giselles.ai",
+    "changeset": "changeset",
+    "version": "changeset version",
+    "test": "turbo test",
+    "tidy": "knip --no-config-hints",
+    "strip-workspace": "pnpm -F strip-workspace strip-workspace",
+    "prevd": "pnpm i && pnpm build-sdk",
+    "vd": "vercel dev"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@changesets/cli": "^2.28.1",
+    "@types/node": "catalog:",
+    "knip": "^5.61.3",
+    "turbo": "2.4.2",
+    "typescript": "catalog:"
+  },
+  "packageManager": "pnpm@10.16.0",
+  "engines": {
+    "node": ">=22"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "7.1.3"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "tidy": "knip --no-config-hints",
     "strip-workspace": "pnpm -F strip-workspace strip-workspace",
     "prevd": "pnpm i && pnpm build-sdk",
-    "vd": "vercel dev"
+    "vd": "vercel dev",
+    "report:colors": "node scripts/report-colors.mjs",
+    "report:colors:out": "node scripts/report-colors.mjs --out .reports/report-colors.json"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/scripts/report-colors.mjs
+++ b/scripts/report-colors.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * Color usage report (rg-based, ESM, no TypeScript)
+ *
+ * Generates a JSON report summarizing color-related usages across the repo:
+ * - Tailwind color utilities (text-*, bg-*, border-*, ring-*, outline-*, divide-*, from-*, via-*, to-*, fill-*, stroke-*)
+ * - Specific key items: text-white-900, text-black-600/20, color-border-focused
+ * - Color literals: hex (#fff/#ffffff/#ffffffff), rgba()/hsla()/hsl()/oklch()
+ * - CSS variables: --color-*, --brand-*, --text-*, --bg-*, --surface-*, --border-*, --ring-*, --shadow-*
+ * - SVG attributes: fill= / stroke= (in *.svg files only)
+ *
+ * Usage:
+ *   node scripts/report-colors.mjs
+ *   node scripts/report-colors.mjs --out .reports/report-colors.json
+ *
+ * Notes:
+ * - Requires ripgrep (`rg`) to be installed and available on PATH.
+ * - Excludes common build/output directories: node_modules, .next, dist, build, out, coverage
+ * - Searches common source extensions: css, scss, ts, tsx, js, jsx, svg, md, mdx (except for the SVG-only query)
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+/**
+ * @typedef {{ type: "begin" | "match" | "end" | string, data: any }} RgEvent
+ * @typedef {{ path: { text: string }, lines: { text: string }, line_number: number, absolute_offset: number, submatches: Array<{ start: number, end: number, match: { text: string } }> }} RgMatch
+ * @typedef {{ path: string, line: number, match: string, context: string }} Finding
+ */
+
+/** @param {string} message */
+function fail(message) {
+  console.error(`[report-colors] ${message}`);
+  process.exit(1);
+}
+
+function hasRg() {
+  const res = spawnSync("rg", ["--version"], { encoding: "utf8" });
+  return res.status === 0 && typeof res.stdout === "string" && res.stdout.includes("ripgrep");
+}
+
+/**
+ * @param {string} pattern
+ * @param {{ caseInsensitive?: boolean, svgOnly?: boolean }} opts
+ * @returns {Finding[]}
+ */
+function runRg(pattern, opts = {}) {
+  const excludeGlobs = [
+    "!**/node_modules/**",
+    "!**/.next/**",
+    "!**/dist/**",
+    "!**/build/**",
+    "!**/out/**",
+    "!**/coverage/**",
+  ];
+
+  const includeGlobsAll = [
+    "**/*.css",
+    "**/*.scss",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.md",
+    "**/*.mdx",
+    "**/*.svg",
+  ];
+  const includeGlobsSvg = ["**/*.svg"];
+
+  const args = [
+    "-n", // show line numbers
+    "--json", // machine-readable
+    "--hidden", // include dotfiles if any
+  ];
+
+  // case-insensitive by default
+  if (opts.caseInsensitive !== false) {
+    args.push("-i");
+  }
+
+  // globs
+  const includeGlobs = opts.svgOnly ? includeGlobsSvg : includeGlobsAll;
+  for (const g of excludeGlobs) args.push("--glob", g);
+  for (const g of includeGlobs) args.push("--glob", g);
+
+  // pattern
+  args.push("-e", pattern);
+
+  const res = spawnSync("rg", args, { encoding: "utf8" });
+  // 0: matches found, 1: no matches, others: error
+  if (res.status !== 0 && res.status !== 1) {
+    if (res.stdout) console.error(res.stdout);
+    if (res.stderr) console.error(res.stderr);
+    fail(`ripgrep failed (status ${res.status}) for pattern: ${pattern}`);
+  }
+
+  const findings = [];
+
+  const stdout = res.stdout || "";
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+    let ev;
+    try {
+      ev = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!ev || ev.type !== "match") continue;
+    const m = ev.data;
+    if (!m || !m.path || !m.lines) continue;
+    const path = m.path.text;
+    const lineNum = m.line_number;
+    const context = m.lines.text;
+    for (const sm of m.submatches || []) {
+      findings.push({
+        path,
+        line: lineNum,
+        match: sm.match.text,
+        context,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/** @param {Finding[]} items */
+function uniqPaths(items) {
+  return new Set(items.map((f) => f.path)).size;
+}
+
+/** @param {Finding[]} items @param {number} [n] */
+function slicePreview(items, n = 10) {
+  return items.slice(0, n);
+}
+
+function buildReport(rootDir) {
+  // Patterns (as strings passed to rg, NOT JS RegExp)
+  const patterns = {
+    // Tailwind color utilities with optional scale and opacity suffix
+    // e.g., text-white-900, bg-gray-200/20, border-brand-500, ring-focused
+    tailwindUtilities:
+      "\\b(?:text|bg|border|ring|outline|divide|from|via|to|fill|stroke)-[a-zA-Z-]+(?:-\\d{1,3})?(?:/\\d{1,3})?\\b",
+
+    // Specific high-priority items to consolidate
+    specific: "\\btext-white-900\\b|\\btext-black-600/20\\b|\\bcolor-border-focused\\b",
+
+    // Hex colors, 3/4 or 6/8 digits
+    hexColors: "#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b",
+
+    // Functional notations
+    functionalColors: "\\b(?:rgba?|hsla?|oklch)\\([^)]*\\)",
+
+    // CSS variable definitions
+    cssVariables: "--(?:color|brand|text|bg|surface|border|ring|shadow)[-\\w]*\\s*:",
+
+    // SVG attributes (search *.svg only)
+    svgAttrs: "fill=|stroke=",
+  };
+
+  // Run searches
+  const tailwindUtilities = runRg(patterns.tailwindUtilities, {});
+  const specific = runRg(patterns.specific, {});
+  const hexColors = runRg(patterns.hexColors, {});
+  const functionalColors = runRg(patterns.functionalColors, {});
+  const cssVariables = runRg(patterns.cssVariables, {});
+  const svgAttrs = runRg(patterns.svgAttrs, { svgOnly: true });
+
+  // Special items broken out
+  const textWhite900 = runRg("\\btext-white-900\\b", {});
+  const textBlack600_20 = runRg("\\btext-black-600/20\\b", {});
+  const colorBorderFocused = runRg("\\bcolor-border-focused\\b", {});
+
+  // Summary
+  const breakdown = {
+    tailwindUtilities: {
+      matches: tailwindUtilities.length,
+      files: uniqPaths(tailwindUtilities),
+    },
+    specific: {
+      matches: specific.length,
+      files: uniqPaths(specific),
+    },
+    hexColors: {
+      matches: hexColors.length,
+      files: uniqPaths(hexColors),
+    },
+    functionalColors: {
+      matches: functionalColors.length,
+      files: uniqPaths(functionalColors),
+    },
+    cssVariables: {
+      matches: cssVariables.length,
+      files: uniqPaths(cssVariables),
+    },
+    svgAttrs: {
+      matches: svgAttrs.length,
+      files: uniqPaths(svgAttrs),
+    },
+  };
+
+  const totalMatches =
+    breakdown.tailwindUtilities.matches +
+    breakdown.specific.matches +
+    breakdown.hexColors.matches +
+    breakdown.functionalColors.matches +
+    breakdown.cssVariables.matches +
+    breakdown.svgAttrs.matches;
+
+  const filesTouched = uniqPaths([
+    ...tailwindUtilities,
+    ...specific,
+    ...hexColors,
+    ...functionalColors,
+    ...cssVariables,
+    ...svgAttrs,
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    rootDir,
+    options: {
+      caseInsensitive: true,
+      excludeGlobs: [
+        "!**/node_modules/**",
+        "!**/.next/**",
+        "!**/dist/**",
+        "!**/build/**",
+        "!**/out/**",
+        "!**/coverage/**",
+      ],
+      includeGlobs: [
+        "**/*.css",
+        "**/*.scss",
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.md",
+        "**/*.mdx",
+        "**/*.svg",
+      ],
+    },
+    patterns: {
+      tailwindUtilities: {
+        regex: patterns.tailwindUtilities,
+        totalMatches: breakdown.tailwindUtilities.matches,
+        fileCount: breakdown.tailwindUtilities.files,
+        preview: slicePreview(tailwindUtilities),
+      },
+      specific: {
+        regex: patterns.specific,
+        totalMatches: breakdown.specific.matches,
+        fileCount: breakdown.specific.files,
+        preview: slicePreview(specific),
+      },
+      hexColors: {
+        regex: patterns.hexColors,
+        totalMatches: breakdown.hexColors.matches,
+        fileCount: breakdown.hexColors.files,
+        preview: slicePreview(hexColors),
+      },
+      functionalColors: {
+        regex: patterns.functionalColors,
+        totalMatches: breakdown.functionalColors.matches,
+        fileCount: breakdown.functionalColors.files,
+        preview: slicePreview(functionalColors),
+      },
+      cssVariables: {
+        regex: patterns.cssVariables,
+        totalMatches: breakdown.cssVariables.matches,
+        fileCount: breakdown.cssVariables.files,
+        preview: slicePreview(cssVariables),
+      },
+      svgAttrs: {
+        regex: patterns.svgAttrs,
+        totalMatches: breakdown.svgAttrs.matches,
+        fileCount: breakdown.svgAttrs.files,
+        preview: slicePreview(svgAttrs),
+      },
+    },
+    findings: {
+      tailwindUtilities,
+      specific,
+      hexColors,
+      functionalColors,
+      cssVariables,
+      svgAttrs,
+    },
+    specialItems: {
+      textWhite900,
+      textBlack600_20,
+      colorBorderFocused,
+    },
+    summary: {
+      totalMatches,
+      filesTouched,
+      breakdown,
+    },
+  };
+}
+
+/** @param {string[]} argv */
+function parseArgs(argv) {
+  const outIndex = argv.indexOf("--out");
+  if (outIndex !== -1) {
+    const val = argv[outIndex + 1];
+    if (!val || val.startsWith("-")) {
+      fail("Expected a value after --out");
+    }
+    return { outPath: val };
+  }
+  return { outPath: undefined };
+}
+
+(function main() {
+  if (!hasRg()) {
+    fail("ripgrep (rg) not found on PATH. Please install ripgrep to run this script.");
+  }
+
+  const cwd = process.cwd();
+  const { outPath } = parseArgs(process.argv.slice(2));
+  const report = buildReport(cwd);
+  const json = JSON.stringify(report, null, 2);
+
+  if (outPath) {
+    const absOut = resolve(cwd, outPath);
+    const dir = dirname(absOut);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(absOut, json, "utf8");
+    console.log(`[report-colors] Wrote report to ${absOut}`);
+  } else {
+    // Print to stdout for ad-hoc inspection
+    console.log(json);
+  }
+})();

--- a/scripts/report-colors.ts
+++ b/scripts/report-colors.ts
@@ -1,0 +1,398 @@
+/**
+ * Color usage report (rg-based)
+ *
+ * Generates a JSON report summarizing color-related usages across the repo:
+ * - Tailwind color utilities (text-*, bg-*, border-*, ring-*, outline-*, divide-*, from-*, via-*, to-*, fill-*, stroke-*)
+ * - Specific key items: text-white-900, text-black-600/20, color-border-focused
+ * - Color literals: hex (#fff/#ffffff/#ffffffff), rgba()/hsla()/hsl()/oklch()
+ * - CSS variables: --color-*, --brand-*, --text-*, --bg-*, --surface-*, --border-*, --ring-*, --shadow-*
+ * - SVG attributes: fill= / stroke= (in *.svg files only)
+ *
+ * By default, the report is printed to stdout.
+ * Optionally, write to a file with: `pnpm tsx scripts/report-colors.ts --out .reports/report-colors.json`
+ *
+ * Notes:
+ * - Requires ripgrep (`rg`) to be installed and available on PATH.
+ * - Excludes common build/output directories: node_modules, .next, dist, build, out, coverage
+ * - Searches common source extensions: css, scss, ts, tsx, js, jsx, svg, md, mdx (except for the SVG-only query)
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+type RgEvent =
+	| { type: "begin"; data: unknown }
+	| { type: "match"; data: RgMatch }
+	| { type: "end"; data: unknown }
+	| { type: string; data: unknown };
+
+type RgMatch = {
+	path: { text: string };
+	lines: { text: string };
+	line_number: number;
+	absolute_offset: number;
+	submatches: Array<{ start: number; end: number; match: { text: string } }>;
+};
+
+type Finding = {
+	path: string;
+	line: number;
+	match: string;
+	context: string;
+};
+
+type CategoryReport = {
+	regex: string;
+	totalMatches: number;
+	fileCount: number;
+	findings: Finding[];
+};
+
+type SpecialItemsReport = {
+	textWhite900: Finding[];
+	textBlack600_20: Finding[];
+	colorBorderFocused: Finding[];
+};
+
+type Report = {
+	generatedAt: string;
+	rootDir: string;
+	options: {
+		caseInsensitive: boolean;
+		excludeGlobs: string[];
+		includeGlobs: string[];
+	};
+	patterns: {
+		tailwindUtilities: Omit<CategoryReport, "findings"> & { preview: Finding[] };
+		specific: Omit<CategoryReport, "findings"> & { preview: Finding[] };
+		hexColors: Omit<CategoryReport, "findings"> & { preview: Finding[] };
+		functionalColors: Omit<CategoryReport, "findings"> & { preview: Finding[] };
+		cssVariables: Omit<CategoryReport, "findings"> & { preview: Finding[] };
+		svgAttrs: Omit<CategoryReport, "findings"> & { preview: Finding[] };
+	};
+	findings: {
+		tailwindUtilities: Finding[];
+		specific: Finding[];
+		hexColors: Finding[];
+		functionalColors: Finding[];
+		cssVariables: Finding[];
+		svgAttrs: Finding[];
+	};
+	specialItems: SpecialItemsReport;
+	summary: {
+		totalMatches: number;
+		filesTouched: number;
+		breakdown: Record<
+			keyof Report["findings"],
+			{ matches: number; files: number }
+		>;
+	};
+};
+
+function fail(message: string): never {
+	console.error(`[report-colors] ${message}`);
+	process.exit(1);
+}
+
+function hasRg(): boolean {
+	const res = spawnSync("rg", ["--version"], { encoding: "utf8" });
+	return res.status === 0 && res.stdout.includes("ripgrep");
+}
+
+function runRg(
+	pattern: string,
+	opts: {
+		caseInsensitive?: boolean;
+		svgOnly?: boolean;
+	},
+): Finding[] {
+	const excludeGlobs = [
+		"!**/node_modules/**",
+		"!**/.next/**",
+		"!**/dist/**",
+		"!**/build/**",
+		"!**/out/**",
+		"!**/coverage/**",
+	];
+
+	const includeGlobsAll = [
+		"**/*.css",
+		"**/*.scss",
+		"**/*.ts",
+		"**/*.tsx",
+		"**/*.js",
+		"**/*.jsx",
+		"**/*.md",
+		"**/*.mdx",
+		"**/*.svg",
+	];
+	const includeGlobsSvg = ["**/*.svg"];
+
+	const args = [
+		"-n", // show line numbers
+		"--json", // machine-readable
+		"--hidden", // include dotfiles if any
+	];
+
+	// case-insensitive (default: true)
+	if (opts.caseInsensitive !== false) {
+		args.push("-i");
+	}
+
+	// globs
+	const includeGlobs = opts.svgOnly ? includeGlobsSvg : includeGlobsAll;
+	for (const g of excludeGlobs) args.push("--glob", g);
+	for (const g of includeGlobs) args.push("--glob", g);
+
+	// pattern
+	args.push("-e", pattern);
+
+	const res = spawnSync("rg", args, { encoding: "utf8" });
+	if (res.status !== 0 && res.status !== 1) {
+		// 0: matches found, 1: no matches, others: error
+		console.error(res.stdout);
+		console.error(res.stderr);
+		fail(`ripgrep failed (status ${res.status}) for pattern: ${pattern}`);
+	}
+
+	const findings: Finding[] = [];
+
+	for (const line of res.stdout.split("\n")) {
+		if (!line.trim()) continue;
+		let ev: RgEvent;
+		try {
+			ev = JSON.parse(line) as RgEvent;
+		} catch {
+			// ignore non-JSON lines (shouldn't happen with --json)
+			continue;
+		}
+		if (ev.type !== "match") continue;
+		const m = (ev as { data: RgMatch }).data;
+		const path = m.path.text;
+		const lineNum = m.line_number;
+		const context = m.lines.text;
+		for (const sm of m.submatches) {
+			findings.push({
+				path,
+				line: lineNum,
+				match: sm.match.text,
+				context,
+			});
+		}
+	}
+
+	return findings;
+}
+
+function uniqPaths(items: Finding[]): number {
+	return new Set(items.map((f) => f.path)).size;
+}
+
+function slicePreview(items: Finding[], n = 10): Finding[] {
+	return items.slice(0, n);
+}
+
+function buildReport(rootDir: string): Report {
+	// Patterns
+	const patterns = {
+		// Tailwind color utilities with optional scale and opacity suffix:
+		// e.g., text-white-900, bg-gray-200/20, border-brand-500, ring-focused
+		tailwindUtilities:
+			String.raw`\b(?:text|bg|border|ring|outline|divide|from|via|to|fill|stroke)-[a-zA-Z-]+(?:-\d{1,3})?(?:/\d{1,3})?\b`,
+		// Specific high-priority items to consolidate
+		specific:
+			String.raw`\btext-white-900\b|\btext-black-600/20\b|\bcolor-border-focused\b`,
+		// Hex colors, 3/4 or 6/8 digits
+		hexColors:
+			String.raw`#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b`,
+		// Functional notations
+		functionalColors: String.raw`\b(?:rgba?|hsla?|oklch)\([^)]*\)`,
+		// CSS variable definitions
+		cssVariables:
+			String.raw`--(?:color|brand|text|bg|surface|border|ring|shadow)[-\w]*\s*:`,
+		// SVG attributes
+		svgAttrs: String.raw`fill=|stroke=`,
+	};
+
+	// Run searches
+	const tailwindUtilities = runRg(patterns.tailwindUtilities, {});
+	const specific = runRg(patterns.specific, {});
+	const hexColors = runRg(patterns.hexColors, {});
+	const functionalColors = runRg(patterns.functionalColors, {});
+	const cssVariables = runRg(patterns.cssVariables, {});
+	const svgAttrs = runRg(patterns.svgAttrs, { svgOnly: true });
+
+	// Special items broken out
+	const textWhite900 = runRg(String.raw`\btext-white-900\b`, {});
+	const textBlack600_20 = runRg(String.raw`\btext-black-600/20\b`, {});
+	const colorBorderFocused = runRg(String.raw`\bcolor-border-focused\b`, {});
+
+	// Summary
+	const breakdown = {
+		tailwindUtilities: {
+			matches: tailwindUtilities.length,
+			files: uniqPaths(tailwindUtilities),
+		},
+		specific: {
+			matches: specific.length,
+			files: uniqPaths(specific),
+		},
+		hexColors: {
+			matches: hexColors.length,
+			files: uniqPaths(hexColors),
+		},
+		functionalColors: {
+			matches: functionalColors.length,
+			files: uniqPaths(functionalColors),
+		},
+		cssVariables: {
+			matches: cssVariables.length,
+			files: uniqPaths(cssVariables),
+		},
+		svgAttrs: {
+			matches: svgAttrs.length,
+			files: uniqPaths(svgAttrs),
+		},
+	};
+
+	const totalMatches =
+		breakdown.tailwindUtilities.matches +
+		breakdown.specific.matches +
+		breakdown.hexColors.matches +
+		breakdown.functionalColors.matches +
+		breakdown.cssVariables.matches +
+		breakdown.svgAttrs.matches;
+
+	const filesTouched = uniqPaths([
+		...tailwindUtilities,
+		...specific,
+		...hexColors,
+		...functionalColors,
+		...cssVariables,
+		...svgAttrs,
+	]);
+
+	const report: Report = {
+		generatedAt: new Date().toISOString(),
+		rootDir,
+		options: {
+			caseInsensitive: true,
+			excludeGlobs: [
+				"!**/node_modules/**",
+				"!**/.next/**",
+				"!**/dist/**",
+				"!**/build/**",
+				"!**/out/**",
+				"!**/coverage/**",
+			],
+			includeGlobs: [
+				"**/*.css",
+				"**/*.scss",
+				"**/*.ts",
+				"**/*.tsx",
+				"**/*.js",
+				"**/*.jsx",
+				"**/*.md",
+				"**/*.mdx",
+				"**/*.svg",
+			],
+		},
+		patterns: {
+			tailwindUtilities: {
+				regex: patterns.tailwindUtilities,
+				totalMatches: breakdown.tailwindUtilities.matches,
+				fileCount: breakdown.tailwindUtilities.files,
+				preview: slicePreview(tailwindUtilities),
+			},
+			specific: {
+				regex: patterns.specific,
+				totalMatches: breakdown.specific.matches,
+				fileCount: breakdown.specific.files,
+				preview: slicePreview(specific),
+			},
+			hexColors: {
+				regex: patterns.hexColors,
+				totalMatches: breakdown.hexColors.matches,
+				fileCount: breakdown.hexColors.files,
+				preview: slicePreview(hexColors),
+			},
+			functionalColors: {
+				regex: patterns.functionalColors,
+				totalMatches: breakdown.functionalColors.matches,
+				fileCount: breakdown.functionalColors.files,
+				preview: slicePreview(functionalColors),
+			},
+			cssVariables: {
+				regex: patterns.cssVariables,
+				totalMatches: breakdown.cssVariables.matches,
+				fileCount: breakdown.cssVariables.files,
+				preview: slicePreview(cssVariables),
+			},
+			svgAttrs: {
+				regex: patterns.svgAttrs,
+				totalMatches: breakdown.svgAttrs.matches,
+				fileCount: breakdown.svgAttrs.files,
+				preview: slicePreview(svgAttrs),
+			},
+		},
+		findings: {
+			tailwindUtilities,
+			specific,
+			hexColors,
+			functionalColors,
+			cssVariables,
+			svgAttrs,
+		},
+		specialItems: {
+			textWhite900,
+			textBlack600_20,
+			colorBorderFocused,
+		},
+		summary: {
+			totalMatches,
+			filesTouched,
+			breakdown,
+		},
+	};
+
+	return report;
+}
+
+function parseArgs(argv: string[]): { outPath?: string } {
+	const outIndex = argv.indexOf("--out");
+	if (outIndex !== -1) {
+		const val = argv[outIndex + 1];
+		if (!val || val.startsWith("-")) {
+			fail("Expected a value after --out");
+		}
+		return { outPath: val };
+	}
+	return {};
+}
+
+(function main() {
+	if (!hasRg()) {
+		fail(
+			"ripgrep (rg) not found on PATH. Please install ripgrep to run this script.",
+		);
+	}
+
+	const cwd = process.cwd();
+	const { outPath } = parseArgs(process.argv.slice(2));
+	const report = buildReport(cwd);
+	const json = JSON.stringify(report, null, 2);
+
+	if (outPath) {
+		const absOut = resolve(cwd, outPath);
+		const dir = dirname(absOut);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+		writeFileSync(absOut, json, "utf8");
+		console.log(`[report-colors] Wrote report to ${absOut}`);
+	} else {
+		// Print to stdout for ad-hoc inspection
+		console.log(json);
+	}
+})();


### PR DESCRIPTION
## Summary
Add a repo-wide color usage report (Phase 0 foundation) to support the color unification plan. No runtime/UI changes.

## Related Issue
- Ref: Color unification plan (Phase 0). Add issue number if available.

## Changes
- Add `scripts/report-colors.mjs` (rg-based JSON report):
  - Scans Tailwind color utilities, hex/rgba/hsla/oklch literals, CSS variables, and SVG fill/stroke.
  - Highlights: `text-white-900`, `text-black-600/20`, `color-border-focused`.
- Add npm scripts:
  - `report:colors` (prints JSON)
  - `report:colors:out` (writes `.reports/report-colors.json`)

## Testing
- Ran: `pnpm format`, `pnpm check-types`, `pnpm tidy`, `pnpm test` (all passed).
- Requires `ripgrep` (rg) to run the report.

## Other Information
- Next steps:
  - Run `pnpm report:colors:out` and review the 3 focus items’ distribution.
  - Phase 1: add `tokens.css` (primitives) + `aliases.css` (v3 bridge), no behavior change.