### PR TITLE
refactor!: rename apps-to-workspace relation from plural to singular

### DIFF
--- a/apps/studio.giselles.ai/app/v2/stage/data-loader.ts
+++ b/apps/studio.giselles.ai/app/v2/stage/data-loader.ts
@@ -52,7 +52,7 @@ async function userApps(teamIds: TeamId[]) {
 						appEntryNodeId: true,
 					},
 					with: {
-						workspaces: {
+						workspace: {
 							columns: {
 								id: true,
 								name: true,
@@ -68,7 +68,7 @@ async function userApps(teamIds: TeamId[]) {
 					teams.flatMap((team) =>
 						team.apps.map(async (app) => {
 							const workspace = await giselleEngine.getWorkspace(
-								app.workspaces.id,
+								app.workspace.id,
 							);
 							const appEntryNode = workspace.nodes.find(
 								(node) => node.id === app.appEntryNodeId,

--- a/apps/studio.giselles.ai/db/schema.ts
+++ b/apps/studio.giselles.ai/db/schema.ts
@@ -849,7 +849,7 @@ export const appRelations = relations(apps, ({ one }) => ({
 		fields: [apps.teamDbId],
 		references: [teams.dbId],
 	}),
-	workspaces: one(workspaces, {
+	workspace: one(workspaces, {
 		fields: [apps.workspaceDbId],
 		references: [workspaces.dbId],
 	}),


### PR DESCRIPTION
## Overview

This PR standardizes the naming convention for the apps-to-workspace relationship from plural (`workspaces`) to singular (`workspace`) throughout the codebase. This change better reflects the actual one-to-one relationship between an app and its workspace, improving code clarity and consistency.

## Changes

- **Schema Update**: Modified `appRelations` to define a singular `workspace` relation instead of `workspaces`
- **Data Loader Refactor**: Updated all query includes and property access from `workspaces` to `workspace`
- **Workspace ID Lookups**: Adjusted workspace ID retrieval logic to work with the singular relation

## ⚠️ Breaking Changes

- The relation name has changed from `app.workspaces` to `app.workspace` in all queries and data access patterns
- Any code referencing `app.workspaces` must be updated to `app.workspace`
- If this relation name is exposed via API responses or DTOs, consumers will need to update their field references from `workspaces` to `workspace`

## Testing

- [ ] Verified all database queries execute successfully with the new relation name
- [ ] Confirmed workspace data is correctly loaded and associated with apps
- [ ] Tested that workspace ID lookups function properly with the singular relation
- [ ] Checked for any remaining references to the plural `workspaces` relation

## Review Notes

- Please pay special attention to any API endpoints or external integrations that might be affected by this naming change
- Verify that all instances of the plural relation have been updated - a search for `app.workspaces` should return no results
- Consider if we need to add migration notes or update API documentation to reflect this breaking change

## Related Issues

_Please add any related issue numbers here_