### PR TITLE
feat(studio): add document ingestion infrastructure for text files

### DIFF
--- a/apps/studio.giselles.ai/app/api/vector-stores/document/[documentVectorStoreId]/documents/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/[documentVectorStoreId]/documents/route.ts
@@ -18,6 +18,7 @@ import {
 	DOCUMENT_VECTOR_STORE_MAX_FILE_SIZE_MB,
 	DOCUMENT_VECTOR_STORE_SUPPORTED_FILE_TYPE_LABEL,
 } from "@/lib/vector-stores/document/constants";
+import { ingestDocument } from "@/lib/vector-stores/document/ingest";
 import {
 	resolveSupportedDocumentFile,
 	sanitizeDocumentFileName,
@@ -277,6 +278,11 @@ export async function POST(
 				fileName: originalFileName,
 				sourceId,
 				storageKey,
+			});
+
+			// Trigger ingestion asynchronously (fire and forget)
+			ingestDocument(sourceId).catch((error) => {
+				console.error(`Failed to ingest document ${sourceId}:`, error);
 			});
 		} catch (dbError) {
 			console.error(

--- a/apps/studio.giselles.ai/lib/vector-stores/document/database.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/database.ts
@@ -1,0 +1,63 @@
+import type { DocumentVectorStoreSourceId } from "@giselles-ai/types";
+import { eq } from "drizzle-orm";
+import { db } from "@/drizzle/db";
+import type {
+	DocumentVectorStoreSourceIngestStatus,
+	DocumentVectorStoreSourceUploadStatus,
+} from "@/drizzle/schema";
+import { documentVectorStoreSources } from "@/drizzle/schema";
+
+export async function getDocumentVectorStoreSource(
+	sourceId: DocumentVectorStoreSourceId,
+) {
+	const source = await db.query.documentVectorStoreSources.findFirst({
+		where: eq(documentVectorStoreSources.id, sourceId),
+	});
+
+	return source ?? null;
+}
+
+interface UpdateSourceStatusParams {
+	sourceId: DocumentVectorStoreSourceId;
+	uploadStatus?: DocumentVectorStoreSourceUploadStatus;
+	uploadErrorCode?: string | null;
+	ingestStatus?: DocumentVectorStoreSourceIngestStatus;
+	ingestErrorCode?: string | null;
+	ingestedAt?: Date | null;
+}
+
+export async function updateDocumentVectorStoreSourceStatus(
+	params: UpdateSourceStatusParams,
+) {
+	const {
+		sourceId,
+		uploadStatus,
+		uploadErrorCode,
+		ingestStatus,
+		ingestErrorCode,
+		ingestedAt,
+	} = params;
+
+	const updateData: Record<string, unknown> = {};
+
+	if (uploadStatus !== undefined) {
+		updateData.uploadStatus = uploadStatus;
+	}
+	if (uploadErrorCode !== undefined) {
+		updateData.uploadErrorCode = uploadErrorCode;
+	}
+	if (ingestStatus !== undefined) {
+		updateData.ingestStatus = ingestStatus;
+	}
+	if (ingestErrorCode !== undefined) {
+		updateData.ingestErrorCode = ingestErrorCode;
+	}
+	if (ingestedAt !== undefined) {
+		updateData.ingestedAt = ingestedAt;
+	}
+
+	await db
+		.update(documentVectorStoreSources)
+		.set(updateData)
+		.where(eq(documentVectorStoreSources.id, sourceId));
+}

--- a/apps/studio.giselles.ai/lib/vector-stores/document/ingest/extract-text.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/ingest/extract-text.ts
@@ -1,0 +1,45 @@
+import { extractText } from "@giselle-sdk/document-preprocessor";
+import { resolveSupportedDocumentFile } from "../utils";
+
+interface ExtractTextOptions {
+	signal?: AbortSignal;
+}
+
+interface ExtractTextResult {
+	text: string;
+	fileType: "txt" | "md";
+}
+
+/**
+ * Extract text content from TXT or Markdown files
+ * @param buffer - File content buffer
+ * @param fileName - Original file name for type detection
+ * @param options - Optional extraction settings
+ * @returns Extracted text and file type
+ * @throws Error if file type is unsupported
+ */
+export function extractTextFromDocument(
+	buffer: Buffer,
+	fileName: string,
+	options?: ExtractTextOptions,
+): ExtractTextResult {
+	const { signal } = options ?? {};
+
+	signal?.throwIfAborted();
+
+	const fileTypeInfo = resolveSupportedDocumentFile({ name: fileName });
+
+	if (!fileTypeInfo) {
+		throw new Error(`Unsupported file type: ${fileName}`);
+	}
+
+	if (fileTypeInfo.extension === ".pdf") {
+		throw new Error("PDF extraction is not supported in this function");
+	}
+
+	const { text } = extractText(buffer);
+
+	const fileType = fileTypeInfo.extension === ".md" ? "md" : "txt";
+
+	return { text, fileType };
+}

--- a/apps/studio.giselles.ai/lib/vector-stores/document/ingest/index.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/ingest/index.ts
@@ -1,0 +1,1 @@
+export { ingestDocument } from "./ingest-document";

--- a/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
@@ -1,0 +1,164 @@
+import type { DocumentVectorStoreSourceId } from "@giselles-ai/types";
+import { createClient } from "@supabase/supabase-js";
+import {
+	getDocumentVectorStoreSource,
+	updateDocumentVectorStoreSourceStatus,
+} from "../database";
+import { extractTextFromDocument } from "./extract-text";
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+	throw new Error("Missing Supabase credentials");
+}
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+interface IngestDocumentOptions {
+	signal?: AbortSignal;
+}
+
+interface IngestDocumentResult {
+	sourceId: DocumentVectorStoreSourceId;
+	text: string;
+	fileType: "txt" | "md";
+	success: boolean;
+}
+
+type IngestErrorCode =
+	| "source-not-found"
+	| "file-not-found"
+	| "extraction-failed"
+	| "unsupported-type"
+	| "invalid-state";
+
+/**
+ * Ingest a document source by extracting text content
+ * This function:
+ * 1. Validates the source exists and is in the correct state
+ * 2. Downloads the file from Supabase storage
+ * 3. Extracts text content (for TXT/MD files)
+ * 4. Updates the source status
+ *
+ * @param sourceId - Document vector store source ID
+ * @param options - Optional ingestion settings
+ * @returns Ingestion result with extracted text
+ * @throws Error with code if ingestion fails
+ */
+export async function ingestDocument(
+	sourceId: DocumentVectorStoreSourceId,
+	options?: IngestDocumentOptions,
+): Promise<IngestDocumentResult> {
+	const { signal } = options ?? {};
+
+	try {
+		signal?.throwIfAborted();
+
+		// Mark as running
+		await updateDocumentVectorStoreSourceStatus({
+			sourceId,
+			ingestStatus: "running",
+			ingestErrorCode: null,
+		});
+
+		// Get source from database
+		const source = await getDocumentVectorStoreSource(sourceId);
+
+		if (!source) {
+			throw Object.assign(new Error("Source not found"), {
+				code: "source-not-found" as IngestErrorCode,
+			});
+		}
+
+		// Validate source state
+		if (source.uploadStatus !== "uploaded") {
+			throw Object.assign(new Error("Source upload is not completed"), {
+				code: "invalid-state" as IngestErrorCode,
+			});
+		}
+
+		signal?.throwIfAborted();
+
+		// Download file from storage
+		const { data: fileData, error: downloadError } = await supabase.storage
+			.from(source.storageBucket)
+			.download(source.storageKey);
+
+		if (downloadError || !fileData) {
+			throw Object.assign(
+				new Error(`Failed to download file: ${downloadError?.message}`),
+				{ code: "file-not-found" as IngestErrorCode },
+			);
+		}
+
+		signal?.throwIfAborted();
+
+		// Convert blob to buffer
+		const arrayBuffer = await fileData.arrayBuffer();
+		const buffer = Buffer.from(arrayBuffer);
+
+		// Extract text content
+		let text: string;
+		let fileType: "txt" | "md";
+
+		try {
+			const result = extractTextFromDocument(buffer, source.fileName, {
+				signal,
+			});
+			text = result.text;
+			fileType = result.fileType;
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("Unsupported")) {
+				throw Object.assign(error, {
+					code: "unsupported-type" as IngestErrorCode,
+				});
+			}
+			throw Object.assign(new Error("Text extraction failed"), {
+				code: "extraction-failed" as IngestErrorCode,
+				cause: error,
+			});
+		}
+
+		signal?.throwIfAborted();
+
+		// Mark as completed
+		await updateDocumentVectorStoreSourceStatus({
+			sourceId,
+			ingestStatus: "completed",
+			ingestErrorCode: null,
+			ingestedAt: new Date(),
+		});
+
+		return {
+			sourceId,
+			text,
+			fileType,
+			success: true,
+		};
+	} catch (error) {
+		// Handle abort
+		if (signal?.aborted) {
+			await updateDocumentVectorStoreSourceStatus({
+				sourceId,
+				ingestStatus: "idle",
+				ingestErrorCode: null,
+			});
+			throw error;
+		}
+
+		// Handle other errors
+		const errorCode =
+			error && typeof error === "object" && "code" in error
+				? (error.code as IngestErrorCode)
+				: ("extraction-failed" as IngestErrorCode);
+
+		await updateDocumentVectorStoreSourceStatus({
+			sourceId,
+			ingestStatus: "failed",
+			ingestErrorCode: errorCode,
+		});
+
+		throw error;
+	}
+}

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -23,6 +23,7 @@
 		"@giselle-internal/ui": "workspace:*",
 		"@giselle-internal/workflow-designer-ui": "workspace:*",
 		"@giselle-sdk/data-type": "workspace:*",
