### PR TITLE
Restore the type for the unnecessary type example

### DIFF
--- a/.claude/agents/ts-coder.md
+++ b/.claude/agents/ts-coder.md
@@ -218,7 +218,7 @@ function formatDate(date: Date) {
 }
 
 // Over-engineered: Explicit types for self-evident returns
-export function createUser(data: UserData) {
+export function createUser(data: UserData): User {
   return new User(data);  // The annotation adds no value
 }
 ```


### PR DESCRIPTION
Restored a missing return type annotation to createUser function used as an example of unnecessary typing that was removed during a previous edit of the agent definition.