### PR TITLE
chore(settings): replace white/black bg-/border-* with semantic/alias…

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
@@ -120,7 +120,7 @@ export function RepositoryItem({
 	return (
 		<div
 			className={cn(
-				"group relative rounded-[12px] overflow-hidden w-full bg-white/[0.02] backdrop-blur-[8px] border-[0.5px] border-white/8 shadow-[inset_0_1px_1px_rgba(255,255,255,0.4),inset_0_-1px_1px_rgba(255,255,255,0.2)] before:content-[''] before:absolute before:inset-0 before:bg-white before:opacity-[0.02] before:rounded-[inherit] before:pointer-events-none hover:border-white/12 transition-colors duration-200",
+				"group relative rounded-[12px] overflow-hidden w-full bg-white/[0.02] backdrop-blur-[8px] border-[0.5px] border-border shadow-[inset_0_1px_1px_rgba(255,255,255,0.4),inset_0_-1px_1px_rgba(255,255,255,0.2)] before:content-[''] before:absolute before:inset-0 before:bg-white before:opacity-[0.02] before:rounded-[inherit] before:pointer-events-none hover:border-border transition-colors duration-200",
 			)}
 		>
 			<div className="px-[24px] py-[16px]">
@@ -148,7 +148,7 @@ export function RepositoryItem({
 							</DropdownMenuTrigger>
 							<DropdownMenuContent
 								align="end"
-								className="w-[180px] bg-black-850 border-[0.5px] border-black-400 rounded-[8px]"
+								className="w-[180px] bg-surface border-[0.5px] border-border-muted rounded-[8px]"
 							>
 								<DropdownMenuItem
 									onClick={handleManualIngest}
@@ -464,7 +464,7 @@ function SyncStatusBadge({
 				type="button"
 				aria-label="Verify repository status"
 				onClick={onVerify}
-				className="flex items-center px-2 py-1 rounded-full border border-white/20 w-auto hover:bg-white/5 transition-colors duration-200"
+				className="flex items-center px-2 py-1 rounded-full border border-border w-auto hover:bg-white/5 transition-colors duration-200"
 			>
 				{badgeContent}
 			</button>


### PR DESCRIPTION
### **User description**
### Summary
Safely replace hardcoded white/black bg-/border- utilities with semantic/bridge aliases in the settings repository item. Small, focused change as part of Phase 3.

### Changes
- apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
  - `bg-black-*/bg-white-*` → `bg-surface` (surface alias)
  - `border-white-*`/`border-black-*` → `border-border` / `border-border-muted`
  - Dropdown surface now uses `bg-surface` + `border-border-muted`
  - Status badge buttons use `border-border`

### Behavior
- No logic changes; visual differences should be negligible. Aliases map to the same dark-surface semantics via the v3 bridge.

### Why
- Reduce direct color dependencies and align with token/semantic usage.
- Prepare for Tailwind v4 and staged removal of the v3 bridge.

### How to Review
- Open the repository item in settings (dark background).
- Verify dropdown surface, badge borders, and hover states look the same.

### Follow-ups
- Continue the same replacements on remaining settings files (`team-members-list-item.tsx`, etc.) as small PRs.
- Add minimal aliases only if a missing variant appears (separate tiny PR).

### Checklist
- Formatted, built, and tests pass
- Scope-limited, non-breaking


___

### **PR Type**
Other


___

### **Description**
- Replace hardcoded white/black border utilities with semantic aliases

- Update dropdown menu styling to use semantic tokens

- Replace status badge border with semantic border token


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Colors"] --> B["Semantic Tokens"]
  B --> C["border-white/8"] 
  B --> D["border-border"]
  B --> E["border-black-400"]
  B --> F["border-border-muted"]
  C --> D
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repository-item.tsx</strong><dd><code>Replace hardcoded borders with semantic tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx

<ul><li>Replace <code>border-white/8</code> and <code>hover:border-white/12</code> with <code>border-border</code><br> <li> Update dropdown menu from <code>bg-black-850 border-black-400</code> to <code>bg-surface </code><br><code>border-border-muted</code><br> <li> Change status badge button border from <code>border-white/20</code> to <br><code>border-border</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1937/files#diff-7081ecafde073350a2fc722beae87dd986b2f8d55ca73cd48ffdfe62908296c6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace hardcoded white/black classes with semantic `bg-surface`, `border-border`, and `border-border-muted` in the repository item and dropdown.
> 
> - **Styling** (`apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx`):
>   - Card/container uses `border-border` (incl. hover) instead of `border-white/*`.
>   - Dropdown menu uses `bg-surface` and `border-border-muted` instead of `bg-black-850`/`border-black-400`.
>   - Status badge verify button uses `border-border` instead of `border-white/20`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97f7f2b9715d701ce6d7aa4a93ad033b69aa72c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed styling in Settings > Team > Vector Stores repository items: updated container borders, dropdown background/border, and verify button border to new theme tokens.
  * Updated Sync Status badge with a new border color for visual consistency.
  * Changes affect appearance only; no functional or behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->