+		"@giselle-sdk/document-preprocessor": "workspace:*",
 		"@giselle-sdk/giselle": "workspace:*",
 		"@giselle-sdk/github-tool": "workspace:*",
 		"@giselle-sdk/langfuse": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       '@giselle-sdk/data-type':
         specifier: workspace:*
         version: link:../../packages/data-type
+      '@giselle-sdk/document-preprocessor':
+        specifier: workspace:*
+        version: link:../../packages/document-preprocessor
       '@giselle-sdk/giselle':
         specifier: workspace:*
         version: link:../../packages/giselle
@@ -1604,28 +1607,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.0.6':
     resolution: {integrity: sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.0.6':
     resolution: {integrity: sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.0.6':
     resolution: {integrity: sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.0.6':
     resolution: {integrity: sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==}
@@ -2280,92 +2279,78 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -2461,28 +2446,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.2':
     resolution: {integrity: sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.2':
     resolution: {integrity: sha512-o1RV/KOODQh6dM6ZRJGZbc+MOAHww33Vbs5JC9Mp1gDk8cpEO+cYC/l7rweiEalkSm5/1WGa4zY7xrNwObN4+Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.2':
     resolution: {integrity: sha512-/VUnh7w8RElYZ0IV83nUcP/J4KJ6LLYliiBIri3p3aW2giF+PAVgZb6mk8jbQSB3WlTai8gEmCAr7kptFa1H6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.2':
     resolution: {integrity: sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg==}
@@ -3036,49 +3017,41 @@ packages:
     resolution: {integrity: sha512-EXkMvem90Pdw0bw0TlOhAHFAGLopb1LaVwsxF+iSc/zQtuR62kl2jGMQRvsW4NHaF+nUN29H8IYQDzox4gxsRw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.5.2':
     resolution: {integrity: sha512-UvA2QZB73XPXmFweDRyXyUchN1YnEx+cca7a/ojdhT+stDe0WKMK32y27oabWokJJsZZOd+W40dD7sxjzx7K/g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.5.2':
     resolution: {integrity: sha512-0rllGQIAmeb+vAtmco0PnTzqlMs0DQs+QvHu/8AQAmgrlKBZDJJmRvLqMv6EXgTrLlWxoM0o9oNf7mZ0tEenUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.5.2':
     resolution: {integrity: sha512-kfE5ALnGsxEyz/e6lZbNUyPjZwTIuExTVJLVzjT/RjvaltSZ6J0u/6/CKsVFD3t686yqse1fnXuydUsgAFmuXg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.5.2':
     resolution: {integrity: sha512-O6lbEl+heEd3QS2GOwm+iDGMqEWA18X/b9JNodzEHe2TJeOJAV/5xJ7jQTGA2seoy6/REhW744O35DyPFxZ2aQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.5.2':
     resolution: {integrity: sha512-6ZASmeqVq+xEQZz/EH+U4j1hPeqVQ8Eo58oYrt9FGJhseowAh6TAOHXe80HAJH6HQTcws1fhS/A7I4hm6NOgZA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.5.2':
     resolution: {integrity: sha512-MYTtU3sKGZfvOYVpUfFHFcxLGOI8WN5BIQeWgNnNDEBHasthEDnyeNYpj6QbLd3XMz84gGA1G+mKMm/lVUF6hA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.5.2':
     resolution: {integrity: sha512-7u1ANU1jkDUbC5ZxGXWDs0OLuUvV3DzqHUI+g41wHdz0iLoVSJ7rR+hl/crHIm4PpFkYbpU+joRslM5OLxeKlw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-wasm32-wasi@11.5.2':
     resolution: {integrity: sha512-2tOsCVH+THg9b9h6MiTymTrveSUWAOaQGj2CPQ4XJncxECsZY6MfxKLul+XsW4KLpstE89KBemRIQi6Il0Twew==}
@@ -4153,127 +4126,106 @@ packages:
     resolution: {integrity: sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.49.0':
     resolution: {integrity: sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.35.0':
     resolution: {integrity: sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.49.0':
     resolution: {integrity: sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.35.0':
     resolution: {integrity: sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.49.0':
     resolution: {integrity: sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.35.0':
     resolution: {integrity: sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.49.0':
     resolution: {integrity: sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.35.0':
     resolution: {integrity: sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.49.0':
     resolution: {integrity: sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.35.0':
     resolution: {integrity: sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.49.0':
     resolution: {integrity: sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.35.0':
     resolution: {integrity: sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.49.0':
     resolution: {integrity: sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.49.0':
     resolution: {integrity: sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.35.0':
     resolution: {integrity: sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.49.0':
     resolution: {integrity: sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.35.0':
     resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.49.0':
     resolution: {integrity: sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.35.0':
     resolution: {integrity: sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.49.0':
     resolution: {integrity: sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.35.0':
     resolution: {integrity: sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==}
@@ -4706,28 +4658,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.10':
     resolution: {integrity: sha512-saScU0cmWvg/Ez4gUmQWr9pvY9Kssxt+Xenfx1LG7LmqjcrvBnw4r9VjkFcqmbBb7GCBwYNcZi9X3/oMda9sqQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.10':
     resolution: {integrity: sha512-/G3ao/ybV9YEEgAXeEg28dyH6gs1QG8tvdN9c2MNZdUXYBaIY/Gx0N6RlJzfLy/7Nkdok4kaxKPHKJUlAaoTdA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.10':
     resolution: {integrity: sha512-LNr7X8fTiKGRtQGOerSayc2pWJp/9ptRYAa4G+U+cjw9kJZvkopav1AQc5HHD+U364f71tZv6XamaHKgrIoVzA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.10':
     resolution: {integrity: sha512-d6ekQpopFQJAcIK2i7ZzWOYGZ+A6NzzvQ3ozBvWFdeyqfOZdYHU66g5yr+/HC4ipP1ZgWsqa80+ISNILk+ae/Q==}
@@ -6571,28 +6519,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}


### PR DESCRIPTION
## Summary
- Add database utilities for managing document vector store source records
- Implement document ingestion pipeline for TXT and Markdown files
- Trigger automatic ingestion on document upload

## Related Issue
part of #1827

## Changes
- **Database layer**: Add `getDocumentVectorStoreSource` and `updateDocumentVectorStoreSourceStatus` helper functions
- **Ingestion pipeline**: Implement `ingestDocument` orchestration with text extraction and status management
- **Text extraction**: Support plain text and Markdown files via `@giselle-sdk/document-preprocessor`
- **Upload integration**: Fire-and-forget ingestion trigger after successful uploads

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
