### PR TITLE
Unify Start Manual Flow dialog to use ui/dialog DialogContent (remove Radix overlay/content)

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
@@ -1,12 +1,11 @@
 import { Button } from "@giselle-internal/ui/button";
 import {
 	Dialog,
-	DialogPortal,
+	DialogContent,
 	DialogTitle,
 	DialogTrigger,
 } from "@giselle-internal/ui/dialog";
 import { DropdownMenu } from "@giselle-internal/ui/dropdown-menu";
-import { GlassSurfaceLayers } from "@giselle-internal/ui/glass-surface";
 import { useToasts } from "@giselle-internal/ui/toast";
 import type { ConnectionId, NodeId, TriggerNode } from "@giselle-sdk/data-type";
 import {
@@ -21,7 +20,6 @@ import {
 } from "@giselle-sdk/giselle/react";
 import clsx from "clsx/lite";
 import { PlayIcon, UngroupIcon } from "lucide-react";
-import { Dialog as RadixDialog } from "radix-ui";
 import { useCallback, useMemo, useState } from "react";
 import { NodeIcon } from "../../../icons/node";
 import { isPromptEmpty } from "../../lib/validate-prompt";
@@ -55,36 +53,7 @@ type NodeGroupMenuItem = {
 };
 
 function CenteredDialogContent({ children }: React.PropsWithChildren) {
-	return (
-		<DialogPortal>
-			<RadixDialog.Overlay
-				className="fixed inset-0 z-50"
-				style={{ background: "var(--color-dialog-overlay)" }}
-			/>
-			<div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
-				<RadixDialog.Content
-					className={clsx(
-						"relative pointer-events-auto overflow-y-auto overflow-x-hidden outline-none",
-						"w-[500px] max-h-[85%]",
-						"bg-transparent shadow-xl text-text p-6 rounded-[12px]",
-					)}
-				>
-					<GlassSurfaceLayers
-						radiusClass="rounded-[12px]"
-						withBaseFill={false}
-						withTopHighlight
-						borderStyle="solid"
-						borderTone="muted"
-						blurClass="backdrop-blur-md"
-						zIndexClass="z-0"
-					/>
-					{/* Subtle dark hairline to make muted slightly darker than default */}
-					{/* Removed aux hairline here; now provided by GlassSurfaceLayers default */}
-					{children}
-				</RadixDialog.Content>
-			</div>
-		</DialogPortal>
-	);
+	return <DialogContent>{children}</DialogContent>;
 }
 
 function RunOptionItem({


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplify dialog implementation by replacing custom Radix UI wrapper

- Remove manual overlay and content composition logic

- Use unified `DialogContent` component from ui/dialog package

- Eliminate unnecessary `GlassSurfaceLayers` and styling complexity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom Radix Dialog<br/>with Overlay & Content"] -- "Refactor to" --> B["Unified DialogContent<br/>Component"]
  A -- "Remove" --> C["GlassSurfaceLayers<br/>Manual Styling"]
  B -- "Simplifies" --> D["Cleaner Dialog<br/>Implementation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-button.tsx</strong><dd><code>Simplify dialog to use unified DialogContent component</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx

<ul><li>Replace <code>DialogPortal</code> with <code>DialogContent</code> import from ui/dialog<br> <li> Remove Radix UI <code>Dialog</code> import and manual overlay/content composition<br> <li> Remove <code>GlassSurfaceLayers</code> import and complex styling logic<br> <li> Simplify <code>CenteredDialogContent</code> component to single-line wrapper using <br><code>DialogContent</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2029/files#diff-8a9745738738ef2c3b8f9ac4e66ea3a2abdefa3e5b53e53845092b4165130db6">+2/-33</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the dialog rendering mechanism within the workflow designer to improve code maintainability. No change to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->