### PR TITLE
chore(settings): move white/black bg-/border-* to semantic/aliases (invite-member-dialog, user-teams) — Phase 3

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/account/user-teams.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/user-teams.tsx
@@ -50,7 +50,7 @@ export default function UserTeams({
 
 	return (
 		<>
-			<div className="relative overflow-hidden rounded-[12px] backdrop-blur-md bg-white/[0.02] border-[0.5px] border-white/15 shadow-[inset_0_1px_1px_rgba(255,255,255,0.4),inset_0_-1px_1px_rgba(255,255,255,0.2)] before:content-[''] before:absolute before:inset-0 before:bg-white before:opacity-[0.02] before:rounded-[inherit] before:pointer-events-none py-2">
+			<div className="relative overflow-hidden rounded-[12px] backdrop-blur-md bg-white/[0.02] border-[0.5px] border-border-muted shadow-[inset_0_1px_1px_rgba(255,255,255,0.4),inset_0_-1px_1px_rgba(255,255,255,0.2)] before:content-[''] before:absolute before:inset-0 before:bg-white before:opacity-[0.02] before:rounded-[inherit] before:pointer-events-none py-2">
 				<div
 					className="flex items-center gap-x-[11px] mt-4 mb-2 mx-4 py-2 px-3 rounded-[8px]"
 					style={{
@@ -72,7 +72,7 @@ export default function UserTeams({
 					{filteredTeams.map((team, idx) => (
 						<UserTeamsItem
 							className={cn(
-								"border-t border-white/5 mx-4",
+								"border-t border-border-muted mx-4",
 								idx === 0 && "border-t-0",
 							)}
 							key={team.id}
@@ -162,7 +162,7 @@ function UserTeamsItem({
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="end"
-					className="p-1 border-[0.25px] border-white/10 rounded-[8px] min-w-[165px] bg-black-900 shadow-none"
+					className="p-1 border-[0.25px] border-border-muted rounded-[8px] min-w-[165px] bg-surface shadow-none"
 				>
 					<DropdownMenuItem className="p-0">
 						<ChangeTeamAndAction

--- a/apps/studio.giselles.ai/app/(main)/settings/team/agent-usage-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/agent-usage-dialog.tsx
@@ -18,7 +18,7 @@ export function AgentUsageDialog({ activities }: AgentUsageDialogProps) {
 			<DialogTrigger asChild>
 				<Button variant="primary">View All Logs</Button>
 			</DialogTrigger>
-			<DialogContent className="border-[0.5px] border-black-400 px-[24px] pt-[16px] pb-[24px] bg-black-850 max-w-7xl">
+			<DialogContent className="border-[0.5px] border-border px-[24px] pt-[16px] pb-[24px] bg-surface max-w-7xl">
 				<DialogHeader>
 					<DialogTitle className="text-white-400 text-[16px] leading-[27.2px] tracking-normal font-sans">
 						App Usage Logs

--- a/apps/studio.giselles.ai/app/(main)/settings/team/agent-usage-table.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/agent-usage-table.tsx
@@ -31,7 +31,7 @@ export function AgentUsageTable({
 						activities.map((activity) => (
 							<div
 								key={`${activity.agentId}-${activity.startTime}`}
-								className="grid grid-cols-4 items-center gap-1 py-2 border-b-[0.5px] border-black-400 text-white-400 font-sans font-medium text-[12px] leading-[14.4px] tracking-normal"
+								className="grid grid-cols-4 items-center gap-1 py-2 border-b-[0.5px] border-border text-white-400 font-sans font-medium text-[12px] leading-[14.4px] tracking-normal"
 							>
 								<div className="break-words max-w-xs text-blue-80">
 									{activity.agentName ?? activity.agentId}

--- a/apps/studio.giselles.ai/app/(main)/settings/team/invitation-list-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/invitation-list-item.tsx
@@ -105,7 +105,7 @@ export function InvitationListItem({
 	};
 
 	return (
-		<div className="px-2 py-4 border-t-[0.5px] border-white/10 first:border-t-0 font-sans">
+		<div className="px-2 py-4 border-t-[0.5px] border-border-muted first:border-t-0 font-sans">
 			<div className="flex items-center justify-between gap-2">
 				<div className="flex gap-x-2 items-center">
 					<div className="flex-shrink-0 opacity-50">
@@ -142,7 +142,7 @@ export function InvitationListItem({
 							</DropdownMenuTrigger>
 							<DropdownMenuContent
 								align="end"
-								className="p-1 border-[0.25px] border-white/10 rounded-[8px] min-w-[165px] bg-black-900 shadow-none"
+								className="p-1 border-[0.25px] border-border-muted rounded-[8px] min-w-[165px] bg-surface shadow-none"
 							>
 								<DropdownMenuItem
 									onSelect={(e) => {

--- a/apps/studio.giselles.ai/app/(main)/settings/team/invite-member-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/invite-member-dialog.tsx
@@ -388,7 +388,7 @@ export function InviteMemberDialog({
 								</DropdownMenuTrigger>
 								<DropdownMenuContent
 									align="end"
-									className="min-w-[120px] rounded-[8px] border-[0.25px] border-white/10 bg-black-850 p-1 shadow-none"
+									className="min-w-[120px] rounded-[8px] border-[0.25px] border-border-muted bg-surface p-1 shadow-none"
 								>
 									<button
 										type="button"


### PR DESCRIPTION
### **User description**
### Summary
Safely migrate hardcoded white/black bg-/border-* utilities to semantic/bridge aliases in the settings scope. Small, focused batch.

### Changes
- apps/studio.giselles.ai/app/(main)/settings/team/invite-member-dialog.tsx
  - Dropdown surface: `bg-surface` + `border-border-muted` (replaces `bg-black-850` + `border-white/10`)
- apps/studio.giselles.ai/app/(main)/settings/account/user-teams.tsx
  - Card container: `border-border-muted` (replaces `border-white/15`)
  - Item separators: `border-border-muted` (replaces `border-white/5`)
  - Dropdown surface: `bg-surface` + `border-border-muted` (replaces `bg-black-900` + `border-white/10`)
- team/invitation-list-item.tsx
- team/agent-usage-table.tsx
- team/agent-usage-dialog.tsx

### Behavior
- No logic changes; visuals should be effectively unchanged.
- Aliases map to equivalent dark-surface semantics via the v3 bridge.

### Why
- Reduce direct color dependencies and align with token/semantic usage.
- Prepares for Tailwind v4 and staged removal of the v3 bridge.

### How to Review
- Open settings pages (Invite Member, User Teams) on dark background.
- Verify dropdown/card surfaces and separators render correctly (contrast intact).

### Checklist
- Formatted; build/tests pass
- Scope-limited; non‑breaking


___

### **PR Type**
Enhancement


___

### **Description**
- Replace hardcoded color utilities with semantic aliases

- Update dropdown styling in invite member dialog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Colors"] -- "migrate to" --> B["Semantic Aliases"]
  B --> C["Dropdown Styling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>invite-member-dialog.tsx</strong><dd><code>Update dropdown colors to semantic aliases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/invite-member-dialog.tsx

<ul><li>Replace <code>bg-black-850</code> with <code>bg-surface</code> for dropdown background<br> <li> Replace <code>border-white/10</code> with <code>border-border-muted</code> for dropdown border</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1939/files#diff-17f661b01d73eaceda54a7300b6dc44d9e576d532d9a5764885a8ea250aa43c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces hardcoded white/black border/background classes with semantic tokens across Settings team/account components.
> 
> - **Styling token migration**
>   - `apps/studio.giselles.ai/app/(main)/settings/account/user-teams.tsx`
>     - Card/container and item dividers: `border-border-muted` (from `border-white/*`).
>     - Dropdown surface: `bg-surface` + `border-border-muted` (from `bg-black-900` + `border-white/10`).
>   - `apps/studio.giselles.ai/app/(main)/settings/team/invitation-list-item.tsx`
>     - Row separator and dropdown surface: `border-border-muted` + `bg-surface` (from `border-white/10`, `bg-black-900`).
>   - `apps/studio.giselles.ai/app/(main)/settings/team/invite-member-dialog.tsx`
>     - Role dropdown surface: `bg-surface` + `border-border-muted` (from `bg-black-850`, `border-white/10`).
>   - `apps/studio.giselles.ai/app/(main)/settings/team/agent-usage-dialog.tsx`
>     - Dialog surface: `bg-surface` + `border-border` (from `bg-black-850`, `border-black-400`).
>   - `apps/studio.giselles.ai/app/(main)/settings/team/agent-usage-table.tsx`
>     - Row dividers: `border-border` (from `border-black-400`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d2da6b5fe608e88be934619143aa597cf9f315e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated dropdown and menu surface styling across Team Settings (Invite Member dialog and related lists) to use new theme tokens for borders and backgrounds.
  * Standardized border treatments on team and invitation list items for consistent contrast and spacing.
  * Purely visual polish—no changes to behavior, structure, or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->