### PR TITLE
fix: Handle invalid workspaceId with notFound in layout

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -33,7 +33,12 @@ export default async function Layout({
 	params: Promise<{ workspaceId: string }>;
 	children: ReactNode;
 }) {
-	const workspaceId = WorkspaceId.parse((await params).workspaceId);
+	const { data: workspaceId, success } = WorkspaceId.safeParse(
+		(await params).workspaceId,
+	);
+	if (!success) {
+		return notFound();
+	}
 
 	const agent = await db.query.agents.findFirst({
 		where: (agents, { eq }) => eq(agents.workspaceId, workspaceId),


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
I updated the params validation to use safeParse instead of parse, and made it return notFound() when validation fails.
## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->
- params validation to use safeParse instead of parse

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
