### PR TITLE
fix: After copying a node, make the pasted node the active selection.

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/node/use-node-manipulation.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/node/use-node-manipulation.ts
@@ -7,7 +7,8 @@ const OFFSET_X = 200;
 const OFFSET_Y = 100;
 
 export function useNodeManipulation() {
-	const { data, copyNode, copiedNode, setCopiedNode } = useWorkflowDesigner();
+	const { data, copyNode, copiedNode, setCopiedNode, setUiNodeState } =
+		useWorkflowDesigner();
 
 	const copy = useCallback(
 		(onError?: () => void) => {
@@ -44,13 +45,16 @@ export function useNodeManipulation() {
 			// Validate the copied node using Zod schema
 			try {
 				const validatedNode = Node.parse(copiedNode);
-				copyNode(validatedNode, { ui: { position } });
+				copyNode(validatedNode, {
+					ui: { position, selected: true },
+				});
+				setUiNodeState(copiedNode.id, { selected: false });
 			} catch (error) {
 				console.error("Failed to paste node - validation error:", error);
 				onError?.();
 			}
 		},
-		[copiedNode, data.ui.nodeState, copyNode],
+		[copiedNode, data.ui.nodeState, copyNode, setUiNodeState],
 	);
 
 	const duplicate = useCallback(


### PR DESCRIPTION
## Summary

  - Fixes the issue where pasting a node kept the original node selected; the pasted node is now auto-selected for immediate editing.

  ## Related Issue
N/A

  ## Changes

  - Updated useNodeManipulation so copyNode marks the cloned node as selected: true.
  - Added a call to setUiNodeState right after paste to clear the selection on the source node.

  ## Testing

  - Manually verified in the workflow editor: select a node → Cmd+C → Cmd+V → the newly pasted node becomes the active selection.

  ## Other Information
