### PR TITLE
feat: add document vector store backend infrastructure and properties panel

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/data.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/data.ts
@@ -1,26 +1,18 @@
 import type { components } from "@octokit/openapi-types";
-import { desc, eq, inArray } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import {
 	db,
-	documentEmbeddingProfiles,
-	documentVectorStoreSources,
-	documentVectorStores,
 	githubRepositoryContentStatus,
 	githubRepositoryIndex,
 } from "@/drizzle";
 import type { RepositoryWithStatuses } from "@/lib/vector-stores/github";
+
+export type { DocumentVectorStoreWithProfiles } from "@/lib/vector-stores/document/queries";
+export { getDocumentVectorStores } from "@/lib/vector-stores/document/queries";
+
 import { getGitHubIdentityState } from "@/services/accounts";
 import { fetchCurrentTeam } from "@/services/teams";
 import type { InstallationWithRepos } from "./types";
-
-type DocumentVectorStoreRow = typeof documentVectorStores.$inferSelect;
-type DocumentVectorStoreSourceRow =
-	typeof documentVectorStoreSources.$inferSelect;
-
-export type DocumentVectorStoreWithProfiles = DocumentVectorStoreRow & {
-	embeddingProfileIds: number[];
-	sources: DocumentVectorStoreSourceRow[];
-};
 
 export async function getGitHubRepositoryIndexes(): Promise<
 	RepositoryWithStatuses[]
@@ -65,74 +57,6 @@ export async function getGitHubRepositoryIndexes(): Promise<
 	}
 
 	return Array.from(repositoryMap.values());
-}
-
-export async function getDocumentVectorStores(): Promise<
-	DocumentVectorStoreWithProfiles[]
-> {
-	const team = await fetchCurrentTeam();
-
-	const records = await db
-		.select({
-			store: documentVectorStores,
-			embeddingProfileId: documentEmbeddingProfiles.embeddingProfileId,
-		})
-		.from(documentVectorStores)
-		.leftJoin(
-			documentEmbeddingProfiles,
-			eq(
-				documentEmbeddingProfiles.documentVectorStoreDbId,
-				documentVectorStores.dbId,
-			),
-		)
-		.where(eq(documentVectorStores.teamDbId, team.dbId))
-		.orderBy(desc(documentVectorStores.createdAt));
-
-	const storeMap = new Map<number, DocumentVectorStoreWithProfiles>();
-
-	for (const record of records) {
-		const { store, embeddingProfileId } = record;
-		const existing = storeMap.get(store.dbId);
-		if (!existing) {
-			storeMap.set(store.dbId, {
-				...store,
-				embeddingProfileIds:
-					embeddingProfileId !== null && embeddingProfileId !== undefined
-						? [embeddingProfileId]
-						: [],
-				sources: [],
-			});
-			continue;
-		}
-		if (embeddingProfileId !== null && embeddingProfileId !== undefined) {
-			existing.embeddingProfileIds.push(embeddingProfileId);
-		}
-	}
-
-	const storeDbIds = Array.from(storeMap.keys());
-	if (storeDbIds.length === 0) {
-		return [];
-	}
-
-	const sourceRecords = await db
-		.select({
-			storeDbId: documentVectorStoreSources.documentVectorStoreDbId,
-			source: documentVectorStoreSources,
-		})
-		.from(documentVectorStoreSources)
-		.where(
-			inArray(documentVectorStoreSources.documentVectorStoreDbId, storeDbIds),
-		)
-		.orderBy(desc(documentVectorStoreSources.createdAt));
-
-	for (const record of sourceRecords) {
-		const store = storeMap.get(record.storeDbId);
-		if (store) {
-			store.sources.push(record.source);
-		}
-	}
-
-	return Array.from(storeMap.values());
 }
 
 export async function getInstallationsWithRepos(): Promise<

