### PR TITLE
chore(colors): foundation v3 - stage: replace text-white-900 with text-inverse; add codemods

### DIFF
--- a/apps/studio.giselles.ai/app/stage/(top)/form-input-renderer.tsx
+++ b/apps/studio.giselles.ai/app/stage/(top)/form-input-renderer.tsx
@@ -20,7 +20,7 @@ export function FormInputRenderer({
 				return (
 					<fieldset key={input.name} className={clsx("grid gap-2")}>
 						<label
-							className="text-[14px] font-medium text-white-900"
+							className="text-[14px] font-medium text-inverse"
 							htmlFor={input.name}
 						>
 							{input.label}

--- a/apps/studio.giselles.ai/app/stage/(top)/form.tsx
+++ b/apps/studio.giselles.ai/app/stage/(top)/form.tsx
@@ -317,9 +317,7 @@ function Form({
 												<p
 													className={clsx(
 														"text-[14px] font-sans truncate",
-														appId === app.id
-															? "text-blue-400"
-															: "text-white-900",
+														appId === app.id ? "text-blue-400" : "text-inverse",
 													)}
 												>
 													{app.workspaceName || "Untitled"}

--- a/apps/studio.giselles.ai/app/stage/(top)/team-card.tsx
+++ b/apps/studio.giselles.ai/app/stage/(top)/team-card.tsx
@@ -19,7 +19,7 @@ export function TeamCard({ team }: TeamCardProps) {
 		>
 			<div className="space-y-1">
 				<div
-					className="text-[10px] text-white-900 leading-tight overflow-hidden text-left"
+					className="text-[10px] text-inverse leading-tight overflow-hidden text-left"
 					style={{
 						display: "-webkit-box",
 						WebkitLineClamp: 2,

--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/ui/sidebar.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/ui/sidebar.tsx
@@ -102,7 +102,7 @@ export function Sidebar({ data }: { data: Promise<SidebarDataObject> }) {
 				<div className="pt-[16px] mb-[20px] px-[16px] md:px-[32px]">
 					<Link
 						href="/stage/acts"
-						className="flex items-center gap-[8px] text-white-900 hover:text-white-700 transition-colors group"
+						className="flex items-center gap-[8px] text-inverse hover:text-white-700 transition-colors group"
 					>
 						<ChevronLeftIcon className="size-[24px] group-hover:-translate-x-1 transition-transform" />
 						<span className="text-[16px] font-medium">Back to Acts</span>
@@ -129,7 +129,7 @@ export function Sidebar({ data }: { data: Promise<SidebarDataObject> }) {
 
 					{/* App Name */}
 					<div>
-						<h1 className="text-[24px] font-semibold text-white-900 mb-[4px]">
+						<h1 className="text-[24px] font-semibold text-inverse mb-[4px]">
 							{appName}
 						</h1>
 						<p className="text-[14px] text-white-400">{teamName}</p>

--- a/apps/studio.giselles.ai/app/stage/acts/components/filterable-acts-list.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/components/filterable-acts-list.tsx
@@ -353,7 +353,7 @@ export function FilterableActsList({
 					{/* Search */}
 					<div className="search-input relative flex-1">
 						<div
-							className="flex items-center gap-1 flex-wrap w-full pl-2 pr-10 py-1 rounded-[8px] h-10 text-white-900 placeholder-white-600 focus-within:outline-none transition-colors text-[14px]"
+							className="flex items-center gap-1 flex-wrap w-full pl-2 pr-10 py-1 rounded-[8px] h-10 text-inverse placeholder-white-600 focus-within:outline-none transition-colors text-[14px]"
 							style={{ backgroundColor: "rgba(255, 255, 255, 0.05)" }}
 						>
 							{searchTags.map((tag) => {
@@ -387,7 +387,7 @@ export function FilterableActsList({
 								value={inputValue}
 								onChange={(e) => setInputValue(e.target.value)}
 								onKeyDown={handleInputKeyDown}
-								className="flex-1 min-w-0 bg-transparent border-none outline-none text-white-900 placeholder-white-600 text-[14px]"
+								className="flex-1 min-w-0 bg-transparent border-none outline-none text-inverse placeholder-white-600 text-[14px]"
 							/>
 						</div>
 						<Search className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-white-600" />
@@ -500,7 +500,7 @@ export function FilterableActsList({
 										Object.keys(statusLabels) as StatusFilter[],
 									);
 								}}
-								className="px-4 py-2 bg-white/10 text-white-900 rounded-lg hover:bg-white/20 transition-colors"
+								className="px-4 py-2 bg-white/10 text-inverse rounded-lg hover:bg-white/20 transition-colors"
 							>
 								Clear filters
 							</button>
@@ -667,7 +667,7 @@ export function FilterableActsList({
 																	e.stopPropagation();
 																	handleReload();
 																}}
-																className="text-white-700 hover:text-white-900 transition-colors p-1"
+																className="text-white-700 hover:text-inverse transition-colors p-1"
 																title="Reload this task"
 															>
 																<RefreshCw className="w-3 h-3" />
@@ -675,7 +675,7 @@ export function FilterableActsList({
 														) : (
 															<button
 																type="button"
-																className="text-white-700 hover:text-white-900 transition-colors p-1"
+																className="text-white-700 hover:text-inverse transition-colors p-1"
 																title="Archive task"
 																onClick={(e) => {
 																	e.stopPropagation();

--- a/apps/studio.giselles.ai/app/stage/ui/mobile-header.tsx
+++ b/apps/studio.giselles.ai/app/stage/ui/mobile-header.tsx
@@ -7,15 +7,15 @@ export function MobileHeader() {
 			<div className="md:hidden fixed top-0 left-0 right-0 bg-[var(--color-stage-background)] border-b border-white/10 px-4 z-20 h-16 flex items-center justify-between">
 				{/* Left side: G icon + Stage */}
 				<div className="flex items-center gap-2">
-					<GiselleIcon className="text-white-900 w-6 h-6" />
-					<span className="text-white-900 text-lg font-semibold">Stage</span>
+					<GiselleIcon className="text-inverse w-6 h-6" />
+					<span className="text-inverse text-lg font-semibold">Stage</span>
 				</div>
 
 				{/* Right side: Icons */}
 				<div className="flex items-center gap-4">
 					<button
 						type="button"
-						className="text-white-700 hover:text-white-900 transition-colors"
+						className="text-white-700 hover:text-inverse transition-colors"
 					>
 						<BellIcon className="w-5 h-5" />
 					</button>

--- a/package.json
+++ b/package.json
@@ -1,43 +1,45 @@
 {
-  "name": "giselle-project",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "build": "turbo build",
-    "build-sdk": "turbo build --filter '@giselle-sdk/*'",
-    "build-data-type": "turbo build --filter '@giselle-sdk/data-type'",
-    "check-types": "turbo check-types",
-    "format": "biome check --write .",
-    "clean": "turbo clean",
-    "dev": "turbo dev --filter playground",
-    "dev:studio.giselles.ai": "NODE_NO_WARNINGS=1 turbo dev --filter studio.giselles.ai",
-    "changeset": "changeset",
-    "version": "changeset version",
-    "test": "turbo test",
-    "tidy": "knip --no-config-hints",
-    "strip-workspace": "pnpm -F strip-workspace strip-workspace",
-    "prevd": "pnpm i && pnpm build-sdk",
-    "vd": "vercel dev",
-    "report:colors": "node scripts/report-colors.mjs",
-    "report:colors:out": "node scripts/report-colors.mjs --out .reports/report-colors.json",
-    "codemod:text-black-600-20": "node scripts/codemods/replace-text-black-600-20.mjs",
-    "codemod:text-black-600-20:apply": "node scripts/codemods/replace-text-black-600-20.mjs --apply"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "catalog:",
-    "@changesets/cli": "^2.28.1",
-    "@types/node": "catalog:",
-    "knip": "^5.61.3",
-    "turbo": "2.4.2",
-    "typescript": "catalog:"
-  },
-  "packageManager": "pnpm@10.16.0",
-  "engines": {
-    "node": ">=22"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "7.1.3"
-    }
-  }
+	"name": "giselle-project",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"build": "turbo build",
+		"build-sdk": "turbo build --filter '@giselle-sdk/*'",
+		"build-data-type": "turbo build --filter '@giselle-sdk/data-type'",
+		"check-types": "turbo check-types",
+		"format": "biome check --write .",
+		"clean": "turbo clean",
+		"dev": "turbo dev --filter playground",
+		"dev:studio.giselles.ai": "NODE_NO_WARNINGS=1 turbo dev --filter studio.giselles.ai",
+		"changeset": "changeset",
+		"version": "changeset version",
+		"test": "turbo test",
+		"tidy": "knip --no-config-hints",
+		"strip-workspace": "pnpm -F strip-workspace strip-workspace",
+		"prevd": "pnpm i && pnpm build-sdk",
+		"vd": "vercel dev",
+		"report:colors": "node scripts/report-colors.mjs",
+		"report:colors:out": "node scripts/report-colors.mjs --out .reports/report-colors.json",
+		"codemod:text-black-600-20": "node scripts/codemods/replace-text-black-600-20.mjs",
+		"codemod:text-black-600-20:apply": "node scripts/codemods/replace-text-black-600-20.mjs --apply",
+		"codemod:text-white-900": "node scripts/codemods/replace-text-white-900-to-inverse.mjs",
+		"codemod:text-white-900:apply": "node scripts/codemods/replace-text-white-900-to-inverse.mjs --apply"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "catalog:",
+		"@changesets/cli": "^2.28.1",
+		"@types/node": "catalog:",
+		"knip": "^5.61.3",
+		"turbo": "2.4.2",
+		"typescript": "catalog:"
+	},
+	"packageManager": "pnpm@10.16.0",
+	"engines": {
+		"node": ">=22"
+	},
+	"pnpm": {
+		"overrides": {
+			"vite": "7.1.3"
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,41 +1,43 @@
 {
-	"name": "giselle-project",
-	"version": "0.1.0",
-	"private": true,
-	"scripts": {
-		"build": "turbo build",
-		"build-sdk": "turbo build --filter '@giselle-sdk/*'",
-		"build-data-type": "turbo build --filter '@giselle-sdk/data-type'",
-		"check-types": "turbo check-types",
-		"format": "biome check --write .",
-		"clean": "turbo clean",
-		"dev": "turbo dev --filter playground",
-		"dev:studio.giselles.ai": "NODE_NO_WARNINGS=1 turbo dev --filter studio.giselles.ai",
-		"changeset": "changeset",
-		"version": "changeset version",
-		"test": "turbo test",
-		"tidy": "knip --no-config-hints",
-		"strip-workspace": "pnpm -F strip-workspace strip-workspace",
-		"prevd": "pnpm i && pnpm build-sdk",
-		"vd": "vercel dev",
-		"report:colors": "node scripts/report-colors.mjs",
-		"report:colors:out": "node scripts/report-colors.mjs --out .reports/report-colors.json"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "catalog:",
-		"@changesets/cli": "^2.28.1",
-		"@types/node": "catalog:",
-		"knip": "^5.61.3",
-		"turbo": "2.4.2",
-		"typescript": "catalog:"
-	},
-	"packageManager": "pnpm@10.16.0",
-	"engines": {
-		"node": ">=22"
-	},
-	"pnpm": {
-		"overrides": {
-			"vite": "7.1.3"
-		}
-	}
+  "name": "giselle-project",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "turbo build",
+    "build-sdk": "turbo build --filter '@giselle-sdk/*'",
+    "build-data-type": "turbo build --filter '@giselle-sdk/data-type'",
+    "check-types": "turbo check-types",
+    "format": "biome check --write .",
+    "clean": "turbo clean",
+    "dev": "turbo dev --filter playground",
+    "dev:studio.giselles.ai": "NODE_NO_WARNINGS=1 turbo dev --filter studio.giselles.ai",
+    "changeset": "changeset",
+    "version": "changeset version",
+    "test": "turbo test",
+    "tidy": "knip --no-config-hints",
+    "strip-workspace": "pnpm -F strip-workspace strip-workspace",
+    "prevd": "pnpm i && pnpm build-sdk",
+    "vd": "vercel dev",
+    "report:colors": "node scripts/report-colors.mjs",
+    "report:colors:out": "node scripts/report-colors.mjs --out .reports/report-colors.json",
+    "codemod:text-black-600-20": "node scripts/codemods/replace-text-black-600-20.mjs",
+    "codemod:text-black-600-20:apply": "node scripts/codemods/replace-text-black-600-20.mjs --apply"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@changesets/cli": "^2.28.1",
+    "@types/node": "catalog:",
+    "knip": "^5.61.3",
+    "turbo": "2.4.2",
+    "typescript": "catalog:"
+  },
+  "packageManager": "pnpm@10.16.0",
+  "engines": {
+    "node": ">=22"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "7.1.3"
+    }
+  }
 }

--- a/scripts/codemods/replace-text-black-600-20.mjs
+++ b/scripts/codemods/replace-text-black-600-20.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * replace-text-black-600-20.mjs
+ *
+ * Codemod: Replace `text-black-600/20` with `text-text/20`
+ * - Targets: JSX/TSX/CSS (and optionally JS/JSX/TS/SCSS/MDX by default)
+ * - Default mode: dry-run (prints summary without modifying files)
+ *
+ * Usage:
+ *   node giselle/scripts/codemods/replace-text-black-600-20.mjs
+ *   node giselle/scripts/codemods/replace-text-black-600-20.mjs --apply
+ *   node giselle/scripts/codemods/replace-text-black-600-20.mjs --root . --apply
+ *   node giselle/scripts/codemods/replace-text-black-600-20.mjs --ext ts,tsx,jsx,css --apply
+ *
+ * Notes:
+ * - This is a straightforward string replacement (global) for `text-black-600/20` -> `text-text/20`.
+ * - It intentionally keeps logic minimal and obvious (Less is more).
+ */
+
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import process from "node:process";
+
+/** Configuration defaults */
+const DEFAULT_EXTS = ["ts", "tsx", "jsx", "js", "css", "scss", "mdx"];
+const DEFAULT_IGNORE_DIRS = new Set([
+	"node_modules",
+	".git",
+	".next",
+	"dist",
+	"build",
+	"out",
+	"coverage",
+]);
+
+/** Replacement pair */
+const FROM = "text-black-600/20";
+const TO = "text-text/20";
+
+/** CLI args */
+function parseArgs(argv) {
+	const args = {
+		root: process.cwd(),
+		apply: false,
+		exts: DEFAULT_EXTS,
+		verbose: false,
+	};
+
+	for (let i = 2; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--apply") {
+			args.apply = true;
+		} else if (a === "--verbose") {
+			args.verbose = true;
+		} else if (a === "--root") {
+			const v = argv[++i];
+			if (!v) fail("--root requires a value");
+			args.root = resolve(v);
+		} else if (a === "--ext") {
+			const v = argv[++i];
+			if (!v) fail("--ext requires a comma-separated value");
+			args.exts = v
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean);
+		} else if (a === "--help" || a === "-h") {
+			printHelp();
+			process.exit(0);
+		} else {
+			console.error(`Unknown argument: ${a}`);
+			printHelp();
+			process.exit(1);
+		}
+	}
+
+	return args;
+}
+
+function printHelp() {
+	console.log(`Replace 'text-black-600/20' with 'text-text/20' (dry-run by default)
+
+Options:
+  --apply           Write changes to disk (default: dry-run)
+  --root <path>     Root directory to scan (default: current working directory)
+  --ext <list>      Comma-separated list of file extensions (default: ${DEFAULT_EXTS.join(",")})
+  --verbose         Print per-file details
+  -h, --help        Show this help
+
+Examples:
+  node giselle/scripts/codemods/replace-text-black-600-20.mjs
+  node giselle/scripts/codemods/replace-text-black-600-20.mjs --apply
+  node giselle/scripts/codemods/replace-text-black-600-20.mjs --root . --ext ts,tsx,jsx,css --apply
+`);
+}
+
+function fail(message) {
+	console.error(`[codemod] ${message}`);
+	process.exit(1);
+}
+
+/** Simple recursive directory walk with extension filtering and ignore list */
+async function* walk(dir, exts, rootDir) {
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const name = entry.name;
+		if (entry.isDirectory()) {
+			if (DEFAULT_IGNORE_DIRS.has(name)) continue;
+			yield* walk(resolve(dir, name), exts, rootDir);
+			continue;
+		}
+		// filter by extension
+		const idx = name.lastIndexOf(".");
+		if (idx === -1) continue;
+		const ext = name.slice(idx + 1);
+		if (!exts.includes(ext)) continue;
+		yield resolve(dir, name);
+	}
+}
+
+/** Perform a global replacement, returns number of replacements */
+function replaceAllCount(haystack, needle, replacement) {
+	if (!haystack.includes(needle))
+		return { changed: false, count: 0, content: haystack };
+	const count = haystack.split(needle).length - 1;
+	const content = haystack.replaceAll(needle, replacement);
+	return { changed: true, count, content };
+}
+
+async function main() {
+	const args = parseArgs(process.argv);
+	const root = args.root;
+	const exts = args.exts;
+
+	let scannedFiles = 0;
+	let changedFiles = 0;
+	let totalReplacements = 0;
+
+	const changed = [];
+
+	for await (const file of walk(root, exts, root)) {
+		scannedFiles++;
+		let content;
+		try {
+			const st = await stat(file);
+			if (!st.isFile()) continue;
+			content = await readFile(file, "utf8");
+		} catch {
+			continue;
+		}
+
+		const {
+			changed: didChange,
+			count,
+			content: next,
+		} = replaceAllCount(content, FROM, TO);
+		if (!didChange) continue;
+
+		totalReplacements += count;
+		changedFiles++;
+		changed.push({ file: relative(root, file), count });
+
+		if (args.apply) {
+			await writeFile(file, next, "utf8");
+		}
+	}
+
+	// Output summary
+	const summary = {
+		root,
+		exts,
+		apply: args.apply,
+		scannedFiles,
+		changedFiles,
+		totalReplacements,
+		from: FROM,
+		to: TO,
+		changes: args.verbose ? changed : changed.slice(0, 50), // avoid too verbose by default
+		truncated: !args.verbose && changed.length > 50 ? changed.length - 50 : 0,
+	};
+
+	console.log(JSON.stringify(summary, null, 2));
+
+	if (!args.apply) {
+		console.log(
+			"\n[dry-run] No files were modified. Re-run with --apply to write changes.",
+		);
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/codemods/replace-text-white-900-to-inverse.mjs
+++ b/scripts/codemods/replace-text-white-900-to-inverse.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * replace-text-white-900-to-inverse.mjs
+ *
+ * Codemod: Replace `text-white-900` with `text-inverse`
+ * - Targets: JSX/TSX/CSS (and optionally JS/JSX/TS/SCSS/MDX by default)
+ * - Default mode: dry-run (prints summary without modifying files)
+ *
+ * Usage:
+ *   node giselle/scripts/codemods/replace-text-white-900-to-inverse.mjs
+ *   node giselle/scripts/codemods/replace-text-white-900-to-inverse.mjs --apply
+ *   node giselle/scripts/codemods/replace-text-white-900-to-inverse.mjs --root . --apply
+ *   node giselle/scripts/codemods/replace-text-white-900-to-inverse.mjs --ext ts,tsx,jsx,css --apply
+ *
+ * Notes:
+ * - This is a straightforward string replacement (global) for `text-white-900` -> `text-inverse`.
+ * - It intentionally keeps logic minimal and obvious (Less is more).
+ */
+
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import process from "node:process";
+
+/** Configuration defaults */
+const DEFAULT_EXTS = ["ts", "tsx", "jsx", "js", "css", "scss", "mdx"];
+const DEFAULT_IGNORE_DIRS = new Set([
+	"node_modules",
+	".git",
+	".next",
+	"dist",
+	"build",
+	"out",
+	"coverage",
+]);
+
+/** Replacement pair */
+const FROM = "text-white-900";
+const TO = "text-inverse";
+
+/** CLI args */
+function parseArgs(argv) {
+	const args = {
+		root: process.cwd(),
+		apply: false,
+		exts: DEFAULT_EXTS,
+		verbose: false,
+	};
+
+	for (let i = 2; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--apply") {
+			args.apply = true;
+		} else if (a === "--verbose") {
+			args.verbose = true;
+		} else if (a === "--root") {
+			const v = argv[++i];
+			if (!v) fail("--root requires a value");
+			args.root = resolve(v);
+		} else if (a === "--ext") {
+			const v = argv[++i];
+			if (!v) fail("--ext requires a comma-separated value");
+			args.exts = v
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean);
+		} else if (a === "--help" || a === "-h") {
+			printHelp();
+			process.exit(0);
+		} else {
+			console.error(`Unknown argument: ${a}`);
+			printHelp();
+			process.exit(1);
+		}
+	}
+
+	return args;
+}
+
+function printHelp() {
+	console.log(`Replace 'text-white-900' with 'text-inverse' (dry-run by default)
+
+Options:
+  --apply           Write changes to disk (default: dry-run)
+  --root <path>     Root directory to scan (default: current working directory)
+  --ext <list>      Comma-separated list of file extensions (default: ${DEFAULT_EXTS.join(",")})
+  --verbose         Print per-file details
+  -h, --help        Show this help
+
+Examples:
+  node giselle/scripts/codemods/replace-text-white-900-to-inverse.mjs
+  node giselle/scripts/codemods/replace-text-white-900-to-inverse.mjs --apply
+  node giselle/scripts/codemods/replace-text-white-900-to-inverse.mjs --root . --ext ts,tsx,jsx,css --apply
+`);
+}
+
+function fail(message) {
+	console.error(`[codemod] ${message}`);
+	process.exit(1);
+}
+
+/** Simple recursive directory walk with extension filtering and ignore list */
+async function* walk(dir, exts, rootDir) {
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const name = entry.name;
+		if (entry.isDirectory()) {
+			if (DEFAULT_IGNORE_DIRS.has(name)) continue;
+			yield* walk(resolve(dir, name), exts, rootDir);
+			continue;
+		}
+		// filter by extension
+		const idx = name.lastIndexOf(".");
+		if (idx === -1) continue;
+		const ext = name.slice(idx + 1);
+		if (!exts.includes(ext)) continue;
+		yield resolve(dir, name);
+	}
+}
+
+/** Perform a global replacement, returns number of replacements */
+function replaceAllCount(haystack, needle, replacement) {
+	if (!haystack.includes(needle))
+		return { changed: false, count: 0, content: haystack };
+	const count = haystack.split(needle).length - 1;
+	const content = haystack.replaceAll(needle, replacement);
+	return { changed: true, count, content };
+}
+
+async function main() {
+	const args = parseArgs(process.argv);
+	const root = args.root;
+	const exts = args.exts;
+
+	let scannedFiles = 0;
+	let changedFiles = 0;
+	let totalReplacements = 0;
+
+	const changed = [];
+
+	for await (const file of walk(root, exts, root)) {
+		scannedFiles++;
+		let content;
+		try {
+			const st = await stat(file);
+			if (!st.isFile()) continue;
+			content = await readFile(file, "utf8");
+		} catch {
+			continue;
+		}
+
+		const {
+			changed: didChange,
+			count,
+			content: next,
+		} = replaceAllCount(content, FROM, TO);
+		if (!didChange) continue;
+
+		totalReplacements += count;
+		changedFiles++;
+		changed.push({ file: relative(root, file), count });
+
+		if (args.apply) {
+			await writeFile(file, next, "utf8");
+		}
+	}
+
+	// Output summary
+	const summary = {
+		root,
+		exts,
+		apply: args.apply,
+		scannedFiles,
+		changedFiles,
+		totalReplacements,
+		from: FROM,
+		to: TO,
+		changes: args.verbose ? changed : changed.slice(0, 50), // avoid too verbose by default
+		truncated: !args.verbose && changed.length > 50 ? changed.length - 50 : 0,
+	};
+
+	console.log(JSON.stringify(summary, null, 2));
+
+	if (!args.apply) {
+		console.log(
+			"\n[dry-run] No files were modified. Re-run with --apply to write changes.",
+		);
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
### **User description**
## Summary
Foundation v3 for color unification. Apply safe replacements in Stage views and add codemods to streamline future swaps. No functional/behavior changes.

## Related Issue
- Follow-up to colors-foundation-v1/v2
- Ref: Color unification plan (Phase 3: safe replacements)

## Changes
- Replace `text-white-900` → `text-inverse` in Stage-only files (dark background, safe)
- Add codemods:
  - `scripts/codemods/replace-text-white-900-to-inverse.mjs`
  - `scripts/codemods/replace-text-black-600-20.mjs`
- Wire npm scripts:
  - `pnpm codemod:text-white-900` / `:apply`
  - `pnpm codemod:text-black-600-20` / `:apply`

## Testing
- Ran: `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, `pnpm test` (all passed)
- Manual scope check: Stage uses dark background, so `text-inverse` is visually correct

## Other Information
- Next steps:
  - Continue safe replacements in other dark-background scopes
  - Optionally add alias variants (e.g., hover) if needed before v4 migration
  - Introduce `semantic.css` in a non-breaking, scoped manner


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `text-white-900` with `text-inverse` in Stage views

- Add codemods for automated text color replacements

- Wire npm scripts for dry-run and apply modes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stage Views"] --> B["text-white-900"]
  B --> C["text-inverse"]
  D["Codemod Scripts"] --> E["npm Scripts"]
  E --> F["Automated Replacements"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>form-input-renderer.tsx</strong><dd><code>Replace text-white-900 with text-inverse in label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-1f6780204c6c34f637f904a5cbe7c7087053e32324b69be07bd76cfb14bf58bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>form.tsx</strong><dd><code>Replace text-white-900 with text-inverse in app name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-dd283776631894e7ee3d5be2074fc2aa2141a4ad2e211aab35b05dc8a638e91e">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>team-card.tsx</strong><dd><code>Replace text-white-900 with text-inverse in team text</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-a2dea490c39b5dd7d5c9a1afca746728a58d5d24801d6263a761edbfbac92057">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sidebar.tsx</strong><dd><code>Replace text-white-900 with text-inverse in navigation and title</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-85488f883f677463d3363cf1d62f5067ac07a5d25f90d5c38ffb61661700cd80">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>filterable-acts-list.tsx</strong><dd><code>Replace text-white-900 with text-inverse in search and buttons</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-516853a00978e4ce32f4634988428a56465c8cb4126ae47d307ce320fdcadb11">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mobile-header.tsx</strong><dd><code>Replace text-white-900 with text-inverse in header elements</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-f65ef509c30ed82823f5c71f35f6dda71767cd3d4e3a0b9884c3e5cc7b1295c4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>replace-text-black-600-20.mjs</strong><dd><code>Add codemod for text-black-600/20 to text-text/20 replacement</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-7d242781155eb53c915bd755e14a831836fc441c5c80ffd4f97fc34391d54e0d">+193/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>replace-text-white-900-to-inverse.mjs</strong><dd><code>Add codemod for text-white-900 to text-inverse replacement</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-cd3c308146409a9f59a36a0aa9bb8e4ceef3782c33561d7355b82e8cd0ef3c9e">+193/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add npm scripts for text color codemods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1868/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Unified text color to “inverse” across labels, app selection, team cards, sidebars, filterable lists, and mobile headers for improved dark-theme consistency, including hover states.

- Chores
  - Added codemod utilities to automate color token migrations and reporting, with dry-run/apply modes and JSON summaries.
  - Updated scripts to output color reports to a standardized location.

- Refactor
  - Replaced legacy white text tokens with the new inverse token throughout the interface without altering behavior or layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->