### PR TITLE
fix: collect all connections between same nodes in sliceGraphFromNode

### DIFF
--- a/packages/giselle/src/engine/utils/__fixtures__/multiple-connections-same-nodes.ts
+++ b/packages/giselle/src/engine/utils/__fixtures__/multiple-connections-same-nodes.ts
@@ -1,0 +1,194 @@
+/**
+ * Multiple Connections Between Same Nodes Test Fixture
+ *
+ * This fixture tests the scenario where one node has multiple outputs
+ * connected to the same target node - a common pattern when passing
+ * multiple parameters from a trigger to an action.
+ *
+ * Node Structure:
+ *
+ * ┌─────────────────────────────┐
+ * │ On Issue Comment Created    │
+ * │ (GitHub Trigger)            │
+ * │ nd-nwdgrtVwC070isLr         │
+ * └──┬──────────────┬───────────┘
+ *    │              │
+ *    │ Issue Number │ Issue Title
+ *    │              │
+ *    ▼              ▼
+ * ┌─────────────────────────────┐
+ * │ Create Issue Comment        │
+ * │ (GitHub Action)             │
+ * │ nd-PlnxfHCFVLCuVJcb         │
+ * └─────────────────────────────┘
+ *
+ * Key Points:
+ * - Trigger has 4 outputs: issueComment, issueNumber, issueTitle, issueBody
+ * - Action has 2 inputs: issueNumber, body
+ * - TWO connections from same trigger to same action:
+ *   1. issueNumber (otp-dpz92nyiAVTcoLs6) → issueNumber (inp-rKOQKGqGb7Qeps2X)
+ *   2. issueTitle (otp-CTj1biBXwjzZuqNo) → body (inp-FiinOx0HrQqamro9)
+ *
+ * This tests the bug fix where filter() instead of find() ensures ALL
+ * connections between the same two nodes are collected.
+ */
+
+import type { Workspace } from "@giselle-sdk/data-type";
+
+export const multipleConnectionsSameNodesFixture: Workspace = {
+	id: "wrks-JJqRLOtbigJ6Tc58",
+	schemaVersion: "20250221",
+	nodes: [
+		{
+			id: "nd-nwdgrtVwC070isLr",
+			name: "On Issue Comment Created",
+			type: "operation",
+			inputs: [],
+			outputs: [
+				{
+					id: "otp-QAq4xmw2KdTuLgP2",
+					label: "Issue Comment",
+					accessor: "body",
+				},
+				{
+					id: "otp-dpz92nyiAVTcoLs6",
+					label: "Issue Number",
+					accessor: "issueNumber",
+				},
+				{
+					id: "otp-CTj1biBXwjzZuqNo",
+					label: "Issue Title",
+					accessor: "issueTitle",
+				},
+				{
+					id: "otp-Mhi9HxfxtZQ6fcTt",
+					label: "Issue Body",
+					accessor: "issueBody",
+				},
+			],
+			content: {
+				type: "trigger",
+				provider: "github",
+				state: {
+					status: "configured",
+					flowTriggerId: "fltg-ZtwjC12CVW5kPdUu",
+				},
+			},
+		},
+		{
+			id: "nd-PlnxfHCFVLCuVJcb",
+			name: "Create Issue Comment",
+			type: "operation",
+			inputs: [
+				{
+					id: "inp-rKOQKGqGb7Qeps2X",
+					label: "issueNumber",
+					accessor: "issueNumber",
+					isRequired: true,
+				},
+				{
+					id: "inp-FiinOx0HrQqamro9",
+					label: "body",
+					accessor: "body",
+					isRequired: true,
+				},
+			],
+			outputs: [
+				{
+					id: "otp-FZaotlnouWEScbaJ",
+					label: "output",
+					accessor: "action-result",
+				},
+			],
+			content: {
+				type: "action",
+				command: {
+					provider: "github",
+					state: {
+						status: "configured",
+						commandId: "github.create.issueComment",
+						repositoryNodeId: "R_kgDON5_TWw",
+						installationId: 81253657,
+					},
+				},
+			},
+		},
+	],
+	connections: [
+		{
+			id: "cnnc-mzeOjkqocn9YFhlD",
+			outputNode: {
+				id: "nd-nwdgrtVwC070isLr",
+				type: "operation",
+				content: {
+					type: "trigger",
+				},
+			},
+			outputId: "otp-dpz92nyiAVTcoLs6",
+			inputNode: {
+				id: "nd-PlnxfHCFVLCuVJcb",
+				type: "operation",
+				content: {
+					type: "action",
+				},
+			},
+			inputId: "inp-rKOQKGqGb7Qeps2X",
+		},
+		{
+			id: "cnnc-pf2KwXJAoEEBCE1n",
+			outputNode: {
+				id: "nd-nwdgrtVwC070isLr",
+				type: "operation",
+				content: {
+					type: "trigger",
+				},
+			},
+			outputId: "otp-CTj1biBXwjzZuqNo",
+			inputNode: {
+				id: "nd-PlnxfHCFVLCuVJcb",
+				type: "operation",
+				content: {
+					type: "action",
+				},
+			},
+			inputId: "inp-FiinOx0HrQqamro9",
+		},
+	],
+	ui: {
+		nodeState: {
+			"nd-nwdgrtVwC070isLr": {
+				position: {
+					x: -199.3909277921317,
+					y: 1051.8414322662375,
+				},
+				selected: true,
+				showError: false,
+				highlighted: false,
+				measured: {
+					width: 260,
+					height: 260,
+				},
+			},
+			"nd-PlnxfHCFVLCuVJcb": {
+				position: {
+					x: 310.4926866012552,
+					y: 1063.047396001855,
+				},
+				selected: false,
+				showError: false,
+				highlighted: false,
+				measured: {
+					width: 229,
+					height: 195,
+				},
+			},
+		},
+		viewport: {
+			x: 543.0285601454921,
+			y: -789.8216993868937,
+			zoom: 0.9113626570467636,
+		},
+		currentShortcutScope: "canvas",
+		selectedConnectionIds: [],
+	},
+};

