### PR TITLE
fix(github-tool): skip binary files containing NUL bytes in document loaders

### DIFF
--- a/packages/github-tool/src/document-loaders/blobs/archive-loader.ts
+++ b/packages/github-tool/src/document-loaders/blobs/archive-loader.ts
@@ -150,6 +150,10 @@ export function createGitHubArchiveLoader(
 		const textDecoder = new TextDecoder("utf-8", { fatal: true });
 		try {
 			const decodedContent = textDecoder.decode(contentBytes);
+			if (decodedContent.includes("\u0000")) {
+				console.warn(`Blob contains NUL bytes, skipping: ${metadata.path}`);
+				return null;
+			}
 			return { content: decodedContent, metadata };
 		} catch {
 			return null;

--- a/packages/github-tool/src/document-loaders/blobs/tree-loader.ts
+++ b/packages/github-tool/src/document-loaders/blobs/tree-loader.ts
@@ -113,6 +113,10 @@ async function loadBlob(
 	const textDecoder = new TextDecoder("utf-8", { fatal: true });
 	try {
 		const decodedContent = textDecoder.decode(contentInBytes);
+		if (decodedContent.includes("\u0000")) {
+			console.warn(`Blob contains NUL bytes, skipping: ${path}`);
+			return null;
+		}
 		return {
 			content: decodedContent,
 			metadata: {


### PR DESCRIPTION
### **User description**
## Summary
Add validation to detect and skip binary files that contain NUL bytes after UTF-8 decoding. This prevents binary content from being processed as text documents in both archive-loader and tree-loader.

## Related Issue
None.

## Testing
This issue occurred in the GitHub Vector Store that we use internally, so we will check its operation after release.

## Other Information


___

### **PR Type**
Bug fix


___

### **Description**
- Add NUL byte validation to skip binary files

- Prevent binary content from being processed as text

- Apply fix to both archive-loader and tree-loader


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UTF-8 Decode"] --> B["Check for NUL bytes"]
  B --> C{"Contains \u0000?"}
  C -->|Yes| D["Skip file with warning"]
  C -->|No| E["Process as text document"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>archive-loader.ts</strong><dd><code>Add binary file detection via NUL bytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/document-loaders/blobs/archive-loader.ts

<ul><li>Add NUL byte detection after UTF-8 decoding<br> <li> Skip files containing <code>\u0000</code> with warning message<br> <li> Return null for binary files to prevent processing</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1904/files#diff-2bddf5152767aa157a9a8e3137fcbe805c2dd56fd7b8d523754f46774c7ea4e3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tree-loader.ts</strong><dd><code>Add NUL byte validation for binary detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/document-loaders/blobs/tree-loader.ts

<ul><li>Add NUL byte validation after text decoding<br> <li> Log warning and skip binary files containing <code>\u0000</code><br> <li> Prevent binary content from being processed as text</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1904/files#diff-5c6e6adf02142561e5d25caf260c600c287e79e2d66995f5e9fd98d2a9b97701">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of binary or malformed files by detecting NUL bytes in decoded content and skipping those files.
  - Added warnings in logs when such files are encountered, providing clearer diagnostics.
  - Reduces ingestion errors and prevents unexpected behavior during document loading.
  - Enhances reliability and stability of content processing, resulting in more consistent indexing and fewer failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->