### PR TITLE
refactor: Extract reusable GitHub setup badge component

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx
@@ -4,7 +4,6 @@ import {
 	isTriggerNode,
 	isVectorStoreNode,
 } from "@giselle-sdk/data-type";
-import { CircleAlertIcon } from "lucide-react";
 import type { ReactElement } from "react";
 import { useGitHubVectorStoreStatus } from "../../lib/use-github-vector-store-status";
 import {
@@ -12,17 +11,7 @@ import {
 	GitHubRepositoryBadgeFromRepo,
 	GitHubRepositoryBadgeFromTrigger,
 } from "./";
-
-function RequiresSetupBadge(): ReactElement {
-	return (
-		<div className="flex items-center justify-center">
-			<div className="inline-flex items-center justify-center text-slate-400 font-semibold rounded-full text-[12px] pl-[10px] pr-[12px] py-2 gap-[6px] animate-pulse [animation-duration:2s]">
-				<CircleAlertIcon className="size-[18px]" />
-				<span>REQUIRES SETUP</span>
-			</div>
-		</div>
-	);
-}
+import { RequiresSetupBadge } from "./requires-setup-badge";
 
 export function GitHubNodeInfo({
 	node,

--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/index.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/index.ts
@@ -2,3 +2,4 @@ export * from "./github-node-info";
 export * from "./github-repository-badge";
 export * from "./github-repository-badge-from-repo";
 export * from "./github-repository-badge-from-trigger";
+export * from "./requires-setup-badge";

--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/requires-setup-badge.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/requires-setup-badge.tsx
@@ -1,0 +1,13 @@
+import { CircleAlertIcon } from "lucide-react";
+import type { ReactElement } from "react";
+
+export function RequiresSetupBadge(): ReactElement {
+	return (
+		<div className="flex items-center justify-center">
+			<div className="inline-flex items-center justify-center text-slate-400 font-semibold rounded-full text-[12px] pl-[10px] pr-[12px] py-2 gap-[6px] animate-pulse [animation-duration:2s]">
+				<CircleAlertIcon className="size-[18px]" />
+				<span>REQUIRES SETUP</span>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
### **User description**
## Summary
refactor: Extract reusable GitHub setup badge component.

## Related Issue
part of #1827

## Changes
- move RequiresSetupBadge into its own module so other node UIs can share it
- replace the inline badge definition in GitHubNodeInfo with an import of the new component
- re-export the badge from the node UI index for consistent consumption

## Testing
https://github.com/giselles-ai/giselle/pull/1916#issuecomment-3363896850

## Other Information
This PR is a preliminary step to use this batch in Document Vector Store Node.

___

### **PR Type**
Enhancement


___

### **Description**
- Extract `RequiresSetupBadge` component into reusable module

- Enable component sharing across different node UIs

- Add proper export structure for consistent consumption


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHubNodeInfo component"] -- "extract" --> B["RequiresSetupBadge module"]
  B -- "import" --> A
  B -- "export" --> C["UI index module"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requires-setup-badge.tsx</strong><dd><code>Create standalone RequiresSetupBadge component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/node/ui/requires-setup-badge.tsx

<ul><li>Create new standalone component file<br> <li> Move <code>RequiresSetupBadge</code> component with CircleAlert icon<br> <li> Maintain original styling and animation properties</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1916/files#diff-d8898edd8081cf42fc94f006a231dce78a3891b0e8483c3d422d9d4767379ed5">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github-node-info.tsx</strong><dd><code>Replace inline component with import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/node/ui/github-node-info.tsx

<ul><li>Remove inline <code>RequiresSetupBadge</code> component definition<br> <li> Add import statement for extracted component<br> <li> Clean up unused CircleAlertIcon import</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1916/files#diff-04a432f5330b71ae1b0607d73e3e5f13b6fd8e61211f48e922424e0527ee48c7">+1/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export new RequiresSetupBadge component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/node/ui/index.ts

<ul><li>Add export for <code>requires-setup-badge</code> module<br> <li> Enable external consumption of the component</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1916/files#diff-60299ccf90ab0c08f671300cc89db5bb4efff38e932a70d836ac270e2c5f0b53">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Requires Setup” badge on applicable GitHub nodes, with a pulsing alert icon to clearly highlight configuration needs.
- Style
  - Unified and polished badge styling across trigger, repo, and vector store paths for a consistent experience.
- Refactor
  - Centralized the badge into a shared UI component and made it available via the UI package for reuse, improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->