### PR TITLE
feat(team): enforce admin role and Pro plan for team invitations

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/actions.ts
@@ -620,8 +620,20 @@ export async function sendInvitationsAction(
 	emails: string[],
 	role: TeamRole,
 ): Promise<SendInvitationsResult> {
-	const currentUser = await fetchCurrentUser();
+	const currentUserRoleResult = await getCurrentUserRole();
+	if (
+		!currentUserRoleResult.success ||
+		currentUserRoleResult.data !== "admin"
+	) {
+		throw new Error("Only admin users can send invitations");
+	}
+
 	const currentTeam = await fetchCurrentTeam();
+	if (!isProPlan(currentTeam)) {
+		throw new Error("Team invitations require a Pro plan");
+	}
+
+	const currentUser = await fetchCurrentUser();
 
 	const invitationPromises = emails.map(
 		async (email): Promise<InvitationResult> => {


### PR DESCRIPTION
### **User description**
## Summary
Enforce admin role and Pro plan for team invitations.

## Related Issue
None.

## Changes
Add validation checks to sendInvitationsAction:
- Verify current user has admin role before sending invitations
- Verify current team is on Pro plan before allowing invitations

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add admin role validation before sending team invitations

- Add Pro plan requirement check for team invitation feature

- Reorder user and team fetching logic for early validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sendInvitationsAction"] --> B["Check admin role"]
  B --> C["Verify Pro plan"]
  C --> D["Fetch current user"]
  D --> E["Send invitations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Add role and plan validation to invitation action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/actions.ts

<ul><li>Add <code>getCurrentUserRole()</code> check to verify admin permissions before <br>sending invitations<br> <li> Add <code>isProPlan()</code> validation to ensure team has Pro plan subscription<br> <li> Reorder code to fetch current user after validation checks<br> <li> Throw descriptive errors for unauthorized access and plan restrictions</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1991/files#diff-9c391e21a587fcb12de4d739d67013b37a6a46bad1c8b34d6a4608303093dc49">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Gate `sendInvitationsAction` behind admin role and Pro plan checks, throwing errors if unmet.
> 
> - **Team invitations**:
>   - Enforce admin-only access using `getCurrentUserRole()` in `apps/studio.giselles.ai/app/(main)/settings/team/actions.ts`.
>   - Require Pro plan via `isProPlan(currentTeam)` before creating invitations.
>   - Minor refactor: fetch `currentUser` after permission/plan checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c10ab2c5b804ee8fd3cae0389888f0744a36ae7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Team invitations are now restricted to admins only.
  - Sending invitations requires the team to be on a Pro plan.
  - Earlier validation provides quicker feedback when permissions or plan requirements aren’t met.
  - Invitation creation and email delivery remain unchanged for eligible users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->