### PR TITLE
refactor: remove `experimental_github-webhook` route

### DIFF
--- a/packages/giselle/src/next/next-giselle-engine.ts
+++ b/packages/giselle/src/next/next-giselle-engine.ts
@@ -158,11 +158,8 @@ export function createHttpHandler({
 					input: await getBody(request),
 				});
 			}
-			/** Experimental implementation for handling webhooks with GiselleEngine */
-			if (
-				routerPath === "experimental_github-webhook" ||
-				routerPath === "github-webhook"
-			) {
+			/** Handle GitHub webhooks with GiselleEngine */
+			if (routerPath === "github-webhook") {
 				try {
 					await verifyRequestAsGitHubWebook({
 						secret:


### PR DESCRIPTION
### **User description**
## Summary
refactor: remove `experimental_github-webhook` route

## Related Issue
None.

## Changes
Just remove unused `experimental_github-webhook` route

## Testing
https://github.com/giselles-ai/giselle/pull/1947#issuecomment-3375343259

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Other


___

### **Description**
- Remove experimental GitHub webhook route handling

- Simplify webhook routing logic to single endpoint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] --> B["Route Check"]
  B --> C["github-webhook only"]
  C --> D["GitHub Webhook Handler"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next-giselle-engine.ts</strong><dd><code>Remove experimental webhook route condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/next/next-giselle-engine.ts

<ul><li>Remove <code>experimental_github-webhook</code> route from condition check<br> <li> Keep only <code>github-webhook</code> route handling<br> <li> Update comment to reflect current implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1947/files#diff-5226483ce6c21ed6f8aac31a651a6740b887a477cf8b03043c926ea119ba797a">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the `experimental_github-webhook` route so only `github-webhook` is handled.
> 
> - **Backend**
>   - **GitHub Webhooks**: In `packages/giselle/src/next/next-giselle-engine.ts`, remove `experimental_github-webhook` route; keep `github-webhook` path with existing verification and 202 response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4993b8079264997e0a620266c9d3ca13dc6c696. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated GitHub webhook handling to a single, standard endpoint for verification and processing; the experimental alternate path is no longer supported.
  - Simplified control flow for webhook requests to improve reliability.

- **Chores**
  - Cleaned up legacy experimental webhook path references.

Note: If you previously used the experimental GitHub webhook path, update your configuration to use the standard GitHub webhook endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->