### PR TITLE
feat: add runner syncing, simplify generation selection and stream handling

### DIFF
--- a/packages/giselle/src/react/generations/generate-content-runner.tsx
+++ b/packages/giselle/src/react/generations/generate-content-runner.tsx
@@ -73,6 +73,15 @@ export function GenerateContentRunner({
 		didPerformingContentGeneration.current = false;
 		didListeningContentGeneration.current = false;
 		reachedStreamEnd.current = false;
+
+		// Clear message queue to prevent stale messages from previous generation
+		messageUpdateQueue.current.clear();
+
+		// Cancel pending animation frame to prevent applying stale updates
+		if (pendingUpdate.current !== null) {
+			cancelAnimationFrame(pendingUpdate.current);
+			pendingUpdate.current = null;
+		}
 	}, [generation.id]);
 
 	const flushMessageUpdates = useCallback(() => {

--- a/packages/giselle/src/react/generations/generate-content-runner.tsx
+++ b/packages/giselle/src/react/generations/generate-content-runner.tsx
@@ -66,10 +66,13 @@ export function GenerateContentRunner({
 	const reachedStreamEnd = useRef(false);
 	const messageUpdateQueue = useRef<Map<UIMessage["id"], UIMessage>>(new Map());
 	const pendingUpdate = useRef<number | null>(null);
+	const prevGenerationId = useRef(generation.id);
 
 	// Reset lifecycle refs when generation changes
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally depend on generation.id only
 	useEffect(() => {
+		if (prevGenerationId.current === generation.id) {
+			return;
+		}
 		didPerformingContentGeneration.current = false;
 		didListeningContentGeneration.current = false;
 		reachedStreamEnd.current = false;

--- a/packages/giselle/src/react/generations/generate-content-runner.tsx
+++ b/packages/giselle/src/react/generations/generate-content-runner.tsx
@@ -67,6 +67,14 @@ export function GenerateContentRunner({
 	const messageUpdateQueue = useRef<Map<UIMessage["id"], UIMessage>>(new Map());
 	const pendingUpdate = useRef<number | null>(null);
 
+	// Reset lifecycle refs when generation changes
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally depend on generation.id only
+	useEffect(() => {
+		didPerformingContentGeneration.current = false;
+		didListeningContentGeneration.current = false;
+		reachedStreamEnd.current = false;
+	}, [generation.id]);
+
 	const flushMessageUpdates = useCallback(() => {
 		if (messageUpdateQueue.current.size === 0) return;
 

--- a/packages/giselle/src/react/generations/generate-content-runner.tsx
+++ b/packages/giselle/src/react/generations/generate-content-runner.tsx
@@ -85,6 +85,8 @@ export function GenerateContentRunner({
 			cancelAnimationFrame(pendingUpdate.current);
 			pendingUpdate.current = null;
 		}
+
+		prevGenerationId.current = generation.id;
 	}, [generation.id]);
 
 	const flushMessageUpdates = useCallback(() => {

--- a/packages/giselle/src/react/generations/hooks/use-node-generations.ts
+++ b/packages/giselle/src/react/generations/hooks/use-node-generations.ts
@@ -55,7 +55,6 @@ export function useNodeGenerations({
 		if (isLoading || data === undefined) {
 			return;
 		}
-		console.log(data);
 		addGenerationRunner(data);
 	}, [isLoading, data, addGenerationRunner]);
 

--- a/packages/giselle/src/react/generations/store.ts
+++ b/packages/giselle/src/react/generations/store.ts
@@ -24,8 +24,12 @@ export const useGenerationStore = create<GenerationStore>((set) => ({
 	addGenerationRunner: (generations) =>
 		set((state) => {
 			const arr = Array.isArray(generations) ? generations : [generations];
+			const incomingIds = new Set(arr.map((g) => g.id));
+			const filteredExisting = state.generations.filter(
+				(g) => !incomingIds.has(g.id),
+			);
 			return {
-				generations: [...state.generations, ...arr],
+				generations: [...filteredExisting, ...arr],
 			};
 		}),
 	updateGeneration: (generation) =>


### PR DESCRIPTION
### **User description**
- Add runner syncing to keep local runners with remote state
- Simplify generation selection logic for clearer, more predictable behavior
- Simplify stream handling to reduce complexity and improve reliability

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1886 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1863 
<!-- GitButler Footer Boundary Bottom -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add runner syncing to keep local state with remote

- Simplify generation selection logic for better predictability

- Separate stream handling into distinct lifecycle phases

- Prevent duplicate generations in store with deduplication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remote Generations"] --> B["Sync to Store"]
  B --> C["Filter & Deduplicate"]
  C --> D["Current Generation"]
  E["Generation Runner"] --> F["Start Generation"]
  F --> G["Listen to Stream"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-node-generations.ts</strong><dd><code>Sync generations and simplify selection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/generations/hooks/use-node-generations.ts

<ul><li>Add <code>useEffect</code> to sync remote generations with local store<br> <li> Simplify generation selection by removing complex deduplication logic<br> <li> Filter generations directly from store instead of merging sources</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1886/files#diff-2f83b7daf603844ebdbfebb93f97c301549a1d32d055ac6a48491c6d5703099f">+26/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Add generation deduplication in store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/generations/store.ts

<ul><li>Add deduplication logic to prevent duplicate generations<br> <li> Filter existing generations before adding new ones<br> <li> Use Set-based approach for efficient ID matching</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1886/files#diff-f68396126c6eb3d1892c499be361a1cd99195a027cf7e582e57258309c7da43a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generate-content-runner.tsx</strong><dd><code>Separate generation start and stream handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/generations/generate-content-runner.tsx

<ul><li>Split generation lifecycle into separate refs for start and listen <br>phases<br> <li> Separate <code>useEffect</code> hooks for starting and listening to generation<br> <li> Remove stream processing from generation start effect</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1886/files#diff-2c379d72b0ffc6a407142851cf2101fcadb036b4ad95963f2ea55ab8681640f4">+18/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sync remote generations into local store, split generation start/listen handling, and deduplicate generations while simplifying selection logic.
> 
> - **Generations/Runner**:
>   - `generate-content-runner.tsx`: Split lifecycle into start and listen phases using separate refs/effects; reset refs/queues on generation change; cancel pending animation frames; trigger stream processing only when status is `running`.
> - **Hook**:
>   - `use-node-generations.ts`: Sync fetched generations into local runners via `addGenerationRunner`; simplify current generation selection by filtering store-only data; use `isLoading` from SWR.
> - **Store**:
>   - `store.ts`: Deduplicate on `addGenerationRunner` by filtering existing entries with matching IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2489fef349642f32524d4df6714346836257973a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Eliminated duplicate generation entries when adding new items.
  - More reliably selects the most recent active generation for a node.
  - Ensures content streaming starts only when a generation is actively running, preventing missed or premature processing.
  - Prevents stale updates across generation changes by clearing pending work and queues.

- Refactor
  - Two-phase generation lifecycle with lifecycle resets for greater stability.
  - Streamlined generation selection and deduplication logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->