### PR TITLE
feat: add Cohere embed-4 multimodal embedding cost calculation support

### DIFF
--- a/packages/langfuse/src/trace-embedding.ts
+++ b/packages/langfuse/src/trace-embedding.ts
@@ -50,10 +50,13 @@ export async function traceEmbedding(args: {
 			],
 		});
 
-		const totalTokens = usage?.tokens ?? 0;
+		const textTokens = usage?.tokens ?? 0;
+		const imageTokens = usage?.imageTokens ?? 0;
 		const cost = await calculateEmbeddingDisplayCost(provider, model, {
-			tokens: totalTokens,
+			tokens: textTokens,
+			imageTokens,
 		});
+		const totalTokens = textTokens + imageTokens;
 
 		trace.generation({
 			name: operation,

--- a/packages/language-model/src/costs/embedding-costs.test.ts
+++ b/packages/language-model/src/costs/embedding-costs.test.ts
@@ -31,4 +31,30 @@ describe("calculateEmbeddingDisplayCost", () => {
 		// $0.15 per 1M tokens => 1000 tokens = $0.00015
 		expect(cost.totalCostForDisplay).toBeCloseTo(0.00015, 10);
 	});
+
+	it("computes cost for Cohere embed-4", async () => {
+		const cost = await calculateEmbeddingDisplayCost("cohere", "embed-4", {
+			tokens: 1000,
+		});
+		// $0.12 per 1M tokens => 1000 tokens = $0.00012
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.00012, 10);
+	});
+
+	it("computes cost for Cohere embed-4 image tokens", async () => {
+		const cost = await calculateEmbeddingDisplayCost("cohere", "embed-4", {
+			tokens: 0,
+			imageTokens: 1000,
+		});
+		// $0.47 per 1M tokens => 1000 tokens = $0.00047
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.00047, 10);
+	});
+
+	it("computes combined cost for Cohere embed-4 text and image tokens", async () => {
+		const cost = await calculateEmbeddingDisplayCost("cohere", "embed-4", {
+			tokens: 1000,
+			imageTokens: 500,
+		});
+		// Text: $0.12 per 1M => $0.00012, Image: $0.47 per 1M => 500 => $0.000235, total => $0.000355
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.000355, 10);
+	});
 });

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -227,7 +227,8 @@ export function getValidPricing(
  */
 type EmbeddingModelPrice = {
 	validFrom: string;
-	costPerMegaToken: number; // USD per 1,000,000 tokens
+	costPerMegaToken: number; // USD per 1,000,000 tokens (text tokens)
+	imageCostPerMegaToken?: number; // USD per 1,000,000 tokens (image tokens)
 };
 
 export type EmbeddingModelPriceTable = Record<
@@ -286,6 +287,18 @@ export const googleEmbeddingPricing: EmbeddingModelPriceTable = {
 			{
 				validFrom: "2025-08-28T00:00:00Z",
 				costPerMegaToken: 0.15,
+			},
+		],
+	},
+};
+
+export const cohereEmbeddingPricing: EmbeddingModelPriceTable = {
+	"embed-4": {
+		prices: [
+			{
+				validFrom: "2025-09-26T00:00:00Z",
+				costPerMegaToken: 0.12,
+				imageCostPerMegaToken: 0.47,
 			},
 		],
 	},

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -237,6 +237,7 @@ const queryService = createPostgresQueryService({
 
 - `OPENAI_API_KEY`: Required for OpenAI embedders
 - `GOOGLE_GENERATIVE_AI_API_KEY`: Required for Google Gemini embedders
+- `COHERE_API_KEY`: Required for Cohere embedders
 - `DATABASE_URL`: PostgreSQL connection string with pgvector extension
 
 ## Development

--- a/packages/rag/src/embedder/ai-sdk-embedder.test.ts
+++ b/packages/rag/src/embedder/ai-sdk-embedder.test.ts
@@ -65,6 +65,35 @@ describe("createAiSdkEmbedder", () => {
 		);
 	});
 
+	it("should include image token usage when provided", async () => {
+		const mockEmbedding = [0.1, 0.2, 0.3];
+		const mockUsage = { tokens: 10, imageTokens: 5 };
+		const embeddingCompleteCallback = vi.fn();
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(embed as any).mockResolvedValue({
+			embedding: mockEmbedding,
+			usage: mockUsage,
+		});
+
+		const embedder = createAiSdkEmbedder(
+			{
+				apiKey: "test-api-key",
+				profile: mockProfile,
+				embeddingComplete: embeddingCompleteCallback,
+			},
+			mockGetModel,
+		);
+
+		await embedder.embed("test text");
+
+		expect(embeddingCompleteCallback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				usage: { tokens: 10, imageTokens: 5 },
+			}),
+		);
+	});
+
 	it("should call embeddingComplete callback after embedMany", async () => {
 		const mockEmbeddings = [
 			[0.1, 0.2, 0.3],

--- a/packages/rag/src/embedder/ai-sdk-embedder.test.ts
+++ b/packages/rag/src/embedder/ai-sdk-embedder.test.ts
@@ -94,6 +94,64 @@ describe("createAiSdkEmbedder", () => {
 		);
 	});
 
+	it("should retain image-only usage", async () => {
+		const mockEmbedding = [0.1, 0.2, 0.3];
+		const mockUsage = { imageTokens: 7 };
+		const embeddingCompleteCallback = vi.fn();
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(embed as any).mockResolvedValue({
+			embedding: mockEmbedding,
+			usage: mockUsage,
+		});
+
+		const embedder = createAiSdkEmbedder(
+			{
+				apiKey: "test-api-key",
+				profile: mockProfile,
+				embeddingComplete: embeddingCompleteCallback,
+			},
+			mockGetModel,
+		);
+
+		await embedder.embed("image input");
+
+		expect(embeddingCompleteCallback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				usage: { tokens: 0, imageTokens: 7 },
+			}),
+		);
+	});
+
+	it("should preserve zero-token text usage", async () => {
+		const mockEmbedding = [0.1, 0.2, 0.3];
+		const mockUsage = { tokens: 0 };
+		const embeddingCompleteCallback = vi.fn();
+
+		// biome-ignore lint/suspicious/noExplicitAny: mock
+		(embed as any).mockResolvedValue({
+			embedding: mockEmbedding,
+			usage: mockUsage,
+		});
+
+		const embedder = createAiSdkEmbedder(
+			{
+				apiKey: "test-api-key",
+				profile: mockProfile,
+				embeddingComplete: embeddingCompleteCallback,
+			},
+			mockGetModel,
+		);
+
+		await embedder.embed("");
+
+		expect(embeddingCompleteCallback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				usage: { tokens: 0 },
+			}),
+		);
+	});
+
 	it("should call embeddingComplete callback after embedMany", async () => {
 		const mockEmbeddings = [
 			[0.1, 0.2, 0.3],

--- a/packages/rag/src/embedder/ai-sdk-embedder.ts
+++ b/packages/rag/src/embedder/ai-sdk-embedder.ts
@@ -26,16 +26,19 @@ export function createAiSdkEmbedder(
 		if (!rawUsage || typeof rawUsage !== "object") {
 			return undefined;
 		}
-		const usageWithTokens = rawUsage as { tokens?: unknown };
-		if (typeof usageWithTokens.tokens !== "number") {
-			return undefined;
-		}
-		const normalized: { tokens: number; imageTokens?: number } = {
-			tokens: usageWithTokens.tokens,
+		const usageWithNumbers = rawUsage as {
+			tokens?: unknown;
+			imageTokens?: unknown;
 		};
-		const usageWithImages = rawUsage as { imageTokens?: unknown };
-		if (typeof usageWithImages.imageTokens === "number") {
-			normalized.imageTokens = usageWithImages.imageTokens;
+		const hasTokens = typeof usageWithNumbers.tokens === "number";
+		const tokens = hasTokens ? (usageWithNumbers.tokens as number) : 0;
+		const normalized: { tokens: number; imageTokens?: number } = { tokens };
+		const hasImageTokens = typeof usageWithNumbers.imageTokens === "number";
+		if (hasImageTokens) {
+			normalized.imageTokens = usageWithNumbers.imageTokens as number;
+		}
+		if (!hasTokens && !hasImageTokens) {
+			return undefined;
 		}
 		return normalized;
 	};

--- a/packages/rag/src/embedder/types.ts
+++ b/packages/rag/src/embedder/types.ts
@@ -7,7 +7,7 @@ export interface EmbeddingMetrics {
 	model: string;
 	provider: "openai" | "google" | "cohere";
 	dimensions: number;
-	usage?: { tokens: number };
+	usage?: { tokens: number; imageTokens?: number };
 	operation: "embed" | "embedMany";
 	startTime: Date;
 	endTime: Date;


### PR DESCRIPTION
### **User description**
## Summary
- Add support for Cohere's embed-4 multimodal embedding model with separate text and image
token tracking
- Extend embedding cost calculation to handle different pricing for text ($0.12/1M) and image
tokens ($0.47/1M)
- Update Langfuse tracing to accurately track and report both token types

## Related Issue
part of #1827

## Changes
- Configure Cohere embed-4 pricing in model prices table
- Extend `EmbeddingMetrics` to support optional `imageTokens` field
- Update cost calculation to handle Cohere provider with dual token pricing
- Fix Langfuse traces to track text and image tokens independently
- Add comprehensive test coverage for multimodal embedding scenarios

## Testing
https://github.com/giselles-ai/giselle/pull/1881#issuecomment-3336850331

## Other Information
The embedding process will be implemented in the next PR.


___

### **PR Type**
Enhancement


___

### **Description**
- Add Cohere embed-4 multimodal embedding cost calculation support

- Extend embedding metrics to track text and image tokens separately

- Update Langfuse tracing for dual token type reporting

- Add comprehensive test coverage for multimodal scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EmbeddingMetrics"] --> B["normalizeUsage helper"]
  B --> C["Text + Image tokens"]
  C --> D["Cohere pricing table"]
  D --> E["Cost calculation"]
  E --> F["Langfuse traces"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trace-embedding.ts</strong><dd><code>Separate text and image token tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/langfuse/src/trace-embedding.ts

<ul><li>Separate text and image token tracking in usage<br> <li> Pass both token types to cost calculation<br> <li> Calculate total tokens as sum of text and image</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-759d9723bf8c7ca1e9ef57c0b33c45b2e2effb0aba2c8821bc441f62e499f6f0">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Extend cost calculation for image tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/index.ts

<ul><li>Add Cohere provider support to cost calculation<br> <li> Extend usage type to include optional imageTokens<br> <li> Implement separate cost calculation for text and image tokens<br> <li> Handle different pricing for text vs image tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-df9a3d559770f2a99e5d418a460d01e4e3a2cd75bcc922252ef012790816235e">+39/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ai-sdk-embedder.ts</strong><dd><code>Add image token support to embedder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/embedder/ai-sdk-embedder.ts

<ul><li>Add normalizeUsage helper to safely extract token counts<br> <li> Support optional imageTokens in usage tracking<br> <li> Update embeddingComplete callback to pass normalized usage</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-351a004f14445d36ef61102994110e92985ee617465506005cefdd0006fb3fc7">+23/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add imageTokens to EmbeddingMetrics type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/embedder/types.ts

- Extend EmbeddingMetrics usage type with optional imageTokens field


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-e2dd08f059ce052b64e0815647526893f03d1752c220ba08ef6d9e81a46f0f72">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>embedding-costs.test.ts</strong><dd><code>Add Cohere embed-4 cost calculation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/embedding-costs.test.ts

<ul><li>Add test for Cohere embed-4 text token pricing<br> <li> Add test for image token pricing<br> <li> Add test for combined text and image token cost calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-b292703e48ba7493aa3ffb70aa3cd9db04a08cb4828d5b76d7338281b204037f">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ai-sdk-embedder.test.ts</strong><dd><code>Add image token usage test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/embedder/ai-sdk-embedder.test.ts

<ul><li>Add test for image token usage tracking<br> <li> Verify embeddingComplete callback receives imageTokens</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-7d240297188e2933d9b1f9bee62ddae2fac479580ec0e8926886acc90bac0863">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Add Cohere embed-4 pricing configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Add imageCostPerMegaToken field to EmbeddingModelPrice type<br> <li> Create cohereEmbeddingPricing table with embed-4 model<br> <li> Configure text tokens at $0.12/1M and image tokens at $0.47/1M</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Cohere API key requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/README.md

- Document COHERE_API_KEY environment variable requirement


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1881/files#diff-81ec08a944f897c05d3b292b3f38e4ce29c2c87671146b826ff45a98859d85e0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding cost calculations now separate text and image tokens and report combined costs.
  * Added Cohere embed-4 pricing, including image token rates.

* **Documentation**
  * Added COHERE_API_KEY to environment variables for Cohere embedders.

* **Tests**
  * New tests for Cohere embed-4 text, image, and combined cost scenarios.
  * Tests verifying embedder usage reporting includes image token usage.

* **Refactor**
  * Standardized normalization of embedding usage and improved token reporting for traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->