### PR TITLE
BREAKING: Remove fal LLM provider support from playground and studio apps

### DIFF
--- a/apps/playground/giselle-engine.ts
+++ b/apps/playground/giselle-engine.ts
@@ -102,10 +102,6 @@ if (
 // 	};
 // }
 
-if (process.env.FAL_API_KEY) {
-	llmProviders.push("fal");
-}
-
 let sampleAppWorkspaceIds: WorkspaceId[] | undefined;
 if (process.env.SAMPLE_APP_WORKSPACE_IDS) {
 	const workspaceIdStrings = process.env.SAMPLE_APP_WORKSPACE_IDS.split(",")

--- a/apps/studio.giselles.ai/app/giselle-engine.ts
+++ b/apps/studio.giselles.ai/app/giselle-engine.ts
@@ -202,7 +202,7 @@ const generateContentProcessor =
 export const giselleEngine = NextGiselleEngine({
 	basePath: "/api/giselle",
 	storage,
-	llmProviders: ["openai", "anthropic", "google", "fal"],
+	llmProviders: ["openai", "anthropic", "google"],
 	onConsumeAgentTime,
 	telemetry: {
 		isEnabled: true,

--- a/apps/studio.giselles.ai/app/stage/acts/[actId]/[stepId]/page.tsx
+++ b/apps/studio.giselles.ai/app/stage/acts/[actId]/[stepId]/page.tsx
@@ -41,9 +41,6 @@ function getModelInfo(generation: Generation): {
 				case "google":
 					iconName = "search";
 					break;
-				case "fal":
-					iconName = "image";
-					break;
 			}
 
 			return { provider, modelName, iconName };


### PR DESCRIPTION
## Overview

This PR removes the "fal" LLM provider from the playground and studio applications. The decision to consolidate our supported LLM providers was made to focus our maintenance efforts on the most widely-used and stable providers (OpenAI, Anthropic, and Google), reducing complexity and improving overall system reliability.


## Related Issue
Part of https://github.com/giselles-ai/giselle/issues/2061

## ⚠️ Breaking Changes

- **Removed "fal" LLM provider support entirely**
  - The provider is no longer available in the playground and studio apps
  - `FAL_API_KEY` environment variable no longer has any effect
  - Existing configurations referencing "fal" provider will need to be updated

## Changes

- **Provider Configuration:**
  - Removed "fal" from the `llmProviders` list
  - Eliminated conditional logic that included "fal" based on environment configuration
  - Consolidated supported providers to: `openai`, `anthropic`, `google`

- **UI Updates:**
  - Removed "fal" icon handling from the provider selection UI
  - Cleaned up provider icon mapping logic

- **Environment Variables:**
  - `FAL_API_KEY` is now deprecated and can be removed from deployments

## Testing

- Verified provider list displays correctly in both playground and studio apps
- Confirmed that OpenAI, Anthropic, and Google providers continue to function as expected
- Tested UI rendering to ensure no broken icon references
- Validated that removing FAL_API_KEY from environment doesn't cause any errors

## Review Notes

- **Migration Impact:** Please review if we need to provide migration guidance for users who may have been using the "fal" provider
- **Documentation:** Confirm if any documentation updates are needed to reflect this change
- **Error Handling:** Verify that appropriate error messages are shown if existing configs reference the removed provider

## Related Issues

_Please link any related issues or discussions about provider consolidation_

---

**Action Required:** Teams using the "fal" provider should migrate to one of the supported providers (OpenAI, Anthropic, or Google) before merging this PR.