### PR TITLE
feat(flags): resumable generation feature flag and usage across codebase

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/layout.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/layout.tsx
@@ -9,7 +9,6 @@ export default function Layout({ children }: { children: ReactNode }) {
 				layoutV3: true,
 				stage: true,
 				aiGateway: false,
-				resumableGeneration: false,
 				googleUrlContext: false,
 				documentVectorStore: false,
 			}}

--- a/apps/studio.giselles.ai/app/deprecated/workspaces/[workspaceId]/layout.tsx
+++ b/apps/studio.giselles.ai/app/deprecated/workspaces/[workspaceId]/layout.tsx
@@ -12,7 +12,6 @@ import {
 	docVectorStoreFlag,
 	googleUrlContextFlag,
 	layoutV3Flag,
-	resumableGenerationFlag,
 	stageFlag,
 	webSearchActionFlag,
 } from "@/flags";
@@ -73,7 +72,6 @@ export default async function Layout({
 	const layoutV3 = await layoutV3Flag();
 	const stage = await stageFlag();
 	const aiGateway = await aiGatewayFlag();
-	const resumableGeneration = await resumableGenerationFlag();
 	const googleUrlContext = await googleUrlContextFlag();
 	const data = await giselleEngine.getWorkspace(workspaceId);
 	const documentVectorStore = await docVectorStoreFlag();
@@ -125,7 +123,6 @@ export default async function Layout({
 				layoutV3,
 				stage,
 				aiGateway,
-				resumableGeneration,
 				googleUrlContext,
 				documentVectorStore,
 			}}

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
@@ -7,7 +7,6 @@ import {
 	docVectorStoreFlag,
 	googleUrlContextFlag,
 	layoutV3Flag,
-	resumableGenerationFlag,
 	stageFlag,
 	webSearchActionFlag,
 } from "@/flags";
@@ -53,7 +52,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 	const layoutV3 = await layoutV3Flag();
 	const stage = await stageFlag();
 	const aiGateway = await aiGatewayFlag();
-	const resumableGeneration = await resumableGenerationFlag();
 	const googleUrlContext = await googleUrlContextFlag();
 	const data = await giselleEngine.getWorkspace(workspaceId);
 	const documentVectorStore = await docVectorStoreFlag();
@@ -72,7 +70,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 		layoutV3,
 		stage,
 		aiGateway,
-		resumableGeneration,
 		googleUrlContext,
 		data,
 		documentVectorStore,
@@ -82,7 +79,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 			layoutV3,
 			stage,
 			aiGateway,
-			resumableGeneration,
 			googleUrlContext,
 			documentVectorStore,
 		},

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -116,25 +116,6 @@ export const aiGatewayFlag = flag<boolean>({
 	],
 });
 
