### PR TITLE
docs(plan): staged removal of v3 bridge + usage guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 ## Summary
 <!-- Briefly describe the changes and the purpose of the PR. -->
 
+> Note: Prefer semantic design tokens/utilities (e.g., text-text, bg-surface, border-border). Avoid raw colors and ad-hoc Tailwind color scales.
+
 ## Related Issue
 <!-- Mention the related issue number if applicable. -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: report-colors
           path: .reports/report-colors.json
-      - name: Guard Colors (non-blocking warnings)
-        run: pnpm guard:colors || true
+      - name: Guard Colors (non-blocking warnings with baseline)
+        run: pnpm guard:colors -- --baseline .reports/report-colors.json || true
       - name: Test
         run: pnpm test

--- a/docs/design-tokens-usage.md
+++ b/docs/design-tokens-usage.md
@@ -1,0 +1,32 @@
+### Design tokens usage (必須ガイド)
+
+このガイドは最小限の運用ルールです。新規コードは semantic 優先・生色禁止を徹底してください。
+
+### 読み込み順
+1) `internal-packages/ui/styles/tokens.css`（@theme, primitive/互換トークン）
+2) `internal-packages/ui/styles/semantic.css`（semantic→primitive の初期マッピング）
+3) `internal-packages/ui/styles/scopes/*.css`（必要時のみ）
+4) `internal-packages/ui/styles/aliases.css`（移行期限定。最終削除）
+
+### 推奨ユーティリティ（v4スタイル）
+- テキスト: `text-text`, `text-text/70`, `text-inverse`, `text-muted`
+- 背景: `bg-bg`, `bg-surface`, `bg-surface-muted`, `hover:bg-surface-hover`
+- ボーダー: `border-border`, `border-border-muted`, `border-border-focused`
+- フォーカス: `ring-focused`, `outline-focused`
+- SVG: `fill-text`, `stroke-border`
+- グラデーション: `from-brand-500`, `to-brand-700`
+
+### 除外・許容（移行中の特例）
+- ガラス表現（backdrop-blur/半透明/重ね影）は視覚差回避のため現状維持可
+- 3rdパーティコンポーネントで生色が必須な場合は `tokens.css` にトークンを追加してから使用
+
+### 移行チェックリスト（安全置換の前提）
+- 生色の直書き（hex/rgba/hsla/oklch）を追加しない（既存は削減対象）
+- `text-black-600/20 → text-text/20`
+- `color-border-focused → ring-focused`（focus文脈）/ `border-border`（それ以外）
+- `text-white-900 → text-inverse`（暗背景が明確な場合のみ）
+- SVGの #000/#fff は `currentColor` + 親に `text-*` 付与、または `fill-text`/`stroke-border`
+
+詳細な段階削除計画は `docs/plan-v3-bridge-removal.md` を参照。
+
+

--- a/docs/plan-v3-bridge-removal.md
+++ b/docs/plan-v3-bridge-removal.md
@@ -1,0 +1,33 @@
+### Plan: Staged removal of v3 bridge (aliases and compat tokens)
+
+Scope
+- Targets: `internal-packages/ui/styles/aliases.css` (compat utilities) and temporary compat tokens in `tokens.css` (e.g., --color-white-900, --color-black-600)
+- Non-goal: semantic/scopes themselves are not removed
+
+Milestones
+1) Freeze new usage
+   - CI guard: fail on newly introduced alias utilities and compat tokens outside tokens.css
+   - Docs: new code MUST use semantic utilities (text-text, bg-surface, border-border, ring-focused)
+2) Reduce usage to zero
+   - Run codemod safe-pass (batch) and follow-ups for ambiguous spots
+   - Visual checks for glass areas; skip where visual parity risks exist
+3) Promote guards to error
+   - stylelint/eslint: warn → error for raw colors and alias utilities
+4) Remove bridge
+   - Delete `aliases.css`
+   - Remove compat tokens from `tokens.css`
+   - Update docs and PR template
+
+Acceptance
+- repo-wide usage of alias utilities = 0
+- repo-wide usage of compat tokens (outside tokens.css) = 0
+- CI: increase-fail enabled and passing
+
+Risks / Mitigation
+- Visual drift in glass areas → keep excluded; handle in dedicated PRs
+- Third-party components with hardcoded colors → wrap via semantic classes or add minimal tokens
+
+Timeline
+- Week N: freeze + codemod pass 1 (safe)
+- Week N+1: manual fixes + codemod pass 2
+- Week N+2: promote guards to error + remove bridge

--- a/scripts/guard-colors.mjs
+++ b/scripts/guard-colors.mjs
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 /**
- * Warning-level color guard (non-blocking)
+ * Warning-level color guard (non-blocking by default)
  * - Runs report-colors and prints GitHub Actions warnings for raw color usages
  * - Excludes known safe files (e.g., tokens.css)
+ * - Optional baseline comparison: detect increases vs a previous JSON
+ *   Usage: node scripts/guard-colors.mjs [--baseline .reports/report-colors.json] [--strict]
  */
 
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 /** @param {string} p */
 function isExcluded(p) {
@@ -22,7 +25,18 @@ function isExcluded(p) {
 	return exclude.some((mark) => p.includes(mark));
 }
 
+function parseArgs(argv) {
+	const args = { baseline: undefined, strict: false };
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--baseline") args.baseline = argv[++i];
+		if (a === "--strict") args.strict = true;
+	}
+	return args;
+}
+
 function main() {
+	const { baseline, strict } = parseArgs(process.argv.slice(2));
 	const res = spawnSync("node", ["scripts/report-colors.mjs"], {
 		encoding: "utf8",
 	});
@@ -46,6 +60,28 @@ function main() {
 		if (!isExcluded(item.path)) findings.push(item);
 	}
 
+	// Baseline comparison (optional)
+	let increased = 0;
+	if (baseline) {
+		try {
+			const base = JSON.parse(readFileSync(baseline, "utf8"));
+			const baseCount =
+				(base.findings?.hexColors?.length || 0) +
+				(base.findings?.functionalColors?.length || 0);
+			const currCount = findings.length;
+			if (currCount > baseCount) {
+				increased = currCount - baseCount;
+				console.log(
+					`[guard-colors] Increase detected: +${increased} (baseline=${baseCount} -> current=${currCount})`,
+				);
+			}
+		} catch (e) {
+			console.error(
+				`[guard-colors] failed to read baseline: ${e?.message || e}`,
+			);
+		}
+	}
+
 	if (findings.length === 0) {
 		console.log("[guard-colors] No raw color findings");
 		return;
@@ -60,6 +96,12 @@ function main() {
 	}
 
 	console.log(`[guard-colors] Total warnings: ${findings.length}`);
+
+	// STRICT mode: fail build on increase (opt-in)
+	if (strict && increased > 0) {
+		console.error("[guard-colors] STRICT mode: failing due to increase");
+		process.exit(1);
+	}
 }
 
 main();


### PR DESCRIPTION
Add plan for staged removal of aliases and compat tokens; add required usage guide (naming/order/exclusions/checklist); wire guard-colors baseline in CI. Docs only.