--- a/packages/giselle/src/engine/utils/workspace/slice-graph-from-node.ts
+++ b/packages/giselle/src/engine/utils/workspace/slice-graph-from-node.ts
@@ -55,23 +55,19 @@ export function sliceGraphFromNode(
 			if (predNode === undefined) {
 				continue;
 			}
-
-			const connection = graph.connections.find(
+			const connections = graph.connections.filter(
 				(connection) =>
 					connection.outputNode.id === predNode.id &&
 					connection.inputNode.id === currentNode.id,
 			);
-			if (connection === undefined) {
-				continue;
+			for (const connection of connections) {
+				if (!visited.has(connection.id)) {
+					sliceConnections.push(connection);
+					sliceNodeMap.set(predNode.id, predNode);
+					sliceNodeMap.set(currentNode.id, currentNode);
+					visited.add(connection.id);
+				}
 			}
-
-			if (!visited.has(connection.id)) {
-				sliceConnections.push(connection);
-				sliceNodeMap.set(predNode.id, predNode);
-				sliceNodeMap.set(currentNode.id, currentNode);
-				visited.add(connection.id);
-			}
-
 			// Continue backward traversal from operation nodes
 			if (predNode.type === "operation") {
 				backwardQueue.push(pred);
@@ -95,19 +91,18 @@ export function sliceGraphFromNode(
 			if (nextNode === undefined) {
 				continue;
 			}
-			const connection = graph.connections.find(
+			const connections = graph.connections.filter(
 				(connection) =>
 					connection.outputNode.id === currentNode.id &&
 					connection.inputNode.id === nextNode.id,
 			);
-			if (connection === undefined) {
-				continue;
-			}
-			if (!visited.has(connection.id)) {
-				sliceConnections.push(connection);
-				sliceNodeMap.set(currentNode.id, currentNode);
-				sliceNodeMap.set(nextNode.id, nextNode);
-				visited.add(connection.id);
+			for (const connection of connections) {
+				if (!visited.has(connection.id)) {
+					sliceConnections.push(connection);
+					sliceNodeMap.set(currentNode.id, currentNode);
+					sliceNodeMap.set(nextNode.id, nextNode);
+					visited.add(connection.id);
+				}
 			}
 
 			if (nextNode.type === "operation" && !processedBackward.has(next)) {
@@ -121,20 +116,18 @@ export function sliceGraphFromNode(
 				if (refNode === undefined) {
 					continue;
 				}
-				const refConnection = graph.connections.find(
+				const refConnections = graph.connections.filter(
 					(connection) =>
 						connection.outputNode.id === refNode.id &&
 						connection.inputNode.id === nextNode.id,
 				);
-				if (refConnection === undefined) {
-					continue;
-				}
-
-				if (!visited.has(refConnection.id)) {
-					sliceConnections.push(refConnection);
-					sliceNodeMap.set(nextNode.id, nextNode);
-					sliceNodeMap.set(refNode.id, refNode);
-					visited.add(refConnection.id);
+				for (const refConnection of refConnections) {
+					if (!visited.has(refConnection.id)) {
+						sliceConnections.push(refConnection);
+						sliceNodeMap.set(nextNode.id, nextNode);
+						sliceNodeMap.set(refNode.id, refNode);
+						visited.add(refConnection.id);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### **User description**
## Summary
Fixed a bug in `sliceGraphFromNode` where only the first connection was collected when multiple connections existed between the same two nodes. Changed `find()` to `filter()` to ensure all connections are collected in forward, backward, and reference traversals.

## Related Issue
N/A

## Changes
- **Modified `slice-graph-from-node.ts`**: Changed `find()` to `filter()` in three places (forward traversal, backward traversal, and reference traversal within forward traversal) to collect all connections between the same nodes
- **Added test fixture**: Created `multiple-connections-same-nodes.ts` with real GitHub Issue trigger data
- **Added test case**: "should collect all connections when multiple connections exist between same nodes (real data)" to verify the fix

## Testing
- All existing tests pass (4/4 tests in slice-graph-from-node.test.ts)
- New test case specifically validates that all connections between same nodes are collected
- Verified with real workspace data from GitHub Issue Comment trigger with 2 connections to the same action node
- Each connection's outputId and inputId mappings are verified in the test

## Other Information
- This bug affected any scenario where one node has multiple outputs connected to the same target node (e.g., passing multiple parameters from a trigger to an action)
- The fix ensures backward compatibility - existing single connections continue to work as before
- All required commands executed successfully: `pnpm format`, `pnpm build-sdk`, `pnpm test`


___

### **PR Type**
Bug fix


___

### **Description**
- Changed `find()` to `filter()` in graph traversal to collect all connections between same nodes

- Added comprehensive test fixture with real GitHub trigger data

- Added test case validating multiple connections collection

- Fixed backward, forward, and reference traversal logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["find() method"] -- "replaced with" --> B["filter() method"]
  B --> C["Collect all connections"]
  C --> D["Test fixture added"]
  D --> E["Test validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multiple-connections-same-nodes.ts</strong><dd><code>Add test fixture for multiple connections scenario</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/utils/__fixtures__/multiple-connections-same-nodes.ts

<ul><li>Created test fixture with GitHub trigger and action nodes<br> <li> Defined two connections between same nodes (issueNumber and <br>issueTitle)<br> <li> Documented node structure and connection mappings<br> <li> Included complete workspace configuration with UI state</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2002/files#diff-c89ccc87e1e726ff1329ea494932496cd32a9cccacf5bff5181feddff171d7e7">+194/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>slice-graph-from-node.test.ts</strong><dd><code>Add test case for multiple connections between nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/utils/workspace/slice-graph-from-node.test.ts

<ul><li>Imported new <code>multipleConnectionsSameNodesFixture</code><br> <li> Added test case verifying all connections are collected<br> <li> Validated correct node and connection counts<br> <li> Verified output/input ID mappings for each connection</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2002/files#diff-7e83861278b15ac679aaf2b87f5c78a42b4ebe04767070cbea938589d5edbad8">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>slice-graph-from-node.ts</strong><dd><code>Replace find with filter for connection collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/utils/workspace/slice-graph-from-node.ts

<ul><li>Changed <code>find()</code> to <code>filter()</code> in backward traversal logic<br> <li> Changed <code>find()</code> to <code>filter()</code> in forward traversal logic<br> <li> Changed <code>find()</code> to <code>filter()</code> in reference traversal logic<br> <li> Wrapped connection processing in loops to handle multiple connections</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2002/files#diff-7088b1e8167459a54a0a34b901ded7da53909fee2ebba5162aab4240dc6b76fa">+24/-31</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

