### PR TITLE
Configure Dependabot for security-only npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,19 @@
 
 version: 2
 updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Tokyo"
+    # Ignore scheduled version bumps; Dependabot still opens PRs for security advisories.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION

## Summary
Add npm package ecosystem to Dependabot configuration with daily checks at 08:00 JST, but ignore all scheduled version updates (major/minor/patch). This ensures Dependabot only opens PRs for security advisories, reducing PR noise from routine dependency bumps.

## Testing
After merging, please check the operation by triggering the following Dependabot alerts:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add npm Dependabot config with daily 08:00 Asia/Tokyo checks that ignore version bumps, leaving only security advisories; GitHub Actions schedule remains monthly.
> 
> - **Dependabot config** (`.github/dependabot.yml`):
>   - Add `npm` ecosystem with daily checks at 08:00 Asia/Tokyo, ignoring `version-update:semver-*` (major/minor/patch) to allow only security advisory PRs.
>   - Keep `github-actions` updates on a monthly schedule at 10:00 Asia/Tokyo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d80385476604272a35373f10a06ecfc875b8eb65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Configured automated npm dependency checks to run daily at 08:00 Asia/Tokyo, suppressing routine dependency PRs while permitting version-bump updates.
  - GitHub Actions dependency checks remain on a monthly schedule.
  - Applies to npm packages in the root project.
  - No user-facing changes; no impact on UI or APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->