### PR TITLE
refactor(ui): remove react-resizable-panels types and group/section components to simplify resize handle file

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/resizable-section.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/resizable-section.tsx
@@ -1,72 +1,12 @@
 "use client";
 
 import clsx from "clsx/lite";
-import type { ReactNode } from "react";
-import { Panel, PanelGroup } from "react-resizable-panels";
-
-interface ResizableSectionProps {
-	children: ReactNode;
-	title?: string;
-	defaultSize?: number;
-	minSize?: number;
-	maxSize?: number;
-	collapsible?: boolean;
-	className?: string;
-}
-
-interface ResizableSectionGroupProps {
-	children: ReactNode;
-	direction?: "horizontal" | "vertical";
-	className?: string;
-}
 
 interface ResizeHandleProps {
 	direction?: "horizontal" | "vertical";
 	className?: string;
 	onMouseDown?: (e: React.MouseEvent) => void;
 	style?: React.CSSProperties;
-}
-
-function ResizableSectionGroup({
-	children,
-	direction = "vertical",
-	className,
-}: ResizableSectionGroupProps) {
-	return (
-		<PanelGroup
-			direction={direction}
-			className={clsx("flex-1 flex", className)}
-		>
-			{children}
-		</PanelGroup>
-	);
-}
-
-function ResizableSection({
-	children,
-	title,
-	defaultSize = 50,
-	minSize = 20,
-	maxSize,
-	collapsible = false,
-	className,
-}: ResizableSectionProps) {
-	return (
-		<Panel
-			defaultSize={defaultSize}
-			minSize={minSize}
-			maxSize={maxSize}
-			collapsible={collapsible}
-			className={className}
-		>
-			{title && (
-				<div className="px-4 py-2 border-b border-border bg-surface-background/50">
-					<h3 className="text-sm font-medium text-inverse">{title}</h3>
-				</div>
-			)}
-			<div className="flex-1 overflow-hidden h-full">{children}</div>
-		</Panel>
-	);
 }
 
 export function ResizeHandle({


### PR DESCRIPTION
### **User description**
- Remove react-resizable-panels types
- Remove group and section components
- Simplify resize handle file by consolidating related logic and dependencies


___

### **PR Type**
Enhancement


___

### **Description**
- Remove unused react-resizable-panels types and components

- Delete ResizableSectionGroup and ResizableSection wrapper components

- Simplify resizable-section.tsx to focus on ResizeHandle only

- Reduce file complexity and external dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["resizable-section.tsx<br/>with Panel/PanelGroup"] -- "Remove unused<br/>components" --> B["resizable-section.tsx<br/>ResizeHandle only"]
  C["ResizableSectionProps<br/>ResizableSectionGroupProps"] -- "Delete types" --> D["ResizeHandleProps<br/>only"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resizable-section.tsx</strong><dd><code>Remove wrapper components and simplify file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/resizable-section.tsx

<ul><li>Removed ResizableSectionGroup and ResizableSection component <br>implementations<br> <li> Deleted ResizableSectionProps and ResizableSectionGroupProps type <br>definitions<br> <li> Removed imports for Panel and PanelGroup from react-resizable-panels<br> <li> Retained ResizeHandle component and ResizeHandleProps interface as <br>core functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2075/files#diff-82400ad2a92c506a84d0870234782454b420424e3e12515d5c00864d4ac3b852">+0/-60</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies the properties panel UI by deleting section/group components and react-resizable-panels types, leaving a standalone ResizeHandle.
> 
> - **UI (properties panel)**:
>   - Remove `react-resizable-panels` types and usage; delete `Panel`/`PanelGroup`-based `ResizableSection` and `ResizableSectionGroup`.
>   - Keep and refine `ResizeHandle` as a standalone component with simplified props and styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ee93634d499b3a25dc9e60d1f4547600b494450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal resizable panel architecture by consolidating section components while maintaining core resize functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->