### PR TITLE
fix: default ClickableText button type to "button"

### DIFF
--- a/apps/studio.giselles.ai/components/ui/clickable-text.tsx
+++ b/apps/studio.giselles.ai/components/ui/clickable-text.tsx
@@ -20,15 +20,24 @@ interface ClickableTextProps
 }
 
 const ClickableText = forwardRef<HTMLButtonElement, ClickableTextProps>(
-	({ className, variant, asChild = false, ...props }, ref) => {
+	({ className, variant, asChild = false, type, ...props }, ref) => {
 		const Comp = asChild ? Slot : "button";
-		return (
-			<Comp
-				className={cn(clickableTextVariant({ variant, className }))}
-				ref={ref}
-				{...props}
-			/>
-		);
+		const sharedProps = {
+			className: cn(clickableTextVariant({ variant, className })),
+			ref,
+		};
+
+		if (asChild) {
+			return (
+				<Comp
+					{...sharedProps}
+					{...props}
+					{...(type !== undefined && { type })}
+				/>
+			);
+		}
+
+		return <Comp {...sharedProps} {...props} type={type ?? "button"} />;
 	},
 );
 ClickableText.displayName = "ClickableText";


### PR DESCRIPTION
### **User description**
Prevents unintended form submissions by explicitly setting type="button" when used as a native button element. The type prop can still be overridden when needed.

## Summary
fix: default ClickableText button type to "button"

## Related Issue
None.

## Changes
Prevents unintended form submissions by explicitly setting type="button" when used as a native button element. The type prop can still be overridden when needed.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Default button type to "button" to prevent form submissions

- Maintain type prop override capability for flexibility

- Refactor component logic for better prop handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ClickableText Component"] --> B["Check asChild prop"]
  B --> C["asChild = true: Use Slot with conditional type"]
  B --> D["asChild = false: Use button with type='button' default"]
  C --> E["Preserve type override capability"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clickable-text.tsx</strong><dd><code>Default button type to prevent form submissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/components/ui/clickable-text.tsx

<ul><li>Extract <code>type</code> prop from component props for explicit handling<br> <li> Add conditional logic to set default <code>type="button"</code> for native button <br>elements<br> <li> Preserve type override capability when <code>asChild</code> is true<br> <li> Refactor component structure with shared props object</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1963/files#diff-5e12d51f6195ded53d88e61976c5613cbbd416acbc575cb47ff8187e3be7b4f3">+17/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clickable text now accepts and respects the button type, enabling finer control (e.g., submit, reset, button) across usages, including when used as a child component.
- Bug Fixes
  - Defaults clickable text to a non-submitting button to prevent unintended form submissions.
  - Ensures consistent behavior and prop forwarding whether used standalone or as a child, improving reliability in complex layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->