### PR TITLE
Remove team type assignment from account init

### DIFF
--- a/apps/studio.giselles.ai/services/accounts/actions/initialize-account.ts
+++ b/apps/studio.giselles.ai/services/accounts/actions/initialize-account.ts
@@ -42,7 +42,6 @@ export const initializeAccount = async (
 			.values({
 				id: createTeamId(),
 				name: "My Project",
-				type: internalAccount ? "internal" : "customer",
 				plan: internalAccount ? "internal" : "free",
 			})
 			.returning({


### PR DESCRIPTION
### **User description**
## Summary
Remove team type assignment from account init

## Related Issue
Part of https://github.com/giselles-ai/giselle/issues/2061


## Changes
Just remove team type assignment from account init

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
This is a fix for a missing deletion in https://github.com/giselles-ai/giselle/pull/2135.
I noticed this when I tried to delete a column in https://github.com/giselles-ai/giselle/pull/2144 and the build failed.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove obsolete team type assignment from account initialization

- Fixes incomplete deletion from previous PR #2135

- Retains plan assignment logic for internal/customer distinction


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Account Initialization"] -- "removes type field" --> B["Team Creation"]
  B -- "keeps plan field" --> C["Team Record"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialize-account.ts</strong><dd><code>Remove team type field from initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/services/accounts/actions/initialize-account.ts

<ul><li>Removes <code>type</code> field assignment from team insertion values<br> <li> Retains <code>plan</code> field for internal/customer distinction<br> <li> Completes cleanup from previous PR #2135</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2145/files#diff-f552615f00954db0d0327de7dc465148041fe19fca802a59177885e2dd3a0c53">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stop setting `teams.type` when creating a new team; only `plan` is assigned based on email.
> 
> - **Accounts Service**:
>   - Update `apps/studio.giselles.ai/services/accounts/actions/initialize-account.ts` to omit setting `teams.type` when inserting a team; retain `plan` selection (`internal` vs `free`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 859464877f32c6073d843e8e00ef0dbb1f5f25a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected team field handling during account initialization to ensure proper configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->