### PR TITLE
Ensure Next engine sets waitUntil via after

### DIFF
--- a/apps/studio.giselles.ai/app/giselle-engine.ts
+++ b/apps/studio.giselles.ai/app/giselle-engine.ts
@@ -19,7 +19,6 @@ import {
 import { openaiVectorStore } from "@giselle-sdk/vector-store-adapters";
 import { tasks as jobs } from "@trigger.dev/sdk";
 import type { ModelMessage, ProviderMetadata } from "ai";
-import { after } from "next/server";
 import { createStorage } from "unstorage";
 import { waitForLangfuseFlush } from "@/instrumentation.node";
 import { GenerationMetadata } from "@/lib/generation-metadata";
@@ -388,7 +387,6 @@ export const giselleEngine = NextGiselleEngine({
 			process.env.VERCEL_ENV === "preview" ? "Giselle(preview)" : "Giselle",
 	},
 	logger,
-	waitUntil: after,
 });
 
 // Content generation processor: Trigger.dev implementation

--- a/packages/giselle/src/next/next-giselle-engine.ts
+++ b/packages/giselle/src/next/next-giselle-engine.ts
@@ -19,7 +19,8 @@ import {
 } from "../http";
 import { type RequestContext, requestContextStore } from "./context";
 
-interface NextGiselleEngineConfig extends GiselleEngineConfig {
+interface NextGiselleEngineConfig
+	extends Omit<GiselleEngineConfig, "waitUntil"> {
 	basePath: string;
 	useAfterFunction?: boolean;
 }
@@ -181,7 +182,7 @@ export function createHttpHandler({
 }
 
 export function NextGiselleEngine(config: NextGiselleEngineConfig) {
-	const giselleEngine = GiselleEngine(config);
+	const giselleEngine = GiselleEngine({ ...config, waitUntil: after });
 	const httpHandler = createHttpHandler({
 		giselleEngine,
 		config,


### PR DESCRIPTION
### **User description**
## Summary
- drop the explicit waitUntil config from the studio Next wrapper
- depend on NextGiselleEngine to apply next/server after internally
- narrow the Next configuration type to omit waitUntil overrides

## Testing
- pnpm biome check --write apps/studio.giselles.ai/app/giselle-engine.ts
- pnpm biome check --write packages/giselle/src/next/next-giselle-engine.ts


___

### **PR Type**
Enhancement


___

### **Description**
- Remove explicit `waitUntil` configuration from studio Next wrapper

- NextGiselleEngine now internally applies `next/server` after function

- Narrow Next configuration type to omit `waitUntil` overrides


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Studio App"] -- "removes waitUntil config" --> B["NextGiselleEngine"]
  B -- "internally sets waitUntil: after" --> C["GiselleEngine"]
  D["NextGiselleEngineConfig"] -- "omits waitUntil from type" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>giselle-engine.ts</strong><dd><code>Remove explicit waitUntil configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/giselle-engine.ts

<ul><li>Remove <code>after</code> import from <code>next/server</code><br> <li> Remove explicit <code>waitUntil: after</code> configuration parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1973/files#diff-235b6c6d2e5711d3bbc50862c678e55f5d79296fc35007dab4dc963a82b5be63">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>next-giselle-engine.ts</strong><dd><code>Internalize waitUntil configuration with after function</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/next/next-giselle-engine.ts

<ul><li>Extend <code>NextGiselleEngineConfig</code> to omit <code>waitUntil</code> from base type<br> <li> Internally set <code>waitUntil: after</code> when creating <code>GiselleEngine</code><br> <li> Import and use <code>after</code> function from <code>next/server</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1973/files#diff-5226483ce6c21ed6f8aac31a651a6740b887a477cf8b03043c926ea119ba797a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> NextGiselleEngine now sets `waitUntil` internally using `after`, and the studio app removes its explicit `waitUntil` config with the Next config type narrowed to omit it.
> 
> - **Next integration**:
>   - **Internalize waitUntil**: `NextGiselleEngine` passes `waitUntil: after` to `GiselleEngine` (`packages/giselle/src/next/next-giselle-engine.ts`).
>   - **Type narrowing**: `NextGiselleEngineConfig` now `extends Omit<GiselleEngineConfig, "waitUntil">` to prevent external overrides.
> - **Studio app**:
>   - Remove `after` import and drop `waitUntil: after` from `NextGiselleEngine` config (`apps/studio.giselles.ai/app/giselle-engine.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0ff0b0286d08c89edd72812a67a3c722d246ece. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined Next.js integration by removing the wait-until behavior and associated server-side hook.
  - Simplified configuration: the Next.js-specific engine config no longer accepts a waitUntil option.
  - Internal initialization updated to maintain expected behavior without additional setup.
  - Most projects require no changes; only setups relying on waitUntil should adjust accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->