--- a/apps/studio.giselles.ai/app/api/vector-stores/document/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+import { docVectorStoreFlag } from "@/flags";
+import { getDocumentVectorStores } from "@/lib/vector-stores/document/queries";
+
+export async function GET() {
+	const enabled = await docVectorStoreFlag();
+	if (!enabled) {
+		return NextResponse.json({ error: "Not Found" }, { status: 404 });
+	}
+
+	try {
+		const stores = await getDocumentVectorStores();
+		return NextResponse.json(
+			{
+				documentVectorStores: stores.map((store) => ({
+					id: store.id,
+					name: store.name,
+					embeddingProfileIds: store.embeddingProfileIds,
+					sources: store.sources.map((source) => ({
+						id: source.id,
+						fileName: source.fileName,
+						ingestStatus: source.ingestStatus,
+						ingestErrorCode: source.ingestErrorCode,
+					})),
+				})),
+			},
+			{ status: 200 },
+		);
+	} catch (error) {
+		console.error("Failed to fetch document vector stores:", error);
+		return NextResponse.json(
+			{ error: "Failed to fetch document vector stores" },
+			{ status: 500 },
+		);
+	}
+}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -17,6 +17,7 @@ import {
 	stageFlag,
 	webSearchActionFlag,
 } from "@/flags";
+import { getDocumentVectorStores } from "@/lib/vector-stores/document/queries";
 import { getGitHubRepositoryIndexes } from "@/lib/vector-stores/github";
 import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
