### PR TITLE
feat(vector-store): implement dual-path document ingestion with atomic claim

### DIFF
--- a/apps/studio.giselles.ai/app/api/vector-stores/document/[documentVectorStoreId]/documents/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/[documentVectorStoreId]/documents/route.ts
@@ -32,6 +32,7 @@ import type {
 import { fetchCurrentTeam } from "@/services/teams";
 
 export const runtime = "nodejs";
+export const maxDuration = 800;
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -303,7 +304,8 @@ export async function POST(
 				storageKey,
 			});
 
-			// Trigger ingestion after response is sent (survives serverless freeze)
+			// Trigger ingestion immediately after response is sent
+			// If this fails or times out, cron job will retry (/api/vector-stores/document/ingest)
 			after(() => {
 				ingestDocument(sourceId, {
 					embeddingProfileIds: store.embeddingProfileIds,

--- a/apps/studio.giselles.ai/app/api/vector-stores/document/[documentVectorStoreId]/documents/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/[documentVectorStoreId]/documents/route.ts
@@ -306,13 +306,13 @@ export async function POST(
 
 			// Trigger ingestion immediately after response is sent
 			// If this fails or times out, cron job will retry (/api/vector-stores/document/ingest)
-			after(() => {
+			after(() =>
 				ingestDocument(sourceId, {
 					embeddingProfileIds: store.embeddingProfileIds,
 				}).catch((error) => {
 					console.error(`Failed to ingest document ${sourceId}:`, error);
-				});
-			});
+				}),
+			);
 		} catch (dbError) {
 			console.error(
 				`Failed to persist metadata for ${originalFileName}. Rolling back this file.`,

--- a/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/fetch-ingest-targets.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/fetch-ingest-targets.ts
@@ -20,8 +20,12 @@ interface DocumentIngestTarget {
  * Fetch document sources that need to be ingested
  *
  * Target documents are:
- * - idle
- * - running and updated more than 15 minutes ago (stale)
+ * - idle: Newly uploaded documents waiting for initial ingestion
+ * - running and updated more than 15 minutes ago (stale): Likely interrupted by timeout
+ *
+ * NOTE: Documents with 'failed' status are intentionally excluded.
+ * Failed ingestions indicate permanent errors (invalid file, missing API keys, etc.)
+ * that would repeatedly fail. These require manual intervention or re-upload.
  *
  * @returns Document sources to ingest
  */

--- a/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/fetch-ingest-targets.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/fetch-ingest-targets.ts
@@ -1,0 +1,95 @@
+import type { EmbeddingProfileId } from "@giselle-sdk/data-type";
+import { and, eq, inArray, lt, or } from "drizzle-orm";
+import {
+	db,
+	documentEmbeddingProfiles,
+	documentVectorStoreSources,
+	documentVectorStores,
+} from "@/drizzle";
+import type { DocumentVectorStoreSourceId } from "@/packages/types";
+
+const STALE_THRESHOLD_MINUTES = 15;
+
+interface DocumentIngestTarget {
+	sourceId: DocumentVectorStoreSourceId;
+	sourceDbId: number;
+	embeddingProfileIds: EmbeddingProfileId[];
+}
+
+/**
+ * Fetch document sources that need to be ingested
+ *
+ * Target documents are:
+ * - idle
+ * - running and updated more than 15 minutes ago (stale)
+ *
+ * @returns Document sources to ingest
+ */
+export async function fetchIngestTargets(): Promise<DocumentIngestTarget[]> {
+	// Consider running status as stale if it hasn't been updated for 15 minutes
+	const staleThreshold = new Date(
+		Date.now() - STALE_THRESHOLD_MINUTES * 60 * 1000,
+	);
+
+	// Get sources that need ingestion
+	const sources = await db
+		.select({
+			id: documentVectorStoreSources.id,
+			dbId: documentVectorStoreSources.dbId,
+			documentVectorStoreDbId:
+				documentVectorStoreSources.documentVectorStoreDbId,
+			ingestStatus: documentVectorStoreSources.ingestStatus,
+			updatedAt: documentVectorStoreSources.updatedAt,
+		})
+		.from(documentVectorStoreSources)
+		.where(
+			or(
+				eq(documentVectorStoreSources.ingestStatus, "idle"),
+				and(
+					eq(documentVectorStoreSources.ingestStatus, "running"),
+					lt(documentVectorStoreSources.updatedAt, staleThreshold),
+				),
+			),
+		);
+
+	if (sources.length === 0) {
+		return [];
+	}
+
+	// Get embedding profiles for the stores
+	const storeDbIds = Array.from(
+		new Set(sources.map((s) => s.documentVectorStoreDbId)),
+	);
+
+	const storeProfiles = await db
+		.select({
+			storeDbId: documentVectorStores.dbId,
+			embeddingProfileId: documentEmbeddingProfiles.embeddingProfileId,
+		})
+		.from(documentVectorStores)
+		.leftJoin(
+			documentEmbeddingProfiles,
+			eq(
+				documentEmbeddingProfiles.documentVectorStoreDbId,
+				documentVectorStores.dbId,
+			),
+		)
+		.where(inArray(documentVectorStores.dbId, storeDbIds));
+
+	// Build map of store -> embedding profiles
+	const profileMap = new Map<number, EmbeddingProfileId[]>();
+	for (const record of storeProfiles) {
+		if (record.embeddingProfileId) {
+			const profiles = profileMap.get(record.storeDbId) ?? [];
+			profiles.push(record.embeddingProfileId);
+			profileMap.set(record.storeDbId, profiles);
+		}
+	}
+
+	// Build ingest targets
+	return sources.map((source) => ({
+		sourceId: source.id,
+		sourceDbId: source.dbId,
+		embeddingProfileIds: profileMap.get(source.documentVectorStoreDbId) ?? [],
+	}));
+}

--- a/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/route.ts
@@ -1,3 +1,15 @@
+/**
+ * Cron job endpoint for document embedding ingestion
+ *
+ * This endpoint processes documents that were not successfully ingested during upload:
+ * - Documents in 'idle' status: Initial ingestion not yet attempted or failed to start
+ * - Documents in 'running' status for >15 minutes: Likely interrupted by timeout
+ *
+ * Documents with 'failed' status are NOT retried by this cron job.
+ * Failed status indicates permanent errors (e.g., unsupported file type, missing API keys,
+ * invalid embedding profiles) that would fail repeatedly. Users should re-upload or
+ * fix configuration issues for these documents.
+ */
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { ingestDocument } from "@/lib/vector-stores/document/ingest";

--- a/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/ingest/route.ts
@@ -1,0 +1,71 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { ingestDocument } from "@/lib/vector-stores/document/ingest";
+import { fetchIngestTargets } from "./fetch-ingest-targets";
+
+export const maxDuration = 800;
+
+const bearerPrefix = "Bearer ";
+
+const digest = (value: string) =>
+	createHash("sha256").update(value, "utf8").digest();
+
+const isAuthorized = (authHeader: string | null, secret: string) => {
+	if (!authHeader?.startsWith(bearerPrefix)) {
+		return false;
+	}
+
+	const providedSecret = authHeader.slice(bearerPrefix.length).trim();
+
+	if (providedSecret.length === 0) {
+		return false;
+	}
+
+	return timingSafeEqual(digest(secret), digest(providedSecret));
+};
+
+export async function GET(request: NextRequest) {
+	const cronSecret = process.env.CRON_SECRET;
+
+	if (!cronSecret) {
+		console.error("CRON_SECRET environment variable is not set");
+		return new Response("Server misconfigured", { status: 500 });
+	}
+
+	const authHeader = request.headers.get("authorization");
+	if (!isAuthorized(authHeader, cronSecret)) {
+		return new Response("Unauthorized", {
+			status: 401,
+		});
+	}
+
+	const targets = await fetchIngestTargets();
+
+	// Process documents sequentially to avoid overwhelming the embedding API
+	let successCount = 0;
+	let failureCount = 0;
+
+	for (const target of targets) {
+		try {
+			await ingestDocument(target.sourceId, {
+				embeddingProfileIds: target.embeddingProfileIds,
+			});
+			successCount++;
+		} catch (error) {
+			console.error(
+				`Failed to ingest document ${target.sourceId}:`,
+				error instanceof Error ? error.message : error,
+			);
+			failureCount++;
+		}
+	}
+
+	return Response.json(
+		{
+			processed: targets.length,
+			success: successCount,
+			failure: failureCount,
+		},
+		{ status: 200 },
+	);
+}

--- a/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
@@ -247,6 +247,8 @@ export async function ingestDocument(
 		}
 
 		// Handle other errors
+		// Mark as 'failed' for permanent errors that should not be retried by cron job
+		// (e.g., unsupported file type, missing API keys, invalid embedding profiles)
 		const errorCode =
 			error && typeof error === "object" && "code" in error
 				? (error.code as IngestErrorCode)

--- a/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts
@@ -4,6 +4,8 @@ import type {
 } from "@giselle-sdk/data-type";
 import type { DocumentVectorStoreSourceId } from "@giselles-ai/types";
 import { createClient } from "@supabase/supabase-js";
+import { and, eq, lt, or } from "drizzle-orm";
+import { db, documentVectorStoreSources } from "@/drizzle";
 import {
 	deleteDocumentEmbeddingsByProfiles,
 	getDocumentVectorStoreSource,
@@ -30,13 +32,15 @@ interface IngestDocumentOptions {
 
 interface IngestDocumentResult {
 	sourceId: DocumentVectorStoreSourceId;
-	text: string;
-	fileType: "txt" | "md";
-	chunks: string[];
-	chunkCount: number;
-	embeddingProfileIds: EmbeddingProfileId[];
-	embeddingCount: number;
+	text?: string;
+	fileType?: "txt" | "md";
+	chunks?: string[];
+	chunkCount?: number;
+	embeddingProfileIds?: EmbeddingProfileId[];
+	embeddingCount?: number;
 	success: boolean;
+	skipped?: boolean;
+	reason?: string;
 }
 
 type IngestErrorCode =
@@ -73,6 +77,48 @@ export async function ingestDocument(
 	try {
 		signal?.throwIfAborted();
 
+		// Atomically claim this document for processing
+		// This prevents race conditions between after() hook, cron job, and multiple cron instances
+		const STALE_THRESHOLD_MINUTES = 15;
+		const staleThreshold = new Date(
+			Date.now() - STALE_THRESHOLD_MINUTES * 60 * 1000,
+		);
+
+		const claimResult = await db
+			.update(documentVectorStoreSources)
+			.set({
+				ingestStatus: "running",
+				ingestErrorCode: null, // Clear any previous error
+				updatedAt: new Date(), // Reset stale detection timer
+			})
+			.where(
+				and(
+					eq(documentVectorStoreSources.id, sourceId),
+					eq(documentVectorStoreSources.uploadStatus, "uploaded"), // Only claim uploaded documents
+					or(
+						// Claim idle documents
+						eq(documentVectorStoreSources.ingestStatus, "idle"),
+						// Claim stale running documents
+						and(
+							eq(documentVectorStoreSources.ingestStatus, "running"),
+							lt(documentVectorStoreSources.updatedAt, staleThreshold),
+						),
+					),
+				),
+			);
+
+		// Check if we successfully claimed the document
+		if (claimResult.rowCount === 0) {
+			// Document is already being processed by another worker
+			console.log(`Document ${sourceId} is already being processed, skipping`);
+			return {
+				sourceId,
+				success: false,
+				skipped: true,
+				reason: "already-processing",
+			};
+		}
+
 		// Get source from database
 		const source = await getDocumentVectorStoreSource(sourceId);
 
@@ -81,20 +127,6 @@ export async function ingestDocument(
 				code: "source-not-found" as IngestErrorCode,
 			});
 		}
-
-		// Validate source state before marking as running
-		if (source.uploadStatus !== "uploaded") {
-			throw Object.assign(new Error("Source upload is not completed"), {
-				code: "invalid-state" as IngestErrorCode,
-			});
-		}
-
-		// Mark as running (after validation)
-		await updateDocumentVectorStoreSourceStatus({
-			sourceId,
-			ingestStatus: "running",
-			ingestErrorCode: null,
-		});
 
 		signal?.throwIfAborted();
 

--- a/apps/studio.giselles.ai/vercel.json
+++ b/apps/studio.giselles.ai/vercel.json
@@ -3,6 +3,10 @@
 		{
 			"path": "/api/vector-stores/github/ingest",
 			"schedule": "*/10 * * * *"
+		},
+		{
+			"path": "/api/vector-stores/document/ingest",
+			"schedule": "*/3 * * * *"
 		}
 	]
 }


### PR DESCRIPTION
### **User description**
## Summary
Implements document embedding ingestion with dual processing paths: immediate processing via `after()` hook and background processing via Vercel Cron Jobs, with atomic claim mechanism to prevent race conditions.


https://github.com/user-attachments/assets/32818687-b817-43de-89f8-c2ec21f2a42e



## Related Issue
part of #1827


## Changes

### 1. Dual Ingestion Paths
- **Immediate processing**: `after()` hook triggers ingestion immediately after upload (best effort)
- **Background processing**: Cron job runs every **3 minutes** to process idle/stale documents
- Configured `maxDuration=800` for upload route to support after() processing

### 2. Cron Job Infrastructure
- Added `/api/vector-stores/document/ingest` endpoint for background processing
- Added `fetchIngestTargets()` to query documents needing ingestion
- Configured cron schedule: runs every **3 minutes** (`vercel.json`)

### 3. Atomic Claim Mechanism
- Prevents race conditions when multiple workers attempt to process same document:
- `after()` hook in upload route
- Cron job processing idle documents
- Multiple concurrent cron instances
- Uses database-level optimistic locking with atomic `UPDATE ... WHERE`
- Validates `uploadStatus='uploaded'` before claiming to prevent invalid state errors
- Clears `ingestErrorCode` when claiming to ensure clean retry state
- Returns `{skipped: true}` when document is already being processed
- Cron endpoint tracks and reports skipped documents

### 4. Stale Detection & Recovery
- Documents stuck in `running` status for >15 minutes are considered stale
- Likely interrupted by timeout or deployment
- Automatically reclaimed by next cron execution or subsequent uploads

### 5. Intentional Failed Document Exclusion
- Documents with `failed` status are **NOT** retried by cron job
- Failed status indicates permanent errors:
- Unsupported file type
- Missing API keys
- Invalid embedding profiles
- Requires manual intervention or re-upload

## Workflow

User uploads document
        ↓
File saved to Supabase Storage
        ↓
DB record created (ingestStatus: 'idle', uploadStatus: 'uploaded')
        ↓
        ├─ after() executes ──────────────────┐
        │  ├─ Success → Embeddings generated  │ Immediate processing
        │  └─ Fail/timeout → Stays in 'idle'  │ (best effort)
        │                                      │
        └─ [Wait up to 3 minutes] ────────────┘
                ↓
        Cron job fetches idle/stale documents
                ↓
        Atomic claim: UPDATE ingestStatus='running', ingestErrorCode=null
                    WHERE sourceId=? AND uploadStatus='uploaded'
                    AND ingestStatus IN ('idle', stale 'running')
                ↓
            Success? (rowCount > 0)
            ├─ No → Skip (already processing or invalid state)
            └─ Yes → Process: Extract → Chunk → Generate embeddings → Store → Mark completed

## Testing
https://github.com/giselles-ai/giselle/pull/1898#issuecomment-3355129744

## Other Information

### Benefits

- **Fast user experience**: `after()` provides immediate processing for most uploads
- **Reliability**: Cron job ensures all documents eventually get processed
- **Race condition prevention**: Database-level atomicity ensures no duplicate processing
- **Resilience**: Automatic recovery from stale/interrupted jobs
- **Clean retry state**: Error codes cleared on retry attempts

### Tradeoffs

- **Complexity**: Dual ingestion paths require atomic claim coordination
- **Resource usage**: `maxDuration=800` allows longer processing in upload route
- Acceptable tradeoffs for better user experience and reliability


___

### **PR Type**
Enhancement


___

### **Description**
- Implement dual-path document ingestion with immediate and background processing

- Add atomic claim mechanism to prevent race conditions

- Configure cron job for automatic retry of failed/stale documents

- Set maxDuration to 800 seconds for long-running operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Document Upload"] --> B["Save to Storage"]
  B --> C["Create DB Record"]
  C --> D["after() Hook Processing"]
  C --> E["Cron Job Processing"]
  D --> F["Atomic Claim"]
  E --> F
  F --> G["Generate Embeddings"]
  G --> H["Mark Completed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Configure upload route for dual ingestion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/api/vector-stores/document/[documentVectorStoreId]/documents/route.ts

<ul><li>Set <code>maxDuration</code> to 800 seconds for long-running operations<br> <li> Update <code>after()</code> hook to trigger immediate document ingestion<br> <li> Add comment explaining cron job fallback mechanism</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1898/files#diff-714b5af6482956c183f5259a69c5c2944c92c5ea5e9e7e83f474cb95ef059845">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vercel.json</strong><dd><code>Configure cron schedule for document processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/vercel.json

<ul><li>Add cron schedule for document ingestion endpoint<br> <li> Configure to run every 3 minutes (<code>*/3 * * * *</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1898/files#diff-e0d678485e399b6265b76720e978c79c69ab66a79e35459ff72b100847423860">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fetch-ingest-targets.ts</strong><dd><code>Add query for document ingest targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/api/vector-stores/document/ingest/fetch-ingest-targets.ts

<ul><li>Create function to query documents needing ingestion<br> <li> Target idle documents and stale running documents (>15 minutes)<br> <li> Exclude failed documents from automatic retry<br> <li> Fetch associated embedding profiles for each vector store</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1898/files#diff-dac59f2decda3c07d863092a8640be79eb5f7223459ca4c739bf3751569f7d79">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add cron job endpoint for background processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/api/vector-stores/document/ingest/route.ts

<ul><li>Create cron job endpoint with bearer token authentication<br> <li> Process documents sequentially to avoid API rate limits<br> <li> Return processing statistics (success/failure/skipped counts)<br> <li> Set <code>maxDuration</code> to 800 seconds for embedding generation</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1898/files#diff-048b136dc9c882190d7d03407a3179cdca88f6ca984a238e78b905427e13ef52">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ingest-document.ts</strong><dd><code>Add atomic claim mechanism for concurrent processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/lib/vector-stores/document/ingest/ingest-document.ts

<ul><li>Implement atomic claim mechanism using database UPDATE with WHERE <br>conditions<br> <li> Prevent race conditions between multiple processing instances<br> <li> Return skipped status when document already being processed<br> <li> Clear error codes on retry attempts for clean state</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1898/files#diff-a496db27f70a2bdc44e9f7f1166d532787d7a7320b6c481204c0b22ad3fb7bff">+54/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token-protected cron endpoint to process document ingestion in the background.
  * Ingestion now scheduled immediately after uploads and also via the cron every 3 minutes.
  * Increased max runtime for ingestion tasks to support larger jobs.

* **Bug Fixes**
  * Prevented duplicate/parallel processing with an atomic claiming mechanism.
  * Failures during ingestion no longer block uploads and are retried by the cron; clearer success/skip/failure reporting.

* **Chores**
  * Deployment config updated to include the new ingestion cron.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->