### PR TITLE
refactor: extract document vector store queries to shared module

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/data.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/data.ts
@@ -1,26 +1,18 @@
 import type { components } from "@octokit/openapi-types";
-import { desc, eq, inArray } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import {
 	db,
-	documentEmbeddingProfiles,
-	documentVectorStoreSources,
-	documentVectorStores,
 	githubRepositoryContentStatus,
 	githubRepositoryIndex,
 } from "@/drizzle";
 import type { RepositoryWithStatuses } from "@/lib/vector-stores/github";
+
+export type { DocumentVectorStoreWithProfiles } from "@/lib/vector-stores/document/queries";
+export { getDocumentVectorStores } from "@/lib/vector-stores/document/queries";
+
 import { getGitHubIdentityState } from "@/services/accounts";
 import { fetchCurrentTeam } from "@/services/teams";
 import type { InstallationWithRepos } from "./types";
-
-type DocumentVectorStoreRow = typeof documentVectorStores.$inferSelect;
-type DocumentVectorStoreSourceRow =
-	typeof documentVectorStoreSources.$inferSelect;
-
-export type DocumentVectorStoreWithProfiles = DocumentVectorStoreRow & {
-	embeddingProfileIds: number[];
-	sources: DocumentVectorStoreSourceRow[];
-};
 
 export async function getGitHubRepositoryIndexes(): Promise<
 	RepositoryWithStatuses[]
@@ -65,74 +57,6 @@ export async function getGitHubRepositoryIndexes(): Promise<
 	}
 
 	return Array.from(repositoryMap.values());
-}
-
-export async function getDocumentVectorStores(): Promise<
-	DocumentVectorStoreWithProfiles[]
-> {
-	const team = await fetchCurrentTeam();
-
-	const records = await db
-		.select({
-			store: documentVectorStores,
-			embeddingProfileId: documentEmbeddingProfiles.embeddingProfileId,
-		})
-		.from(documentVectorStores)
-		.leftJoin(
-			documentEmbeddingProfiles,
-			eq(
-				documentEmbeddingProfiles.documentVectorStoreDbId,
-				documentVectorStores.dbId,
-			),
-		)
-		.where(eq(documentVectorStores.teamDbId, team.dbId))
-		.orderBy(desc(documentVectorStores.createdAt));
-
-	const storeMap = new Map<number, DocumentVectorStoreWithProfiles>();
-
-	for (const record of records) {
-		const { store, embeddingProfileId } = record;
-		const existing = storeMap.get(store.dbId);
-		if (!existing) {
-			storeMap.set(store.dbId, {
-				...store,
-				embeddingProfileIds:
-					embeddingProfileId !== null && embeddingProfileId !== undefined
-						? [embeddingProfileId]
-						: [],
-				sources: [],
-			});
-			continue;
-		}
-		if (embeddingProfileId !== null && embeddingProfileId !== undefined) {
-			existing.embeddingProfileIds.push(embeddingProfileId);
-		}
-	}
-
-	const storeDbIds = Array.from(storeMap.keys());
-	if (storeDbIds.length === 0) {
-		return [];
-	}
-
-	const sourceRecords = await db
-		.select({
-			storeDbId: documentVectorStoreSources.documentVectorStoreDbId,
-			source: documentVectorStoreSources,
-		})
-		.from(documentVectorStoreSources)
-		.where(
-			inArray(documentVectorStoreSources.documentVectorStoreDbId, storeDbIds),
-		)
-		.orderBy(desc(documentVectorStoreSources.createdAt));
-
-	for (const record of sourceRecords) {
-		const store = storeMap.get(record.storeDbId);
-		if (store) {
-			store.sources.push(record.source);
-		}
-	}
-
-	return Array.from(storeMap.values());
 }
 
 export async function getInstallationsWithRepos(): Promise<

--- a/apps/studio.giselles.ai/lib/vector-stores/document/queries.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/queries.ts
@@ -1,0 +1,83 @@
+import { desc, eq, inArray } from "drizzle-orm";
+
+import {
+	db,
+	documentEmbeddingProfiles,
+	documentVectorStoreSources,
+	documentVectorStores,
+} from "@/drizzle";
+import { fetchCurrentTeam } from "@/services/teams";
+
+export type DocumentVectorStoreWithProfiles =
+	typeof documentVectorStores.$inferSelect & {
+		embeddingProfileIds: number[];
+		sources: (typeof documentVectorStoreSources.$inferSelect)[];
+	};
+
+export async function getDocumentVectorStores(): Promise<
+	DocumentVectorStoreWithProfiles[]
+> {
+	const team = await fetchCurrentTeam();
+
+	const records = await db
+		.select({
+			store: documentVectorStores,
+			embeddingProfileId: documentEmbeddingProfiles.embeddingProfileId,
+		})
+		.from(documentVectorStores)
+		.leftJoin(
+			documentEmbeddingProfiles,
+			eq(
+				documentEmbeddingProfiles.documentVectorStoreDbId,
+				documentVectorStores.dbId,
+			),
+		)
+		.where(eq(documentVectorStores.teamDbId, team.dbId))
+		.orderBy(desc(documentVectorStores.createdAt));
+
+	const storeMap = new Map<number, DocumentVectorStoreWithProfiles>();
+
+	for (const record of records) {
+		const { store, embeddingProfileId } = record;
+		const existing = storeMap.get(store.dbId);
+		if (!existing) {
+			storeMap.set(store.dbId, {
+				...store,
+				embeddingProfileIds:
+					embeddingProfileId !== null && embeddingProfileId !== undefined
+						? [embeddingProfileId]
+						: [],
+				sources: [],
+			});
+			continue;
+		}
+		if (embeddingProfileId !== null && embeddingProfileId !== undefined) {
+			existing.embeddingProfileIds.push(embeddingProfileId);
+		}
+	}
+
+	const storeDbIds = Array.from(storeMap.keys());
+	if (storeDbIds.length === 0) {
+		return [];
+	}
+
+	const sourceRecords = await db
+		.select({
+			storeDbId: documentVectorStoreSources.documentVectorStoreDbId,
+			source: documentVectorStoreSources,
+		})
+		.from(documentVectorStoreSources)
+		.where(
+			inArray(documentVectorStoreSources.documentVectorStoreDbId, storeDbIds),
+		)
+		.orderBy(desc(documentVectorStoreSources.createdAt));
+
+	for (const record of sourceRecords) {
+		const store = storeMap.get(record.storeDbId);
+		if (store) {
+			store.sources.push(record.source);
+		}
+	}
+
+	return Array.from(storeMap.values());
+}


### PR DESCRIPTION
## Summary
refactor: extract document vector store queries to shared module.

## Related Issue
part of #1827

## Changes
Move getDocumentVectorStores function from settings/data.ts to lib/vector-stores/document/queries.ts to enable reuse across the application.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->
