### PR TITLE
Create shared URL validation helper for Workflow Designer UI

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx
@@ -2,6 +2,7 @@
 
 import { Send } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { validateUrl } from "../lib/validate-url";
 
 interface Message {
 	id: string;
@@ -12,16 +13,7 @@ interface Message {
 
 // Normalize and validate a URL for link usage (http/https only). Returns URL or null.
 function toSafeLinkUrl(raw: string): URL | null {
-	if (!raw || typeof raw !== "string") return null;
-	try {
-		const parsed = new URL(raw.trim());
-		if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-			return parsed;
-		}
-		return null;
-	} catch {
-		return null;
-	}
+	return validateUrl(raw);
 }
 
 // Function to render message content with URL styling

--- a/internal-packages/workflow-designer-ui/src/editor/lib/validate-url.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/lib/validate-url.ts
@@ -1,0 +1,34 @@
+/**
+ * Normalize and validate a URL string.
+ * Returns a Web URL object when the string is valid and matches the allowed protocols.
+ * @param raw - Raw user input to validate.
+ * @param options - Optional restrictions for accepted protocols.
+ */
+export function validateUrl(
+	raw: string | null | undefined,
+	options?: {
+		allowedProtocols?: string[];
+	},
+): URL | null {
+	if (raw === undefined || raw === null) {
+		return null;
+	}
+
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) {
+		return null;
+	}
+
+	try {
+		const parsed = new URL(trimmed);
+		const allowedProtocols = options?.allowedProtocols;
+		if (Array.isArray(allowedProtocols) && allowedProtocols.length > 0) {
+			return allowedProtocols.includes(parsed.protocol) ? parsed : null;
+		}
+		return parsed.protocol === "http:" || parsed.protocol === "https:"
+			? parsed
+			: null;
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
### **User description**
Part of #1069.

## Summary
- add a shared `validateUrl` helper that normalizes user input and enforces protocol rules in the Workflow Designer UI (`internal-packages/workflow-designer-ui/src/editor/lib/validate-url.ts:1`)
- reuse the helper in the chat panel so HTTP/HTTPS links share the same validation logic (`internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx:13`)
- leverage the helper in the Web Page node properties panel to enforce https-only input and reuse normalized URLs before persisting (`internal-packages/workflow-designer-ui/src/editor/properties-panel/web-page-node-properties-panel/index.tsx:164`)

## Testing
- Not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved URL handling for links and web page inputs: invalid formats are rejected, HTTPS is enforced, and a clearer “Invalid URL format. Use https://” message is shown.
  - Normalizes valid URLs for consistent processing and safer navigation.

- Refactor
  - Centralized URL validation into a shared utility to ensure consistent behavior and reduce duplication across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add shared `validateUrl` helper for consistent URL validation

- Centralize protocol enforcement and normalization logic

- Replace duplicate validation code in chat and web page panels

- Enforce HTTPS-only URLs for web page node inputs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["validateUrl helper"] --> B["Chat Panel"]
  A --> C["Web Page Properties"]
  B --> D["HTTP/HTTPS link validation"]
  C --> E["HTTPS-only enforcement"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate-url.ts</strong><dd><code>Add shared URL validation utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/lib/validate-url.ts

<ul><li>Create new shared <code>validateUrl</code> function with protocol filtering<br> <li> Support configurable allowed protocols via options parameter<br> <li> Return normalized URL object or null for invalid inputs<br> <li> Handle edge cases like null, undefined, and empty strings</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1876/files#diff-9f505ebb32752e2236928eac06ded0c84d7972f6c5f2a41f835a9f49610b1758">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat-panel.tsx</strong><dd><code>Refactor to use shared URL validator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx

<ul><li>Replace local <code>toSafeLinkUrl</code> implementation with shared <code>validateUrl</code><br> <li> Remove duplicate URL validation logic<br> <li> Maintain same HTTP/HTTPS protocol validation behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1876/files#diff-11adb72d8a633420c7ac25d48fad5f23f7c75f9aff31e375e81a1d644871437b">+2/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Enforce HTTPS-only validation for web pages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/web-page-node-properties-panel/index.tsx

<ul><li>Replace manual URL parsing with <code>validateUrl</code> helper<br> <li> Enforce HTTPS-only protocol restriction for web page URLs<br> <li> Use normalized URL strings from validation helper<br> <li> Improve error message clarity for invalid URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1876/files#diff-60b9c3510a13126ac50509faa9761f7709576e9dae00259fecad3bf3590915fb">+9/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

