### PR TITLE
feat(studio): add text chunking for document ingestion

### DIFF
--- a/apps/studio.giselles.ai/lib/vector-stores/document/ingest/chunk-text.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/ingest/chunk-text.ts
@@ -1,0 +1,67 @@
+import type { ChunkerFunction } from "@giselle-sdk/rag";
+import { createDefaultChunker } from "@giselle-sdk/rag";
+
+interface ChunkTextOptions {
+	/**
+	 * Custom chunker function. If not provided, uses the default chunker.
+	 */
+	chunker?: ChunkerFunction;
+	/**
+	 * Optional signal for aborting the operation
+	 */
+	signal?: AbortSignal;
+}
+
+interface ChunkTextResult {
+	/**
+	 * Array of text chunks
+	 */
+	chunks: string[];
+	/**
+	 * Number of chunks created
+	 */
+	chunkCount: number;
+}
+
+/**
+ * Chunk text content into smaller pieces suitable for embedding
+ *
+ * Default configuration:
+ * - maxLines: 150 lines per chunk
+ * - overlap: 30 lines between chunks
+ * - maxChars: 6000 characters per chunk
+ *
+ * @param text - The text content to chunk
+ * @param options - Optional chunking configuration
+ * @returns Array of text chunks with metadata
+ */
+export function chunkText(
+	text: string,
+	options?: ChunkTextOptions,
+): ChunkTextResult {
+	const { chunker, signal } = options ?? {};
+
+	// Check for abort signal
+	signal?.throwIfAborted();
+
+	if (!text || text.trim().length === 0) {
+		return {
+			chunks: [],
+			chunkCount: 0,
+		};
+	}
+
+	// Use provided chunker or default
+	const chunkFn = chunker ?? createDefaultChunker();
+
+	// Chunk the text
+	const chunks = chunkFn(text);
+
+	// Filter out empty chunks
+	const nonEmptyChunks = chunks.filter((chunk) => chunk.trim().length > 0);
+
+	return {
+		chunks: nonEmptyChunks,
+		chunkCount: nonEmptyChunks.length,
+	};
+}

--- a/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
@@ -33,6 +33,7 @@ type IngestErrorCode =
 	| "source-not-found"
 	| "file-not-found"
 	| "extraction-failed"
+	| "chunking-failed"
 	| "unsupported-type"
 	| "invalid-state";
 
@@ -127,7 +128,15 @@ export async function ingestDocument(
 		signal?.throwIfAborted();
 
 		// Chunk the text into smaller pieces
-		const chunkResult = chunkText(text, { signal });
+		let chunkResult: ReturnType<typeof chunkText>;
+		try {
+			chunkResult = chunkText(text, { signal });
+		} catch (error) {
+			throw Object.assign(new Error("Text chunking failed"), {
+				code: "chunking-failed" as IngestErrorCode,
+				cause: error,
+			});
+		}
 
 		signal?.throwIfAborted();
 


### PR DESCRIPTION
### **User description**
## Summary
Implement text chunking functionality to prepare extracted text for embedding generation.

## Related Issue
part of #1827

## Changes
- Add chunk-text.ts with chunkText function using @giselle-sdk/rag default chunker
- Integrate text chunking into ingest pipeline after extraction step
- Configure default chunking: 150 lines/chunk, 30 lines overlap, 6000 chars max
- Return chunks array and count in IngestDocumentResult
- Support abort signals for cancellable operations

The chunker splits extracted text into manageable pieces suitable for embedding models, enabling efficient vector search on document content.

## Testing
https://github.com/giselles-ai/giselle/pull/1892#issuecomment-3352191056

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add text chunking functionality for document ingestion

- Integrate chunking into ingest pipeline after text extraction

- Configure default chunking parameters (150 lines, 30 overlap, 6000 chars)

- Return chunks array and count in ingestion results


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Document Source"] --> B["Extract Text"]
  B --> C["Chunk Text"]
  C --> D["Return Chunks & Metadata"]
  E["Default Chunker"] --> C
  F["Custom Chunker"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chunk-text.ts</strong><dd><code>New text chunking module implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/lib/vector-stores/document/ingest/chunk-text.ts

<ul><li>Create new <code>chunkText</code> function with configurable chunker support<br> <li> Define interfaces for options and results with chunks array<br> <li> Implement default chunking parameters and abort signal handling<br> <li> Add empty text validation and chunk filtering logic</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1892/files#diff-6abe27be13badfd474558d8b7664891034bfeeb26821d0cf14c343c1b8eca3e4">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ingest-document.ts</strong><dd><code>Integrate chunking into document ingestion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts

<ul><li>Import and integrate <code>chunkText</code> function into ingestion pipeline<br> <li> Add <code>chunks</code> and <code>chunkCount</code> fields to <code>IngestDocumentResult</code><br> <li> Update function documentation to reflect chunking step<br> <li> Call chunking after text extraction with abort signal support</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1892/files#diff-a496db27f70a2bdc44e9f7f1166d532787d7a7320b6c481204c0b22ad3fb7bff">+14/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Document ingestion now splits extracted text into smaller chunks to improve search and embedding quality.
  - Ingestion results include the generated chunks and a total chunk count for easier monitoring and downstream use.
  - Supports cancellation during chunking for faster stops on long ingests.
  - Gracefully handles empty or whitespace-only documents, returning zero chunks.
  - Filters out empty chunks to ensure cleaner, higher-quality content in the resulting dataset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a `chunkText` utility and integrates chunked output (with counts) into the ingestion flow after text extraction, with abort handling and a new `chunking-failed` error.
> 
> - **Ingestion Pipeline**:
>   - Integrates `chunkText` after text extraction in `ingest-document.ts`.
>   - Extends `IngestDocumentResult` with `chunks` and `chunkCount`.
>   - Adds `chunking-failed` to `IngestErrorCode`; propagates abort checks.
> - **Chunking Utility**:
>   - New `chunk-text.ts` providing `chunkText` using `@giselle-sdk/rag` default chunker.
>   - Supports `AbortSignal`, filters empty chunks, and returns chunk metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d6c61b621fd46682d61694e827ab84bf5e926a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->