### PR TITLE
chore(ci,semantic): add colors report and semantic.css scaffold (PR v…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,7 @@ jobs:
       - run: pnpm knip
       - name: Build SDK
         run: pnpm build-sdk
+      - name: Report Colors (non-blocking)
+        run: pnpm report:colors || true
       - name: Test
         run: pnpm test

--- a/internal-packages/ui/styles/semantic.css
+++ b/internal-packages/ui/styles/semantic.css
@@ -1,0 +1,13 @@
+/* semantic.css (Phase 1.5 scaffold) - not applied globally yet */
+
+@layer utilities {
+	:root {
+		/* map semantic vars to primitives (light defaults) */
+		--color-text: var(--color-gray-50);
+		--color-text-inverse: var(--color-white);
+		--color-surface: var(--color-gray-950);
+		--color-border: var(--color-gray-700);
+		--color-border-muted: var(--color-gray-800);
+		--color-focused: var(--color-info-500);
+	}
+}


### PR DESCRIPTION
### **Purpose**

Add a foundational scaffold for the upcoming **semantic color system** (not yet applied) and introduce a **color report step** in CI (non-blocking, warning level).
This prepares the groundwork for the v4 migration and enables early visibility into raw color usage.

---

### **Modified Files**

```
internal-packages/ui/styles/semantic.css   (initial light values → primitives map)
.github/workflows/ci.yml                   (adds non-blocking `pnpm report:colors` step)
```

---

### **Expected Impact**

* Establish the base structure for semantic color variables in preparation for v4
* Surface direct/raw color usage in CI logs for easier detection (to be made fail-on-later)
* No runtime effect on existing UI since `semantic.css` is not yet applied

---

### **Risk**

* None for current UI; `semantic.css` is dormant (not imported)
* CI logs will include color report output but will not block merges

---

### **Verification**

* Confirmed CI outputs color report successfully (no failures)
* `format / build-sdk / test` passed

---

### **Checklist**

* [x] No breaking changes
* [x] Build & tests passed
* [x] CI color report verified
* [ ] (Planned) Add minimal usage note to `docs/README` in a follow-up commit/PR

---
