### PR TITLE
fix: sanitize NUL characters in RAG document processing

### DIFF
--- a/packages/github-tool/src/document-loaders/blobs/archive-loader.ts
+++ b/packages/github-tool/src/document-loaders/blobs/archive-loader.ts
@@ -2,7 +2,11 @@ import { createHash } from "node:crypto";
 import { type Dirent, promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, normalize } from "node:path";
-import type { Document, DocumentLoader } from "@giselle-sdk/rag";
+import {
+	type Document,
+	type DocumentLoader,
+	replaceNullCharacters,
+} from "@giselle-sdk/rag";
 import type { Octokit } from "@octokit/core";
 import { extract } from "tar";
 import { executeRestRequest } from "../utils";
@@ -150,7 +154,10 @@ export function createGitHubArchiveLoader(
 		const textDecoder = new TextDecoder("utf-8", { fatal: true });
 		try {
 			const decodedContent = textDecoder.decode(contentBytes);
-			return { content: decodedContent, metadata };
+			return {
+				content: replaceNullCharacters(decodedContent),
+				metadata,
+			};
 		} catch {
 			return null;
 		}

--- a/packages/github-tool/src/document-loaders/blobs/tree-loader.ts
+++ b/packages/github-tool/src/document-loaders/blobs/tree-loader.ts
@@ -1,5 +1,9 @@
-import type { Document, DocumentLoader } from "@giselle-sdk/rag";
-import { DocumentLoaderError } from "@giselle-sdk/rag";
+import {
+	type Document,
+	type DocumentLoader,
+	DocumentLoaderError,
+	replaceNullCharacters,
+} from "@giselle-sdk/rag";
 import type { Octokit } from "@octokit/core";
 import { executeRestRequest } from "../utils";
 
@@ -114,7 +118,7 @@ async function loadBlob(
 	try {
 		const decodedContent = textDecoder.decode(contentInBytes);
 		return {
-			content: decodedContent,
+			content: replaceNullCharacters(decodedContent),
 			metadata: {
 				owner,
 				repo,

--- a/packages/rag/src/chunk-store/postgres/utils.test.ts
+++ b/packages/rag/src/chunk-store/postgres/utils.test.ts
@@ -139,5 +139,31 @@ describe("chunk-store/postgres/utils", () => {
 				team_id: 123,
 			});
 		});
+
+		it("replaces NUL bytes in chunk content with a safe character", () => {
+			const chunks = [
+				{ content: "hello\u0000world", index: 0, embedding: [1, 2] },
+			];
+
+			const metadata = {};
+			const columnMapping = {
+				documentKey: "doc_key",
+				chunkContent: "content",
+				chunkIndex: "idx",
+				version: "version",
+			};
+
+			const [record] = prepareChunkRecords(
+				"doc123",
+				chunks,
+				metadata,
+				columnMapping,
+				{},
+				1,
+				2,
+			);
+
+			expect(record.record.content).toBe("hello\uFFFDworld");
+		});
 	});
 });

--- a/packages/rag/src/chunk-store/postgres/utils.ts
+++ b/packages/rag/src/chunk-store/postgres/utils.ts
@@ -3,6 +3,7 @@ import { escapeIdentifier } from "pg";
 import * as pgvector from "pgvector/pg";
 import { EMBEDDING_COLUMNS } from "../../database/constants";
 import { ConfigurationError } from "../../errors";
+import { replaceNullCharacters } from "../../utils";
 import type { ColumnMapping } from "../column-mapping";
 import { REQUIRED_COLUMN_KEYS } from "../column-mapping";
 import type { ChunkWithEmbedding } from "../types";
