### PR TITLE
fix: ensure completion callbacks are invoked for all node types

### DIFF
--- a/packages/giselle/src/engine/acts/run-act.ts
+++ b/packages/giselle/src/engine/acts/run-act.ts
@@ -68,9 +68,11 @@ async function executeStep(args: {
 		switch (args.generation.context.operationNode.content.type) {
 			case "action":
 				await executeAction(args);
+				await args.callbacks?.onCompleted?.();
 				break;
 			case "imageGeneration":
 				await generateImage({ ...args, useExperimentalStorage: true });
+				await args.callbacks?.onCompleted?.();
 				break;
 			case "textGeneration": {
 				await startContentGeneration(args);
@@ -88,9 +90,11 @@ async function executeStep(args: {
 			}
 			case "trigger":
 				await resolveTrigger(args);
+				await args.callbacks?.onCompleted?.();
 				break;
 			case "query":
 				await executeQuery(args);
+				await args.callbacks?.onCompleted?.();
 				break;
 			default: {
 				const _exhaustiveCheck: never =
@@ -98,7 +102,6 @@ async function executeStep(args: {
 				throw new Error(`Unhandled step type: ${_exhaustiveCheck}`);
 			}
 		}
-		await args.callbacks?.onCompleted?.();
 	} catch (_e) {
 		console.log(_e);
 		await args.callbacks?.onFailed?.(args.generation);


### PR DESCRIPTION
### **User description**
## Summary
- Fixed an issue where GitHub Action, Query, Trigger, and Image Generation nodes were incorrectly marked as failed
despite successful execution
- Moved `onCompleted` callbacks to individual switch cases for proper execution flow

## Problem
After PR #1942 was merged, nodes were showing as failed (❌) even when they executed successfully. This affected:
- GitHub Action nodes
- Query nodes
- Trigger nodes
- Image Generation nodes

## Root Cause
The shared `onCompleted` callback placed after the switch statement wasn't being reached consistently. While
theoretically it should execute after any successful case, the asynchronous nature of `executeAction` and `executeQuery`
(which use `useGenerationExecutor`) was preventing the callback from being invoked properly.

## Solution
Moved the `onCompleted` callback invocation into each individual case block (except `textGeneration` which manages its
own callbacks). This ensures:
- Each node type calls its completion callback immediately after successful execution
- Clear separation between success and failure paths
- Consistent behavior across all node types

## Changes
- Added `await args.callbacks?.onCompleted?.()` after `executeAction()`
- Added `await args.callbacks?.onCompleted?.()` after `executeQuery()`
- Added `await args.callbacks?.onCompleted?.()` after `resolveTrigger()`
- Added `await args.callbacks?.onCompleted?.()` after `generateImage()`
- Removed the shared `onCompleted` call after the switch statement


## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed completion callbacks for action, query, trigger, and image generation nodes

- Moved callback invocation from shared location to individual switch cases

- Resolved false failure status issue after PR #1942


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Switch Statement"] --> B["Action Node"]
  A --> C["Query Node"] 
  A --> D["Trigger Node"]
  A --> E["Image Generation Node"]
  A --> F["Text Generation Node"]
  B --> G["executeAction()"]
  C --> H["executeQuery()"]
  D --> I["resolveTrigger()"]
  E --> J["generateImage()"]
  G --> K["onCompleted callback"]
  H --> L["onCompleted callback"]
  I --> M["onCompleted callback"]
  J --> N["onCompleted callback"]
  F --> O["Existing callback handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-act.ts</strong><dd><code>Move completion callbacks to individual switch cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/acts/run-act.ts

<ul><li>Added <code>onCompleted</code> callback invocation after <code>executeAction()</code>, <br><code>executeQuery()</code>, <code>resolveTrigger()</code>, and <code>generateImage()</code><br> <li> Removed shared <code>onCompleted</code> callback after switch statement<br> <li> Maintained existing callback handling for <code>textGeneration</code> case</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1974/files#diff-4480a9dbbde20e6b5b43e9f753090fbe5c17a46a47c52a84c5280e71ba295d8b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Call onCompleted within action, imageGeneration, trigger, and query cases; keep textGeneration’s status-based callbacks; remove trailing global onCompleted.
> 
> - **Engine** (`packages/giselle/src/engine/acts/run-act.ts`):
>   - **executeStep**:
>     - Invoke `callbacks.onCompleted()` inside individual cases: `action`, `imageGeneration`, `trigger`, `query`.
>     - Preserve `textGeneration` flow: wait for completion, call `onFailed` or `onCompleted` based on final status.
>     - Remove shared `onCompleted` call after the switch to avoid missed/duplicate invocations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed547d2f70619c6637b0ac69c12d4d8fe7324049. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Step-level completion updates now occur after each action, image generation, trigger, and query step, improving real-time progress visibility.
- Bug Fixes
  - Eliminated duplicate completion notifications that could appear after multi-step runs.
  - Ensures failed text generations are correctly reported as failures.
- Improvements
  - More precise completion signaling for text generation, only after confirmed finish.
  - More consistent and reliable status updates across all steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->