-export const resumableGenerationFlag = flag<boolean>({
-	key: "resumable-generation",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("RESUMABLE_GENERATION_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return false;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable resumable generation",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const googleUrlContextFlag = flag<boolean>({
 	key: "google-url-context",
 	async decide() {

--- a/packages/giselle/src/engine/generations/generate-content.ts
+++ b/packages/giselle/src/engine/generations/generate-content.ts
@@ -77,7 +77,6 @@ export function generateContent({
 	return useGenerationExecutor({
 		context,
 		generation,
-		useResumableGeneration: true,
 		metadata,
 		execute: async ({
 			finishGeneration,

--- a/packages/giselle/src/engine/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/engine/generations/internal/use-generation-executor.ts
@@ -59,7 +59,6 @@ type FinishGeneration = (args: FinishGenerationArgs) => Promise<{
 export async function useGenerationExecutor<T>(args: {
 	context: GiselleEngineContext;
 	generation: QueuedGeneration | RunningGeneration;
-	useResumableGeneration?: boolean;
 	signal?: AbortSignal;
 	metadata?: GenerationMetadata;
 	execute: (utils: {

--- a/packages/giselle/src/react/feature-flags/context.ts
+++ b/packages/giselle/src/react/feature-flags/context.ts
@@ -5,7 +5,6 @@ export interface FeatureFlagContextValue {
 	layoutV3: boolean;
 	stage: boolean;
 	aiGateway: boolean;
-	resumableGeneration: boolean;
 	googleUrlContext: boolean;
 	documentVectorStore: boolean;
 }

--- a/packages/giselle/src/react/workspace/provider.tsx
+++ b/packages/giselle/src/react/workspace/provider.tsx
@@ -48,7 +48,6 @@ export function WorkspaceProvider({
 				layoutV3: featureFlag?.layoutV3 ?? false,
 				stage: featureFlag?.stage ?? false,
 				aiGateway: featureFlag?.aiGateway ?? false,
-				resumableGeneration: featureFlag?.resumableGeneration ?? false,
 				googleUrlContext: featureFlag?.googleUrlContext ?? false,
 				documentVectorStore: featureFlag?.documentVectorStore ?? false,
 			}}


### PR DESCRIPTION
### **User description**
Summary
- Add a new feature flag "resumable generation"
- Integrate flag usage across the codebase where resumable generation behavior is required

Changes
- Introduced the resumable generation feature flag
- Updated code paths to check and respect the new flag
- Applied flag usage consistently across modules handle generation/resumption logic

Notes
- No other behavioral changes beyond enabling conditional resumable generation based on the flag


___

### **PR Type**
Enhancement


___

### **Description**
- Remove resumable generation feature flag from codebase

- Delete flag definition and all references across modules

- Simplify feature flag context and provider implementations

- Clean up flag usage in data loaders and layout files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["resumableGenerationFlag<br/>Definition"] -->|removed| B["flags.ts"]
  C["Flag Imports"] -->|removed| D["data-loader.ts<br/>layout.tsx"]
  E["Feature Flag Context"] -->|simplified| F["context.ts<br/>provider.tsx"]
  G["Generation Executor"] -->|parameter removed| H["use-generation-executor.ts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Delete resumable generation flag definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Removed <code>resumableGenerationFlag</code> function definition (19 lines)<br> <li> Deleted flag configuration including key, decide logic, description, <br>and options<br> <li> Removed environment variable handling for <code>RESUMABLE_GENERATION_FLAG</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data-loader.ts</strong><dd><code>Remove resumable generation flag usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts

<ul><li>Removed import of <code>resumableGenerationFlag</code> from flags module<br> <li> Deleted flag invocation and variable assignment<br> <li> Removed <code>resumableGeneration</code> from returned data object and feature <br>flags object</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-9f7a6561fcf469be8edd13cdb7931f806dfd8adc5f6becf1cb4d98511624df70">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generate-content.ts</strong><dd><code>Remove resumable generation parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/generate-content.ts

<ul><li>Removed <code>useResumableGeneration: true</code> parameter from <br><code>useGenerationExecutor</code> call<br> <li> Simplified function call by eliminating hardcoded resumable generation <br>setting</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-6ab3c51cb67cb03720ff1de73ed827c9579f5b92b971f922005bb897d7d79ff4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-generation-executor.ts</strong><dd><code>Remove resumable generation parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/engine/generations/internal/use-generation-executor.ts

<ul><li>Removed <code>useResumableGeneration?: boolean</code> optional parameter from <br>function signature<br> <li> Simplified function interface by eliminating unused parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-645da4ddaf278f6429309520143adef3cd2dc3f58b65f760c4e2b96202218c23">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>context.ts</strong><dd><code>Remove resumable generation from context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/feature-flags/context.ts

<ul><li>Removed <code>resumableGeneration: boolean</code> property from <br><code>FeatureFlagContextValue</code> interface<br> <li> Simplified feature flag context structure</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-51e00df034c44dc1e5319c55d0effbebeb1358b9492f9c4f140b4caafe891bbe">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Remove resumable generation flag config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/playground/app/workspaces/[workspaceId]/layout.tsx

<ul><li>Removed <code>resumableGeneration: false</code> from feature flag configuration <br>object<br> <li> Simplified workspace provider props</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-4bcbefb23b47c4c61b927ade9b43dd978e216008f1c243a471a937c8c9a122ba">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Remove resumable generation flag usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/deprecated/workspaces/[workspaceId]/layout.tsx

<ul><li>Removed import of <code>resumableGenerationFlag</code> from flags module<br> <li> Deleted flag invocation and variable assignment<br> <li> Removed <code>resumableGeneration</code> from feature flag object passed to <br>WorkspaceProvider</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-3fb9d4ecf8331a386afb043ef92a0db6b311cd30ecfdee59a88002febfaf15a9">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>provider.tsx</strong><dd><code>Remove resumable generation from provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/provider.tsx

<ul><li>Removed <code>resumableGeneration</code> property assignment from <br>FeatureFlagContext value<br> <li> Simplified feature flag context initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2074/files#diff-8a9be06df265f969925b0eaaa2a4817e372f5a9038025ba24b59438ce6c69744">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the resumable generation feature flag and its usage across apps, React context/provider, and generation engine.
> 
> - **Flags and Feature Wiring**:
>   - Delete `resumableGenerationFlag` from `apps/studio.giselles.ai/flags.ts` and remove related environment/edge-config handling.
>   - Remove `resumableGeneration` from `FeatureFlagContextValue` (`packages/giselle/src/react/feature-flags/context.ts`) and from `WorkspaceProvider` value wiring (`packages/giselle/src/react/workspace/provider.tsx`).
> - **App Integrations**:
>   - Strip `resumableGeneration` from `featureFlag` props in `apps/playground/app/workspaces/[workspaceId]/layout.tsx` and `apps/studio.giselles.ai/app/deprecated/workspaces/[workspaceId]/layout.tsx`.
>   - Remove loading/return of `resumableGeneration` in `apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts`.
> - **Engine**:
>   - Remove `useResumableGeneration` option from `useGenerationExecutor` API and its call site in `packages/giselle/src/engine/generations/generate-content.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60946f9452444ec393040da68ea731d3fb434859. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed resumable generation feature flag and consolidated related configurations across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->