### PR TITLE
fix: handle duplicate connections in buildLevels to prevent negative in-degrees

### DIFF
--- a/packages/giselle/src/engine/utils/build-levels.ts
+++ b/packages/giselle/src/engine/utils/build-levels.ts
@@ -86,9 +86,15 @@ export function buildLevels(
 			remainingNodes.delete(nodeId);
 
 			// Decrease in-degree of children
+			// Track processed edges to avoid double-decrementing duplicates
+			const processedDecrements = new Set<string>();
 			for (const conn of operationConnections) {
 				if (conn.outputNode.id === nodeId) {
-					inDegrees[conn.inputNode.id]--;
+					const edgeKey = `${conn.outputNode.id}-${conn.inputNode.id}`;
+					if (!processedDecrements.has(edgeKey)) {
+						processedDecrements.add(edgeKey);
+						inDegrees[conn.inputNode.id]--;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### **User description**
## Summary
Fixed a bug in `buildLevels` function where duplicate connections between the same nodes caused negative in-degrees during the topological sort, resulting in incorrect execution level ordering.

## Related Issue
N/A

## Changes
- Fixed duplicate edge handling in `buildLevels` function (packages/giselle/src/engine/utils/build-levels.ts)
  - Added `processedDecrements` Set to track processed edges during in-degree decrement phase
  - Prevents the same edge from being decremented multiple times
- Added regression test case "should handle many duplicate connections and maintain correct in-degrees"

## Testing
- All existing tests pass (12 tests in build-levels.test.ts)
- Added specific regression test that reproduces the bug:
  - 5 duplicate connections: Trigger → Middle
  - 2 duplicate connections: Trigger → Final  
  - 1 connection: Middle → Final
  - Verifies correct level ordering: Level 0 (Trigger), Level 1 (Middle), Level 2 (Final)
  - Without the fix, Middle would get in-degree of -4, causing incorrect ordering

## Other Information
The bug occurred when the same connection (same outputNode.id and inputNode.id) existed multiple times in the connections array. The in-degree increment phase correctly handled duplicates, but the decrement phase did not, causing negative in-degrees and incorrect topological sort results.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed duplicate connection handling in `buildLevels` topological sort

- Added edge tracking to prevent negative in-degrees during decrement phase

- Added regression test with multiple duplicate connections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate Connections"] --> B["processedDecrements Set"]
  B --> C["Track Edge Keys"]
  C --> D["Prevent Double Decrement"]
  D --> E["Correct In-Degrees"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-levels.ts</strong><dd><code>Prevent duplicate edge processing in topological sort</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/utils/build-levels.ts

<ul><li>Added <code>processedDecrements</code> Set to track processed edges<br> <li> Implemented edge key generation (<code>outputNode.id-inputNode.id</code>)<br> <li> Added conditional check to prevent duplicate edge decrements<br> <li> Ensures each unique edge decrements in-degree only once</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2007/files#diff-e9bce236a93e168514b30e8d5201aabcff28dd2a9f15970657cf75e4556b5270">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-levels.test.ts</strong><dd><code>Add regression test for duplicate connection handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/utils/build-levels.test.ts

<ul><li>Added regression test for many duplicate connections scenario<br> <li> Tests 5 duplicate Trigger→Middle and 2 duplicate Trigger→Final <br>connections<br> <li> Verifies correct 3-level ordering: Trigger, Middle, Final<br> <li> Includes detailed comments explaining the bug behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2007/files#diff-02bc1ee80ee2c476277dab531c32fff51af4daf106c4716fa61653a3a232b685">+99/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevent negative in-degrees in `buildLevels` by avoiding double-decrement on duplicate edges and add a regression test validating correct level ordering.
> 
> - **Engine / utils**:
>   - `packages/giselle/src/engine/utils/build-levels.ts`: Prevent double in-degree decrements for duplicate edges by tracking processed edge keys during the decrement phase, ensuring correct level ordering.
> - **Tests**:
>   - `packages/giselle/src/engine/utils/build-levels.test.ts`: Add regression test covering many duplicate connections to verify stable in-degrees and proper 3-level ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43c30235b08c4cf58c07513349735ca573cfef4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects handling of duplicate connections during level computation, ensuring accurate in-degree updates and stable node ordering in graphs with repeated edges.
  * Improves reliability of graph processing in complex connection scenarios without changing the API.

* **Tests**
  * Adds a regression test covering scenarios with many duplicate connections to verify correct level assignment and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->