@@ -123,7 +124,7 @@ export function prepareChunkRecords<TMetadata extends Record<string, unknown>>(
 	return chunks.map((chunk) => ({
 		record: {
 			[columnMapping.documentKey]: documentKey,
-			[columnMapping.chunkContent]: chunk.content,
+			[columnMapping.chunkContent]: replaceNullCharacters(chunk.content),
 			[columnMapping.chunkIndex]: chunk.index,
 			...metadataColumns,
 			...scope,

--- a/packages/rag/src/index.ts
+++ b/packages/rag/src/index.ts
@@ -6,3 +6,4 @@ export * from "./embedder";
 export * from "./errors";
 export * from "./ingest";
 export * from "./query-service";
+export * from "./utils";

--- a/packages/rag/src/utils/index.ts
+++ b/packages/rag/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./text";

--- a/packages/rag/src/utils/text.test.ts
+++ b/packages/rag/src/utils/text.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { replaceNullCharacters } from "./text";
+
+describe("replaceNullCharacters", () => {
+	it("returns the original string when it does not contain NUL characters", () => {
+		const input = "hello";
+		expect(replaceNullCharacters(input)).toBe(input);
+	});
+
+	it("replaces NUL characters with the Unicode replacement character", () => {
+		const input = "hello\u0000world";
+		const result = replaceNullCharacters(input);
+		expect(result).toBe("hello\uFFFDworld");
+	});
+
+	it("supports overriding the replacement character", () => {
+		const input = "a\u0000b\u0000c";
+		const result = replaceNullCharacters(input, "?");
+		expect(result).toBe("a?b?c");
+	});
+});

--- a/packages/rag/src/utils/text.ts
+++ b/packages/rag/src/utils/text.ts
@@ -1,0 +1,20 @@
+const NULL_CHARACTER = "\u0000";
+const DEFAULT_REPLACEMENT = "\uFFFD";
+
+/**
+ * Replace NUL ("\\u0000") characters with a safe replacement before persisting text.
+ *
+ * PostgreSQL text columns reject NUL bytes, so we swap them with the Unicode
+ * replacement character by default. The function is idempotent and skips
+ * allocation when the input does not contain NUL characters.
+ */
+export function replaceNullCharacters(
+	value: string,
+	replacement: string = DEFAULT_REPLACEMENT,
+): string {
+	if (!value.includes(NULL_CHARACTER)) {
+		return value;
+	}
+
+	return value.replaceAll(NULL_CHARACTER, replacement);
+}


### PR DESCRIPTION
### **User description**
## Summary
Sanitize NUL characters in RAG document processing.

## Background
PostgreSQL text columns cannot store NUL characters, causing insertion failures when processing certain files from GitHub
 repositories. This PR replaces NUL bytes with the Unicode replacement character (`\uFFFD`) before storage.

## Changes
- Add `replaceNullCharacters` utility to sanitize NUL bytes (`\u0000`) in document content
- Apply sanitization in PostgreSQL chunk store to prevent database insertion errors
- Apply sanitization in GitHub document loaders (archive and tree) to handle files containing NUL bytes

## Testing
Verify tests pass with `pnpm test`

https://github.com/giselles-ai/giselle/pull/1905#issuecomment-3358749022

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Add `replaceNullCharacters` utility to sanitize NUL bytes

- Fix PostgreSQL insertion errors in chunk storage

- Sanitize GitHub document content before processing

- Replace NUL characters with Unicode replacement character


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Documents"] --> B["replaceNullCharacters"]
  B --> C["Sanitized Content"]
  C --> D["PostgreSQL Storage"]
  E["RAG Chunks"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>text.ts</strong><dd><code>Add NUL character sanitization utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/utils/text.ts

<ul><li>Create <code>replaceNullCharacters</code> utility function<br> <li> Replace NUL bytes with Unicode replacement character<br> <li> Add idempotent optimization for strings without NUL characters</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-513ad5daf72f533535077fef266d3e664cd37b9c102b7ed4ac9abeeb42e128f0">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>text.test.ts</strong><dd><code>Add tests for text sanitization utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/utils/text.test.ts

<ul><li>Add comprehensive tests for <code>replaceNullCharacters</code><br> <li> Test normal strings, NUL replacement, and custom replacement</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-bf9f174ad0cb1ae01721c4c264523ab6bc4ec4b43cfb96bef87d3ba639a5155e">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.test.ts</strong><dd><code>Test NUL handling in chunk storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/chunk-store/postgres/utils.test.ts

<ul><li>Add test for NUL character replacement in chunks<br> <li> Verify sanitization works in chunk preparation</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-6e02c8df702e136983471603ecfa3a77306b0a90090c1e4ea952e669bb0cf86e">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Sanitize chunk content in PostgreSQL store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/chunk-store/postgres/utils.ts

<ul><li>Import <code>replaceNullCharacters</code> utility<br> <li> Apply sanitization to chunk content before storage</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-23c4ae24070b19bb0b2000d8395bdffdd3fc2675aa3ea793bf4585d525890540">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>archive-loader.ts</strong><dd><code>Sanitize GitHub archive document content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/document-loaders/blobs/archive-loader.ts

<ul><li>Import <code>replaceNullCharacters</code> from RAG package<br> <li> Apply sanitization to decoded archive content</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-2bddf5152767aa157a9a8e3137fcbe805c2dd56fd7b8d523754f46774c7ea4e3">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tree-loader.ts</strong><dd><code>Sanitize GitHub tree document content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/document-loaders/blobs/tree-loader.ts

<ul><li>Import <code>replaceNullCharacters</code> from RAG package<br> <li> Apply sanitization to decoded blob content</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-5c6e6adf02142561e5d25caf260c600c287e79e2d66995f5e9fd98d2a9b97701">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export text utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/utils/index.ts

- Export text utilities from utils module


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-8179195a6a181e8f45c4e86e1b52d54438399d0b209bdb393160b46e10f2a487">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export utils from main package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/rag/src/index.ts

- Export utils module from main package


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1905/files#diff-28f1ee37921016a1e7e31c6ec7ec5b1066f15767d5141e875d49f7ef70ba5101">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Sanitizes text by replacing invalid NUL characters in loaded files and stored chunks, preventing crashes, broken previews, and indexing failures.
- Tests
  - Added unit and integration tests to ensure reliable text sanitization behavior.
- Chores
  - Exposed text utilities through the public API to enable consistent sanitization across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->