### PR TITLE
Add destructive variant to button component

### DIFF
--- a/internal-packages/ui/components/button.tsx
+++ b/internal-packages/ui/components/button.tsx
@@ -8,7 +8,8 @@ type ButtonStyle =
 	| "glass"
 	| "outline"
 	| "link"
-	| "primary";
+	| "primary"
+	| "destructive";
 type ButtonSize = "compact" | "default" | "large";
 interface ButtonProps
 	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "style"> {
@@ -50,6 +51,7 @@ export function Button({
 				"data-[style=primary]:border data-[style=primary]:border-black/70",
 				"data-[style=primary]:shadow-[inset_0_1px_1px_rgba(255,255,255,0.05),0_2px_8px_rgba(5,10,20,0.4),0_1px_2px_rgba(0,0,0,0.3)]",
 				"data-[style=primary]:transition-all data-[style=primary]:duration-200 data-[style=primary]:active:scale-[0.98]",
+				"data-[style=destructive]:bg-error-900/10 data-[style=destructive]:text-error-900 data-[style=destructive]:border data-[style=destructive]:border-error-900/20 data-[style=destructive]:hover:bg-error-900/20",
 				"cursor-pointer transition-colors",
 				className,
 			)}
@@ -63,11 +65,36 @@ export function Button({
 					<div className="absolute inset-0 bg-(image:--glass-button-bg-hover) opacity-0 hover:opacity-100 transition-opacity" />
 				</>
 			)}
-			{leftIcon && <div className="*:size-[13px] *:text-text">{leftIcon}</div>}
+			{leftIcon && (
+				<div
+					className={clsx(
+						"*:size-[13px]",
+						style === "destructive" ? "*:text-error-900" : "*:text-text",
+					)}
+				>
+					{leftIcon}
+				</div>
+			)}
 			<Slot.Slottable>
-				<div className="text-[13px] text-text">{children}</div>
+				<div
+					className={clsx(
+						"text-[13px]",
+						style === "destructive" ? "text-error-900" : "text-text",
+					)}
+				>
+					{children}
+				</div>
 			</Slot.Slottable>
-			{rightIcon && <div className="*:size-[13px]">{rightIcon}</div>}
+			{rightIcon && (
+				<div
+					className={clsx(
+						"*:size-[13px]",
+						style === "destructive" ? "*:text-error-900" : "*:text-text",
+					)}
+				>
+					{rightIcon}
+				</div>
+			)}
 		</Comp>
 	);
 }


### PR DESCRIPTION
## Summary
Adds a `destructive` variant to the `Button` component for actions that require a clear warning.

## Related Issue
N/A

## Changes
- Added `"destructive"` to the `ButtonStyle` type.
- Implemented `destructive` variant styles using `bg-error-900/10`, `text-error-900`, `border-error-900/20`, and `hover:bg-error-900/20`.
- Conditionally applied `text-error-900` to button text and icons when the `destructive` style is active.

## Testing
- Verified formatting, type checks, and linting.
- Confirmed visual styles for the new `destructive` variant.

## Other Information
The `destructive` variant uses error-related colors, similar to the styling seen in `revoke-invitation-dialog.tsx`, to visually indicate a potentially irreversible action.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e24f670-8910-45b2-bdb0-6482fc396c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e24f670-8910-45b2-bdb0-6482fc396c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

