### PR TITLE
chore: update text embedding pricing

### DIFF
--- a/packages/language-model/src/costs/embedding-costs.test.ts
+++ b/packages/language-model/src/costs/embedding-costs.test.ts
@@ -8,8 +8,8 @@ describe("calculateEmbeddingDisplayCost", () => {
 			"text-embedding-3-small",
 			{ tokens: 1000 },
 		);
-		// $0.01 per 1M tokens => 1000 tokens = $0.00001
-		expect(cost.totalCostForDisplay).toBeCloseTo(0.00001, 10);
+		// $0.02 per 1M tokens => 1000 tokens = $0.00002
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.00002, 10);
 	});
 
 	it("computes cost for OpenAI text-embedding-3-large", async () => {
@@ -18,8 +18,8 @@ describe("calculateEmbeddingDisplayCost", () => {
 			"text-embedding-3-large",
 			{ tokens: 2000 },
 		);
-		// $0.065 per 1M tokens => 2000 tokens = $0.00013
-		expect(cost.totalCostForDisplay).toBeCloseTo(0.00013, 10);
+		// $0.13 per 1M tokens => 2000 tokens = $0.00026
+		expect(cost.totalCostForDisplay).toBeCloseTo(0.00026, 10);
 	});
 
 	it("computes cost for Google gemini-embedding-001", async () => {

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -281,16 +281,16 @@ export const openAiEmbeddingPricing: EmbeddingModelPriceTable = {
 	"text-embedding-3-small": {
 		prices: [
 			{
-				validFrom: "2025-08-28T00:00:00Z",
-				costPerMegaToken: 0.01,
+				validFrom: "2025-10-07T08:00:00Z",
+				costPerMegaToken: 0.02,
 			},
 		],
 	},
 	"text-embedding-3-large": {
 		prices: [
 			{
-				validFrom: "2025-08-28T00:00:00Z",
-				costPerMegaToken: 0.065,
+				validFrom: "2025-10-07T08:00:00Z",
+				costPerMegaToken: 0.13,
 			},
 		],
 	},


### PR DESCRIPTION
### **User description**
## Summary
chore: update text embedding pricing

## Related Issue
https://github.com/giselles-ai/giselle/pull/1755#discussion_r2306311733

## Changes

Model | Cost | 
-- | -- | 
text-embedding-3-small | $0.02 | 
text-embedding-3-large | $0.13 | 

🔗 [Embeddings](https://platform.openai.com/docs/pricing#embeddings)

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
https://platform.openai.com/docs/pricing 

<img width="1492" height="602" alt="image" src="https://github.com/user-attachments/assets/eaa522d4-7e39-4d87-bd63-68999e3ebcd4" />


___

### **PR Type**
Other


___

### **Description**
- Update OpenAI text embedding model pricing

- Increase costs for text-embedding-3-small and text-embedding-3-large

- Update pricing effective date to October 7, 2025


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Pricing"] --> B["Price Update"]
  B --> C["text-embedding-3-small: $0.01 → $0.02"]
  B --> D["text-embedding-3-large: $0.065 → $0.13"]
  C --> E["New Pricing Effective"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Update OpenAI embedding model pricing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Update <code>text-embedding-3-small</code> cost from $0.01 to $0.02 per mega token<br> <li> Update <code>text-embedding-3-large</code> cost from $0.065 to $0.13 per mega token<br> <li> Change pricing effective date from 2025-08-28 to 2025-10-07</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1949/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates OpenAI embedding prices (text-embedding-3-small/large) and aligns test expectations with the new rates.
> 
> - **Pricing**:
>   - Update OpenAI embedding pricing in `packages/language-model/src/costs/model-prices.ts`:
>     - `text-embedding-3-small`: `costPerMegaToken` 0.01 → 0.02; `validFrom` → `2025-10-07T08:00:00Z`.
>     - `text-embedding-3-large`: `costPerMegaToken` 0.065 → 0.13; `validFrom` → `2025-10-07T08:00:00Z`.
> - **Tests**:
>   - Adjust expected display costs in `packages/language-model/src/costs/embedding-costs.test.ts` for the updated OpenAI embedding prices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8347e2d328dbde796a17dd8477434cb8285e8fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenAI embedding pricing: text-embedding-3-small increased from $0.01 to $0.02 per 1M tokens; text-embedding-3-large increased from $0.065 to $0.13 per 1M tokens.
  * New pricing effective 2025-10-07T08:00:00Z.

* **Tests**
  * Updated cost assertions in embedding tests to reflect the new pricing; time-dependent test behavior made deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->