### PR TITLE
fix: Add PR diff support for GitHub trigger PR closed

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/trigger-input-dialog/helpers.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/trigger-input-dialog/helpers.ts
@@ -87,6 +87,7 @@ const githubEventInputs: GithubEventInputMap = {
 		title: { label: "Title", type: "text", required: true },
 		body: { label: "Body", type: "multiline-text", required: false },
 		number: { label: "Number", type: "number", required: true },
+		diff: { label: "diff", type: "multiline-text", required: false },
 		pullRequestUrl: { label: "Pull request URL", type: "text", required: true },
 	},
 	"github.pull_request.opened": {

--- a/packages/flow/src/trigger/github.ts
+++ b/packages/flow/src/trigger/github.ts
@@ -143,6 +143,7 @@ const githubPullRequestClosedTrigger = {
 			title: z.string(),
 			body: z.string(),
 			number: z.number(),
+			diff: z.string(),
 			pullRequestUrl: z.string(),
 		}),
 	},

--- a/packages/giselle/src/engine/github/trigger-utils.test.ts
+++ b/packages/giselle/src/engine/github/trigger-utils.test.ts
@@ -57,6 +57,21 @@ function createIssueEvent(
 	} as WebhookEvent<typeof name>;
 }
 
+function createIssueLabeledEvent(
+	issue: { title: string; body: string | null; number: number },
+	labelName: string,
+): WebhookEvent {
+	return {
+		name: "issues.labeled",
+		data: {
+			payload: {
+				issue,
+				label: { name: labelName },
+			},
+		},
+	} as WebhookEvent<"issues.labeled">;
+}
+
 function createIssueCommentEvent(issue: {
 	title: string;
 	body: string | null;
@@ -86,6 +101,21 @@ function createPullRequestEvent(
 		name,
 		data: { payload: { pull_request: pr, repository: { node_id: "r_1234" } } },
 	} as WebhookEvent<typeof name>;
+}
+
+function createPullRequestLabeledEvent(
+	pr: { title: string; body: string | null; number: number },
+	labelName: string,
+): WebhookEvent {
+	return {
+		name: "pull_request.labeled",
+		data: {
+			payload: {
+				pull_request: pr,
+				label: { name: labelName },
+			},
+		},
+	} as WebhookEvent<"pull_request.labeled">;
 }
 
 function createPullRequestReviewCommentEvent(pr: {
@@ -158,6 +188,39 @@ describe("resolveTrigger", () => {
 			["issueNumber", "2"],
 		] as const)("resolve %s", async (accessor, expected) => {
 			const trigger = createTrigger("github.issue.closed");
+			const output = createOutput(accessor);
+			const result = await resolveTrigger({
+				output,
+				githubTrigger,
+				trigger,
+				webhookEvent,
+				...appAuth,
+			});
+			expect(result).toEqual({
+				type: "generated-text",
+				outputId: output.id,
+				content: expected,
+			});
+		});
+	});
+
+	describe("issue labeled", () => {
+		const webhookEvent = createIssueLabeledEvent(
+			{
+				title: "Labeled issue title",
+				body: "Labeled issue body",
+				number: 7,
+			},
+			"bug",
+		);
+		const githubTrigger = githubTriggers["github.issue.labeled"];
+		test.each([
+			["title", "Labeled issue title"],
+			["body", "Labeled issue body"],
+			["issueNumber", "7"],
+			["labelName", "bug"],
+		] as const)("resolve %s", async (accessor, expected) => {
+			const trigger = createTrigger("github.issue.labeled");
 			const output = createOutput(accessor);
 			const result = await resolveTrigger({
 				output,
@@ -319,4 +382,37 @@ describe("resolveTrigger", () => {
 			});
 		});
 	}
+
+	describe("pull request labeled", () => {
+		const webhookEvent = createPullRequestLabeledEvent(
+			{
+				title: "Labeled PR title",
+				body: "Labeled PR body",
+				number: 8,
+			},
+			"enhancement",
+		);
+		const githubTrigger = githubTriggers["github.pull_request.labeled"];
+		test.each([
+			["pullRequestTitle", "Labeled PR title"],
+			["pullRequestBody", "Labeled PR body"],
+			["pullRequestNumber", "8"],
+			["labelName", "enhancement"],
+		] as const)("resolve %s", async (accessor, expected) => {
+			const trigger = createTrigger("github.pull_request.labeled");
+			const output = createOutput(accessor);
+			const result = await resolveTrigger({
+				output,
+				githubTrigger,
+				trigger,
+				webhookEvent,
+				...appAuth,
+			});
+			expect(result).toEqual({
+				type: "generated-text",
+				outputId: output.id,
+				content: expected,
+			});
+		});
+	});
 });

--- a/packages/giselle/src/engine/github/trigger-utils.test.ts
+++ b/packages/giselle/src/engine/github/trigger-utils.test.ts
@@ -300,7 +300,8 @@ describe("resolveTrigger", () => {
 				["body", `${title} body`],
 				["number", "5"],
 				["pullRequestUrl", "https://example.com/pr/5"],
-			] as const)("resolve %s", async (accessor, expected) => {
+				["diff", "diff"],
+			])("resolve %s", async (accessor, expected) => {
 				const trigger = createTrigger(id);
 				const output = createOutput(accessor);
 				const result = await resolveTrigger({


### PR DESCRIPTION
### **User description**
## Summary

  - Added PR diff fetching capability for GitHub Pull Request Closed trigger
  - Added missing test cases for Issue Labeled and Pull Request Labeled triggers

  ## Changes

  - **Pull Request Closed trigger**: Added `diff` field support to fetch PR diffs on close events (similar to PR opened/ready_for_review)
  - **Test coverage**: Added test cases for Issue Labeled and Pull Request Labeled triggers, increasing total tests from 30 to 41
  - **UI support**: Updated workflow designer UI to include diff field for PR Closed trigger

## Testing
<!-- Briefly describe the testing steps or results. -->

https://github.com/user-attachments/assets/5320dc57-fa53-409e-9fcb-29435e16587a


## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add diff field support for GitHub PR closed trigger

- Add test coverage for issue and PR labeled triggers

- Update UI to include diff field for PR closed events

- Make PR closed trigger async to support diff fetching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub PR Closed Event"] --> B["Fetch PR Diff"]
  B --> C["Return Diff Content"]
  D["UI Helper"] --> E["Add Diff Field"]
  F["Test Suite"] --> G["Add Labeled Trigger Tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.ts</strong><dd><code>Add diff field to PR closed trigger UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/trigger-input-dialog/helpers.ts

<ul><li>Add <code>diff</code> field to GitHub pull request closed trigger configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1872/files#diff-4b9fcb7d3869d00f236a9edb15324cc731583fb83152a6abb4b26d6e82899194">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github.ts</strong><dd><code>Add diff field to PR closed schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/flow/src/trigger/github.ts

- Add `diff` field to pull request closed trigger payload schema


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1872/files#diff-91f34f9842eebe08dad6f0264fb79277952218b763bd2a35c44c21fb664040dd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trigger-utils.test.ts</strong><dd><code>Add tests for labeled triggers and diff</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/github/trigger-utils.test.ts

<ul><li>Add test helper functions for issue and PR labeled events<br> <li> Add comprehensive test cases for issue labeled trigger<br> <li> Add comprehensive test cases for pull request labeled trigger<br> <li> Add diff test case for PR closed trigger</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1872/files#diff-552f20b9d9dd1086a397b93c6b1a87b45ee35d2b1777ea484a7aaa3faf569ef7">+98/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trigger-utils.ts</strong><dd><code>Add async diff support to PR closed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/github/trigger-utils.ts

<ul><li>Make <code>resolvePullRequestClosedTrigger</code> async function<br> <li> Add diff case handling with <code>getPullRequestDiff</code> API call<br> <li> Update function signature to return Promise</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1872/files#diff-6974b1a2873b6487a0ed15bf2e8a01b5788eda8de86ee4a8ea0588d8c6ae821b">+23/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to retrieve and use the diff content when a GitHub pull_request.closed trigger runs.
  - Introduced an optional "diff" input in the trigger dialog for closed pull requests.
- Improvements
  - Enhanced trigger processing to fetch PR diffs on demand for more informative outputs.
- Compatibility
  - No breaking changes; existing triggers and inputs continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->