### PR TITLE
Integrate document vector store with query node

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
@@ -249,8 +249,14 @@ function getDataSourceDisplayInfo(
 		if (state.status === "configured") {
 			const storeId = state.documentVectorStoreId;
 			const store = documentStoreMap.get(storeId);
+			if (!store) {
+				return {
+					line1: storeId,
+					line2: "Requires setup",
+				};
+			}
 			return {
-				line1: store?.name ?? storeId,
+				line1: store.name,
 				line2: summarizeDocumentStoreStatus(store),
 			};
 		}

--- a/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
@@ -1,4 +1,8 @@
 import type { Generation } from "@giselle-sdk/giselle";
+import {
+	useVectorStore,
+	type VectorStoreContextValue,
+} from "@giselle-sdk/giselle/react";
 import clsx from "clsx/lite";
 import {
 	ChevronDownIcon,
@@ -8,6 +12,7 @@ import {
 import { useMemo, useState } from "react";
 import { z } from "zod/v4";
 import { GitHubIcon, WilliIcon } from "../icons";
+import { DocumentVectorStoreIcon } from "../icons/node/document-vector-store-icon";
 
 const gitHubPRContextSchema = z.object({
 	prContext: z.string().optional(),
@@ -194,28 +199,76 @@ function PRContextDisplay({
 	);
 }
 
+type DocumentVectorStoreSummary = NonNullable<
+	VectorStoreContextValue["documentStores"]
+>[number];
+
 type DataSourceDisplayInfo = {
 	line1: string;
 	line2?: string;
 };
 
+function summarizeDocumentStoreStatus(
+	store: DocumentVectorStoreSummary | undefined,
+): string | undefined {
+	if (!store) {
+		return undefined;
+	}
+	const total = store.sources.length;
+	if (total === 0) {
+		return "No uploads yet";
+	}
+	const failed = store.sources.filter(
+		(source) => source.ingestStatus === "failed",
+	).length;
+	if (failed > 0) {
+		return `${failed}/${total} failed`;
+	}
+	const running = store.sources.filter(
+		(source) => source.ingestStatus === "running",
+	).length;
+	if (running > 0) {
+		return `${running}/${total} processing`;
+	}
+	const completed = store.sources.filter(
+		(source) => source.ingestStatus === "completed",
+	).length;
+	if (completed === total) {
+		return `${total} ready`;
+	}
+	return `${completed}/${total} ready`;
+}
+
 function getDataSourceDisplayInfo(
 	result: ReturnType<typeof getGenerationQueryResult>[number],
+	documentStoreMap: Map<string, DocumentVectorStoreSummary>,
 ): DataSourceDisplayInfo {
-	if (
-		result.source.provider === "github" &&
-		result.source.state.status === "configured"
-	) {
+	const { provider, state } = result.source;
+
+	if (provider === "document") {
+		if (state.status === "configured") {
+			const storeId = state.documentVectorStoreId;
+			const store = documentStoreMap.get(storeId);
+			return {
+				line1: store?.name ?? storeId,
+				line2: summarizeDocumentStoreStatus(store),
+			};
+		}
 		return {
-			line1: `${result.source.state.owner}/${result.source.state.repo}`,
-			line2:
-				result.source.state.contentType === "pull_request"
-					? "Pull Requests"
-					: "Code",
+			line1: "Document vector store",
+			line2: "Requires setup",
 		};
 	}
+
+	if (provider === "github" && state.status === "configured") {
+		return {
+			line1: `${state.owner}/${state.repo}`,
+			line2: state.contentType === "pull_request" ? "Pull Requests" : "Code",
+		};
+	}
+
 	return {
-		line1: "GitHub vector store",
+		line1: "Vector store",
 	};
 }
 
@@ -223,14 +276,18 @@ function DataSourceTab({
 	result,
 	isActive,
 	onClick,
+	documentStoreMap,
 }: {
 	result: ReturnType<typeof getGenerationQueryResult>[number];
 	isActive: boolean;
 	onClick: () => void;
+	documentStoreMap: Map<string, DocumentVectorStoreSummary>;
 }) {
-	const displayInfo = getDataSourceDisplayInfo(result);
+	const displayInfo = getDataSourceDisplayInfo(result, documentStoreMap);
 	const recordCount = result.records?.length || 0;
-	const isGitHub = result.source?.provider === "github";
+	const provider = result.source?.provider;
+	const isGitHub = provider === "github";
+	const isDocument = provider === "document";
 
 	return (
 		<button
@@ -244,6 +301,12 @@ function DataSourceTab({
 			)}
 		>
 			{isGitHub && <GitHubIcon className="w-[14px] h-[14px] flex-shrink-0" />}
+			{isDocument && (
+				<DocumentVectorStoreIcon
+					className="w-[14px] h-[14px] flex-shrink-0"
+					aria-hidden="true"
+				/>
+			)}
 			<div className="flex flex-col items-start leading-tight whitespace-nowrap">
 				<span className="text-[13px] font-medium">{displayInfo.line1}</span>
 				{displayInfo.line2 && (
@@ -272,6 +335,7 @@ function QueryResultCard({
 	const [expandedRecords, setExpandedRecords] = useState<Set<number>>(
 		new Set(),
 	);
+	const isDocumentResult = result.source.provider === "document";
 
 	const toggleRecord = (recordIndex: number) => {
 		setExpandedRecords((prev) => {
@@ -316,6 +380,20 @@ function QueryResultCard({
 							<span className="text-[12px] font-semibold text-white-700">
 								Chunk #{record.chunkIndex}
 							</span>
+							{isDocumentResult && (
+								<div className="flex flex-col text-[11px] text-white-500">
+									{record.metadata.documentKey ? (
+										<span className="break-all">
+											File: {record.metadata.documentKey}
+										</span>
+									) : null}
+									{record.metadata.documentVectorStoreSourceDbId ? (
+										<span className="break-all">
+											Source ID: {record.metadata.documentVectorStoreSourceDbId}
+										</span>
+									) : null}
+								</div>
+							)}
 						</div>
 						<ScoreIndicator score={record.score} />
 					</div>
@@ -354,6 +432,15 @@ function QueryResultCard({
 
 export function QueryResultView({ generation }: { generation: Generation }) {
 	const [activeTabIndex, setActiveTabIndex] = useState(0);
+	const vectorStore = useVectorStore();
+	const documentStores = vectorStore?.documentStores ?? [];
+	const documentStoreMap = useMemo(() => {
+		const map = new Map<string, DocumentVectorStoreSummary>();
+		documentStores.forEach((store) => {
+			map.set(store.id, store);
+		});
+		return map;
+	}, [documentStores]);
 
 	if (generation.status === "failed") {
 		return (
@@ -404,19 +491,38 @@ export function QueryResultView({ generation }: { generation: Generation }) {
 			{/* Tab Navigation */}
 			<div className="overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
 				<div className="flex gap-[0px] flex-nowrap">
-					{queryResults.map((result, index) => (
-						<DataSourceTab
-							key={`datasource-${index}-github-${result.source.state.status === "configured" ? `${result.source.state.owner}-${result.source.state.repo}` : "unconfigured"}`}
-							result={result}
-							isActive={activeTabIndex === index}
-							onClick={() => setActiveTabIndex(index)}
-						/>
-					))}
+					{queryResults.map((result, index) => {
+						const provider = result.source.provider;
+						let descriptor: string = result.source.state.status;
+						if (
+							provider === "github" &&
+							result.source.state.status === "configured"
+						) {
+							descriptor = `${result.source.state.owner}-${result.source.state.repo}-${result.source.state.contentType}`;
+						} else if (
+							provider === "document" &&
+							result.source.state.status === "configured"
+						) {
+							descriptor = result.source.state.documentVectorStoreId;
+						}
+
+						return (
+							<DataSourceTab
+								key={`datasource-${index}-${provider}-${descriptor}`}
+								result={result}
+								isActive={activeTabIndex === index}
+								onClick={() => setActiveTabIndex(index)}
+								documentStoreMap={documentStoreMap}
+							/>
+						);
+					})}
 				</div>
 			</div>
 
 			{/* Tab Content */}
-			<div>{activeResult && <QueryResultCard result={activeResult} />}</div>
+			<div>
+				{activeResult ? <QueryResultCard result={activeResult} /> : null}
+			</div>
 		</div>
 	);
 }

--- a/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
@@ -380,20 +380,13 @@ function QueryResultCard({
 							<span className="text-[12px] font-semibold text-white-700">
 								Chunk #{record.chunkIndex}
 							</span>
-							{isDocumentResult && (
+							{isDocumentResult && record.metadata.documentKey ? (
 								<div className="flex flex-col text-[11px] text-white-500">
-									{record.metadata.documentKey ? (
-										<span className="break-all">
-											File: {record.metadata.documentKey}
-										</span>
-									) : null}
-									{record.metadata.documentVectorStoreSourceDbId ? (
-										<span className="break-all">
-											Source ID: {record.metadata.documentVectorStoreSourceDbId}
-										</span>
-									) : null}
+									<span className="break-all">
+										File: {record.metadata.documentKey}
+									</span>
 								</div>
-							)}
+							) : null}
 						</div>
 						<ScoreIndicator score={record.score} />
 					</div>

--- a/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx
@@ -414,12 +414,17 @@ function QueryResultCard({
 								Metadata
 							</summary>
 							<div className="mt-[4px] pl-[12px] space-y-[2px]">
-								{Object.entries(record.metadata).map(([key, value]) => (
-									<div key={key} className="flex gap-[8px]">
-										<span className="font-medium">{key}:</span>
-										<span className="break-all">{String(value)}</span>
-									</div>
-								))}
+								{Object.entries(record.metadata).map(([key, value]) => {
+									if (key === "documentVectorStoreSourceDbId") {
+										return null;
+									}
+									return (
+										<div key={key} className="flex gap-[8px]">
+											<span className="font-medium">{key}:</span>
+											<span className="break-all">{String(value)}</span>
+										</div>
+									);
+								})}
 							</div>
 						</details>
 					)}

--- a/packages/giselle/src/concepts/generation/output.ts
+++ b/packages/giselle/src/concepts/generation/output.ts
@@ -1,5 +1,9 @@
 import type { LanguageModelV2Source } from "@ai-sdk/provider";
-import { GitHubVectorStoreSource, OutputId } from "@giselle-sdk/data-type";
+import {
+	DocumentVectorStoreSource,
+	GitHubVectorStoreSource,
+	OutputId,
+} from "@giselle-sdk/data-type";
 import { createIdGenerator } from "@giselle-sdk/utils";
 import type { ProviderMetadata } from "ai";
 import { z } from "zod/v4";
@@ -58,7 +62,10 @@ export const SourceOutput = GenerationOutputBase.extend({
 	sources: z.array(z.custom<LanguageModelV2Source>()),
 });
 
-const VectorStoreSource = GitHubVectorStoreSource;
+const VectorStoreSource = z.union([
+	GitHubVectorStoreSource,
+	DocumentVectorStoreSource,
+]);
 const VectorStoreQueryResultRecord = z.object({
 	chunkContent: z.string(),
 	chunkIndex: z.number(),

--- a/packages/giselle/src/engine/operations/execute-query.ts
+++ b/packages/giselle/src/engine/operations/execute-query.ts
@@ -2,6 +2,8 @@ import {
 	DEFAULT_EMBEDDING_PROFILE_ID,
 	DEFAULT_MAX_RESULTS,
 	DEFAULT_SIMILARITY_THRESHOLD,
+	type DocumentVectorStoreSource,
+	type GitHubVectorStoreSource,
 	isQueryNode,
 	isTextNode,
 	NodeId,
@@ -35,6 +37,7 @@ import {
 	queryResultToText,
 } from "../generations/utils";
 import type {
+	DocumentVectorStoreQueryContext,
 	EmbeddingCompleteCallbackFunction,
 	GiselleEngineContext,
 	GitHubQueryContext,
@@ -280,18 +283,23 @@ async function resolveQuery(
 	return resolvedQuery;
 }
 
+type ConfiguredGitHubVectorStoreSource = GitHubVectorStoreSource & {
+	state: Extract<GitHubVectorStoreSource["state"], { status: "configured" }>;
+};
+
+type ConfiguredDocumentVectorStoreSource = DocumentVectorStoreSource & {
+	state: Extract<DocumentVectorStoreSource["state"], { status: "configured" }>;
+};
+
+type ConfiguredVectorStoreSource =
+	| ConfiguredGitHubVectorStoreSource
+	| ConfiguredDocumentVectorStoreSource;
+
 function isConfiguredVectorStoreNode(
 	vectorStoreNode: VectorStoreNode,
 ): vectorStoreNode is VectorStoreNode & {
 	content: {
-		source: {
-			state: {
-				status: "configured";
-				owner: string;
-				repo: string;
-				contentType: "blob" | "pull_request";
-			};
-		};
+		source: ConfiguredVectorStoreSource;
 	};
 } {
 	const { content } = vectorStoreNode;
@@ -440,9 +448,49 @@ async function queryVectorStore(
 					}
 
 					case "document": {
-						throw new Error(
-							"Document vector store query is not yet implemented",
+						if (!vectorStoreQueryServices?.document) {
+							throw new Error(
+								"No document vector store query service provided",
+							);
+						}
+
+						const embeddingProfileId =
+							state.embeddingProfileId ?? DEFAULT_EMBEDDING_PROFILE_ID;
+						const queryContext: DocumentVectorStoreQueryContext = {
+							provider: "document" as const,
+							workspaceId,
+							documentVectorStoreId: state.documentVectorStoreId,
+							embeddingProfileId,
+						};
+						const embeddingCallback = createEngineEmbeddingCallback(
+							runningGeneration,
+							queryContext,
+							context.callbacks?.embeddingComplete,
 						);
+
+						const res = await vectorStoreQueryServices.document.search(
+							query,
+							queryContext,
+							maxResults ?? DEFAULT_MAX_RESULTS,
+							similarityThreshold ?? DEFAULT_SIMILARITY_THRESHOLD,
+							embeddingCallback,
+						);
+						return {
+							type: "vector-store" as const,
+							source,
+							records: res.map((result) => ({
+								chunkContent: result.chunk.content,
+								chunkIndex: result.chunk.index,
+								score: result.similarity,
+								metadata: Object.fromEntries(
+									Object.entries(result.metadata ?? {}).map(([key, value]) => [
+										key,
+										String(value),
+									]),
+								),
+								additional: result.additional,
+							})),
+						};
 					}
 
 					default: {

--- a/packages/giselle/src/engine/operations/execute-query.ts
+++ b/packages/giselle/src/engine/operations/execute-query.ts
@@ -304,8 +304,13 @@ function isConfiguredVectorStoreNode(
 } {
 	const { content } = vectorStoreNode;
 	const { source } = content;
-	const { state } = source;
-	return state.status === "configured";
+	const { provider, state } = source;
+
+	if (state.status !== "configured") {
+		return false;
+	}
+
+	return provider === "github" || provider === "document";
 }
 
 async function queryVectorStore(

--- a/packages/giselle/src/engine/operations/execute-query.ts
+++ b/packages/giselle/src/engine/operations/execute-query.ts
@@ -462,7 +462,7 @@ async function queryVectorStore(
 						const embeddingProfileId =
 							state.embeddingProfileId ?? DEFAULT_EMBEDDING_PROFILE_ID;
 						const queryContext: DocumentVectorStoreQueryContext = {
-							provider: "document" as const,
+							provider: "document",
 							workspaceId,
 							documentVectorStoreId: state.documentVectorStoreId,
 							embeddingProfileId,

--- a/packages/giselle/src/engine/types.ts
+++ b/packages/giselle/src/engine/types.ts
@@ -58,7 +58,7 @@ export type GenerationFailedCallbackFunction = (
 export interface EmbeddingCompleteCallbackFunctionArgs {
 	embeddingMetrics: EmbeddingMetrics;
 	generation: RunningGeneration;
-	queryContext: GitHubQueryContext;
+	queryContext: QueryContext;
 }
 export type EmbeddingCompleteCallbackFunction = (
 	args: EmbeddingCompleteCallbackFunctionArgs,
@@ -83,6 +83,7 @@ export interface GiselleEngineContext {
 	vectorStoreQueryServices?: {
 		github?: GitHubVectorStoreQueryService<Record<string, unknown>>;
 		githubPullRequest?: GitHubVectorStoreQueryService<Record<string, unknown>>;
+		document?: DocumentVectorStoreQueryService<Record<string, unknown>>;
 	};
 	callbacks?: {
 		generationComplete?: GenerationCompleteCallbackFunction;
@@ -147,11 +148,23 @@ export type GitHubQueryContext = {
 	contentType: "blob" | "pullRequest";
 	embeddingProfileId: EmbeddingProfileId;
 };
-export type QueryContext = GitHubQueryContext;
+
+export type DocumentVectorStoreQueryContext = {
+	provider: "document";
+	workspaceId: WorkspaceId;
+	documentVectorStoreId: string;
+	embeddingProfileId: EmbeddingProfileId;
+};
+
+export type QueryContext = GitHubQueryContext | DocumentVectorStoreQueryContext;
 
 export type GitHubVectorStoreQueryService<
 	M extends Record<string, unknown> = Record<string, never>,
 > = QueryService<GitHubQueryContext, M>;
+
+export type DocumentVectorStoreQueryService<
+	M extends Record<string, unknown> = Record<string, never>,
+> = QueryService<DocumentVectorStoreQueryContext, M>;
 
 export interface GiselleEngineConfig {
 	storage: Storage;
@@ -170,6 +183,7 @@ export interface GiselleEngineConfig {
 	vectorStoreQueryServices?: {
 		github?: GitHubVectorStoreQueryService<Record<string, unknown>>;
 		githubPullRequest?: GitHubVectorStoreQueryService<Record<string, unknown>>;
+		document?: DocumentVectorStoreQueryService<Record<string, unknown>>;
 	};
 	callbacks?: {
 		generationComplete?: GenerationCompleteCallbackFunction;


### PR DESCRIPTION
### **User description**
## Summary
- Add document vector store support to query engine operations
- Implement query result visualization for document vector store outputs
- Update generation output types to handle document retrieval results

https://github.com/user-attachments/assets/dccab3ff-c93c-46cf-8eb3-860617a0b866

## Related Issue
part of #1827

## Changes
- Extended `execute-query.ts` to process document vector store queries
- Enhanced query result view UI to display document search results with relevance scores
- Updated engine types to support document vector store integration

## Testing
https://github.com/giselles-ai/giselle/pull/1940#issuecomment-3370248054

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add document vector store support to query engine operations

- Implement query result visualization for document vector store outputs  

- Update generation output types to handle document retrieval results

- Enhance tracing and telemetry for document vector store queries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query Node"] --> B["Vector Store Query"]
  B --> C["GitHub Vector Store"]
  B --> D["Document Vector Store"]
  D --> E["Document Query Service"]
  E --> F["Query Results"]
  F --> G["UI Visualization"]
  C --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>giselle-engine.ts</strong><dd><code>Add document vector store service integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/giselle-engine.ts

<ul><li>Import document vector store query service<br> <li> Add document provider support to tracing function<br> <li> Register document query service in engine configuration<br> <li> Extend telemetry metadata for document vector stores</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1940/files#diff-235b6c6d2e5711d3bbc50862c678e55f5d79296fc35007dab4dc963a82b5be63">+45/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>output.ts</strong><dd><code>Support document vector store in output types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/concepts/generation/output.ts

<ul><li>Import <code>DocumentVectorStoreSource</code> type<br> <li> Extend <code>VectorStoreSource</code> union to include document sources</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1940/files#diff-2957bccfa00e0e485e16a1553fb460bee82b02bb7ad2009edca8670818c7461e">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>execute-query.ts</strong><dd><code>Implement document vector store query operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/operations/execute-query.ts

<ul><li>Add document vector store query context and types<br> <li> Implement document vector store query execution logic<br> <li> Update configured vector store node type definitions<br> <li> Add document provider case in query resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1940/files#diff-3bf5dcda800337e54a682f2ee73b5489afc86e4d14597c65c390587d77982d9f">+58/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Define document vector store query types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/types.ts

<ul><li>Add <code>DocumentVectorStoreQueryContext</code> type definition<br> <li> Extend <code>QueryContext</code> union with document provider<br> <li> Add document query service to engine configuration<br> <li> Update embedding callback to support all query contexts</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1940/files#diff-c0d6a1af4548e95f47f51c05c6860243de8642f174043c3120d42dd6e5c53680">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query-result-view.tsx</strong><dd><code>Add document vector store UI visualization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/query-result-view.tsx

<ul><li>Add document vector store icon and UI components<br> <li> Implement document store status summarization logic<br> <li> Enhance data source display with document store information<br> <li> Add document metadata display in query results</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1940/files#diff-56aa5eec75df28631c61366f27fef8da65e7f0101929fdb5cb1c6c9fcead897c">+127/-21</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds document vector store support end-to-end: engine query execution, types/telemetry, and UI display of document search results.
> 
> - **Engine**:
>   - **Query execution**: Implement `document` provider in `execute-query.ts`, invoking document query service with `DocumentVectorStoreQueryContext`, embedding callbacks, and returning records with metadata/additional fields.
>   - **Types**: Extend `QueryContext` with `DocumentVectorStoreQueryContext`; add `DocumentVectorStoreQueryService` to engine config; generalize embedding callback args; widen configured vector-store source typing.
>   - **Outputs**: Include `DocumentVectorStoreSource` in `VectorStoreSource` union for `query-result`.
>   - **Telemetry/Tracing**: Update embedding tracing to handle both `github` and `document`, adding base metadata (e.g., `workspaceId`, `embeddingProfileId`, `documentVectorStoreId`).
>   - **Service wiring**: Register `document` vector store query service in `giselle-engine.ts`.
> - **UI**:
>   - **Query results**: Show `document` provider with icon, store name/status, stable tab keys; display file `documentKey` and hide internal `documentVectorStoreSourceDbId`; generic "Vector store" labeling when unconfigured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da15d1b1de5d2239a99b5e0f4cfb536b3c14f6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - End-to-end Document vector store support: query results include per-record score, metadata and document key; users can select Document as a data provider.
  - Data source tabs now show a Document provider with icon, store name/ID, and human-friendly status.

- Improvements
  - Multi-provider querying unified across GitHub and Document providers with clearer errors for unsupported providers.
  - Stable provider-specific tab keys and memoized document-store lookups for smoother navigation and improved UI performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->