### PR TITLE
feat: add document vector stores API and workspace integration

### DIFF
--- a/apps/studio.giselles.ai/app/api/vector-stores/document/route.ts
+++ b/apps/studio.giselles.ai/app/api/vector-stores/document/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+import { docVectorStoreFlag } from "@/flags";
+import { getDocumentVectorStores } from "@/lib/vector-stores/document/queries";
+
+export async function GET() {
+	const enabled = await docVectorStoreFlag();
+	if (!enabled) {
+		return NextResponse.json({ error: "Not Found" }, { status: 404 });
+	}
+
+	try {
+		const stores = await getDocumentVectorStores();
+		return NextResponse.json(
+			{
+				documentVectorStores: stores.map((store) => ({
+					id: store.id,
+					name: store.name,
+					embeddingProfileIds: store.embeddingProfileIds,
+					sources: store.sources.map((source) => ({
+						id: source.id,
+						fileName: source.fileName,
+						ingestStatus: source.ingestStatus,
+						ingestErrorCode: source.ingestErrorCode,
+					})),
+				})),
+			},
+			{ status: 200 },
+		);
+	} catch (error) {
+		console.error("Failed to fetch document vector stores:", error);
+		return NextResponse.json(
+			{ error: "Failed to fetch document vector stores" },
+			{ status: 500 },
+		);
+	}
+}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -79,7 +79,7 @@ export default async function Layout({
 	const resumableGeneration = await resumableGenerationFlag();
 	const documentVectorStore = await docVectorStoreFlag();
 	const documentVectorStores = documentVectorStore
-		? await getDocumentVectorStores()
+		? await getDocumentVectorStores(workspaceTeam.dbId)
 		: [];
 	const data = await giselleEngine.getWorkspace(workspaceId, true);
 

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -17,6 +17,7 @@ import {
 	stageFlag,
 	webSearchActionFlag,
 } from "@/flags";
+import { getDocumentVectorStores } from "@/lib/vector-stores/document/queries";
 import { getGitHubRepositoryIndexes } from "@/lib/vector-stores/github";
 import { getGitHubIntegrationState } from "@/packages/lib/github";
 import { getUsageLimitsForTeam } from "@/packages/lib/usage-limits";
@@ -77,6 +78,9 @@ export default async function Layout({
 	const aiGateway = await aiGatewayFlag();
 	const resumableGeneration = await resumableGenerationFlag();
 	const documentVectorStore = await docVectorStoreFlag();
+	const documentVectorStores = documentVectorStore
+		? await getDocumentVectorStores()
+		: [];
 	const data = await giselleEngine.getWorkspace(workspaceId, true);
 
 	// return children
@@ -96,6 +100,19 @@ export default async function Layout({
 			vectorStore={{
 				githubRepositoryIndexes: gitHubRepositoryIndexes,
 				settingPath: "/settings/team/vector-stores",
+				documentSettingPath: "/settings/team/vector-stores/document",
+				githubSettingPath: "/settings/team/vector-stores",
+				documentStores: documentVectorStores.map((store) => ({
+					id: store.id,
+					name: store.name,
+					embeddingProfileIds: store.embeddingProfileIds,
+					sources: store.sources.map((source) => ({
+						id: source.id,
+						fileName: source.fileName,
+						ingestStatus: source.ingestStatus,
+						ingestErrorCode: source.ingestErrorCode,
+					})),
+				})),
 			}}
 			usageLimits={usageLimits}
 			telemetry={{

--- a/apps/studio.giselles.ai/lib/vector-stores/document/queries.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/document/queries.ts
@@ -14,10 +14,10 @@ export type DocumentVectorStoreWithProfiles =
 		sources: (typeof documentVectorStoreSources.$inferSelect)[];
 	};
 
-export async function getDocumentVectorStores(): Promise<
-	DocumentVectorStoreWithProfiles[]
-> {
-	const team = await fetchCurrentTeam();
+export async function getDocumentVectorStores(
+	teamDbId?: number,
+): Promise<DocumentVectorStoreWithProfiles[]> {
+	const targetTeamDbId = teamDbId ?? (await fetchCurrentTeam()).dbId;
 
 	const records = await db
 		.select({
@@ -32,7 +32,7 @@ export async function getDocumentVectorStores(): Promise<
 				documentVectorStores.dbId,
 			),
 		)
-		.where(eq(documentVectorStores.teamDbId, team.dbId))
+		.where(eq(documentVectorStores.teamDbId, targetTeamDbId))
 		.orderBy(desc(documentVectorStores.createdAt));
 
 	const storeMap = new Map<number, DocumentVectorStoreWithProfiles>();

--- a/packages/giselle/src/react/vector-store/context.tsx
+++ b/packages/giselle/src/react/vector-store/context.tsx
@@ -11,7 +11,20 @@ export interface VectorStoreContextValue {
 			embeddingProfileIds: number[];
 		}[];
 	}[];
-	settingPath: string;
+	documentStores?: {
+		id: string;
+		name: string;
+		embeddingProfileIds: number[];
+		sources: Array<{
+			id: string;
+			fileName: string;
+			ingestStatus: "idle" | "running" | "completed" | "failed";
+			ingestErrorCode: string | null;
+		}>;
+	}[];
+	settingPath?: string;
+	documentSettingPath?: string;
+	githubSettingPath?: string;
 }
 
 export const VectorStoreContext = createContext<


### PR DESCRIPTION
## Summary
- Extracted document vector store queries to a shared module for reusability
- Added API endpoint (`/api/vector-stores/document`) for fetching document vector stores
- Integrated document vector stores into workspace context for frontend consumption
- Enhanced vector store context with document store support and separate setting paths

## Related Issue
part of #1827

## Changes
- Created `lib/vector-stores/document/queries.ts` with `getDocumentVectorStores()` function
- Refactored settings page to use the shared query module (removed 82 lines of duplication)
- Added `teamDbId` parameter support to allow flexible team-scoped queries
- Provided document stores in workspace layout behind feature flag
- Extended `VectorStoreContext` type to include document stores and granular setting paths

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
I will implement the UI in the next PR.