### PR TITLE
**BREAKING**: Migrate TriggerProvider to external registry package

### DIFF
--- a/packages/protocol/src/node/operations/index.ts
+++ b/packages/protocol/src/node/operations/index.ts
@@ -1,6 +1,6 @@
 import type { ActionProvider } from "@giselles-ai/action-registry";
+import type { TriggerProvider } from "@giselles-ai/trigger-registry";
 import { z } from "zod/v4";
-import type { TriggerProvider } from "../../trigger";
 import { NodeBase, NodeReferenceBase } from "../base";
 import { ActionContent, ActionContentReference } from "./action";
 import {

--- a/packages/protocol/src/node/operations/trigger.ts
+++ b/packages/protocol/src/node/operations/trigger.ts
@@ -1,10 +1,5 @@
 import { z } from "zod/v4";
-import { TriggerId, type TriggerProvider } from "../../trigger";
-
-export const TriggerProviderLike = z.looseObject({
-	provider: z.string(),
-});
-export type TriggerProviderLike = z.infer<typeof TriggerProviderLike>;
+import { TriggerId } from "../../trigger";
 
 const TriggerUnconfiguredState = z.object({
 	status: z.literal("unconfigured"),
@@ -25,10 +20,7 @@ const TriggerConfigurationState = z.discriminatedUnion("status", [
 
 export const TriggerContent = z.object({
 	type: z.literal("trigger"),
-	provider: z.enum(["manual", "github", "app-entry"] satisfies [
-		TriggerProvider,
-		...TriggerProvider[],
-	]),
+	provider: z.enum(["manual", "github", "app-entry"]),
 	state: TriggerConfigurationState,
 });
 export type TriggerContent = z.infer<typeof TriggerContent>;

--- a/packages/protocol/src/trigger/index.ts
+++ b/packages/protocol/src/trigger/index.ts
@@ -16,8 +16,6 @@ export {
 export const TriggerId = createIdGenerator("fltg");
 export type TriggerId = z.infer<typeof TriggerId.schema>;
 
-export * from "./providers";
-
 export const Trigger = z.object({
 	id: TriggerId.schema,
 	workspaceId: WorkspaceId.schema,

--- a/packages/protocol/src/trigger/providers.ts
+++ b/packages/protocol/src/trigger/providers.ts
@@ -1,1 +1,0 @@
-export type TriggerProvider = "manual" | "github" | "app-entry";


### PR DESCRIPTION
### **User description**
## Overview

This PR externalizes trigger provider typing to a new dedicated package `@giselles-ai/trigger-registry`, aligning the architecture with the existing pattern used for action providers. This change improves separation of concerns by moving trigger provider definitions out of the protocol package into their own registry, making the codebase more modular and maintainable.

## Changes

- **Created new package**: `@giselles-ai/trigger-registry` to house trigger provider definitions
- **Removed TriggerProvider** from protocol package (`providers.ts` deleted, no longer re-exported from `trigger/index.ts`)
- **Updated imports**: All TriggerProvider imports now use `@giselles-ai/trigger-registry` instead of the protocol package
- **Removed TriggerProviderLike**: Eliminated the loose `provider: string` schema from `node/operations/trigger.ts`, tightening type safety
- **Simplified TriggerContent schema**: Provider union now defined directly via `z.enum` rather than referencing protocol-level types

## ⚠️ Breaking Changes

- **TriggerProvider import path changed**: Consumers must update imports from `@giselles-ai/protocol` to `@giselles-ai/trigger-registry`
- **TriggerProviderLike removed**: Any code using the exported `TriggerProviderLike` type or schema will need refactoring

## Testing

- Verified all existing trigger provider values ("manual", "github", "app-entry") remain unchanged
- Confirmed no runtime schema changes to TriggerContent beyond type refactoring
- Ensured imports are correctly resolved across the codebase
- Validated that the new package structure mirrors the established action provider pattern

## Review Notes

- Please verify that all consumer packages have been identified for the breaking change migration
- Confirm the new package naming convention aligns with project standards
- Review whether additional documentation updates are needed for the new package structure

## Related Issues

_Please link any related issues or tasks here_


___

### **PR Type**
Enhancement


___

### **Description**
- Migrate TriggerProvider to external `@giselles-ai/trigger-registry` package

- Remove TriggerProviderLike schema for stricter type safety

- Simplify TriggerContent provider enum definition

- Align trigger provider architecture with action provider pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["protocol/trigger/providers.ts<br/>TriggerProvider type"] -->|"removed"| B["@giselles-ai/trigger-registry<br/>external package"]
  C["protocol/node/operations/trigger.ts<br/>TriggerProviderLike schema"] -->|"removed"| D["Stricter type safety"]
  E["TriggerContent provider enum"] -->|"simplified"| F["Direct z.enum definition"]
  B -->|"imported in"| G["protocol/node/operations/index.ts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update TriggerProvider import source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/protocol/src/node/operations/index.ts

<ul><li>Updated TriggerProvider import to use <code>@giselles-ai/trigger-registry</code> <br>package<br> <li> Removed local import from <code>../../trigger</code><br> <li> Maintains consistent import pattern with ActionProvider</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2137/files#diff-ab7a5f80e77e2b8b5af6e00dec0f003f40f9367fe27da2b7fedaace1e258a363">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trigger.ts</strong><dd><code>Remove TriggerProviderLike and simplify provider enum</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/protocol/src/node/operations/trigger.ts

<ul><li>Removed TriggerProviderLike schema and type definition<br> <li> Removed TriggerProvider import from local trigger module<br> <li> Simplified TriggerContent provider enum to direct string literals<br> <li> Tightens type safety by eliminating loose object schema</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2137/files#diff-8d945c7909f02b6604f2003f440eb2a94c48cee507d4e5964962777fe5c119a4">+2/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Remove providers module re-export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/protocol/src/trigger/index.ts

<ul><li>Removed re-export of providers module (<code>export * from "./providers"</code>)<br> <li> Maintains exports for ManualTrigger and related types<br> <li> Keeps TriggerId and Trigger exports intact</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2137/files#diff-35542b9ec74837104917e0033bab36fe1c97686d2c59d0ebaebcb760f654e7ce">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>providers.ts</strong><dd><code>Delete providers file for externalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/protocol/src/trigger/providers.ts

<ul><li>File deleted entirely<br> <li> TriggerProvider type definition moved to external <br><code>@giselles-ai/trigger-registry</code> package<br> <li> Completes externalization of trigger provider definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2137/files#diff-e606ff09986c30fdafc51c207c4efd282f5e51cebfbd5838031206c3273dcc74">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed `TriggerProvider` and `TriggerProviderLike` type exports from the protocol package.
  * Reorganized trigger-related type imports and simplified provider type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves TriggerProvider to @giselles-ai/trigger-registry, removes protocol providers, and simplifies trigger content schema/types.
> 
> - **Protocol**:
>   - **`node/operations/index.ts`**: Import `TriggerProvider` from `@giselles-ai/trigger-registry`; keep `isTriggerNode` generic typed with external provider.
>   - **`node/operations/trigger.ts`**: Remove `TriggerProviderLike`; define `provider` via `z.enum(["manual","github","app-entry"])`.
>   - **`trigger/index.ts`**: Remove re-export of `./providers`; retain `Trigger`, `TriggerId`, and GitHub/manual exports.
>   - **`trigger/providers.ts`**: Delete file (provider type moved to external registry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5316ce9974352ef7e9a586cb0d1f236b79fb210e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->