### PR TITLE
feat: Add support for Anthropic Claude Sonnet 4.5 model with version fallback

### DIFF
--- a/packages/language-model/src/anthropic.test.ts
+++ b/packages/language-model/src/anthropic.test.ts
@@ -10,6 +10,9 @@ describe("anthropic llm", () => {
 			expect(AnthropicLanguageModelId.parse("claude-4-opus-20250514")).toBe(
 				"claude-4-opus-20250514",
 			);
+			expect(AnthropicLanguageModelId.parse("claude-sonnet-4-5-20250929")).toBe(
+				"claude-sonnet-4-5-20250929",
+			);
 			expect(AnthropicLanguageModelId.parse("claude-4-sonnet-20250514")).toBe(
 				"claude-4-sonnet-20250514",
 			);
@@ -30,6 +33,12 @@ describe("anthropic llm", () => {
 		it("should fallback claude-4-opus-4-* to claude-4-opus-20250514", () => {
 			expect(AnthropicLanguageModelId.parse("claude-4-opus-4-foo")).toBe(
 				"claude-4-opus-20250514",
+			);
+		});
+
+		it("should fallback claude-sonnet-4-5-* to claude-sonnet-4-5-20250929", () => {
+			expect(AnthropicLanguageModelId.parse("claude-sonnet-4-5-foo")).toBe(
+				"claude-sonnet-4-5-20250929",
 			);
 		});
 

--- a/packages/language-model/src/anthropic.ts
+++ b/packages/language-model/src/anthropic.ts
@@ -22,6 +22,7 @@ export const AnthropicLanguageModelId = z
 	.enum([
 		"claude-opus-4-1-20250805",
 		"claude-4-opus-20250514",
+		"claude-sonnet-4-5-20250929",
 		"claude-4-sonnet-20250514",
 		"claude-3-7-sonnet-20250219",
 		"claude-3-5-haiku-20241022",
@@ -36,6 +37,9 @@ export const AnthropicLanguageModelId = z
 		}
 		if (/^claude-4-opus-4-/.test(v)) {
 			return "claude-4-opus-20250514";
+		}
+		if (/^claude-sonnet-4-5-/.test(v)) {
+			return "claude-sonnet-4-5-20250929";
 		}
 		if (/^claude-4-sonnet-4-/.test(v)) {
 			return "claude-4-sonnet-20250514";
@@ -71,6 +75,18 @@ type AnthropicLanguageModel = z.infer<typeof AnthropicLanguageModel>;
 const claude40Opus: AnthropicLanguageModel = {
 	provider: "anthropic",
 	id: "claude-4-opus-20250514",
+	capabilities:
+		Capability.TextGeneration |
+		Capability.PdfFileInput |
+		Capability.Reasoning |
+		Capability.ImageFileInput,
+	tier: Tier.enum.pro,
+	configurations: defaultConfigurations,
+};
+
+const claude45Sonnet: AnthropicLanguageModel = {
+	provider: "anthropic",
+	id: "claude-sonnet-4-5-20250929",
 	capabilities:
 		Capability.TextGeneration |
 		Capability.PdfFileInput |
@@ -130,6 +146,7 @@ const claude41Opus: AnthropicLanguageModel = {
 export const models = [
 	claude41Opus,
 	claude40Opus,
+	claude45Sonnet,
 	claude40Sonnet,
 	claude37Sonnet,
 	claude35Haiku,

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -104,6 +104,21 @@ export const anthropicTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
+	"claude-sonnet-4-5-20250929": {
+		prices: [
+			{
+				validFrom: "2025-09-29T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 3.0,
+					},
+					output: {
+						costPerMegaToken: 15.0,
+					},
+				},
+			},
+		],
+	},
 	"claude-4-sonnet-20250514": {
 		prices: [
 			{


### PR DESCRIPTION
## Overview

This PR adds support for Anthropic's new Claude Sonnet 4.5 model (claude-sonnet-4-5-20250929) to the SDK. The implementation includes model configuration, pricing information, and version normalization to ensure backward compatibility for future model versions.

## Changes

- **Added new model enum value**: `claude-sonnet-4-5-20250929` to `AnthropicLanguageModelId`
- **Configured model capabilities**:
  - Tier: Pro
  - Supported features: Text Generation, Reasoning, PDF and Image file inputs
- **Implemented version fallback**: Any ID matching `claude-sonnet-4-5-*` automatically maps to `claude-sonnet-4-5-20250929`
- **Added pricing information** (effective 2025-09-29):
  - Input: $3.00 per million tokens
  - Output: $15.00 per million tokens
- **Extended model exports**: Included new model in the exported models list

## Testing

- Extended existing test suite to cover the new model family
- Added specific tests for version fallback/normalization logic
- Verified model ID parsing correctly handles the new claude-sonnet-4-5 pattern
- Confirmed all existing tests pass without regression

## Review Notes

- **Non-breaking change**: This is an additive change with no expected breaking impact
- **Note for consumers**: Applications using exhaustive switches over `AnthropicLanguageModelId` enum values may need to handle the new case
- Please review the version normalization approach - this pattern ensures forward compatibility when Anthropic releases new versions of the same model family

## Related Issues

_No related issues at this time_

## Related info
- [Introducing Claude Sonnet 4\.5 \\ Anthropic](https://www.anthropic.com/news/claude-sonnet-4-5)
- [Migrating to Claude 4\.5 \- Claude Docs](https://docs.claude.com/en/docs/about-claude/models/migrating-to-claude-4)
- [Claude Developer Platform \| Claude](https://claude.com/platform/api)