### PR TITLE
fix: Update documentation link for Document Vector Store Node panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/index.tsx
@@ -17,7 +17,11 @@ export function VectorStoreNodePropertiesPanel({
 			<NodePanelHeader
 				node={node}
 				onChangeName={(name) => updateNodeData(node, { name })}
-				docsUrl="https://docs.giselles.ai/en/glossary/github-vector-store-node"
+				docsUrl={
+					node.content.source.provider === "document"
+						? "https://docs.giselles.ai/en/glossary/document-vector-store-node"
+						: "https://docs.giselles.ai/en/glossary/github-vector-store-node"
+				}
 				onDelete={() => deleteNode(node.id)}
 			/>
 			<PropertiesPanelContent>


### PR DESCRIPTION
### **User description**
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->

The documentation linked from the Document Vector Store Node goes to the GitHub Vector Store Node anchor. Fixed to link to the correct section.

<img width="502" height="186" alt="image" src="https://github.com/user-attachments/assets/62f2965c-f514-41e0-b92b-8b6863489547" />

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->

- Create or go to an existing workspace
- Add a Document Vector Store Node and click the documentation link
- Add a GitHub Vector Store Node and click the documentation link

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed documentation link to point to correct node type

- Added conditional logic to route Document and GitHub Vector Store nodes to their respective documentation pages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VectorStoreNode"] --> B{"Check node.content.source.provider"}
  B -->|"document"| C["Document Vector Store docs"]
  B -->|"github"| D["GitHub Vector Store docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add conditional documentation link routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/index.tsx

<ul><li>Replaced hardcoded GitHub Vector Store documentation URL with <br>conditional logic<br> <li> Added check for <code>node.content.source.provider</code> to determine correct <br>documentation link<br> <li> Routes Document Vector Store nodes to their dedicated documentation <br>page<br> <li> Routes GitHub Vector Store nodes to their documentation page</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2186/files#diff-0574b0fd6917a1cfe761f0a8b79ba37696e2ea72ea4623186bc7ff005f8cd50c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation link accuracy in the properties panel by ensuring help resources now match the specific vector store configuration in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->