### PR TITLE
fix: Deleting files from duplicated File Nodes

### DIFF
--- a/packages/giselle/src/react/workspace/store/file-slice.ts
+++ b/packages/giselle/src/react/workspace/store/file-slice.ts
@@ -149,7 +149,7 @@ export const createFileSlice: StateCreator<AppStore, [], [], FileSlice> = (
 		// Only remove from storage if no other nodes reference this file
 		if (referenceCount === 0 && file.status === "uploaded") {
 			await client.removeFile({
-				workspaceId: workspaceId,
+				workspaceId,
 				fileId: actualFileId,
 			});
 		}


### PR DESCRIPTION
### **User description**
## Summary

Fix error when deleting files from duplicated File Nodes by implementing reference counting. Files now only delete from storage when no other nodes reference them.

## Related Issue
N/A

## Changes

- Add reference counting logic in `file-slice.ts` `removeFile()`
- Only delete from storage when reference count reaches zero
- Always update UI state regardless of storage deletion

## Testing


___

### **PR Type**
Bug fix


___

### **Description**
- Implement reference counting for duplicate file node deletion

- Only delete files from storage when no other nodes reference them

- Handle cloned files by tracking original file IDs

- Always update UI state regardless of storage deletion status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File deletion triggered"] --> B["Check if file is cloned"]
  B --> C["Count references across all nodes"]
  C --> D{"Reference count = 0?"}
  D -->|Yes| E["Delete from storage"]
  D -->|No| F["Keep in storage"]
  E --> G["Update UI state"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file-slice.ts</strong><dd><code>Add reference counting for file deletion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/react/workspace/store/file-slice.ts

<ul><li>Added import for <code>isClonedFileDataPayload</code> utility function<br> <li> Implemented reference counting logic to track file usage across nodes<br> <li> Distinguish between original and cloned file IDs using <br><code>originalFileIdForCopy</code><br> <li> Only delete files from storage when reference count reaches zero<br> <li> Simplified UI state update to always execute after deletion check</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2160/files#diff-476a7d82e557b1449f27f9ffd4aad5f9d06cf417a0f012fc7c7d41ce28e0e667">+43/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors file deletion to reference-count files (including clones) and only delete from storage when unreferenced, while always updating UI state.
> 
> - **Workspace store (`packages/giselle/src/react/workspace/store/file-slice.ts`)**:
>   - **Deletion logic (`removeFile`)**:
>     - Add reference counting across `workspace.nodes` to prevent removing files still referenced by other nodes.
>     - Handle cloned files by resolving `actualFileId` via `originalFileIdForCopy`.
>     - Remove from storage only when `referenceCount === 0` and file is `uploaded`; call `client.removeFile` with `actualFileId`.
>     - Always update UI state to remove the file from the current node; early-return if no parent node found.
>   - Add import for `isClonedFileDataPayload`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd4350104ad3f103378313a47d8ffff620c0428b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file deletion to correctly handle cloned files and more accurately track references before removing from storage.
  * Ensures the UI always removes the file from the workspace view and gracefully handles cases where the parent node is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->