### PR TITLE
feat(generation): configurable generation timeout prop and

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -80,6 +80,8 @@ export default async function Layout({
 	// return children
 	return (
 		<WorkspaceProvider
+			// TODO: Make it reference the same timeout setting as in trigger.config.ts
+			generationTimeout={3600 * 1000}
 			integration={{
 				value: {
 					github: gitHubIntegrationState,

--- a/packages/giselle/src/react/generations/zustand-bridge-generation-provider.tsx
+++ b/packages/giselle/src/react/generations/zustand-bridge-generation-provider.tsx
@@ -38,9 +38,11 @@ import { useGenerationStore } from "./store";
 export function ZustandBridgeGenerationProvider({
 	children,
 	generateTextApi = "/api/giselle/generateText",
+	timeout = 1000 * 800,
 }: {
 	children: React.ReactNode;
 	generateTextApi?: string;
+	timeout?: number;
 }) {
 	const client = useGiselleEngine();
 	const { experimental_storage } = useFeatureFlag();
@@ -64,7 +66,6 @@ export function ZustandBridgeGenerationProvider({
 		async (
 			generationId: GenerationId,
 			options?: {
-				timeout?: number;
 				onStart?: (generation: RunningGeneration) => void;
 				onComplete?: (generation: CompletedGeneration) => void;
 				onError?: (generation: FailedGeneration) => void;
@@ -76,11 +77,10 @@ export function ZustandBridgeGenerationProvider({
 			let status = generation.status;
 			let messages =
 				"messages" in generation ? (generation.messages ?? []) : [];
-			const timeoutDuration = options?.timeout || 1000 * 800;
 			const startTime = Date.now();
 
 			while (true) {
-				if (Date.now() - startTime > timeoutDuration) {
+				if (Date.now() - startTime > timeout) {
 					generation = generationListener.current[generationId];
 					const failedGeneration: FailedGeneration = {
 						id: generation.id,
@@ -139,7 +139,7 @@ export function ZustandBridgeGenerationProvider({
 				await new Promise((resolve) => setTimeout(resolve, 500));
 			}
 		},
-		[updateGeneration],
+		[updateGeneration, timeout],
 	);
 
 	const createGenerationRunner: CreateGenerationRunner = useCallback(

--- a/packages/giselle/src/react/workspace/provider.tsx
+++ b/packages/giselle/src/react/workspace/provider.tsx
@@ -30,6 +30,7 @@ export function WorkspaceProvider({
 	featureFlag,
 	vectorStore,
 	flowTrigger,
+	generationTimeout,
 }: {
 	children: ReactNode;
 	integration?: IntegrationProviderProps;
@@ -38,6 +39,7 @@ export function WorkspaceProvider({
 	featureFlag?: FeatureFlagContextValue;
 	vectorStore?: VectorStoreContextValue;
 	flowTrigger?: FlowTriggerContextValue;
+	generationTimeout?: number;
 }) {
 	return (
 		<FeatureFlagContext
@@ -56,7 +58,7 @@ export function WorkspaceProvider({
 					<UsageLimitsProvider limits={usageLimits}>
 						<IntegrationProvider {...integration}>
 							<VectorStoreProvider value={vectorStore}>
-								<ZustandBridgeGenerationProvider>
+								<ZustandBridgeGenerationProvider timeout={generationTimeout}>
 									{children}
 								</ZustandBridgeGenerationProvider>
 							</VectorStoreProvider>


### PR DESCRIPTION
### **User description**
- Add configurable generation timeout property
- Expose timeout option for generation operations


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable generation timeout property to WorkspaceProvider

- Remove hardcoded timeout from waitForGeneration function

- Set default timeout to 800 seconds in generation provider

- Configure 3600 second timeout in workspace layout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WorkspaceProvider"] -- "passes timeout prop" --> B["ZustandBridgeGenerationProvider"]
  B -- "uses timeout in" --> C["waitForGeneration function"]
  D["layout.tsx"] -- "sets 3600s timeout" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Configure workspace generation timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx

<ul><li>Add <code>generationTimeout</code> prop with 3600 second value to WorkspaceProvider<br> <li> Include TODO comment referencing trigger.config.ts timeout setting</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1896/files#diff-15f3074fd9425f9c2957c436fb950d744614df0ac6ce51fd55cfaa5ff2bfb04e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zustand-bridge-generation-provider.tsx</strong><dd><code>Make generation timeout configurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/generations/zustand-bridge-generation-provider.tsx

<ul><li>Add optional <code>timeout</code> parameter with 800 second default<br> <li> Remove timeout option from waitForGeneration function signature<br> <li> Use component-level timeout instead of per-call timeout<br> <li> Update dependency array to include timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1896/files#diff-a0c923520bd186f5486fc5d93291684e3d67562021e3c06fb3e64d540c734762">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provider.tsx</strong><dd><code>Add timeout prop to workspace provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/provider.tsx

<ul><li>Add optional <code>generationTimeout</code> prop to WorkspaceProvider interface<br> <li> Pass timeout prop to ZustandBridgeGenerationProvider component</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1896/files#diff-8a9be06df265f969925b0eaaa2a4817e372f5a9038025ba24b59438ce6c69744">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable generation timeout for workspace operations. The Studio now sets the timeout to 1 hour by default, enabling longer-running generations to complete without interruption.

* **Improvements**
  * Reduced premature timeouts and improved reliability for extended generation tasks.
  * More predictable behavior when handling long-running operations across workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->