### PR TITLE
feat(studio): GitHub Trigger Panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/components/icons/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/components/icons/index.tsx
@@ -1,4 +1,5 @@
 import type { GitHubTriggerEventId } from "@giselle-sdk/flow";
+import { Tag } from "lucide-react";
 
 export interface IconProps {
 	className?: string;
@@ -122,44 +123,7 @@ export function IssueLabeledIcon({
 	title = "Issue Labeled",
 }: IconProps) {
 	return (
-		<svg
-			width={size}
-			height={size}
-			viewBox="0 0 24.79 22.6"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
-			className={className}
-			aria-hidden="true"
-			role="img"
-			aria-label={title}
-		>
-			<title>{title}</title>
-			<g>
-				<path
-					d="M.78,6.93h2.02l2.52,5.39,.14,.3h.06v-5.69h1.48v8.74h-1.88l-2.61-5.44-.19-.42h-.07v5.86H.78V6.93Z"
-					fill="white"
-					stroke="white"
-					strokeMiterlimit="10"
-					strokeWidth=".5"
-				/>
-				<path
-					d="M8.1,6.93h5.48v1.71h-3.94v1.8h3.41v1.58h-3.41v1.93h3.92v1.71h-5.46V6.93Z"
-					fill="white"
-					stroke="white"
-					strokeMiterlimit="10"
-					strokeWidth=".5"
-				/>
-				<path
-					d="M14.66,6.93h1.57l.8,5.65,.22,1.19h.07l1.09-6.84h1.91l1.08,6.84h.07l.19-1.12,.8-5.72h1.56l-1.42,8.74h-2.22l-.87-5.41-.11-.66h-.07l-.09,.66-.89,5.41h-2.23l-1.46-8.74Z"
-					fill="currentColor"
-					stroke="currentColor"
-					strokeMiterlimit="10"
-					strokeWidth=".5"
-				/>
-			</g>
-			<rect width="24.79" height="2.24" fill="currentColor" />
-			<rect y="20.36" width="24.79" height="2.24" fill="currentColor" />
-		</svg>
+		<Tag className={className} size={size} aria-label={title} role="img" />
 	);
 }
 
@@ -322,44 +286,7 @@ export function PullRequestLabeledIcon({
 	title = "Pull Request Labeled",
 }: IconProps) {
 	return (
-		<svg
-			width={size}
-			height={size}
-			viewBox="0 0 24.79 22.6"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
-			className={className}
-			aria-hidden="true"
-			role="img"
-			aria-label={title}
-		>
-			<title>{title}</title>
-			<g>
-				<path
-					d="M.78,6.93h2.02l2.52,5.39,.14,.3h.06v-5.69h1.48v8.74h-1.88l-2.61-5.44-.19-.42h-.07v5.86H.78V6.93Z"
-					fill="white"
-					stroke="white"
-					strokeMiterlimit="10"
-					strokeWidth=".5"
-				/>
-				<path
-					d="M8.1,6.93h5.48v1.71h-3.94v1.8h3.41v1.58h-3.41v1.93h3.92v1.71h-5.46V6.93Z"
-					fill="white"
-					stroke="white"
-					strokeMiterlimit="10"
-					strokeWidth=".5"
-				/>
-				<path
-					d="M14.66,6.93h1.57l.8,5.65,.22,1.19h.07l1.09-6.84h1.91l1.08,6.84h.07l.19-1.12,.8-5.72h1.56l-1.42,8.74h-2.22l-.87-5.41-.11-.66h-.07l-.09,.66-.89,5.41h-2.23l-1.46-8.74Z"
-					fill="currentColor"
-					stroke="currentColor"
-					strokeMiterlimit="10"
-					strokeWidth=".5"
-				/>
-			</g>
-			<rect width="24.79" height="2.24" fill="currentColor" />
-			<rect y="20.36" width="24.79" height="2.24" fill="currentColor" />
-		</svg>
+		<Tag className={className} size={size} aria-label={title} role="img" />
 	);
 }
 


### PR DESCRIPTION
### **User description**
Implements GitHub Trigger Panel.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace custom SVG icons with lucide-react Tag icon

- Simplify IssueLabeledIcon and PullRequestLabeledIcon components

- Reduce code duplication by using standard icon library


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom SVG Icons"] -- "Replace with" --> B["lucide-react Tag Icon"]
  B --> C["IssueLabeledIcon"]
  B --> D["PullRequestLabeledIcon"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Replace custom SVG with lucide-react Tag icon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/trigger-node-properties-panel/providers/github-trigger/components/icons/index.tsx

<ul><li>Import <code>Tag</code> component from lucide-react library<br> <li> Replace custom SVG implementation in <code>IssueLabeledIcon</code> with <code>Tag</code> <br>component<br> <li> Replace custom SVG implementation in <code>PullRequestLabeledIcon</code> with <code>Tag</code> <br>component<br> <li> Maintain accessibility attributes (aria-label, role) in simplified <br>components</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2026/files#diff-08ceeabf5aad383328c064b7d17df7f8d51584e51f59c22a96e3385081f36266">+3/-76</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces Issue/Pull Request labeled event SVGs with lucide-react Tag icon in the GitHub trigger icons component.
> 
> - **UI — GitHub Trigger Icons (`providers/github-trigger/components/icons/index.tsx`)**:
>   - Replace `IssueLabeledIcon` and `PullRequestLabeledIcon` custom SVGs with `lucide-react` `Tag` component.
>   - Add `Tag` import from `lucide-react`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c330d05658d90ab588cb11a6c2fb4fd1c3b4bae3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated interface icons to use consistent library-based icon components, maintaining visual appearance and accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->