### PR TITLE
Remove runV3 feature flag

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -5,7 +5,6 @@ export default function Layout({ children }: { children: ReactNode }) {
 	return (
 		<WorkspaceProvider
 			featureFlag={{
-				runV3: true,
 				webSearchAction: false,
 				layoutV3: true,
 				experimental_storage: true,

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx
@@ -14,7 +14,6 @@ import {
 	googleUrlContextFlag,
 	layoutV3Flag,
 	resumableGenerationFlag,
-	runV3Flag,
 	stageFlag,
 	webSearchActionFlag,
 } from "@/flags";
@@ -71,7 +70,6 @@ export default async function Layout({
 	const gitHubRepositoryIndexes = await getGitHubRepositoryIndexes(
 		workspaceTeam.dbId,
 	);
-	const runV3 = await runV3Flag();
 	const webSearchAction = await webSearchActionFlag();
 	const layoutV3 = await layoutV3Flag();
 	const experimental_storage = await experimental_storageFlag();
@@ -128,7 +126,6 @@ export default async function Layout({
 				},
 			}}
 			featureFlag={{
-				runV3,
 				webSearchAction,
 				layoutV3,
 				experimental_storage,

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -40,25 +40,6 @@ export const webSearchActionFlag = flag<boolean>({
 	],
 });
 
-export const runV3Flag = flag<boolean>({
-	key: "run-v3",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("RUN_V3_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return false;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable Run v3",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const layoutV3Flag = flag<boolean>({
 	key: "layout-v3",
 	async decide() {

--- a/packages/giselle/src/react/feature-flags/context.ts
+++ b/packages/giselle/src/react/feature-flags/context.ts
@@ -1,7 +1,6 @@
 import { createContext, useContext } from "react";
 
 export interface FeatureFlagContextValue {
-	runV3: boolean;
 	webSearchAction: boolean;
 	layoutV3: boolean;
 	experimental_storage: boolean;

--- a/packages/giselle/src/react/workspace/provider.tsx
+++ b/packages/giselle/src/react/workspace/provider.tsx
@@ -44,7 +44,6 @@ export function WorkspaceProvider({
 	return (
 		<FeatureFlagContext
 			value={{
-				runV3: featureFlag?.runV3 ?? false,
 				webSearchAction: featureFlag?.webSearchAction ?? false,
 				layoutV3: featureFlag?.layoutV3 ?? false,
 				experimental_storage: featureFlag?.experimental_storage ?? false,


### PR DESCRIPTION
### **User description**
## Summary
Remove runV3 feature flag.

## Changes
The Run v3 feature is now the default implementation, so the feature flag is no longer needed. This removes the flag definition, imports, and all references across playground, studio layouts, and workspace provider.

## Testing
https://github.com/giselles-ai/giselle/pull/1998#issuecomment-3404612243

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Other


___

### **Description**
- Remove `runV3` feature flag definition and all references

- Clean up flag imports and context values across codebase

- Update workspace providers to remove flag initialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  flags["flags.ts"] -- "removes" --> runV3Flag["runV3Flag definition"]
  context["feature-flags/context.ts"] -- "removes" --> runV3Context["runV3 context value"]
  playground["playground layout"] -- "removes" --> runV3Init1["runV3 initialization"]
  studio["studio layout"] -- "removes" --> runV3Init2["runV3 initialization"]
  provider["workspace provider"] -- "removes" --> runV3Default["runV3 default value"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Delete runV3 feature flag definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Removed <code>runV3Flag</code> function definition entirely<br> <li> Deleted flag configuration including key, decide logic, and options</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1998/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>context.ts</strong><dd><code>Remove runV3 from feature flag context interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/feature-flags/context.ts

<ul><li>Removed <code>runV3</code> boolean property from <code>FeatureFlagContextValue</code> interface</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1998/files#diff-51e00df034c44dc1e5319c55d0effbebeb1358b9492f9c4f140b4caafe891bbe">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Remove runV3 flag from playground workspace provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/playground/app/workspaces/[workspaceId]/layout.tsx

- Removed `runV3: true` from `WorkspaceProvider` featureFlag prop


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1998/files#diff-4bcbefb23b47c4c61b927ade9b43dd978e216008f1c243a471a937c8c9a122ba">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Remove runV3 flag from studio workspace layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/layout.tsx

<ul><li>Removed <code>runV3Flag</code> import statement<br> <li> Deleted <code>runV3</code> flag evaluation call<br> <li> Removed <code>runV3</code> from <code>WorkspaceProvider</code> featureFlag prop</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1998/files#diff-15f3074fd9425f9c2957c436fb950d744614df0ac6ce51fd55cfaa5ff2bfb04e">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provider.tsx</strong><dd><code>Remove runV3 default value from workspace provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/provider.tsx

<ul><li>Removed <code>runV3</code> property initialization from <code>FeatureFlagContext</code> value</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/1998/files#diff-8a9be06df265f969925b0eaaa2a4817e372f5a9038025ba24b59438ce6c69744">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed the legacy “Run V3” feature flag across Playground and Studio workspaces. The toggle is no longer available in settings or UI, and it no longer influences behavior.
- Refactor
  - Simplified the feature flag context by dropping the Run V3 field, keeping all other flags and behaviors unchanged. Existing workflows remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->