### PR TITLE
chore(settings): replace white/black borders and surfaces with semantic/aliases in team members item (Phase 3)

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx
@@ -141,7 +141,7 @@ export function TeamMemberListItem({
 								</DropdownMenuTrigger>
 								<DropdownMenuContent
 									align="end"
-									className="p-1 border-[0.25px] border-white/10 rounded-[8px] min-w-[165px] bg-black-900 shadow-none"
+									className="p-1 border-[0.25px] border-border-muted rounded-[8px] min-w-[165px] bg-surface shadow-none"
 								>
 									{canEditRole && (
 										<>
@@ -179,7 +179,7 @@ export function TeamMemberListItem({
 												Remove
 											</button>
 										</AlertDialogTrigger>
-										<AlertDialogContent className="border-[0.5px] border-black-400 rounded-[8px] bg-black-850">
+										<AlertDialogContent className="border-[0.5px] border-border rounded-[8px] bg-surface">
 											<AlertDialogHeader>
 												<AlertDialogTitle className="text-white-400 text-[20px] leading-[29px] font-geist">
 													Remove Member
@@ -191,7 +191,7 @@ export function TeamMemberListItem({
 											</AlertDialogHeader>
 											<AlertDialogFooter className="mt-4">
 												<AlertDialogCancel
-													className="py-2 px-4 border-[0.5px] border-black-400 rounded-[8px] font-sans"
+													className="py-2 px-4 border-[0.5px] border-border rounded-[8px] font-sans"
 													disabled={isLoading}
 												>
 													Cancel


### PR DESCRIPTION
### **User description**
### Summary
Continue Phase 3 by replacing hardcoded white/black borders and dark surfaces with semantic/bridge aliases in the team members list item. Small, safe-scoped change.

### Changes
- apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx
  - `bg-black-*/bg-white-*` surfaces → `bg-surface`
  - `border-white-*`/`border-black-*` → `border-border` / `border-border-muted` (where applicable)
  - Dialog surfaces/borders and dropdown surfaces now use semantic/bridge aliases

### Behavior
- No logic changes. Visual differences should be negligible; aliases map to equivalent dark-surface semantics via the v3 bridge.

### Why
- Reduce direct color coupling and move toward token/semantic usage.
- Preparation for Tailwind v4 and staged removal of the v3 bridge.

### How to Review
- Open the team members list UI in settings (dark background).
- Verify dialog and dropdown surfaces/borders and hover states look unchanged with proper contrast.

### Follow-ups
- Continue with remaining settings components in separate small PRs.
- Add minimal aliases only if a missing variant is discovered (separate tiny PR).

### Checklist
- Formatted, built, tests pass
- Non-breaking, focused scope


___

### **PR Type**
Other


___

### **Description**
- Replace hardcoded white/black borders with semantic aliases

- Update dropdown and dialog surfaces to use `bg-surface`

- Convert border colors to `border-border` and `border-border-muted`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Colors"] -- "replace" --> B["Semantic Aliases"]
  B --> C["DropdownMenuContent"]
  B --> D["AlertDialogContent"]
  B --> E["AlertDialogCancel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>team-members-list-item.tsx</strong><dd><code>Convert hardcoded colors to semantic aliases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx

<ul><li>Replace <code>border-white/10</code> with <code>border-border-muted</code> in dropdown<br> <li> Replace <code>bg-black-900</code> with <code>bg-surface</code> in dropdown content<br> <li> Replace <code>border-black-400</code> with <code>border-border</code> in dialog components<br> <li> Replace <code>bg-black-850</code> with <code>bg-surface</code> in alert dialog</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1938/files#diff-dbabca02f10d3a96ce327976f713c2fd1ead6a6c85354d249302fb82806f4dfa">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Swap black/white border and surface classes for semantic tokens in the team members dropdown and remove dialog.
> 
> - **UI: `apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx`**
>   - **Dropdown menu (`DropdownMenuContent`)**: `border-white/10` → `border-border-muted`; `bg-black-900` → `bg-surface`.
>   - **Remove dialog (`AlertDialogContent`, `AlertDialogCancel`)**: `border-black-400` → `border-border`; `bg-black-850` → `bg-surface`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee3d09e3a91dbe15c8c00c6b735337181f943f7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->