### PR TITLE
feat!: Add node lifecycle callbacks to workspace store with store rename

### DIFF
--- a/packages/giselle/src/react/workspace/store/store.ts
+++ b/packages/giselle/src/react/workspace/store/store.ts
@@ -13,7 +13,7 @@ export type AppStore = WorkspaceSlice &
 	FileSlice &
 	PropertiesPanelSlice;
 
-export const useAppStore = create<AppStore>()((...a) => ({
+export const appStore = create<AppStore>()((...a) => ({
 	...createWorkspaceSlice(...a),
 	...createViewSlice(...a),
 	...createFileSlice(...a),

--- a/packages/giselle/src/react/workspace/store/use-workflow-designer.ts
+++ b/packages/giselle/src/react/workspace/store/use-workflow-designer.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { WorkflowDesignerContext } from "../context";
-import { type AppStore, useAppStore } from "./store";
+import { type AppStore, appStore } from "./store";
 
 export function useWorkflowDesigner() {
 	const context = useContext(WorkflowDesignerContext);
@@ -19,7 +19,7 @@ type WorkflowDesignerStore = Omit<AppStore, "workspace"> & {
 export function useWorkflowDesignerStore<T>(
 	selector: (workflowDesignerStore: WorkflowDesignerStore) => T,
 ) {
-	return useAppStore((appStore) => {
+	return appStore((appStore) => {
 		if (!appStore.workspace) {
 			throw new Error("Workspace is not initialized");
 		}


### PR DESCRIPTION
### **User description**
## Overview

This PR introduces node lifecycle callbacks to the workspace store, enabling consumers to hook into node creation, update, and deletion events. This enhancement provides better extensibility for applications that need to react to workspace state changes, such as syncing with external systems, logging, or triggering side effects.

**⚠️ Breaking Change:** The Zustand store export has been renamed from `useAppStore` to `appStore`. All consumers must update their imports and method calls accordingly.

## Changes

### Core Functionality
- **Added lifecycle callbacks to workspace store:**
  - New optional callbacks: `onAddNode`, `onUpdateNode`, `onDeleteNode`
  - `initWorkspace` now accepts an options object to register these callbacks
  - Node manipulation methods (`addNode`, `updateNode`, `deleteNode`) now trigger corresponding callbacks

### API Updates
- **Breaking:** Renamed store export from `useAppStore` to `appStore`
  - Update required for all imports and calls: `appStore()`, `appStore.getState()`, `appStore.subscribe()`
- `ZustandBridgeProvider` now accepts optional callback props and passes them to `initWorkspace`

### Internal Refactoring
- Updated all internal references to use the renamed `appStore`
- Autosave and provider initialization behavior remains unchanged

## Testing

- [ ] Verified node lifecycle callbacks are triggered correctly during add/update/delete operations
- [ ] Confirmed backward compatibility for consumers not using callbacks
- [ ] Tested `ZustandBridgeProvider` correctly passes callbacks to store initialization
- [ ] Validated autosave functionality continues to work with the renamed store

## Review Notes

### Areas Requiring Attention

1. **Potential Bug:** The `deleteNode` callback implementation may have an issue - the callback is retrieved after the node is removed from state, which could prevent `deleteNodeCallback` from firing. Please review the execution order in the `deleteNode` method.

2. **Breaking Change Impact:** Please confirm the rename from `useAppStore` to `appStore` aligns with our naming conventions and that all dependent code has been identified for migration.

3. **Callback Error Handling:** Should we add try-catch blocks around callback invocations to prevent user-provided callbacks from breaking core functionality?

## Related Issues

- Closes #[ISSUE_NUMBER] - Add extensibility hooks for workspace node lifecycle events


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add node lifecycle callbacks (onAddNode, onUpdateNode, onDeleteNode) to workspace store

- Rename store export from useAppStore to appStore for consistency

- Update ZustandBridgeProvider to accept and pass callback options

- Fix deleteNode callback execution order to retrieve node before deletion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ZustandBridgeProvider<br/>receives callbacks"] -->|passes options| B["initWorkspace<br/>registers callbacks"]
  B -->|stores callbacks| C["Workspace Store<br/>state"]
  D["addNode"] -->|triggers| E["addNodeCallback"]
  F["updateNode"] -->|triggers| G["updateNodeCallback"]
  H["deleteNode"] -->|triggers| I["deleteNodeCallback"]
  C -->|provides| D
  C -->|provides| F
  C -->|provides| H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>Rename store export to appStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/store/store.ts

<ul><li>Renamed store export from <code>useAppStore</code> to <code>appStore</code><br> <li> Updated Zustand store creation to use new naming convention</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2070/files#diff-e9b2563d56500969b1499f0fe18811ae06f8a32f335e7123545957cc55417f08">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-workflow-designer.ts</strong><dd><code>Update imports and calls to renamed store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/store/use-workflow-designer.ts

<ul><li>Updated import to use renamed <code>appStore</code> instead of <code>useAppStore</code><br> <li> Updated <code>useWorkflowDesignerStore</code> function to call <code>appStore</code> directly</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2070/files#diff-bedb2b6021beef5e810dce284e2b0ce6b4e49d54ab6377c122107424ea294dac">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace-slice.ts</strong><dd><code>Add lifecycle callbacks to workspace operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/store/workspace-slice.ts

<ul><li>Added <code>WorkspaceSliceOptions</code> interface with optional lifecycle <br>callbacks<br> <li> Extended <code>WorkspaceSlice</code> interface with callback properties and updated <br><code>initWorkspace</code> signature<br> <li> Modified <code>initWorkspace</code> to accept options and register callbacks in <br>state<br> <li> Updated <code>addNode</code> to trigger <code>addNodeCallback</code> after node addition<br> <li> Updated <code>updateNode</code> to trigger <code>updateNodeCallback</code> with updated node <br>data<br> <li> Fixed <code>deleteNode</code> to retrieve node before deletion and trigger <br><code>deleteNodeCallback</code><br> <li> Refactored <code>createWorkspaceSlice</code> type signature for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2070/files#diff-f800b6d4cc31e16f91bfbe038fa44d7180217ee8bd79d83411d537df6413aa34">+43/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zustand-bridge-provider.tsx</strong><dd><code>Add callback support to ZustandBridgeProvider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/zustand-bridge-provider.tsx

<ul><li>Added <code>WorkspaceCallbackOptions</code> interface for callback props<br> <li> Updated <code>ZustandBridgeProvider</code> to accept callback props (onAddNode, <br>onUpdateNode, onDeleteNode)<br> <li> Modified <code>initWorkspace</code> call to pass callbacks as options<br> <li> Updated all <code>useAppStore</code> references to <code>appStore</code><br> <li> Added callback props to dependency array in useEffect</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2070/files#diff-09cadf0df478ab59ee9cbce04f0aa135f49f1c3e9cefd1ab98945252d4d90ea2">+23/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds node add/update/delete callbacks to the workspace store and renames the Zustand export from `useAppStore` to `appStore`, updating provider, hooks, and autosave usages.
> 
> - **State Management (Zustand)**
>   - **Workspace Slice (`store/workspace-slice.ts`)**
>     - Add `WorkspaceSliceOptions` with `onAddNode`, `onUpdateNode`, `onDeleteNode`.
>     - Extend `initWorkspace(workspace, options?)` to register callbacks.
>     - Trigger callbacks in `addNode`, `updateNode`, `deleteNode`.
>     - Expose `addNodeCallback`, `updateNodeCallback`, `deleteNodeCallback` in state.
>     - Simplify `StateCreator<WorkspaceSlice>` usage.
>   - **Store (`store/store.ts`)**
>     - Rename export from `useAppStore` to `appStore`.
> - **Hooks/Provider**
>   - **use-workflow-designer (`store/use-workflow-designer.ts`)**: switch selectors to `appStore`.
>   - **ZustandBridgeProvider (`workspace/zustand-bridge-provider.tsx`)**
>     - Add optional props: `onAddNode`, `onUpdateNode`, `onDeleteNode` and pass to `initWorkspace`.
>     - Replace `useAppStore` calls with `appStore` for `subscribe`, `getState`, `setState`, and state access.
>     - Preserve autosave behavior with `appStore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 809c81b4fee0b322578ad93d2ddb92d857bb4245. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ZustandBridgeProvider now supports optional callbacks for workspace node operations (add, update, delete), enabling external listeners to respond to node lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->