### PR TITLE
fix(settings/team): improve role selector UX for non-editable members

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx
@@ -40,11 +40,25 @@ export function TeamMemberListItem({
 	const [role, setRole] = useState(initialRole);
 	const user = userId;
 	const currentUser = currentUserId;
+	const isCurrentUser = user === currentUser;
 
 	const canEditRole =
-		isProPlan && currentUserRole === "admin" && user !== currentUser;
-	const canRemove = user === currentUser || canEditRole;
-	const hasMenu = canEditRole || canRemove;
+		isProPlan && currentUserRole === "admin" && !isCurrentUser;
+	const canRemove = isCurrentUser || canEditRole;
+	const roleLabel = role.charAt(0).toUpperCase() + role.slice(1);
+
+	const selectOptions = [
+		...(canEditRole
+			? [
+					{ value: "admin" as const, label: "Admin" },
+					{ value: "member" as const, label: "Member" },
+				]
+			: []),
+		...(canRemove ? [{ value: "__remove__" as const, label: "Remove" }] : []),
+	];
+
+	const hasMenu = selectOptions.length > 0;
+	const selectValue = canEditRole ? role : undefined;
 
 	const handleRoleChange = (value: string) => {
 		const nextRole = value as TeamRole;
@@ -136,15 +150,9 @@ export function TeamMemberListItem({
 						{hasMenu ? (
 							<Select
 								id={`${userId}-role`}
-								options={[
-									{ value: "admin", label: "Admin" },
-									{ value: "member", label: "Member" },
-									...(canRemove
-										? [{ value: "__remove__", label: "Remove" }]
-										: []),
-								]}
-								placeholder="Role"
-								value={role}
+								options={selectOptions}
+								placeholder={roleLabel}
+								value={selectValue}
 								onValueChange={(v) => {
 									if (v === "__remove__") {
 										setOpen(true);


### PR DESCRIPTION
### **User description**
## Summary
Improve role selector UX for non-editable members.

## Related Issue
fix https://github.com/giselles-ai/giselle/pull/1975#issuecomment-3401398995

## Changes
Refactor role selection logic to conditionally show options based on user permissions.
When users cannot edit roles (non-admin or viewing their own role), the select now displays the current role as a placeholder instead of showing all options, making it clearer that the role cannot be changed.

## Testing

### Free

- [x] Show only `Remove`
- [x] `Cannot remove the last member from the team`

### Pro
#### Admin
##### Myself

- [x] Show only `Remove`

##### Others

- [x] Switch role `Admin/Member`　
- [x] Show `Remove`

#### Member 

##### Myself
- [x] Show only `Remove`

##### Others

- [x] Read only

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved role selector UX for non-editable team members

- Conditionally render select options based on user permissions

- Display current role as placeholder when editing is disabled

- Refactored role selection logic using `isCurrentUser` flag


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User permissions check"] --> B["canEditRole determination"]
  B --> C{"Can edit role?"}
  C -- "Yes" --> D["Show Admin/Member options"]
  C -- "No" --> E["Show role as placeholder"]
  D --> F["Allow role selection"]
  E --> G["Disable role selection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>team-members-list-item.tsx</strong><dd><code>Refactor role selector to conditionally display options</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx

<ul><li>Added <code>isCurrentUser</code> flag to simplify permission checks<br> <li> Introduced <code>selectOptions</code> array that conditionally includes role <br>options based on <code>canEditRole</code><br> <li> Changed select component to show current role as placeholder when <br>editing is disabled<br> <li> Refactored <code>canEditRole</code> and <code>canRemove</code> logic for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1993/files#diff-dbabca02f10d3a96ce327976f713c2fd1ead6a6c85354d249302fb82806f4dfa">+20/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors team member role selector to dynamically show only permitted options and display the current role as a placeholder when editing is not allowed.
> 
> - **Settings UI** (`apps/studio.giselles.ai/app/(main)/settings/team/team-members-list-item.tsx`):
>   - **Role select logic**:
>     - Add `isCurrentUser`; update `canEditRole`/`canRemove` to respect permissions.
>     - Build `selectOptions` dynamically (include `admin`/`member` only if editable; `__remove__` if removable).
>     - Use `roleLabel` as placeholder; set `selectValue` only when editable; compute `hasMenu` from `selectOptions`.
>   - **UX changes**:
>     - For non-editable members, show current role as placeholder and prevent changes.
>     - Preserve "Remove" action via `__remove__` option when allowed; open confirmation dialog on selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de3f96b40be1a914d9a73998a993d9373e9fb7c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Context-aware action menu on team members: shows role changes (Admin/Member) when permitted and a Remove option when applicable, including self-removal.
- UX Improvements
  - Cleaner role display with a capitalized role label.
  - Action menu appears only when there are available actions, reducing clutter.
  - Role selector now reflects the current role when editable and hides irrelevant options otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->