### PR TITLE
fix(flags): default undefined edge flag to true instead of false

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -67,7 +67,7 @@ export const experimental_storageFlag = flag<boolean>({
 		}
 		const edgeConfig = await get(`flag__${this.key}`);
 		if (edgeConfig === undefined) {
-			return false;
+			return true;
 		}
 		return edgeConfig === true || edgeConfig === "true";
 	},


### PR DESCRIPTION
Switch from unstorage to our own implementation of giselle storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experimental storage functionality is now enabled by default when configuration is not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->