### PR TITLE
chore(svg): use currentColor in GoogleWhiteIcon (Phase 3 v3.x-4)

### DIFF
--- a/internal-packages/workflow-designer-ui/src/icons/google.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/google.tsx
@@ -38,7 +38,7 @@ export const GoogleWhiteIcon: FC<SVGProps<SVGSVGElement>> = ({
 		xmlns="http://www.w3.org/2000/svg"
 		viewBox="0 0 48 48"
 		role="graphics-symbol"
-		className={clsx("fill-white-900", className)}
+		className={clsx("fill-current", className)}
 		{...props}
 	>
 		<path d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z" />


### PR DESCRIPTION
### **User description**
### **Purpose**

Convert part of the SVG color definitions to use `currentColor` for theme-aware rendering.
This enables the icons to automatically follow the text color and improves flexibility for theme or scope switching.

---

### **Modified Files**

```
internal-packages/workflow-designer-ui/src/icons/google.tsx (GoogleWhiteIcon)
```

---

### **Expected Impact**

* Icons now inherit color from the parent’s `color` property
* Enhances consistency with text color and supports dynamic theme changes

---

### **Risk**

* Icon color will follow the parent’s `color`, which may lead to unintended inheritance in some layouts

---

### **Verification**

* Visual QA on the target icon to confirm correct color rendering
* `format / test` passed

---

### **Checklist**

* [x] No breaking changes
* [x] Tests passed
* [x] Visual QA completed

---


___

### **PR Type**
Enhancement


___

### **Description**
- Replace hardcoded white fill with `currentColor` in GoogleWhiteIcon

- Enable theme-aware color inheritance from parent elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GoogleWhiteIcon"] -- "replace" --> B["fill-white-900"] 
  B -- "with" --> C["fill-current"]
  C --> D["Theme-aware coloring"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google.tsx</strong><dd><code>Replace hardcoded white with currentColor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/icons/google.tsx

<ul><li>Changed className from <code>fill-white-900</code> to <code>fill-current</code><br> <li> Enables dynamic color inheritance from parent elements</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1929/files#diff-1ad6da2fcfe5b23ff21528e885433afbafddc80b8fbb845679ceceb446547ff6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `GoogleWhiteIcon` to use `fill-current` so it inherits parent text color.
> 
> - **Icons**:
>   - Update `GoogleWhiteIcon` in `internal-packages/workflow-designer-ui/src/icons/google.tsx` to use `className={clsx("fill-current", className)}` instead of `fill-white-900` for theme-aware coloring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d66533d0b496188b2be4c17b8736268879d63ac5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->