### PR TITLE
feat: Improve query panel document store display

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -1,15 +1,57 @@
 import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
 import { isVectorStoreNode, type QueryNode } from "@giselle-sdk/data-type";
-import { defaultName, useWorkflowDesigner } from "@giselle-sdk/giselle/react";
+import {
+	defaultName,
+	useVectorStore,
+	useWorkflowDesigner,
+	type VectorStoreContextValue,
+} from "@giselle-sdk/giselle/react";
 import { TextEditor } from "@giselle-sdk/text-editor/react-internal";
 import { createSourceExtensionJSONContent } from "@giselle-sdk/text-editor-utils";
 import { AtSignIcon, DatabaseZapIcon, X } from "lucide-react";
 import { Toolbar } from "radix-ui";
 import { useMemo } from "react";
 import { GitHubIcon } from "../../../icons";
+import { DocumentVectorStoreIcon } from "../../../icons/node/document-vector-store-icon";
 import { type ConnectedSource, useConnectedSources } from "./sources";
 
-function getDataSourceDisplayInfo(input: ConnectedSource): {
+type DocumentVectorStoreSummary = NonNullable<
+	NonNullable<VectorStoreContextValue["documentStores"]>[number]
+>;
+
+function getDocumentStoreStatus(store?: DocumentVectorStoreSummary): string {
+	if (!store) {
+		return "Store unavailable";
+	}
+	const total = store.sources.length;
+	if (total === 0) {
+		return "No uploads yet";
+	}
+	const failed = store.sources.filter(
+		(source) => source.ingestStatus === "failed",
+	).length;
+	if (failed > 0) {
+		return `${failed}/${total} failed`;
+	}
+	const running = store.sources.filter(
+		(source) => source.ingestStatus === "running",
+	).length;
+	if (running > 0) {
+		return `${running}/${total} processing`;
+	}
+	const completed = store.sources.filter(
+		(source) => source.ingestStatus === "completed",
+	).length;
+	if (completed === total) {
+		return `${total} ready`;
+	}
+	return `${completed}/${total} ready`;
+}
+
+function getDataSourceDisplayInfo(
+	input: ConnectedSource,
+	documentStoreMap: Map<string, DocumentVectorStoreSummary>,
+): {
 	name: string;
 	description: { line1: string; line2?: string };
 	icon: React.ReactElement;
@@ -17,10 +59,12 @@ function getDataSourceDisplayInfo(input: ConnectedSource): {
 	const node = input.node;
 	if (isVectorStoreNode(node)) {
 		const name = node.name ?? "Vector Store";
-		const icon = <GitHubIcon className="w-[14px] h-[14px]" />;
 
 		switch (node.content.source.provider) {
 			case "github": {
+				const icon = (
+					<GitHubIcon className="w-[14px] h-[14px]" aria-hidden="true" />
+				);
 				if (node.content.source.state.status === "configured") {
 					const { owner, repo, contentType } = node.content.source.state;
 					const typeLabel =
@@ -44,11 +88,30 @@ function getDataSourceDisplayInfo(input: ConnectedSource): {
 				};
 			}
 			case "document": {
+				const icon = (
+					<DocumentVectorStoreIcon
+						className="w-[14px] h-[14px]"
+						aria-hidden="true"
+					/>
+				);
+				if (node.content.source.state.status !== "configured") {
+					return {
+						name,
+						description: {
+							line1: name,
+							line2: "Requires setup",
+						},
+						icon,
+					};
+				}
+				const store = documentStoreMap.get(
+					node.content.source.state.documentVectorStoreId,
+				);
 				return {
-					name,
+					name: store?.name ?? name,
 					description: {
-						line1: "Document",
-						line2: node.content.source.state.status,
+						line1: store?.name ?? name,
+						line2: getDocumentStoreStatus(store),
 					},
 					icon,
 				};
@@ -61,13 +124,22 @@ function getDataSourceDisplayInfo(input: ConnectedSource): {
 		description: {
 			line1: "Unknown source",
 		},
-		icon: <DatabaseZapIcon className="w-[14px] h-[14px]" />,
+		icon: <DatabaseZapIcon className="w-[14px] h-[14px]" aria-hidden="true" />,
 	};
 }
 
 export function QueryPanel({ node }: { node: QueryNode }) {
 	const { updateNodeDataContent, deleteConnection, updateNodeData } =
 		useWorkflowDesigner();
+	const vectorStore = useVectorStore();
+	const documentStores = vectorStore?.documentStores ?? [];
+	const documentStoreMap = useMemo(() => {
+		const map = new Map<string, DocumentVectorStoreSummary>();
+		documentStores.forEach((store) => {
+			map.set(store.id, store);
+		});
+		return map;
+	}, [documentStores]);
 	const { all: connectedInputs } = useConnectedSources(node);
 	const connectedDatasourceInputs = useMemo(
 		() =>
@@ -106,75 +178,89 @@ export function QueryPanel({ node }: { node: QueryNode }) {
 									Querying {connectedDatasourceInputs.length} data source
 									{connectedDatasourceInputs.length !== 1 ? "s" : ""}:
 								</span>
-								{connectedDatasourceInputs.map((dataSource) => {
-									const { name, description, icon } =
-										getDataSourceDisplayInfo(dataSource);
+								<ul className="flex items-center gap-[6px] flex-wrap m-0 p-0 list-none">
+									{connectedDatasourceInputs.map((dataSource) => {
+										const { name, description, icon } =
+											getDataSourceDisplayInfo(dataSource, documentStoreMap);
+										const labelPieces = [
+											name,
+											description.line1,
+											description.line2,
+										]
+											.filter((piece): piece is string =>
+												Boolean(piece?.trim()),
+											)
+											.map((piece) => piece.trim());
 
-									return (
-										<div
-											key={dataSource.connection.id}
-											className="flex items-center gap-[6px] px-[8px] py-[4px] rounded-[6px]"
-											style={{
-												backgroundColor: "rgba(131, 157, 195, 0.15)",
-												borderColor: "rgba(131, 157, 195, 0.25)",
-												border: "1px solid",
-												color: "#839DC3",
-											}}
-										>
-											<div className="shrink-0" style={{ color: "#839DC3" }}>
-												{icon}
-											</div>
-											<div className="flex flex-col leading-tight">
-												<span
-													className="text-[10px] font-medium"
-													style={{ color: "#839DC3" }}
-													title={`${name} • ${description.line1}${description.line2 ? ` • ${description.line2}` : ""}`}
-												>
-													{description.line1}
-												</span>
-												{description.line2 && (
-													<span
-														className="text-[9px] opacity-70"
-														style={{ color: "#839DC3" }}
-													>
-														{description.line2}
-													</span>
-												)}
-											</div>
-											<button
-												type="button"
-												onClick={() => {
-													// Remove the connection between Vector Store and this Query node
-													deleteConnection(dataSource.connection.id);
-													// Also remove the dynamically created input associated with this connection
-													updateNodeData(node, {
-														inputs: node.inputs.filter(
-															(input) =>
-																input.id !== dataSource.connection.inputId,
-														),
-													});
-												}}
-												className="ml-1 p-0.5 rounded transition-colors"
+										return (
+											<li
+												key={dataSource.connection.id}
+												className="flex items-center gap-[6px] px-[8px] py-[4px] rounded-[6px]"
 												style={{
-													color: "rgba(131, 157, 195, 0.7)",
+													backgroundColor: "rgba(131, 157, 195, 0.15)",
+													borderColor: "rgba(131, 157, 195, 0.25)",
+													border: "1px solid",
+													color: "#839DC3",
 												}}
-												onMouseEnter={(e) => {
-													e.currentTarget.style.color = "#839DC3";
-													e.currentTarget.style.backgroundColor =
-														"rgba(131, 157, 195, 0.2)";
-												}}
-												onMouseLeave={(e) => {
-													e.currentTarget.style.color =
-														"rgba(131, 157, 195, 0.7)";
-													e.currentTarget.style.backgroundColor = "transparent";
-												}}
-												title="Remove data source"
+												aria-label={labelPieces.join(", ")}
 											>
-												<X className="w-3 h-3" />
-											</button>
-										</div>
-									);
-								})}
+												<div className="shrink-0" style={{ color: "#839DC3" }}>
+													{icon}
+												</div>
+												<div className="flex flex-col leading-tight">
+													<span
+														className="text-[10px] font-medium"
+														style={{ color: "#839DC3" }}
+														title={`${name} • ${description.line1}${description.line2 ? ` • ${description.line2}` : ""}`}
+													>
+														{description.line1}
+													</span>
+													{description.line2 && (
+														<span
+															className="text-[9px] opacity-70"
+															style={{ color: "#839DC3" }}
+														>
+															{description.line2}
+														</span>
+													)}
+												</div>
+												<button
+													type="button"
+													aria-label={`Disconnect ${name}`}
+													onClick={() => {
+														// Remove the connection between Vector Store and this Query node
+														deleteConnection(dataSource.connection.id);
+														// Also remove the dynamically created input associated with this connection
+														updateNodeData(node, {
+															inputs: node.inputs.filter(
+																(input) =>
+																	input.id !== dataSource.connection.inputId,
+															),
+														});
+													}}
+													className="ml-1 p-0.5 rounded transition-colors"
+													style={{
+														color: "rgba(131, 157, 195, 0.7)",
+													}}
+													onMouseEnter={(e) => {
+														e.currentTarget.style.color = "#839DC3";
+														e.currentTarget.style.backgroundColor =
+															"rgba(131, 157, 195, 0.2)";
+													}}
+													onMouseLeave={(e) => {
+														e.currentTarget.style.color =
+															"rgba(131, 157, 195, 0.7)";
+														e.currentTarget.style.backgroundColor =
+															"transparent";
+													}}
+													title="Remove data source"
+												>
+													<X className="w-3 h-3" />
+												</button>
+											</li>
+										);
+									})}
+								</ul>
 							</div>
 						) : (
 							<div className="flex items-center gap-[6px]">

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -24,6 +24,9 @@ function getDocumentStoreStatus(
 	fallbackStatus?: string,
 ): string {
 	if (!store) {
+		if (fallbackStatus === "configured") {
+			return "Requires setup";
+		}
 		return fallbackStatus ?? "Store unavailable";
 	}
 	const total = store.sources.length;

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -19,9 +19,12 @@ type DocumentVectorStoreSummary = NonNullable<
 	NonNullable<VectorStoreContextValue["documentStores"]>[number]
 >;
 
-function getDocumentStoreStatus(store?: DocumentVectorStoreSummary): string {
+function getDocumentStoreStatus(
+	store: DocumentVectorStoreSummary | undefined,
+	fallbackStatus?: string,
+): string {
 	if (!store) {
-		return "Store unavailable";
+		return fallbackStatus ?? "Store unavailable";
 	}
 	const total = store.sources.length;
 	if (total === 0) {
@@ -107,11 +110,21 @@ function getDataSourceDisplayInfo(
 				const store = documentStoreMap.get(
 					node.content.source.state.documentVectorStoreId,
 				);
+				const storeStatus = getDocumentStoreStatus(
+					store,
+					node.content.source.state.status,
+				);
+				const nodeLabel = name;
+				const storeName = store?.name?.trim() ?? "";
+				const descriptionLine1 =
+					storeName.length > 0 && storeName !== nodeLabel
+						? storeName
+						: "Document vector store";
 				return {
-					name: store?.name ?? name,
+					name: nodeLabel,
 					description: {
-						line1: store?.name ?? name,
-						line2: getDocumentStoreStatus(store),
+						line1: descriptionLine1,
+						line2: storeStatus,
 					},
 					icon,
 				};

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -104,7 +104,7 @@ function getDataSourceDisplayInfo(
 					return {
 						name,
 						description: {
-							line1: name,
+							line1: "Document vector store",
 							line2: "Requires setup",
 						},
 						icon,

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx
@@ -16,8 +16,8 @@ import { DocumentVectorStoreIcon } from "../../../icons/node/document-vector-sto
 import { type ConnectedSource, useConnectedSources } from "./sources";
 
 type DocumentVectorStoreSummary = NonNullable<
-	NonNullable<VectorStoreContextValue["documentStores"]>[number]
->;
+	VectorStoreContextValue["documentStores"]
+>[number];
 
 function getDocumentStoreStatus(
 	store: DocumentVectorStoreSummary | undefined,


### PR DESCRIPTION
### **User description**
## Summary
Improve query panel document store display.

https://github.com/user-attachments/assets/650cfabe-74bd-4a4b-b5c2-d984ba508968

## Related Issue
part of #1827

## Changes
- pull document store metadata from the vector store context to show friendly names and ingest status
- add helper utilities for summarizing document store state and reuse them when building connected source descriptors
- swap in the document vector store icon and enrich the rendered list with ARIA labels and tooltips for better accessibility

## Testing
https://github.com/giselles-ai/giselle/pull/1920#issuecomment-3364110197

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced query panel document store display with metadata

- Added document store status tracking and friendly names

- Improved accessibility with ARIA labels and tooltips

- Replaced generic icons with document vector store icons


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Vector Store Context"] --> B["Document Store Map"]
  B --> C["Status Summary"]
  C --> D["Enhanced Display"]
  D --> E["ARIA Labels & Tooltips"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query-panel.tsx</strong><dd><code>Enhanced query panel with document store metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/query-node-properties-panel/query-panel.tsx

<ul><li>Added vector store context integration for document metadata<br> <li> Created document store status tracking utility function<br> <li> Enhanced display with friendly names and ingest status<br> <li> Improved accessibility with ARIA labels and semantic HTML<br> <li> Replaced generic icons with document vector store icons</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1920/files#diff-2f277cc52b1175885fefa342e968f15baeb98b0ab10803c97192777b2cbfd05e">+157/-71</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query panel shows document-store aware names, icons and human-readable statuses for document-backed sources; connected sources render as a focused list with per-item disconnect preserved.
* **Accessibility**
  * Added ARIA labels and aria-hidden on icons; improved titles and screen-reader text structure for list items and controls.
* **Style**
  * Refined item typography, line descriptions and font sizes for clearer scanning and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Query panel now reads document store metadata from context to show friendly names and ingest status, updates icons, and improves accessibility of the connected sources list.
> 
> - **UI/UX**:
>   - Pull document store metadata via `useVectorStore` and build `documentStoreMap` to display friendly names and ingest status in connected sources.
>   - Add `getDocumentStoreStatus` and extend `getDataSourceDisplayInfo` to summarize document-backed sources.
>   - Replace generic icons with `DocumentVectorStoreIcon`; mark decorative icons with `aria-hidden`.
>   - Render connected sources as a semantic list and add ARIA labels/tooltips; add accessible labels to the disconnect control.
> - **Editor Integration**:
>   - Pass updated connected data source descriptors to the query editor header without altering editor behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da13405725965ba8b101b9bfa47ec9a3f0e87c4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->