### PR TITLE
Tokenize chat colors and unify typing indicator

### DIFF
--- a/internal-packages/ui/styles/aliases.css
+++ b/internal-packages/ui/styles/aliases.css
@@ -327,6 +327,14 @@
 			inset 0 0 20px rgba(107, 143, 240, 0.1)
 		) !important;
 	}
+
+	/* User bubble tokenized utilities */
+	.bg-chat-bubble-user {
+		background-color: var(--color-chat-bubble-user-bg, #4a6fd8) !important;
+	}
+	.shadow-chat-bubble-user {
+		box-shadow: var(--shadow-chat-bubble-user, 0 1px 2px 0 rgb(0 0 0 / 0.05)) !important;
+	}
 	.bg-chat-input {
 		background-color: var(
 			--color-chat-input-bg,

--- a/internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx
@@ -170,7 +170,7 @@ export function ChatPanel() {
 								<div
 									className={`max-w-[80%] min-w-0 px-4 py-3 text-sm font-mono ${
 										message.sender === "user"
-											? "font-light bg-[#4A6FD8] text-inverse rounded-[8px] rounded-br-[4px] shadow-sm"
+											? "font-light bg-chat-bubble-user text-inverse rounded-[8px] rounded-br-[4px] shadow-chat-bubble-user"
 											: "font-light bg-chat-bubble-accent text-inverse rounded-[8px] rounded-bl-[4px] border border-chat-bubble-accent shadow-chat-bubble-accent backdrop-blur-sm animate-slide-up-left"
 									}`}
 								>


### PR DESCRIPTION
### **User description**
- Tokenized chat bubble and input colors with new aliases (bg-chat-bubble-accent, border-chat-bubble-accent, shadow-chat-bubble-accent, bg-chat-input, border-chat-input, ring-chat-input)
- Switched typing indicator dots to inverse (white)
- No visual changes besides palette tokens; ready for theme overrides


___

### **PR Type**
Enhancement


___

### **Description**
- Tokenized chat bubble colors with CSS custom properties for theme flexibility

- Tokenized chat input styling with configurable background and border colors

- Changed typing indicator dots from dark to inverse (white) for better visibility

- Replaced hardcoded color values with reusable token classes in chat panel


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded Chat Colors"] -->|"Tokenize with CSS vars"| B["Chat Color Tokens"]
  B -->|"bg-chat-bubble-accent"| C["Chat Bubble Styling"]
  B -->|"bg-chat-input, border-chat-input"| D["Chat Input Styling"]
  E["Dark Typing Dots"] -->|"Change to inverse"| F["White Typing Dots"]
  C -->|"Applied to"| G["Chat Panel Component"]
  D -->|"Applied to"| G
  F -->|"Applied to"| G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliases.css</strong><dd><code>Add tokenized chat color CSS utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ui/styles/aliases.css

<ul><li>Added 6 new chat-specific CSS token classes with fallback values<br> <li> Introduced <code>bg-chat-bubble-accent</code>, <code>border-chat-bubble-accent</code>, and <br><code>shadow-chat-bubble-accent</code> for accent bubble styling<br> <li> Added <code>bg-chat-input</code>, <code>border-chat-input</code>, and <code>ring-chat-input</code> for input <br>field customization<br> <li> Added <code>placeholder:text-inverse/40</code> utility for placeholder text styling</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2015/files#diff-2f8a7a4dcb448519a2ede5ae4a20476f4598cfd53d343c54a9ecd3d2b5d0b2ec">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat-panel.tsx</strong><dd><code>Apply tokenized colors to chat panel component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx

<ul><li>Replaced hardcoded chat bubble colors with <code>bg-chat-bubble-accent</code>, <br><code>border-chat-bubble-accent</code>, and <code>shadow-chat-bubble-accent</code> token classes<br> <li> Updated typing indicator dots from <code>bg-bg</code> to <code>bg-inverse</code> for white <br>appearance<br> <li> Replaced hardcoded chat input styling with <code>bg-chat-input</code> and <br><code>border-chat-input</code> token classes<br> <li> Updated send button colors to use <code>text-accent</code> and <code>text-link-accent</code> <br>tokens instead of hardcoded hex values<br> <li> Changed input placeholder from <code>placeholder-white-600</code> to <br><code>placeholder:text-inverse/40</code> for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2015/files#diff-11adb72d8a633420c7ac25d48fad5f23f7c75f9aff31e375e81a1d644871437b">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated chat bubble visuals with new background, border, and shadow treatments.
  * Refreshed chat input area with new background, border, and focus ring styling.
  * Refined send button text color states for clearer enabled/disabled and hover feedback.
  * Enhanced typing indicator visuals for better consistency with bubble styles.
  * Added placeholder styling for inverse text at reduced opacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds chat-specific CSS token utilities and updates the chat panel to use them, including adjusted typing indicator and input/send styles.
> 
> - **Styles (tokens)**:
>   - Add chat utilities: `bg-chat-bubble-accent`, `border-chat-bubble-accent`, `shadow-chat-bubble-accent`, `bg-chat-bubble-user`, `shadow-chat-bubble-user`, `bg-chat-input`, `border-chat-input`, `ring-chat-input`, and `placeholder:text-inverse/40`.
> - **Chat Panel (`internal-packages/workflow-designer-ui/src/editor/chat/chat-panel.tsx`)**:
>   - Replace hardcoded bubble colors/shadows with `bg-chat-bubble-user` and `bg/border/shadow-chat-bubble-accent`.
>   - Update typing indicator dots from `bg-bg` to `bg-inverse`.
>   - Tokenize textarea with `bg-chat-input`, `border-chat-input`, `focus:ring-chat-input`; switch placeholder to `placeholder:text-inverse/40`.
>   - Use `text-accent` and `hover:text-link-accent` for send button states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43d32c394caa6dc3ffb787e48fd140152dadd5ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->