### PR TITLE
feat: add document vector store type definitions

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -43,9 +43,15 @@ function getDataSourceDisplayInfo(input: ConnectedSource): {
 					icon,
 				};
 			}
-			default: {
-				const _exhaustiveCheck: never = node.content.source.provider;
-				throw new Error(`Unhandled provider: ${_exhaustiveCheck}`);
+			case "document": {
+				return {
+					name,
+					description: {
+						line1: "Document",
+						line2: node.content.source.state.status,
+					},
+					icon,
+				};
 			}
 		}
 	}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
@@ -1,6 +1,7 @@
 import { Select } from "@giselle-internal/ui/select";
 import type {
 	EmbeddingProfileId,
+	GitHubVectorStoreSource,
 	VectorStoreNode,
 } from "@giselle-sdk/data-type";
 import {
@@ -32,11 +33,12 @@ export function GitHubVectorStoreNodePropertiesPanel({
 	// Get repository indexes
 	const githubRepositoryIndexes = vectorStore?.githubRepositoryIndexes ?? [];
 
+	// This component is GitHub-specific
+	const source = node.content.source as GitHubVectorStoreSource;
+
 	// Current content type from node (if configured)
 	const currentContentType =
-		node.content.source.state.status === "configured"
-			? node.content.source.state.contentType
-			: undefined;
+		source.state.status === "configured" ? source.state.contentType : undefined;
 
 	const { isOrphaned, repositoryId, isEmbeddingProfileOrphaned } =
 		useGitHubVectorStoreStatus(node);
@@ -46,8 +48,8 @@ export function GitHubVectorStoreNodePropertiesPanel({
 	const [selectedEmbeddingProfileId, setSelectedEmbeddingProfileId] = useState<
 		EmbeddingProfileId | undefined
 	>(
-		node.content.source.state.status === "configured"
-			? node.content.source.state.embeddingProfileId
+		source.state.status === "configured"
+			? source.state.embeddingProfileId
 			: undefined,
 	);
 
@@ -92,7 +94,7 @@ export function GitHubVectorStoreNodePropertiesPanel({
 				content: {
 					...node.content,
 					source: {
-						...node.content.source,
+						provider: "github",
 						state: {
 							status: "unconfigured",
 						},
@@ -214,7 +216,7 @@ export function GitHubVectorStoreNodePropertiesPanel({
 				content: {
 					...node.content,
 					source: {
-						...node.content.source,
+						provider: "github",
 						state: {
 							status: "configured",
 							owner: selectedRepo.owner,
@@ -234,14 +236,14 @@ export function GitHubVectorStoreNodePropertiesPanel({
 				<p className="text-[14px] py-[1.5px] text-white-400">
 					GitHub Repository
 				</p>
-				{isOrphaned && node.content.source.state.status === "configured" && (
+				{isOrphaned && source.state.status === "configured" && (
 					<div className="flex items-center gap-[6px] text-error-900 text-[13px] mb-[8px]">
 						<TriangleAlert className="size-[16px]" />
 						<span>
 							The repository{" "}
 							<span className="font-mono font-semibold">
-								{node.content.source.state.owner}/
-								{node.content.source.state.repo}
+								{source.state.owner}/
+								{source.state.repo}
 							</span>{" "}
 							is no longer available in your Vector Stores. Please select a
 							different repository or set up this repository again.
@@ -344,7 +346,7 @@ export function GitHubVectorStoreNodePropertiesPanel({
 								Embedding Model
 							</p>
 							{isEmbeddingProfileOrphaned &&
-								node.content.source.state.status === "configured" && (
+								source.state.status === "configured" && (
 									<div className="flex items-center gap-[6px] text-error-900 text-[13px] mb-[8px]">
 										<TriangleAlert className="size-[16px]" />
 										<span>
@@ -363,14 +365,14 @@ export function GitHubVectorStoreNodePropertiesPanel({
 									setSelectedEmbeddingProfileId(maybeId);
 
 									// Update node data with selected profile
-									if (node.content.source.state.status === "configured") {
+									if (source.state.status === "configured") {
 										updateNodeData(node, {
 											content: {
 												...node.content,
 												source: {
-													...node.content.source,
+													provider: "github",
 													state: {
-														...node.content.source.state,
+														...source.state,
 														embeddingProfileId: maybeId,
 													},
 												},

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
@@ -242,8 +242,7 @@ export function GitHubVectorStoreNodePropertiesPanel({
 						<span>
 							The repository{" "}
 							<span className="font-mono font-semibold">
-								{source.state.owner}/
-								{source.state.repo}
+								{source.state.owner}/{source.state.repo}
 							</span>{" "}
 							is no longer available in your Vector Stores. Please select a
 							different repository or set up this repository again.

--- a/packages/data-type/src/node/variables/vector-store.ts
+++ b/packages/data-type/src/node/variables/vector-store.ts
@@ -22,8 +22,25 @@ export const GitHubVectorStoreSource = z.object({
 });
 export type GitHubVectorStoreSource = z.infer<typeof GitHubVectorStoreSource>;
 
+export const DocumentVectorStoreSource = z.object({
+	provider: z.literal("document"),
+	state: z.discriminatedUnion("status", [
+		z.object({
+			status: z.literal("configured"),
+			documentVectorStoreId: z.string(),
+			embeddingProfileId: EmbeddingProfileIdSchema.optional(),
+		}),
+		z.object({
+			status: z.literal("unconfigured"),
+		}),
+	]),
+});
+export type DocumentVectorStoreSource = z.infer<
+	typeof DocumentVectorStoreSource
+>;
+
 export const VectorStoreContent = VectorStoreContentBase.extend({
-	source: GitHubVectorStoreSource,
+	source: z.union([GitHubVectorStoreSource, DocumentVectorStoreSource]),
 });
 export type VectorStoreContent = z.infer<typeof VectorStoreContent>;
 

--- a/packages/giselle/src/engine/operations/execute-query.ts
+++ b/packages/giselle/src/engine/operations/execute-query.ts
@@ -439,6 +439,12 @@ async function queryVectorStore(
 						}
 					}
 
+					case "document": {
+						throw new Error(
+							"Document vector store query is not yet implemented",
+						);
+					}
+
 					default: {
 						const _exhaustiveCheck: never = provider;
 						throw new Error(

--- a/packages/giselle/src/engine/vector-store/types.ts
+++ b/packages/giselle/src/engine/vector-store/types.ts
@@ -1,6 +1,12 @@
 export const githubProvider = "github" as const;
-export type VectorStoreSourceProvider = typeof githubProvider;
-export const vectorStoreSourceProviders = [githubProvider] as const;
+export const documentProvider = "document" as const;
+export type VectorStoreSourceProvider =
+	| typeof githubProvider
+	| typeof documentProvider;
+export const vectorStoreSourceProviders = [
+	githubProvider,
+	documentProvider,
+] as const;
 
 type VectorStoreReference<
 	P extends VectorStoreSourceProvider,
@@ -54,3 +60,16 @@ type GitHubVectorStoreReference = VectorStoreReference<
 export type GitHubVectorStoreInfo = VectorStoreInfo<GitHubVectorStoreReference>;
 export type GitHubVectorStoreIdentifier =
 	VectorStoreIdentifier<GitHubVectorStoreReference>;
+
+// MARK: DocumentVectorStore
+
+type DocumentVectorStoreReference = VectorStoreReference<
+	"document",
+	{
+		documentVectorStoreId: string;
+	}
+>;
+export type DocumentVectorStoreInfo =
+	VectorStoreInfo<DocumentVectorStoreReference>;
+export type DocumentVectorStoreIdentifier =
+	VectorStoreIdentifier<DocumentVectorStoreReference>;

--- a/packages/giselle/src/utils/node-default-name.ts
+++ b/packages/giselle/src/utils/node-default-name.ts
@@ -33,6 +33,7 @@ export const vectorStoreProviderLabel: Record<
 	string
 > = {
 	github: "GitHub Vector Store",
+	document: "Document Vector Store",
 };
 export function vectorStoreNodeDefaultName(
 	vectorStoreProvider: VectorStoreSourceProvider,


### PR DESCRIPTION
### **User description**
## Summary
Add document vector store type definitions.

## Related Issue
part of #1827

## Changes
- Add `DocumentVectorStoreSource` type definitions alongside existing GitHub provider
- Add document provider case to query panel UI to display document vector store information
- Improve type safety in GitHub vector store panel by explicitly casting to `GitHubVectorStoreSource`
- Add placeholder implementation for document provider in query execution
- Add default label "Document Vector Store" for document provider nodes

## Testing
https://github.com/giselles-ai/giselle/pull/1901#issuecomment-3356109542

## Other Information
This PR is a preliminary step to add the Document Vector Store Node feature.


___

### **PR Type**
Enhancement


___

### **Description**
- Add DocumentVectorStoreSource type definitions and schema

- Extend vector store union to support document provider

- Add document provider UI components and labels

- Improve GitHub vector store type safety with explicit casting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Vector Store Types"] --> B["GitHub Provider"]
  A --> C["Document Provider"]
  B --> D["Query Panel UI"]
  C --> D
  D --> E["Execute Query Engine"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vector-store.ts</strong><dd><code>Add DocumentVectorStoreSource schema definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/data-type/src/node/variables/vector-store.ts

<ul><li>Add <code>DocumentVectorStoreSource</code> schema with configured/unconfigured <br>states<br> <li> Extend <code>VectorStoreContent</code> source to union of GitHub and document <br>providers<br> <li> Include <code>documentVectorStoreId</code> and optional <code>embeddingProfileId</code> fields</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1901/files#diff-4b253e037150a0241c7b76e3d763655a96222b389f9a6f948f671694ce5c5e71">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>execute-query.ts</strong><dd><code>Add document provider stub in query execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/operations/execute-query.ts

<ul><li>Add document provider case in vector store query execution<br> <li> Throw not-yet-implemented error for document provider</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1901/files#diff-3bf5dcda800337e54a682f2ee73b5489afc86e4d14597c65c390587d77982d9f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Extend vector store types for document provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/vector-store/types.ts

<ul><li>Add <code>documentProvider</code> constant and extend provider types<br> <li> Add <code>DocumentVectorStoreReference</code>, <code>DocumentVectorStoreInfo</code>, and <br><code>DocumentVectorStoreIdentifier</code> types<br> <li> Update <code>vectorStoreSourceProviders</code> array to include document provider</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1901/files#diff-25e58711b186893c6ecc9114a4e8584d62c588b456e4aaf3a0d948b2c68ca6dd">+21/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-default-name.ts</strong><dd><code>Add document provider default label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/utils/node-default-name.ts

<ul><li>Add "Document Vector Store" label to <code>vectorStoreProviderLabel</code> mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1901/files#diff-49fb98768d2e56da2b3fc40c4911f32344b30ab2c5ef3592160e6f7b8b1e3f76">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query-panel.tsx</strong><dd><code>Add document provider case to query panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx

<ul><li>Add document provider case to display document vector store <br>information<br> <li> Show "Document" and status in query panel UI</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1901/files#diff-2f277cc52b1175885fefa342e968f15baeb98b0ab10803c97192777b2cbfd05e">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Improve GitHub vector store type safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx

<ul><li>Cast node source to <code>GitHubVectorStoreSource</code> for type safety<br> <li> Explicitly specify "github" provider when updating node data<br> <li> Replace spread operator with explicit provider specification</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1901/files#diff-f211cde95d4ce69b93154909e24da0f2d6c4f672e4db0a273c3288e0cb3f0476">+16/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added "Document" as a Vector Store provider with full display support in the properties panel.
  - Nodes using the new provider now show the default name "Document Vector Store".
  - Added support so document-based vector stores are recognized across the app.

- Bug Fixes
  - Execution now returns a clear, explicit error when querying the "Document" provider (execution not yet supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new document vector store provider with schema/types, query panel display, engine handling stub, and improves GitHub panel type safety.
> 
> - **Vector Store Types**:
>   - Add `DocumentVectorStoreSource` schema and include in `VectorStoreContent.source` union.
>   - Extend provider types with `document` (`vector-store/types.ts`), plus `DocumentVectorStoreReference`/`Info`/`Identifier`.
> - **Engine**:
>   - Handle `provider: "document"` in `execute-query` with a not-yet-implemented error.
> - **UI**:
>   - Query panel: add `document` provider case to show "Document" and status.
>   - GitHub panel: improve type safety by using explicit `provider: "github"` updates and typed source usage.
> - **Defaults/Labels**:
>   - Add "Document Vector Store" to `vectorStoreProviderLabel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1872abe00e7193de04cb9afcb1001a421e027dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->