### PR TITLE
fix: honor custom node names in vector-store nodes (BREAKING)

### DIFF
--- a/packages/node-registry/src/node-default-name.ts
+++ b/packages/node-registry/src/node-default-name.ts
@@ -87,7 +87,10 @@ export function defaultName(node: NodeLike) {
 							`Expected vector store node, got ${JSON.stringify(node)}`,
 						);
 					}
-					return vectorStoreNodeDefaultName(node.content.source.provider);
+					return (
+						node.name ??
+						vectorStoreNodeDefaultName(node.content.source.provider)
+					);
 				default:
 					return node.name ?? node.content.type;
 			}


### PR DESCRIPTION
### **User description**
## Overview

This PR restores the expected behavior for vector-store node naming, ensuring that custom node names are properly honored. Previously, vector-store nodes would always use provider-derived default names, ignoring any explicitly set `node.name` value. This change aligns the naming behavior across all node types, giving users consistent control over node naming throughout the system.

## Changes

- **Fixed vector-store node naming logic**: Modified `defaultName` function to check for and use `node.name` when present, before falling back to provider-based defaults
- **Improved consistency**: Vector-store nodes now follow the same naming pattern as other node types in the system

## ⚠️ Breaking Changes

Systems that previously set custom names on vector-store nodes may see different displayed or serialized node names after this change. The new behavior will now show the explicitly set name rather than the provider-derived default that was previously always used.

## Testing

- Verified that vector-store nodes with custom names display the custom name
- Confirmed that vector-store nodes without custom names still use provider-based defaults
- Tested compatibility with existing node serialization/deserialization flows

## Review Notes

- Please pay special attention to any systems that may have been relying on the previous behavior of ignoring custom names
- Consider if any migration or compatibility layer is needed for existing persisted node configurations

## Related Issues

- Addresses feedback from #2140 regarding inconsistent node naming behavior
- Related discussion: https://github.com/giselles-ai/giselle/pull/2140#issuecomment-3514449495


___

### **PR Type**
Bug fix


___

### **Description**
- Honor explicit `node.name` for vector-store nodes

- Fall back to provider-derived defaults when name not set

- Align vector-store naming with other node types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Vector Store Node"] --> B{"node.name exists?"}
  B -->|Yes| C["Use explicit node.name"]
  B -->|No| D["Use provider default"]
  C --> E["Return node name"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-default-name.ts</strong><dd><code>Add explicit node name check for vector-store nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-registry/src/node-default-name.ts

<ul><li>Modified <code>defaultName</code> function to check for explicit <code>node.name</code> first<br> <li> Uses nullish coalescing operator (<code>??</code>) to fall back to provider <br>defaults<br> <li> Ensures vector-store nodes respect custom names like other node types</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2147/files#diff-70e8319c76ee6bdfff462b7250f469e33cb0d7b9ea7cd12c4cc976511535bfe1">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Honor custom names for `variable.vectorStore` nodes in `defaultName`, falling back to provider-based defaults when absent.
> 
> - **Node naming**
>   - Update `packages/node-registry/src/node-default-name.ts`:
>     - `defaultName` for `variable.vectorStore` now uses `node.name` when present, otherwise falls back to `vectorStoreNodeDefaultName(node.content.source.provider)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d471d5e01c54ee60f2d2993bc7bd81902f8a9b1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated default naming behavior for vectorStore nodes to prefer the node's own name when present, with fallback to provider-based naming when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->