@@ -77,6 +78,9 @@ export default async function Layout({
 	const aiGateway = await aiGatewayFlag();
 	const resumableGeneration = await resumableGenerationFlag();
 	const documentVectorStore = await docVectorStoreFlag();
+	const documentVectorStores = documentVectorStore
+		? await getDocumentVectorStores()
+		: [];
 	const data = await giselleEngine.getWorkspace(workspaceId, true);
 
 	// return children
@@ -95,7 +99,19 @@ export default async function Layout({
 			}}
 			vectorStore={{
 				githubRepositoryIndexes: gitHubRepositoryIndexes,
-				settingPath: "/settings/team/vector-stores",
+				documentSettingPath: "/settings/team/vector-stores/document",
+				githubSettingPath: "/settings/team/vector-stores",
+				documentStores: documentVectorStores.map((store) => ({
+					id: store.id,
+					name: store.name,
+					embeddingProfileIds: store.embeddingProfileIds,
+					sources: store.sources.map((source) => ({
+						id: source.id,
+						fileName: source.fileName,
+						ingestStatus: source.ingestStatus,
+						ingestErrorCode: source.ingestErrorCode,
+					})),
+				})),
 			}}
 			usageLimits={usageLimits}
 			telemetry={{

--- a/apps/studio.giselles.ai/lib/vector-stores/document/queries.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/queries.ts
@@ -1,0 +1,83 @@
+import { desc, eq, inArray } from "drizzle-orm";
+
+import {
+	db,
+	documentEmbeddingProfiles,
+	documentVectorStoreSources,
+	documentVectorStores,
+} from "@/drizzle";
+import { fetchCurrentTeam } from "@/services/teams";
+
+export type DocumentVectorStoreWithProfiles =
+	typeof documentVectorStores.$inferSelect & {
+		embeddingProfileIds: number[];
+		sources: (typeof documentVectorStoreSources.$inferSelect)[];
+	};
+
+export async function getDocumentVectorStores(): Promise<
+	DocumentVectorStoreWithProfiles[]
+> {
+	const team = await fetchCurrentTeam();
+
+	const records = await db
+		.select({
+			store: documentVectorStores,
+			embeddingProfileId: documentEmbeddingProfiles.embeddingProfileId,
+		})
+		.from(documentVectorStores)
+		.leftJoin(
+			documentEmbeddingProfiles,
+			eq(
+				documentEmbeddingProfiles.documentVectorStoreDbId,
+				documentVectorStores.dbId,
+			),
+		)
+		.where(eq(documentVectorStores.teamDbId, team.dbId))
+		.orderBy(desc(documentVectorStores.createdAt));
+
+	const storeMap = new Map<number, DocumentVectorStoreWithProfiles>();
+
+	for (const record of records) {
+		const { store, embeddingProfileId } = record;
+		const existing = storeMap.get(store.dbId);
+		if (!existing) {
+			storeMap.set(store.dbId, {
+				...store,
+				embeddingProfileIds:
+					embeddingProfileId !== null && embeddingProfileId !== undefined
+						? [embeddingProfileId]
+						: [],
+				sources: [],
+			});
+			continue;
+		}
+		if (embeddingProfileId !== null && embeddingProfileId !== undefined) {
+			existing.embeddingProfileIds.push(embeddingProfileId);
+		}
+	}
+
+	const storeDbIds = Array.from(storeMap.keys());
+	if (storeDbIds.length === 0) {
+		return [];
+	}
+
+	const sourceRecords = await db
+		.select({
+			storeDbId: documentVectorStoreSources.documentVectorStoreDbId,
+			source: documentVectorStoreSources,
+		})
+		.from(documentVectorStoreSources)
+		.where(
+			inArray(documentVectorStoreSources.documentVectorStoreDbId, storeDbIds),
+		)
+		.orderBy(desc(documentVectorStoreSources.createdAt));
+
+	for (const record of sourceRecords) {
+		const store = storeMap.get(record.storeDbId);
+		if (store) {
+			store.sources.push(record.source);
+		}
+	}
+
+	return Array.from(storeMap.values());
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/document/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/document/index.tsx
@@ -1,0 +1,376 @@
+import { Select } from "@giselle-internal/ui/select";
+import type {
+	DocumentVectorStoreSource,
+	EmbeddingProfileId,
+	VectorStoreNode,
+} from "@giselle-sdk/data-type";
+import {
+	EMBEDDING_PROFILES,
+	isEmbeddingProfileId,
+} from "@giselle-sdk/data-type";
+import {
+	useVectorStore,
+	useWorkflowDesigner,
+	type VectorStoreContextValue,
+} from "@giselle-sdk/giselle/react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import useSWR from "swr";
+
+import { TriangleAlert } from "../../../../icons";
+
+type DocumentVectorStoreIngestStatus =
+	| "idle"
+	| "running"
+	| "completed"
+	| "failed";
+
+interface DocumentVectorStore {
+	id: string;
+	name: string;
+	embeddingProfileIds: number[];
+	sources: Array<{
+		id: string;
+		fileName: string;
+		ingestStatus: DocumentVectorStoreIngestStatus;
+		ingestErrorCode: string | null;
+	}>;
+}
+
+interface DocumentVectorStoresResponse {
+	documentVectorStores: DocumentVectorStore[];
+}
+
+interface DocumentVectorStoresResult {
+	stores: DocumentVectorStore[];
+	isFeatureEnabled: boolean;
+}
+
+const documentVectorStoresFetcher = async (
+	url: string,
+): Promise<DocumentVectorStoresResult> => {
+	const response = await fetch(url, { cache: "no-store" });
+	if (response.status === 404) {
+		return { stores: [], isFeatureEnabled: false };
+	}
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch document vector stores: ${response.status}`,
+		);
+	}
+	const payload = (await response.json()) as DocumentVectorStoresResponse;
+	return { stores: payload.documentVectorStores, isFeatureEnabled: true };
+};
+
+const INGEST_STATUS_STYLE: Record<
+	DocumentVectorStoreIngestStatus,
+	{ label: string; className: string }
+> = {
+	idle: {
+		label: "Pending",
+		className: "bg-yellow-500/10 text-yellow-400 border-yellow-500/30",
+	},
+	running: {
+		label: "Processing",
+		className: "bg-blue-500/10 text-blue-400 border-blue-500/30",
+	},
+	completed: {
+		label: "Ready",
+		className: "bg-green-500/10 text-green-400 border-green-500/30",
+	},
+	failed: {
+		label: "Failed",
+		className: "bg-error-500/10 text-error-500 border-error-500/30",
+	},
+};
+
+function IngestStatusBadge({
+	status,
+	errorCode,
+}: {
+	status: DocumentVectorStoreIngestStatus;
+	errorCode: string | null;
+}) {
+	const { label, className } = INGEST_STATUS_STYLE[status];
+	return (
+		<span
+			className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[12px] font-medium ${className}`}
+			title={errorCode ? `Error: ${errorCode}` : undefined}
+		>
+			{label}
+		</span>
+	);
+}
+
+type DocumentVectorStoreNodePropertiesPanelProps = {
+	node: VectorStoreNode;
+};
+
+export function DocumentVectorStoreNodePropertiesPanel({
+	node,
+}: DocumentVectorStoreNodePropertiesPanelProps) {
+	const { updateNodeData } = useWorkflowDesigner();
+	const vectorStore = useVectorStore();
+	const vectorStoreValue = vectorStore as VectorStoreContextValue | undefined;
+	const settingPath = vectorStoreValue?.documentSettingPath;
+
+	const source = node.content.source as Extract<
+		VectorStoreNode["content"]["source"],
+		{ provider: "document" }
+	>;
+
+	const contextDocumentStores = (vectorStoreValue?.documentStores ??
+		[]) as DocumentVectorStore[];
+	const { data, error, isLoading } = useSWR<DocumentVectorStoresResult>(
+		source.provider === "document" ? "/api/vector-stores/document" : null,
+		documentVectorStoresFetcher,
+		{ fallbackData: { stores: contextDocumentStores, isFeatureEnabled: true } },
+	);
+
+	const documentStores = (data?.stores ??
+		contextDocumentStores) as DocumentVectorStore[];
+	const isFeatureEnabled = data?.isFeatureEnabled ?? true;
+
+	const configuredState =
+		source.state.status === "configured" ? source.state : undefined;
+
+	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
+		configuredState?.documentVectorStoreId,
+	);
+	const [selectedEmbeddingProfileId, setSelectedEmbeddingProfileId] = useState<
+		EmbeddingProfileId | undefined
+	>(configuredState?.embeddingProfileId ?? undefined);
+
+	useEffect(() => {
+		if (source.state.status === "configured") {
+			setSelectedStoreId(source.state.documentVectorStoreId);
+			setSelectedEmbeddingProfileId(
+				source.state.embeddingProfileId ?? undefined,
+			);
+		} else {
+			setSelectedStoreId(undefined);
+			setSelectedEmbeddingProfileId(undefined);
+		}
+	}, [source.state]);
+
+	const selectedStore = useMemo(() => {
+		return documentStores.find((store) => store.id === selectedStoreId);
+	}, [documentStores, selectedStoreId]);
+
+	const embeddingProfileOptions = useMemo(() => {
+		if (!selectedStore) {
+			return [];
+		}
+		return selectedStore.embeddingProfileIds
+			.slice()
+			.sort((a: number, b: number) => a - b)
+			.map((profileId) => {
+				const profile =
+					EMBEDDING_PROFILES[profileId as keyof typeof EMBEDDING_PROFILES];
+				if (!profile) {
+					return {
+						value: profileId,
+						label: `Profile ${profileId}`,
+					};
+				}
+				return {
+					value: profileId,
+					label: `${profile.name} (${profile.dimensions} dimensions)`,
+				};
+			});
+	}, [selectedStore]);
+
+	const handleUpdateNode = useCallback(
+		(storeId: string, embeddingProfileId?: EmbeddingProfileId) => {
+			const store = documentStores.find(
+				(candidate) => candidate.id === storeId,
+			);
+			const updatedOutputs = [...node.outputs];
+			if (updatedOutputs[0]) {
+				updatedOutputs[0] = {
+					...updatedOutputs[0],
+					label: store ? store.name : updatedOutputs[0].label,
+				};
+			}
+
+			const nextState: DocumentVectorStoreSource = {
+				provider: "document",
+				state: {
+					status: "configured",
+					documentVectorStoreId: storeId,
+					...(embeddingProfileId !== undefined ? { embeddingProfileId } : {}),
+				},
+			};
+
+			updateNodeData(node, {
+				outputs: updatedOutputs,
+				content: {
+					...node.content,
+					source: nextState,
+				},
+			});
+		},
+		[documentStores, node, updateNodeData],
+	);
+
+	const handleSelectStore = useCallback(
+		(storeId: string) => {
+			setSelectedStoreId(storeId);
+			const store = documentStores.find(
+				(candidate) => candidate.id === storeId,
+			);
+			const preferredProfile = store?.embeddingProfileIds.find(
+				(id): id is EmbeddingProfileId => isEmbeddingProfileId(id),
+			);
+
+			setSelectedEmbeddingProfileId(preferredProfile);
+			handleUpdateNode(storeId, preferredProfile);
+		},
+		[documentStores, handleUpdateNode],
+	);
+
+	const handleSelectEmbeddingProfile = useCallback(
+		(value: string) => {
+			const maybeId = Number(value);
+			if (!isEmbeddingProfileId(maybeId)) return;
+			setSelectedEmbeddingProfileId(maybeId);
+			if (selectedStoreId) {
+				handleUpdateNode(selectedStoreId, maybeId);
+			}
+		},
+		[handleUpdateNode, selectedStoreId],
+	);
+
+	const isConfiguredButMissingStore = useMemo(() => {
+		if (!configuredState) return false;
+		return !documentStores.some(
+			(store) => store.id === configuredState.documentVectorStoreId,
+		);
+	}, [configuredState, documentStores]);
+
+	if (!isFeatureEnabled) {
+		return (
+			<div className="flex flex-col gap-3 p-4 text-white-400">
+				<span>
+					Document vector stores are not available for this workspace.
+				</span>
+				{settingPath && (
+					<Link href={settingPath} className="text-white-300 underline">
+						Set Up Vector Store
+					</Link>
+				)}
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="p-4 text-error-500">
+				Failed to load document vector stores. Please try again later.
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-[16px] p-0">
+			<div className="space-y-[12px]">
+				<div className="space-y-[4px]">
+					<p className="text-[14px] text-white-400">Document Vector Store</p>
+					{isConfiguredButMissingStore && configuredState && (
+						<div className="flex items-center gap-[6px] text-error-900 text-[13px]">
+							<TriangleAlert className="size-[16px]" />
+							<span>
+								The selected vector store "
+								<span className="font-mono">
+									{configuredState.documentVectorStoreId}
+								</span>
+								" is no longer available. Please choose another store.
+							</span>
+						</div>
+					)}
+					<Select
+						options={documentStores.map((store) => ({
+							value: store.id,
+							label: store.name,
+						}))}
+						value={selectedStoreId ?? ""}
+						onValueChange={
+							!isLoading && documentStores.length > 0
+								? handleSelectStore
+								: undefined
+						}
+						placeholder={
+							isLoading ? "Loading stores..." : "Select a document vector store"
+						}
+						triggerClassName={
+							isLoading || documentStores.length === 0
+								? "opacity-40 pointer-events-none"
+								: undefined
+						}
+					/>
+				</div>
+
+				{!isLoading && documentStores.length === 0 && (
+					<div className="rounded-md border border-dashed border-white/15 bg-black-900/20 px-4 py-6 text-sm text-white-400">
+						No document vector stores available. Create one from settings to use
+						it here.
+					</div>
+				)}
+			</div>
+
+			{selectedStore && embeddingProfileOptions.length > 0 && (
+				<div className="space-y-[8px]">
+					<p className="text-[14px] text-white-400">Embedding Model</p>
+					<Select
+						options={embeddingProfileOptions.map((option) => ({
+							value: option.value.toString(),
+							label: option.label,
+						}))}
+						value={selectedEmbeddingProfileId?.toString() ?? ""}
+						onValueChange={handleSelectEmbeddingProfile}
+						placeholder="Select embedding model"
+					/>
+				</div>
+			)}
+
+			{selectedStore && (
+				<div className="space-y-[8px]">
+					<p className="text-[14px] text-white-400">Uploaded Sources</p>
+					{selectedStore.sources.length > 0 ? (
+						<ul className="space-y-2">
+							{selectedStore.sources.map((docSource) => (
+								<li
+									key={docSource.id}
+									className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-black-950/30 px-3 py-2"
+								>
+									<span className="truncate text-[13px] text-white-400">
+										{docSource.fileName}
+									</span>
+									<IngestStatusBadge
+										status={docSource.ingestStatus}
+										errorCode={docSource.ingestErrorCode}
+									/>
+								</li>
+							))}
+						</ul>
+					) : (
+						<div className="rounded-md border border-dashed border-white/10 bg-black-950/20 px-3 py-4 text-[13px] text-white-400/80">
+							No documents uploaded yet.
+						</div>
+					)}
+				</div>
+			)}
+
+			{settingPath && (
+				<div className="flex justify-end pt-[8px]">
+					<Link
+						href={settingPath}
+						className="text-[14px] text-white-400 underline hover:text-white-300"
+					>
+						Set Up Vector Store
+					</Link>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/index.tsx
@@ -6,6 +6,7 @@ import {
 	PropertiesPanelHeader,
 	PropertiesPanelRoot,
 } from "../ui";
+import { DocumentVectorStoreNodePropertiesPanel } from "./document";
 import { GitHubVectorStoreNodePropertiesPanel } from "./github";
 
 export function VectorStoreNodePropertiesPanel({
@@ -32,5 +33,10 @@ export function VectorStoreNodePropertiesPanel({
 }
 
 function PropertiesPanel({ node }: { node: VectorStoreNode }) {
-	return <GitHubVectorStoreNodePropertiesPanel node={node} />;
+	switch (node.content.source.provider) {
+		case "document":
+			return <DocumentVectorStoreNodePropertiesPanel node={node} />;
+		default:
+			return <GitHubVectorStoreNodePropertiesPanel node={node} />;
+	}
 }

--- a/internal-packages/workflow-designer-ui/src/icons/node/document-vector-store-icon.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/node/document-vector-store-icon.tsx
@@ -1,0 +1,28 @@
+import clsx from "clsx/lite";
+import type { FC, SVGProps } from "react";
+
+export const DocumentVectorStoreIcon: FC<SVGProps<SVGSVGElement>> = ({
+	className,
+	...props
+}) => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		role="graphics-symbol"
+		className={clsx(
+			"stroke-current",
+			"fill-transparent",
+			"[stroke-width:2]",
+			"[stroke-linecap:round]",
+			"[stroke-linejoin:round]",
+			className,
+		)}
+		{...props}
+	>
+		<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+		<path d="M14 2v4a2 2 0 0 0 2 2h4" />
+	</svg>
+);

--- a/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/node/index.tsx
@@ -24,8 +24,8 @@ import { PromptIcon } from "../prompt";
 import { RecraftIcon } from "../recraft";
 import { StableDiffusionIcon } from "../stable-diffusion";
 import { TextFileIcon } from "../text-file";
-
 import { WebPageFileIcon } from "../web-page-file";
+import { DocumentVectorStoreIcon } from "./document-vector-store-icon";
 
 // Node-specific GitHub icon with dark fill for visibility on light backgrounds
 function NodeGitHubIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
@@ -206,6 +206,11 @@ export function NodeIcon({
 					if (!isVectorStoreNode(node)) {
 						throw new Error(
 							`Expected VectorStoreNode, got ${JSON.stringify(node)}`,
+						);
+					}
+					if (node.content.source.provider === "document") {
+						return (
+							<DocumentVectorStoreIcon {...props} data-content-type-icon />
 						);
 					}
 					return <NodeGitHubIcon {...props} data-content-type-icon />;

--- a/packages/giselle/src/react/vector-store/context.tsx
+++ b/packages/giselle/src/react/vector-store/context.tsx
@@ -11,7 +11,19 @@ export interface VectorStoreContextValue {
 			embeddingProfileIds: number[];
 		}[];
 	}[];
-	settingPath: string;
+	documentStores?: {
+		id: string;
+		name: string;
+		embeddingProfileIds: number[];
+		sources: Array<{
+			id: string;
+			fileName: string;
+			ingestStatus: "idle" | "running" | "completed" | "failed";
+			ingestErrorCode: string | null;
+		}>;
+	}[];
+	documentSettingPath?: string;
+	githubSettingPath?: string;
 }
 
 export const VectorStoreContext = createContext<


### PR DESCRIPTION
### **User description**
## Summary
- Extract document vector store queries to shared location for reuse
- Add GET `/api/vector-stores/document` endpoint with feature flag protection
- Pass document vector stores through workspace context to enable UI access
- Extend VectorStoreContext with document stores and separate setting paths
- Add DocumentVectorStoreIcon for visual distinction
- Implement complete properties panel for document vector store configuration

## Related Issue
part of #1827

## Changes
### Backend Infrastructure
- Refactored `getDocumentVectorStores` from settings to shared `lib/vector-stores/document/queries.ts`
- Created new API endpoint `/api/vector-stores/document` for workspace-wide access
- Updated `WorkspaceProvider` to fetch and provide document stores
- Extended `VectorStoreContextValue` with `documentStores` and separate setting paths

### UI Components
- Added `DocumentVectorStoreIcon` component
- Implemented document vector store properties panel with:
  - Store selection dropdown
  - Embedding profile selection (filtered by compatibility)
  - Ingest status display (pending/processing/ready/failed)
  - Error handling for unavailable stores

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
Foundation for document vector store node display and query panel integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Add document vector store backend infrastructure and API endpoint

- Implement complete properties panel for document vector store configuration

- Refactor shared queries and extend workspace context integration

- Add visual distinction with DocumentVectorStoreIcon component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings Module"] -- "extract queries" --> B["Shared Queries Module"]
  B -- "provides data" --> C["API Endpoint"]
  C -- "fetches stores" --> D["Workspace Context"]
  D -- "passes data" --> E["Properties Panel"]
  E -- "displays config" --> F["Document Vector Store Node"]
  G["DocumentVectorStoreIcon"] -- "visual distinction" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>data.ts</strong><dd><code>Extract document vector store queries to shared module</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-60b1f2b5c6082fa67f1a114b1152e6985371adc5539f03238cf77f200ef858eb">+5/-81</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Add document vector stores API endpoint with feature flag</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-5f4b0c95e8a17f3b1dd5c646f0a6c309c50e5ec2ad4ebf80d203eafa91bc01ad">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>queries.ts</strong><dd><code>Create shared document vector store queries module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-47c5d27aa4ad58c39f8a15e4d320d313d31acddaf15ed9c76c733a7a6e3cca13">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>layout.tsx</strong><dd><code>Integrate document stores into workspace context provider</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-15f3074fd9425f9c2957c436fb950d744614df0ac6ce51fd55cfaa5ff2bfb04e">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Implement complete document vector store properties panel</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-53aa9c1027540da248f9a932e7f5542835f3a5029e128eaf162000a4a9b01f72">+376/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Add routing for document vector store properties panel</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-0574b0fd6917a1cfe761f0a8b79ba37696e2ea72ea4623186bc7ff005f8cd50c">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>document-vector-store-icon.tsx</strong><dd><code>Add DocumentVectorStoreIcon component for visual distinction</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-873e36db478fd57655c55cd7f288c9ee79315264b315e48c2fb9cb8c290d8af7">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Integrate DocumentVectorStoreIcon into node icon system</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-deb86932539652a17d0bb14a989c2253d99feac36a7b1d9eee1198af773ab536">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>context.tsx</strong><dd><code>Extend VectorStoreContext with document stores and separate paths</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1908/files#diff-4b74a441a3b61bef48365c4bb8bec8b9ad9f762a89c60552d9d4b97ec82ad432">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for document-based vector stores, including an API to list stores with embedding models and source ingest statuses.
  - Workspace now exposes document and GitHub settings paths and available document stores.
- UI
  - New properties panel to select a document vector store and embedding model within the workflow designer.
  - Displays uploaded sources with clear ingest status and error details.
  - Provider-aware rendering in the properties panel and node icons, including a new document vector store icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->