### PR TITLE
feat(Button): Add destructive style variant with error-themed styling

### DIFF
--- a/internal-packages/ui/components/button.tsx
+++ b/internal-packages/ui/components/button.tsx
@@ -8,7 +8,8 @@ type ButtonStyle =
 	| "glass"
 	| "outline"
 	| "link"
-	| "primary";
+	| "primary"
+	| "destructive";
 type ButtonSize = "compact" | "default" | "large";
 interface ButtonProps
 	extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "style"> {
@@ -50,6 +51,7 @@ export function Button({
 				"data-[style=primary]:border data-[style=primary]:border-black/70",
 				"data-[style=primary]:shadow-[inset_0_1px_1px_rgba(255,255,255,0.05),0_2px_8px_rgba(5,10,20,0.4),0_1px_2px_rgba(0,0,0,0.3)]",
 				"data-[style=primary]:transition-all data-[style=primary]:duration-200 data-[style=primary]:active:scale-[0.98]",
+				"data-[style=destructive]:bg-error-900/10 data-[style=destructive]:text-error-900 data-[style=destructive]:border data-[style=destructive]:border-error-900/20 data-[style=destructive]:hover:bg-error-900/20",
 				"cursor-pointer transition-colors",
 				className,
 			)}
@@ -63,11 +65,36 @@ export function Button({
 					<div className="absolute inset-0 bg-(image:--glass-button-bg-hover) opacity-0 hover:opacity-100 transition-opacity" />
 				</>
 			)}
-			{leftIcon && <div className="*:size-[13px] *:text-text">{leftIcon}</div>}
+			{leftIcon && (
+				<div
+					className={clsx(
+						"*:size-[13px]",
+						style === "destructive" ? "*:text-error-900" : "*:text-text",
+					)}
+				>
+					{leftIcon}
+				</div>
+			)}
 			<Slot.Slottable>
-				<div className="text-[13px] text-text">{children}</div>
+				<div
+					className={clsx(
+						"text-[13px]",
+						style === "destructive" ? "text-error-900" : "text-text",
+					)}
+				>
+					{children}
+				</div>
 			</Slot.Slottable>
-			{rightIcon && <div className="*:size-[13px]">{rightIcon}</div>}
+			{rightIcon && (
+				<div
+					className={clsx(
+						"*:size-[13px]",
+						style === "destructive" ? "*:text-error-900" : "*:text-text",
+					)}
+				>
+					{rightIcon}
+				</div>
+			)}
 		</Comp>
 	);
 }


### PR DESCRIPTION
### **User description**
## Overview

This PR introduces a new "destructive" style variant for the Button component, providing a standardized way to represent dangerous or irreversible actions in the UI. This enhancement improves user experience by clearly differentiating high-risk actions through consistent error-themed styling.

## Changes

- **Added new Button variant:** Introduced `"destructive"` as a new option for the `style` prop
- **Implemented variant-specific styling:** 
  - Error-themed background, border, and hover states for destructive buttons
  - Dynamic text color adaptation based on button variant
  - Standardized icon coloring that respects the button's semantic meaning
- **Enhanced icon behavior:** Right icons now consistently inherit appropriate colors (theme text for standard buttons, error color for destructive)

## Testing

- [ ] Verified visual appearance of destructive buttons in light/dark themes
- [ ] Tested hover and interaction states for the new variant
- [ ] Confirmed existing button variants remain unchanged
- [ ] Validated icon color inheritance works correctly for both left and right icons
- [ ] Checked that TypeScript types compile without errors

## Review Notes

### ⚠️ Breaking Changes
- **Icon color behavior:** Right icons now have enforced color values based on the button variant. Previously applied custom colors to `rightIcon` nodes may be overridden.
- **Type exhaustiveness:** If your code performs exhaustive type checking on the Button's `style` prop, you'll need to handle the new `"destructive"` case.

### Areas for Review
- Please verify the color choices align with our design system's error/danger patterns
- Confirm the breaking change to icon coloring is acceptable for existing implementations
- Review the TypeScript union type expansion for any potential downstream impacts

## Related Issues

_Please link any related issues or design specifications here_


___

### **PR Type**
Enhancement


___

### **Description**
- Add "destructive" style variant to Button component

- Implement error-themed styling for destructive buttons

- Apply dynamic text color to icons and children based on variant

- Support error color inheritance across all button content elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Button style prop"] -->|"Add destructive option"| B["ButtonStyle type"]
  B --> C["Destructive styling"]
  C -->|"Error background/border"| D["Button appearance"]
  C -->|"Error text color"| E["Icons and text"]
  E -->|"leftIcon"| F["Dynamic color"]
  E -->|"children"| F
  E -->|"rightIcon"| F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>button.tsx</strong><dd><code>Add destructive variant with error-themed styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/ui/components/button.tsx

<ul><li>Added <code>"destructive"</code> to <code>ButtonStyle</code> union type<br> <li> Implemented destructive variant styling with error-themed background, <br>border, and hover states<br> <li> Enhanced <code>leftIcon</code> rendering with conditional error color based on <br>button style<br> <li> Enhanced children text rendering with conditional error color based on <br>button style<br> <li> Enhanced <code>rightIcon</code> rendering with conditional error color based on <br>button style</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2119/files#diff-2648bfcf5e6f8fe84db6386ebce86711ff738df013d32761230ce7201ca0eb8f">+31/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #2120 
- <kbd>&nbsp;1&nbsp;</kbd> #2119 👈 
<!-- GitButler Footer Boundary Bottom -->

