### PR TITLE
feat(storage): add experimental_storage backend and opt-in useExperimentalStorage flag for triggers and indices

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/apps/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/apps/actions.ts
@@ -83,6 +83,7 @@ export async function copyAgent(
 
 			const flowTrigger = await giselleEngine.getTrigger({
 				flowTriggerId: node.content.state.flowTriggerId,
+				useExperimentalStorage,
 			});
 			if (
 				flowTrigger &&

--- a/apps/studio.giselles.ai/app/stage/(top)/services.ts
+++ b/apps/studio.giselles.ai/app/stage/(top)/services.ts
@@ -211,6 +211,7 @@ export async function fetchFlowTriggers(
 
 			const flowTrigger = await giselleEngine.getTrigger({
 				flowTriggerId: tmpFlowTrigger.sdkFlowTriggerId,
+				useExperimentalStorage: true,
 			});
 			if (flowTrigger === undefined) {
 				continue;

--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/lib/data.ts
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/lib/data.ts
@@ -16,6 +16,7 @@ export async function getSidebarDataObject(actId: ActId) {
 	}
 	const trigger = await giselleEngine.getTrigger({
 		flowTriggerId: dbAct?.sdkFlowTriggerId,
+		useExperimentalStorage: true,
 	});
 	if (trigger?.configuration.provider !== "manual") {
 		throw new Error(`Trigger with id ${dbAct?.sdkFlowTriggerId} is not manual`);

--- a/apps/studio.giselles.ai/app/stage/showcase/[appId]/actions.ts
+++ b/apps/studio.giselles.ai/app/stage/showcase/[appId]/actions.ts
@@ -35,6 +35,7 @@ export async function fetchWorkspaceFlowTrigger(workspaceId: string): Promise<{
 
 		const flowTrigger = await giselleEngine.getTrigger({
 			flowTriggerId: triggerNode.content.state.flowTriggerId,
+			useExperimentalStorage: true,
 		});
 
 		if (!flowTrigger) {

--- a/packages/giselle/src/engine/acts/run-act.ts
+++ b/packages/giselle/src/engine/acts/run-act.ts
@@ -87,7 +87,11 @@ async function executeStep(args: {
 				break;
 			}
 			case "trigger":
-				await resolveTrigger(args);
+				await resolveTrigger({
+					context: args.context,
+					generation: args.generation,
+					useExperimentalStorage: true,
+				});
 				break;
 			case "query":
 				await executeQuery(args);

--- a/packages/giselle/src/engine/github/handle-webhook-v2.ts
+++ b/packages/giselle/src/engine/github/handle-webhook-v2.ts
@@ -117,10 +117,18 @@ async function process<TEventName extends WebhookEventName>(args: {
 	}
 
 	const githubRepositoryIntegration =
-		await args.deps.getGitHubRepositoryIntegrationIndex({
+		(await args.deps.getGitHubRepositoryIntegrationIndex({
 			storage: args.context.storage,
+			experimental_storage: args.context.experimental_storage,
 			repositoryNodeId: args.event.data.payload.repository.node_id,
-		});
+			useExperimentalStorage: true,
+		})) ??
+		(await args.deps.getGitHubRepositoryIntegrationIndex({
+			storage: args.context.storage,
+			experimental_storage: args.context.experimental_storage,
+			repositoryNodeId: args.event.data.payload.repository.node_id,
+			useExperimentalStorage: false,
+		}));
 
 	if (githubRepositoryIntegration === undefined) {
 		return;
@@ -128,10 +136,19 @@ async function process<TEventName extends WebhookEventName>(args: {
 
 	await Promise.all(
 		githubRepositoryIntegration.flowTriggerIds.map(async (flowTriggerId) => {
-			const trigger = await args.deps.getFlowTrigger({
-				storage: args.context.storage,
-				flowTriggerId,
-			});
+			const trigger =
+				(await args.deps.getFlowTrigger({
+					storage: args.context.storage,
+					experimental_storage: args.context.experimental_storage,
+					flowTriggerId,
+					useExperimentalStorage: true,
+				})) ??
+				(await args.deps.getFlowTrigger({
+					storage: args.context.storage,
+					experimental_storage: args.context.experimental_storage,
+					flowTriggerId,
+					useExperimentalStorage: false,
+				}));
 			if (trigger === undefined) {
 				return;
 			}

--- a/packages/giselle/src/engine/index.ts
+++ b/packages/giselle/src/engine/index.ts
@@ -299,7 +299,10 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		}) => {
 			return await configureTrigger({ ...args, context });
 		},
-		getTrigger: async (args: { flowTriggerId: FlowTriggerId }) => {
+		getTrigger: async (args: {
+			flowTriggerId: FlowTriggerId;
+			useExperimentalStorage?: boolean;
+		}) => {
 			return await getTrigger({ ...args, context });
 		},
 		getGitHubRepositoryFullname: async (args: {
@@ -308,8 +311,10 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		}) => {
 			return await getGitHubRepositoryFullname({ ...args, context });
 		},
-		setTrigger: async (args: { trigger: FlowTrigger }) =>
-			setTrigger({ ...args, context }),
+		setTrigger: async (args: {
+			trigger: FlowTrigger;
+			useExperimentalStorage?: boolean;
+		}) => setTrigger({ ...args, context }),
 		reconfigureGitHubTrigger: async (args: {
 			flowTriggerId: FlowTriggerId;
 			repositoryNodeId: string;
@@ -318,8 +323,10 @@ export function GiselleEngine(config: GiselleEngineConfig) {
 		}) => {
 			return await reconfigureGitHubTrigger({ ...args, context });
 		},
-		deleteTrigger: async (args: { flowTriggerId: FlowTriggerId }) =>
-			deleteTrigger({ ...args, context }),
+		deleteTrigger: async (args: {
+			flowTriggerId: FlowTriggerId;
+			useExperimentalStorage?: boolean;
+		}) => deleteTrigger({ ...args, context }),
 		executeAction: async (args: { generation: QueuedGeneration }) =>
 			executeAction({ ...args, context }),
 		createAndStartAct: async (args: CreateAndStartActInputs) =>

--- a/packages/giselle/src/engine/integrations/utils.ts
+++ b/packages/giselle/src/engine/integrations/utils.ts
@@ -3,6 +3,7 @@ import {
 	GitHubRepositoryIntegrationIndex,
 } from "@giselle-sdk/data-type";
 import type { Storage } from "unstorage";
+import type { GiselleStorage } from "../experimental_storage";
 
 function getGitHubRepositoryIntegrationPath(repositoryNodeId: string): string {
 	return `integrations/github/repositories/${repositoryNodeId}.json`;
@@ -10,11 +11,22 @@ function getGitHubRepositoryIntegrationPath(repositoryNodeId: string): string {
 
 export async function getGitHubRepositoryIntegrationIndex(args: {
 	storage: Storage;
+	experimental_storage: GiselleStorage;
 	repositoryNodeId: string;
+	useExperimentalStorage?: boolean;
 }) {
-	const unsafe = await args.storage.get(
-		getGitHubRepositoryIntegrationPath(args.repositoryNodeId),
-	);
+	const path = getGitHubRepositoryIntegrationPath(args.repositoryNodeId);
+	if (args.useExperimentalStorage) {
+		const exists = await args.experimental_storage.exists(path);
+		if (!exists) {
+			return undefined;
+		}
+		return await args.experimental_storage.getJson({
+			path,
+			schema: GitHubRepositoryIntegrationIndex,
+		});
+	}
+	const unsafe = await args.storage.get(path);
 	if (unsafe === null) {
 		return undefined;
 	}
@@ -23,24 +35,36 @@ export async function getGitHubRepositoryIntegrationIndex(args: {
 
 async function setGitHubRepositoryIntegrationIndex(args: {
 	storage: Storage;
+	experimental_storage: GiselleStorage;
 	repositoryNodeId: string;
 	index: GitHubRepositoryIntegrationIndex;
+	useExperimentalStorage?: boolean;
 }) {
-	await args.storage.set(
-		getGitHubRepositoryIntegrationPath(args.repositoryNodeId),
-		args.index,
-	);
+	const path = getGitHubRepositoryIntegrationPath(args.repositoryNodeId);
+	if (args.useExperimentalStorage) {
+		await args.experimental_storage.setJson({
+			path,
+			data: args.index,
+			schema: GitHubRepositoryIntegrationIndex,
+		});
+		return;
+	}
+	await args.storage.set(path, args.index);
 }
 
 export async function addGitHubRepositoryIntegrationIndex(args: {
 	storage: Storage;
+	experimental_storage: GiselleStorage;
 	flowTriggerId: FlowTriggerId;
 	repositoryNodeId: string;
+	useExperimentalStorage?: boolean;
 }) {
 	const githubRepositoryIntegrationIndex =
 		await getGitHubRepositoryIntegrationIndex({
 			storage: args.storage,
 			repositoryNodeId: args.repositoryNodeId,
+			experimental_storage: args.experimental_storage,
+			useExperimentalStorage: args.useExperimentalStorage,
 		});
 
 	const currentFlowTriggerIds =
@@ -48,6 +72,8 @@ export async function addGitHubRepositoryIntegrationIndex(args: {
 	await setGitHubRepositoryIntegrationIndex({
 		storage: args.storage,
 		repositoryNodeId: args.repositoryNodeId,
+		experimental_storage: args.experimental_storage,
+		useExperimentalStorage: args.useExperimentalStorage,
 		index: {
 			repositoryNodeId: args.repositoryNodeId,
 			flowTriggerIds: [...currentFlowTriggerIds, args.flowTriggerId],
@@ -57,13 +83,17 @@ export async function addGitHubRepositoryIntegrationIndex(args: {
 
 export async function removeGitHubRepositoryIntegrationIndex(args: {
 	storage: Storage;
+	experimental_storage: GiselleStorage;
 	flowTriggerId: FlowTriggerId;
 	repositoryNodeId: string;
+	useExperimentalStorage?: boolean;
 }) {
 	const githubRepositoryIntegrationIndex =
 		await getGitHubRepositoryIntegrationIndex({
 			storage: args.storage,
 			repositoryNodeId: args.repositoryNodeId,
+			experimental_storage: args.experimental_storage,
+			useExperimentalStorage: args.useExperimentalStorage,
 		});
 	if (githubRepositoryIntegrationIndex === undefined) {
 		return;
@@ -73,14 +103,19 @@ export async function removeGitHubRepositoryIntegrationIndex(args: {
 			(id) => id !== args.flowTriggerId,
 		);
 	if (remainingFlowTriggerIds.length === 0) {
-		await args.storage.removeItem(
-			getGitHubRepositoryIntegrationPath(args.repositoryNodeId),
-		);
+		const path = getGitHubRepositoryIntegrationPath(args.repositoryNodeId);
+		if (args.useExperimentalStorage) {
+			await args.experimental_storage.remove(path);
+			return;
+		}
+		await args.storage.removeItem(path);
 		return;
 	}
 	await setGitHubRepositoryIntegrationIndex({
 		storage: args.storage,
 		repositoryNodeId: args.repositoryNodeId,
+		experimental_storage: args.experimental_storage,
+		useExperimentalStorage: args.useExperimentalStorage,
 		index: {
 			repositoryNodeId: args.repositoryNodeId,
 			flowTriggerIds: remainingFlowTriggerIds,

--- a/packages/giselle/src/engine/triggers/configure-trigger.ts
+++ b/packages/giselle/src/engine/triggers/configure-trigger.ts
@@ -28,16 +28,20 @@ export async function configureTrigger(args: {
 		}),
 		setFlowTrigger({
 			storage: args.context.storage,
+			experimental_storage: args.context.experimental_storage,
 			flowTrigger: {
 				id: flowTriggerId,
 				...args.trigger,
 			},
+			useExperimentalStorage: args.useExperimentalStorage,
 		}),
 		args.trigger.configuration.provider === "github"
 			? await addGitHubRepositoryIntegrationIndex({
 					storage: args.context.storage,
+					experimental_storage: args.context.experimental_storage,
 					flowTriggerId,
 					repositoryNodeId: args.trigger.configuration.repositoryNodeId,
+					useExperimentalStorage: args.useExperimentalStorage,
 				})
 			: Promise.resolve(),
 	]);

--- a/packages/giselle/src/engine/triggers/delete-trigger.ts
+++ b/packages/giselle/src/engine/triggers/delete-trigger.ts
@@ -5,9 +5,12 @@ import { deleteFlowTrigger } from "./utils";
 export async function deleteTrigger(args: {
 	context: GiselleEngineContext;
 	flowTriggerId: FlowTriggerId;
+	useExperimentalStorage?: boolean;
 }) {
 	await deleteFlowTrigger({
 		storage: args.context.storage,
 		flowTriggerId: args.flowTriggerId,
+		experimental_storage: args.context.experimental_storage,
+		useExperimentalStorage: args.useExperimentalStorage ?? false,
 	});
 }

--- a/packages/giselle/src/engine/triggers/get-trigger.ts
+++ b/packages/giselle/src/engine/triggers/get-trigger.ts
@@ -5,10 +5,13 @@ import { getFlowTrigger } from "./utils";
 export async function getTrigger(args: {
 	context: GiselleEngineContext;
 	flowTriggerId: FlowTriggerId;
+	useExperimentalStorage?: boolean;
 }) {
 	const flowTrigger = await getFlowTrigger({
 		storage: args.context.storage,
 		flowTriggerId: args.flowTriggerId,
+		experimental_storage: args.context.experimental_storage,
+		useExperimentalStorage: args.useExperimentalStorage ?? false,
 	});
 	return flowTrigger;
 }

--- a/packages/giselle/src/engine/triggers/reconfigure-github-trigger.ts
+++ b/packages/giselle/src/engine/triggers/reconfigure-github-trigger.ts
@@ -21,7 +21,9 @@ export async function reconfigureGitHubTrigger(args: {
 }) {
 	const currentTrigger = await getFlowTrigger({
 		storage: args.context.storage,
+		experimental_storage: args.context.experimental_storage,
 		flowTriggerId: args.flowTriggerId,
+		useExperimentalStorage: args.useExperimentalStorage,
 	});
 	if (currentTrigger === undefined) {
 		throw new Error(`Trigger not found: ${args.flowTriggerId}`);
@@ -36,13 +38,17 @@ export async function reconfigureGitHubTrigger(args: {
 		await Promise.all([
 			removeGitHubRepositoryIntegrationIndex({
 				storage: args.context.storage,
+				experimental_storage: args.context.experimental_storage,
 				flowTriggerId: args.flowTriggerId,
 				repositoryNodeId: oldRepositoryNodeId,
+				useExperimentalStorage: args.useExperimentalStorage,
 			}),
 			addGitHubRepositoryIntegrationIndex({
 				storage: args.context.storage,
+				experimental_storage: args.context.experimental_storage,
 				flowTriggerId: args.flowTriggerId,
 				repositoryNodeId: newRepositoryNodeId,
+				useExperimentalStorage: args.useExperimentalStorage,
 			}),
 		]);
 	}
@@ -58,7 +64,9 @@ export async function reconfigureGitHubTrigger(args: {
 	} satisfies FlowTrigger;
 	await setFlowTrigger({
 		storage: args.context.storage,
+		experimental_storage: args.context.experimental_storage,
 		flowTrigger: updatedTrigger,
+		useExperimentalStorage: args.useExperimentalStorage,
 	});
 
 	const workspace = await getWorkspace({

--- a/packages/giselle/src/engine/triggers/resolve-trigger.ts
+++ b/packages/giselle/src/engine/triggers/resolve-trigger.ts
@@ -15,6 +15,7 @@ import { getFlowTrigger } from "./utils";
 export async function resolveTrigger(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration;
+	useExperimentalStorage: boolean;
 }) {
 	const operationNode = args.generation.context.operationNode;
 	if (!isTriggerNode(operationNode)) {
@@ -26,6 +27,8 @@ export async function resolveTrigger(args: {
 	const triggerData = await getFlowTrigger({
 		storage: args.context.storage,
 		flowTriggerId: operationNode.content.state.flowTriggerId,
+		experimental_storage: args.context.experimental_storage,
+		useExperimentalStorage: args.useExperimentalStorage,
 	});
 	if (triggerData === undefined) {
 		throw new Error("Trigger data not found");
@@ -167,5 +170,6 @@ export async function resolveTrigger(args: {
 		storage: args.context.storage,
 		generation: completedGeneration,
 		experimental_storage: args.context.experimental_storage,
+		useExperimentalStorage: args.useExperimentalStorage,
 	});
 }

--- a/packages/giselle/src/engine/triggers/set-trigger.ts
+++ b/packages/giselle/src/engine/triggers/set-trigger.ts
@@ -5,9 +5,12 @@ import { setFlowTrigger as setFlowTriggerInternal } from "./utils";
 export async function setTrigger(args: {
 	context: GiselleEngineContext;
 	trigger: FlowTrigger;
+	useExperimentalStorage?: boolean;
 }) {
 	await setFlowTriggerInternal({
 		storage: args.context.storage,
+		experimental_storage: args.context.experimental_storage,
 		flowTrigger: args.trigger,
+		useExperimentalStorage: args.useExperimentalStorage ?? false,
 	});
 }

--- a/packages/giselle/src/engine/triggers/utils.ts
+++ b/packages/giselle/src/engine/triggers/utils.ts
@@ -1,5 +1,6 @@
 import { FlowTrigger, type FlowTriggerId } from "@giselle-sdk/data-type";
 import type { Storage } from "unstorage";
+import type { GiselleStorage } from "../experimental_storage";
 import { removeGitHubRepositoryIntegrationIndex } from "../integrations/utils";
 
 function flowTriggerPath(params: { flowTriggerId: FlowTriggerId }) {
@@ -8,32 +9,54 @@ function flowTriggerPath(params: { flowTriggerId: FlowTriggerId }) {
 
 export async function setFlowTrigger({
 	storage,
+	experimental_storage,
 	flowTrigger,
+	useExperimentalStorage = false,
 }: {
 	storage: Storage;
+	experimental_storage: GiselleStorage;
 	flowTrigger: FlowTrigger;
+	useExperimentalStorage?: boolean;
 }) {
-	await storage.set(
-		flowTriggerPath({ flowTriggerId: flowTrigger.id }),
-		flowTrigger,
-	);
+	const path = flowTriggerPath({ flowTriggerId: flowTrigger.id });
+	if (useExperimentalStorage) {
+		await experimental_storage.setJson({
+			path,
+			data: flowTrigger,
+			schema: FlowTrigger,
+		});
+		return;
+	}
+	await storage.set(path, flowTrigger);
 }
 
 export async function getFlowTrigger({
 	storage,
+	experimental_storage,
 	flowTriggerId,
+	useExperimentalStorage = false,
 }: {
 	storage: Storage;
 	flowTriggerId: FlowTriggerId;
+	experimental_storage: GiselleStorage;
+	useExperimentalStorage?: boolean;
 }) {
-	const unsafe = await storage.get(
-		flowTriggerPath({
-			flowTriggerId: flowTriggerId,
-		}),
-		{
-			bypassingCache: true,
-		},
-	);
+	const path = flowTriggerPath({
+		flowTriggerId,
+	});
+	if (useExperimentalStorage) {
+		const exists = await experimental_storage.exists(path);
+		if (!exists) {
+			return undefined;
+		}
+		return await experimental_storage.getJson({
+			path,
+			schema: FlowTrigger,
+		});
+	}
+	const unsafe = await storage.get(path, {
+		bypassingCache: true,
+	});
 	if (unsafe === null) {
 		return undefined;
 	}
@@ -43,21 +66,37 @@ export async function getFlowTrigger({
 
 export async function deleteFlowTrigger({
 	storage,
+	experimental_storage,
 	flowTriggerId,
+	useExperimentalStorage = false,
 }: {
 	storage: Storage;
 	flowTriggerId: FlowTriggerId;
+	experimental_storage: GiselleStorage;
+	useExperimentalStorage?: boolean;
 }) {
-	const trigger = await getFlowTrigger({ storage, flowTriggerId });
+	const trigger = await getFlowTrigger({
+		storage,
+		experimental_storage,
+		flowTriggerId,
+		useExperimentalStorage,
+	});
 	if (trigger === undefined) {
 		throw new Error(`Flow trigger with ID ${flowTriggerId} not found`);
 	}
-	await storage.removeItem(flowTriggerPath({ flowTriggerId }));
+	const path = flowTriggerPath({ flowTriggerId });
+	if (useExperimentalStorage) {
+		await experimental_storage.remove(path);
+	} else {
+		await storage.removeItem(path);
+	}
 	if (trigger.configuration.provider === "github") {
 		await removeGitHubRepositoryIntegrationIndex({
 			storage,
+			experimental_storage,
 			flowTriggerId,
 			repositoryNodeId: trigger.configuration.repositoryNodeId,
+			useExperimentalStorage,
 		});
 	}
 }

--- a/packages/giselle/src/engine/workspaces/copy-workspace.ts
+++ b/packages/giselle/src/engine/workspaces/copy-workspace.ts
@@ -38,7 +38,9 @@ export async function copyWorkspace(args: {
 			const oldFlowTriggerId = node.content.state.flowTriggerId;
 			const oldFlowTrigger = await getFlowTrigger({
 				storage: args.context.storage,
+				experimental_storage: args.context.experimental_storage,
 				flowTriggerId: oldFlowTriggerId,
+				useExperimentalStorage: args.useExperimentalStorage,
 			});
 
 			if (oldFlowTrigger) {
@@ -52,7 +54,9 @@ export async function copyWorkspace(args: {
 
 				await setFlowTrigger({
 					storage: args.context.storage,
+					experimental_storage: args.context.experimental_storage,
 					flowTrigger: newFlowTrigger,
+					useExperimentalStorage: args.useExperimentalStorage,
 				});
 
 				return { oldNodeId: node.id, newFlowTriggerId };
@@ -96,7 +100,7 @@ export async function copyWorkspace(args: {
 			workspaceId: workspaceCopy.id,
 			workspace: Workspace.parse(workspaceCopy),
 			experimental_storage: args.context.experimental_storage,
-			useExperimentalStorage: false,
+			useExperimentalStorage: args.useExperimentalStorage,
 		}),
 		copyFiles({
 			storage: args.context.storage,

--- a/packages/giselle/src/http/router.ts
+++ b/packages/giselle/src/http/router.ts
@@ -262,6 +262,7 @@ export const createJsonRouters = {
 		createHandler({
 			input: z.object({
 				flowTriggerId: FlowTriggerId.schema,
+				useExperimentalStorage: z.boolean().optional(),
 			}),
 			handler: async ({ input }) => {
 				return JsonResponse.json({
@@ -285,6 +286,7 @@ export const createJsonRouters = {
 		createHandler({
 			input: z.object({
 				trigger: FlowTrigger,
+				useExperimentalStorage: z.boolean().optional(),
 			}),
 			handler: async ({ input }) => {
 				return JsonResponse.json({
@@ -308,7 +310,10 @@ export const createJsonRouters = {
 		}),
 	deleteTrigger: (giselleEngine: GiselleEngine) =>
 		createHandler({
-			input: z.object({ flowTriggerId: FlowTriggerId.schema }),
+			input: z.object({
+				flowTriggerId: FlowTriggerId.schema,
+				useExperimentalStorage: z.boolean().optional(),
+			}),
 			handler: async ({ input }) => {
 				await giselleEngine.deleteTrigger(input);
 				return new Response(null, { status: 204 });


### PR DESCRIPTION
### **User description**

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #2005 
- <kbd>&nbsp;1&nbsp;</kbd> #1996 👈 
<!-- GitButler Footer Boundary Bottom -->

Overview
- Introduces an experimental storage backend and an opt-in useExperimentalStorage flag to read/write FlowTrigger and GitHub integration indices from an alternative storage implementation.
- Motivation: enable testing and gradual rollout of a new storage implementation while keeping the existing storage as a safe fallback.

Changes
- Engine API: added optional useExperimentalStorage flag to trigger APIs (get/set/delete) and related engine flows; engine context wires experimental_storage through trigger utilities.
- Trigger utils: implemented schema-backed setJson/getJson/exists/remove against experimental_storage; flows support fallback to legacy storage when appropriate.
- Webhooks: webhook handler attempts experimental_storage first, then falls back to legacy storage.
- Workspace / act flows: copyWorkspace, run-act, resolveTrigger, and related flows propagate useExperimentalStorage.
- Router / HTTP API: trigger JSON endpoints accept optional useExperimentalStorage boolean.
- UI: workflow-designer reads feature flag and passes useExperimentalStorage on get/set trigger requests.
- Utilities: introduced GiselleStorage experimental implementation types and schema-backed JSON ops.
- Fallback behavior: critical paths attempt experimental_storage when requested and maintain legacy fallback to preserve backward compatibility.

Testing
- Manual:
  - Enable experimental_storage feature flag in UI; verify designer reads triggers from experimental storage.
  - Create/update/delete FlowTrigger with useExperimentalStorage=true; confirm data lands in experimental_storage and not legacy storage.
  - Trigger a GitHub webhook; verify handler finds triggers in experimental_storage and falls back to legacy when needed.
  - Copy a workspace with useExperimentalStorage enabled; confirm triggers and integration indices copy into experimental_storage with correct linkage.
  - End-to-end: run-act resolving a trigger stored in experimental_storage.
- Automated:
  - Add unit/integration tests for get/set/delete FlowTrigger across both backends and index add/remove semantics.
- Perf/Security:
  - Smoke test experimental storage ops (exists/getJson) and verify permissions are at least as strict as legacy storage.

ReviewNotes
- Fallback ordering: verify all code paths have consistent ordering (experimental -> legacy) and documented semantics.
- Schema correctness: ensure schemas supplied to getJson/setJson match FlowTrigger and GitHubRepositoryIntegrationIndex shapes.
- Backwards compatibility: default behavior must remain unchanged (useExperimentalStorage is optional/false by default).
- Concurrency/atomicity: check for race conditions when updating indices across two storages (deleteFlowTrigger, index add/remove).
- Runtime wiring: confirm engine context provides experimental_storage and HTTP/routers propagate useExperimentalStorage correctly.
- Security: validate experimental_storage enforces same access controls and does not expose sensitive data.
- Tests: ensure new unit/integration tests cover both storage paths and index update sequences.

RelatedIssues
- None / N/A

If helpful, I can paste this into the GitHub PR body and/or produce a detailed test checklist or unit-test stubs.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `useExperimentalStorage` flag to trigger APIs (get/set/delete/configure)

- Wire experimental storage through engine context and trigger utilities

- Implement fallback logic: experimental storage first, then legacy storage

- Update UI hooks to read feature flag and pass storage preference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["UI Components"] -- "useExperimentalStorage flag" --> Engine["Engine API"]
  Engine -- "storage selection" --> Utils["Trigger Utils"]
  Utils -- "primary" --> ExpStorage["Experimental Storage"]
  Utils -- "fallback" --> LegacyStorage["Legacy Storage"]
  Utils --> GitHub["GitHub Integration Index"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td><strong>utils.ts</strong><dd><code>Add experimental storage support to trigger CRUD operations</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-4ce1122eb0481494b638aee24d7a21d72224de1e6c808b79701f760f2e5522fd">+53/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>utils.ts</strong><dd><code>Add experimental storage to GitHub repository integration index</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-ead18f186d55efc77e0b1b5e54bf01fa6982ad675c31126543eb7ee27c41c017">+45/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Add useExperimentalStorage parameter to trigger API methods</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-96a319ad87ae93d0a9bbf783a2f323c01833adf52dee5d3321684a26b7e1c74a">+12/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>router.ts</strong><dd><code>Add useExperimentalStorage flag to trigger HTTP endpoints</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-642a528890ac508b2bfeb93f61540c69062a6733f4ad3948cf70eefbbdb6bc07">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-github-trigger.ts</strong><dd><code>Read feature flag and pass storage preference to trigger APIs</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-a028ce5581fe76a2c5951fadc050419d8ff8ce50ad61f00430ef82c056aff34b">+19/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-trigger.ts</strong><dd><code>Add experimental storage flag to trigger hook operations</code>&nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-4001c4268fd5b5b33ab4973e4fb4d7978cf80207526c70b4e76869fbe1f01762">+12/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handle-webhook-v2.ts</strong><dd><code>Implement fallback from experimental to legacy storage in webhook </code><br><code>handler</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-4fbb1024b23ef588f3a352932769c8f3284054df3b3ed88026990b21b14dff27">+23/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configure-trigger.ts</strong><dd><code>Wire experimental storage through trigger configuration flow</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-00c40525b4f32aec57058ac3b178ff5a2ce8afaef030b6d884312d965049becf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get-trigger.ts</strong><dd><code>Add experimental storage parameter to getTrigger function</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-7f9ed4ab511eb2bba111344413f7155eb33f9f7cb13b65b8b42f371ca5f4e770">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>set-trigger.ts</strong><dd><code>Add experimental storage parameter to setTrigger function</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-8aca4522a57a136295e68c831d332ce6a11079fcf7f400700a473f8d2fb2f86d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>delete-trigger.ts</strong><dd><code>Add experimental storage parameter to deleteTrigger function</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-a3a5141b19a7283c6acaf0486dfb3f3450ae0ac4670124f2a8c9f046dfa533b8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reconfigure-github-trigger.ts</strong><dd><code>Pass experimental storage flag through GitHub trigger reconfiguration</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-b89fc504f169254f56e21b67b249176e4dfe667416f5bd15399570a356d9a3b0">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resolve-trigger.ts</strong><dd><code>Add experimental storage parameter to trigger resolution flow</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-78dfcf7a19c8cc5ccdbe42e2d44f394920b4d79a556002508c11c4d27ac3e2f3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>copy-workspace.ts</strong><dd><code>Use experimental storage flag when copying workspace triggers</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-4e2ce0e8f103dec2af0cdcd57a0eb820d6cd8e8e89618553c28f19113e5abac4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>run-act.ts</strong><dd><code>Enable experimental storage in trigger resolution during act execution</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-4480a9dbbde20e6b5b43e9f753090fbe5c17a46a47c52a84c5280e71ba295d8b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>actions.ts</strong><dd><code>Pass experimental storage flag when copying agent triggers</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-91bf7f43202611af84b83a2ab7060e56adf19e9030ac1d45b60f853ebd4f1450">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>services.ts</strong><dd><code>Enable experimental storage when fetching flow triggers</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-86fcf5c45bc156026351aceec347601cbff444a5a160dfd8e3c35428ce70d51b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>data.ts</strong><dd><code>Enable experimental storage when retrieving act trigger data</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-b3c8b6038ba2cfb14fda6327c360730b95d0fe5bdf759245c0744f54113edc78">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>actions.ts</strong><dd><code>Enable experimental storage when fetching workspace flow trigger</code></dd></td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1996/files#diff-d7bb0611c79da9f56b63670aa4f436d3f9c200b255406f9d68cbfc17a768f009">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional experimental storage mode for flow triggers across the app.
  * Trigger operations (get, set, delete, resolve) now support this mode.
  * GitHub trigger setup, updates, and webhooks respect the experimental storage setting.
  * Workspace copy and related actions honor the experimental storage option.
  * API endpoints for triggers now accept an optional useExperimentalStorage parameter.
  * Designer UI and Studio screens propagate the feature flag to trigger fetch and update flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->