### PR TITLE
fix: GitHub vector store improvements

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts
@@ -859,14 +859,25 @@ function checkIngestability(
 	contentStatuses: (typeof githubRepositoryContentStatus.$inferSelect)[],
 	now: Date = new Date(),
 ): IngestabilityCheck {
+	const STALE_THRESHOLD_MINUTES = 15;
+	const staleThreshold = new Date(
+		Date.now() - STALE_THRESHOLD_MINUTES * 60 * 1000,
+	);
+
 	for (const contentStatus of contentStatuses) {
 		if (!contentStatus.enabled) {
 			continue;
 		}
 
+		const isStaleRunning =
+			contentStatus.status === "running" &&
+			contentStatus.updatedAt &&
+			contentStatus.updatedAt < staleThreshold;
+
 		const canIngestThis =
 			contentStatus.status === "idle" ||
 			contentStatus.status === "completed" ||
+			isStaleRunning ||
 			(contentStatus.status === "failed" &&
 				contentStatus.retryAfter &&
 				contentStatus.retryAfter <= now);

--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx
@@ -132,8 +132,12 @@ export function ConfigureSourcesDialog({
 							<h3 className="text-text text-[14px] leading-[16.8px] font-sans">
 								Repository
 							</h3>
-							<div className="mt-2 text-link-accent text-[16px] font-geist">
-								{repositoryIndex.owner}/{repositoryIndex.repo}
+							<div className="mt-2 flex items-center rounded-full bg-surface pl-[16px] pr-[16px] py-2 text-white-200 transition-colors text-[12px]">
+								<div className="space-x-[2px]">
+									<span>{repositoryIndex.owner}</span>
+									<span>/</span>
+									<span>{repositoryIndex.repo}</span>
+								</div>
 							</div>
 						</div>
 						{/* Sources Section */}

--- a/internal-packages/workflow-designer-ui/src/editor/node/ui/github-repository-badge.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/node/ui/github-repository-badge.tsx
@@ -11,7 +11,7 @@ export function GitHubRepositoryBadge({
 	repo,
 }: GitHubRepositoryBadgeProps) {
 	return (
-		<div className="flex items-center rounded-full bg-bg pl-[16px] pr-[16px] py-2 text-white-200 transition-colors text-[12px]">
+		<div className="flex items-center rounded-full bg-surface pl-[16px] pr-[16px] py-2 text-white-200 transition-colors text-[12px]">
 			<div className="space-x-[2px]">
 				<span>{owner}</span>
 				<span>/</span>


### PR DESCRIPTION
### **User description**
## Changes

### Layout Improvements
- Change Sources to Ingest section from 2-column grid to vertical stack (1 column)
- Inline "(Required - cannot be disabled)" text with description for Code source

### Bug Fixes
- Allow manual ingest when content status is stale running (more than 15 minutes old)
- Replace bg-bg with bg-surface token for repository badge display
- Restore pill-shaped background styling for repository name display in configure dialog

### Technical Details
- Updated `checkIngestability` function to consider stale running status (matching automatic ingest behavior)
- Fixed repository badge styling to use proper design tokens


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Allow manual ingest when content status is stale (>15 minutes old)

- Change Sources to Ingest layout from 2-column grid to vertical stack

- Inline "(Required - cannot be disabled)" text with description

- Replace bg-bg with bg-surface token for repository badge styling

- Restore pill-shaped background for repository name display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["checkIngestability function"] -->|"Add stale threshold check"| B["Allow manual ingest for stale running status"]
  C["Layout components"] -->|"Change grid to flex column"| D["Vertical stack layout"]
  E["Repository badge styling"] -->|"Replace bg-bg with bg-surface"| F["Proper design token usage"]
  G["Required text display"] -->|"Inline with description"| H["Improved UX"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Add stale running status check to ingestability logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/actions.ts

<ul><li>Add 15-minute stale threshold constant for ingest status checking<br> <li> Implement <code>isStaleRunning</code> logic to detect running status older than <br>threshold<br> <li> Allow manual ingest when content status is stale running<br> <li> Align manual ingest behavior with automatic ingest requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2151/files#diff-c366d76c09210ba11343bfdbd3731fb7db9d49fbaf5d73dc015cbd229d4615f4">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github-repository-badge.tsx</strong><dd><code>Update repository badge to use bg-surface token</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/node/ui/github-repository-badge.tsx

<ul><li>Replace <code>bg-bg</code> token with <code>bg-surface</code> for repository badge background<br> <li> Maintain pill-shaped styling with proper design token usage</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2151/files#diff-6c0f87cd046f1976933956e1e3ff28935bd7e0048070fe0bcd1427cf1ff0cd5c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configure-sources-dialog.tsx</strong><dd><code>Refactor layout and styling for sources dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/configure-sources-dialog.tsx

<ul><li>Change Sources to Ingest section from 2-column grid to vertical flex <br>column layout<br> <li> Restructure repository display with pill-shaped background using <br><code>bg-surface</code> token<br> <li> Inline "(Required - cannot be disabled)" text within description <br>paragraph<br> <li> Add spacing and styling improvements for repository name display</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2151/files#diff-2b78e726ece9177c256c7b9bf64ca0895ac2168eef8f206e172511bf1d11dbab">+15/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Allow manual ingest when a content status is stale-running (>15m) and refresh repository badge and sources configuration UI.
> 
> - **Backend**:
>   - Update `checkIngestability` in `actions.ts` to permit ingest when a `running` status is stale (>15 minutes), aligning manual ingest eligibility.
> - **UI**:
>   - `configure-sources-dialog.tsx`:
>     - Restore pill-styled repository display and switch to `bg-surface`.
>     - Change “Sources to Ingest” from 2-column grid to vertical stack.
>     - Inline “(Required - cannot be disabled)” with description for Code.
>   - `github-repository-badge.tsx`: switch badge background from `bg-bg` to `bg-surface`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c20f245e97226046d7e76c87b4200ff49fde65a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingest status detection with 15-minute stale threshold for running states.

* **Style**
  * Redesigned repository display with styled badge format.
  * Updated sources layout to vertical stack for better readability.
  * Refined GitHub repository badge styling.
  * Enhanced content toggle description display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->