### PR TITLE
ci: upload color report artifact; docs: add Tailwind v4 verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,16 @@ jobs:
       - run: pnpm knip
       - name: Build SDK
         run: pnpm build-sdk
+      - name: Report Colors (non-blocking)
+        run: pnpm report:colors || true
+      - name: Save Report Colors JSON
+        if: always()
+        run: pnpm report:colors:out || true
+      - name: Upload Report Artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-colors
+          path: .reports/report-colors.json
       - name: Test
         run: pnpm test

--- a/docs/tailwind-v4-verification.md
+++ b/docs/tailwind-v4-verification.md
@@ -1,0 +1,18 @@
+# Tailwind v4 verification (non-breaking)
+
+This document outlines the minimal checks to verify token readiness for Tailwind v4.
+
+## Goals
+- Confirm `@theme` primitives are present and consistent (`internal-packages/ui/styles/tokens.css`).
+- Ensure v3 bridge (`aliases.css`) provides required semantic utilities.
+- Validate CI color report JSON is generated and uploaded as artifact.
+
+## Steps
+1. Review tokens in `tokens.css` and confirm coverage for neutrals/brand/status.
+2. Confirm semantic scaffold exists (`semantic-tokens.md`) and is not globally applied.
+3. On any PR, download the `report-colors` artifact from CI and inspect counts.
+4. Prepare an isolated playground branch for the actual v4 bump (separate PR).
+
+No runtime changes in this PR.
+
+


### PR DESCRIPTION
### **User description**
### Summary
Add a non-breaking verification step for Tailwind v4 readiness. This PR introduces CI artifacts and a short checklist to validate tokens and the v3→v4 bridge before the actual upgrade.

### Changes
- Add CI artifact for color reports:
  - Run the existing color report and upload `.reports/report-colors.json` as a GitHub Actions artifact (non-blocking).
- Add docs:
  - `docs/tailwind-v4-verification.md`: a minimal checklist to verify `@theme` primitives, v3 bridge availability, and report visibility.

### Behavior
- No runtime or styling changes.
- CI now always uploads a “report-colors” artifact for inspection.
- Build remains green; steps are non-blocking.

### Why
- Ensure `@theme` primitives (tokens) and the v3 bridge are in place and consistent before bumping to Tailwind v4.
- Provide visibility into color usage via downloadable CI artifacts.

### How to Test
- Open a PR and confirm the “report-colors” artifact is uploaded by CI.
- Download and inspect the JSON; verify counts align with expectations.
- Review `docs/tailwind-v4-verification.md` and check coverage for neutrals/brand/status tokens and semantic scaffolding.

### Future Work
- Create a separate, single-purpose PR to upgrade to Tailwind v4.
- After upgrade, begin staged deprecation of the v3 bridge (aliases) and tighten guards (warnings → errors).

### Checklist
- Non-breaking (CI + docs only)
- Formatted/linted; tests unchanged
- No public API changes


___

### **PR Type**
Other


___

### **Description**
- Add CI artifact upload for color reports

- Create Tailwind v4 verification documentation

- Enable non-blocking color report generation in CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI["CI Workflow"] --> ColorReport["Generate Color Report"]
  ColorReport --> Artifact["Upload report-colors Artifact"]
  Docs["Verification Docs"] --> Checklist["v4 Readiness Checklist"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add color report artifact upload to CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add non-blocking color report generation step<br> <li> Add step to save color report JSON output<br> <li> Add artifact upload for report-colors with JSON file</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1933/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tailwind-v4-verification.md</strong><dd><code>Add Tailwind v4 verification documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tailwind-v4-verification.md

<ul><li>Create verification checklist for Tailwind v4 readiness<br> <li> Document steps to validate tokens and v3 bridge<br> <li> Outline CI artifact inspection process</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1933/files#diff-67910f17ecd5e7c5b7798400c7b335c69a9b2fe4547a773ceb96435d90da7e33">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Always generate and upload the color report JSON in CI and add a Tailwind v4 readiness checklist doc.
> 
> - **CI**:
>   - Always save color report JSON via `pnpm report:colors:out` and upload `.reports/report-colors.json` as `report-colors` using `actions/upload-artifact@v4` (`.github/workflows/ci.yml`).
> - **Docs**:
>   - Add `docs/tailwind-v4-verification.md` outlining minimal checks for `@theme` tokens, v3 bridge, and CI artifact inspection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e78c93b64b010a8a498c27bad2fef334ef3c63f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a Tailwind v4 verification guide outlining how to validate design tokens, semantic scaffolding, and color reporting, with instructions for inspecting CI artifacts and planning an isolated v4 upgrade.
  - Clarifies that there are no runtime changes in this update.

- Chores
  - Enhanced CI to always generate and upload a color report artifact, ensuring visibility of results even when previous steps fail or are non-blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->