### PR TITLE
fix: prompt references missing immediately after connecting inputs

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
@@ -21,6 +21,7 @@ export function PromptPanel({ node }: { node: ImageGenerationNode }) {
 
 	return (
 		<TextEditor
+			key={nodes.map((node) => node.id).join(":")}
 			value={node.content.prompt}
 			onValueChange={(value) => {
 				updateNodeDataContent(node, { prompt: value });

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
@@ -21,7 +21,7 @@ export function PromptPanel({ node }: { node: ImageGenerationNode }) {
 
 	return (
 		<TextEditor
-			key={nodes.map((node) => node.id).join(":")}
+			key={JSON.stringify(nodes.map((node) => node.id))}
 			value={node.content.prompt}
 			onValueChange={(value) => {
 				updateNodeDataContent(node, { prompt: value });

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -82,9 +82,11 @@ export function QueryPanel({ node }: { node: QueryNode }) {
 		<div className="flex flex-col h-full gap-4">
 			<div className="flex-1 min-h-0">
 				<TextEditor
-					key={connectedInputsWithoutDatasource
-						.map((connectedInput) => connectedInput.node.id)
-						.join(":")}
+					key={JSON.stringify(
+						connectedInputsWithoutDatasource.map(
+							(connectedInput) => connectedInput.node.id,
+						),
+					)}
 					placeholder="Write your query here..."
 					value={node.content.query}
 					onValueChange={(value) => {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -82,6 +82,9 @@ export function QueryPanel({ node }: { node: QueryNode }) {
 		<div className="flex flex-col h-full gap-4">
 			<div className="flex-1 min-h-0">
 				<TextEditor
+					key={connectedInputsWithoutDatasource
+						.map((connectedInput) => connectedInput.node.id)
+						.join(":")}
 					placeholder="Write your query here..."
 					value={node.content.query}
 					onValueChange={(value) => {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -17,9 +17,9 @@ export function PromptPanel({ node }: { node: TextGenerationNode }) {
 
 	return (
 		<TextEditor
-			key={connectedSources
-				.map((connectedSource) => connectedSource.id)
-				.join(":")}
+			key={JSON.stringify(
+				connectedSources.map((connectedSource) => connectedSource.node.id),
+			)}
 			placeholder="Write your prompt here..."
 			value={node.content.prompt}
 			onValueChange={(value) => {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -17,7 +17,9 @@ export function PromptPanel({ node }: { node: TextGenerationNode }) {
 
 	return (
 		<TextEditor
-			key={connectedSources.map((connectedSource) => connectedSource.id).join(":")}
+			key={connectedSources
+				.map((connectedSource) => connectedSource.id)
+				.join(":")}
 			placeholder="Write your prompt here..."
 			value={node.content.prompt}
 			onValueChange={(value) => {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -17,6 +17,7 @@ export function PromptPanel({ node }: { node: TextGenerationNode }) {
 
 	return (
 		<TextEditor
+			key={connectedSources.map((connectedSource) => connectedSource.id).join(":")}
 			placeholder="Write your prompt here..."
 			value={node.content.prompt}
 			onValueChange={(value) => {


### PR DESCRIPTION
### **User description**
## Summary

  Ensure each workflow TextEditor remounts with the latest connected sources so embedded references render correctly on first insert.


  ## Related Issue

  N/A

  ## Changes

  - Added a stable key derived from connected node IDs to the Image Generation prompt editor.
  - Applied the same remount key strategy to the Query and Text Generation property panels so their editors rebuild when inputs change.

  ## Testing
### Image Generation Node

  1. Open the Image Generation node’s properties panel and connect a Text node to one of its inputs.
  2. Immediately insert the new connection via the @ menu in the prompt editor.
  3. Confirm the reference chip renders right away without needing to switch tabs.
#### Before

https://github.com/user-attachments/assets/14f2bc8d-8442-4609-94d1-5326dca62567


#### After
https://github.com/user-attachments/assets/e0e40118-e588-44f3-b87c-05f4d30ec43b


  ### Text Generation Node

  1. Open the Text Generation node’s properties panel and connect a Text node to its inputs.
  2. Immediately insert the new connection via the @ menu in the prompt editor.
  3. Confirm the reference chip appears immediately in the prompt.

#### After
https://github.com/user-attachments/assets/cbe6d30a-0a0e-47ac-ae89-de70f41217e0


  ### Query Node

  1. Open the Query node’s properties panel and connect a Text node (non-data-source) to its inputs.
  2. Immediately insert the new connection via the @ menu in the query editor.
  3. Confirm the reference chip renders instantly in the editor.

#### After
https://github.com/user-attachments/assets/1c1d1d10-553d-43b6-a648-11262f081322


  ## Other Information

  - Root cause: when the prompt panel first mounted with an empty connectedSources, Tiptap’s SourceExtension initialized its storage with an empty list and never refreshed it on re-renders, so references stayed hidden
  until the editor was remounted.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix prompt references not rendering immediately after connecting inputs

- Add dynamic keys to TextEditor components to force remount

- Apply fix to Image Generation, Query, and Text Generation nodes

- Ensure embedded references display correctly on first insert


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Connected Sources"] --> B["Dynamic Key Generation"]
  B --> C["TextEditor Remount"]
  C --> D["References Render Immediately"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Add dynamic key to Image Generation prompt editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx

<ul><li>Added dynamic key based on connected node IDs to force TextEditor <br>remount<br> <li> Key generated from <code>nodes.map((node) => node.id).join(":")</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1870/files#diff-a8e7545975c958bbc2f1b3b29e9a6bad5d8a0f4e6072c7cd04a3b2028974b6bc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query-panel.tsx</strong><dd><code>Add dynamic key to Query node editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx

<ul><li>Added dynamic key using connected inputs without datasource<br> <li> Key generated from <br><code>connectedInputsWithoutDatasource.map((connectedInput) => </code><br><code>connectedInput.node.id).join(":")</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1870/files#diff-2f277cc52b1175885fefa342e968f15baeb98b0ab10803c97192777b2cbfd05e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Add dynamic key to Text Generation prompt editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx

<ul><li>Added dynamic key based on connected sources IDs<br> <li> Key generated from <code>connectedSources.map((connectedSource) => </code><br><code>connectedSource.id).join(":")</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1870/files#diff-b948e855ed4caae9a25e3a70cdf48c528051a145191609c3acff7fad495ae4bf">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editor now reliably refreshes when connected inputs change in prompt panels.
  * Resolved stale content when adding, removing, or reordering connections in query panels.
  * Improved consistency of the editing experience for image- and text-generation nodes.
  * Ensured editor state updates to reflect new or reordered input sources immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->