### PR TITLE
fix!: Correct typo in GitHub installation resolver naming (installtion → installation)

### DIFF
--- a/apps/playground/giselle.ts
+++ b/apps/playground/giselle.ts
@@ -62,7 +62,7 @@ if (
 			privateKey: "",
 			resolver: {
 				installationIdForRepo: () => 1234,
-				installtionIds: () => [1234],
+				installationIds: () => [1234],
 			},
 		},
 		authV2: {

--- a/apps/studio.giselles.ai/app/giselle.ts
+++ b/apps/studio.giselles.ai/app/giselle.ts
@@ -209,7 +209,7 @@ export const giselle = NextGiselle({
 				privateKey: "",
 				resolver: {
 					installationIdForRepo: () => 1234,
-					installtionIds: () => [1234],
+					installationIds: () => [1234],
 				},
 			},
 			authV2: {

--- a/packages/giselle/src/github/get-github-repositories.ts
+++ b/packages/giselle/src/github/get-github-repositories.ts
@@ -27,7 +27,7 @@ export async function getGitHubRepositories(args: { context: GiselleContext }) {
 	const githubAppId = githubConfig.auth.appId;
 	const githubAppPrivateKey = githubConfig.auth.privateKey;
 
-	const installationIds = await githubConfig.auth.resolver.installtionIds();
+	const installationIds = await githubConfig.auth.resolver.installationIds();
 
 	const repos: Repository[] = [];
 	await Promise.all(

--- a/packages/giselle/src/types/integrations.ts
+++ b/packages/giselle/src/types/integrations.ts
@@ -3,16 +3,16 @@ import type {
 	GitHubPersonalAccessTokenAuth,
 } from "@giselles-ai/github-tool";
 
-interface GitHubInstalltionAppAuthResolver {
+interface GitHubInstallationAppAuthResolver {
 	installationIdForRepo: (repositoryNodeId: string) => Promise<number> | number;
-	installtionIds: () => Promise<number[]> | number[];
+	installationIds: () => Promise<number[]> | number[];
 }
 
 export interface GitHubIntegrationConfig {
 	auth:
 		| GitHubPersonalAccessTokenAuth
 		| (Omit<GitHubInstallationAppAuth, "installationId"> & {
-				resolver: GitHubInstalltionAppAuthResolver;
+				resolver: GitHubInstallationAppAuthResolver;
 		  });
 	authV2: {
 		appId: string;


### PR DESCRIPTION
## Overview

This PR fixes a typo in the GitHub installation resolver interface and method names, correcting "installtion" to "installation" throughout the codebase. While this is primarily a naming correction, it introduces breaking changes that require updates to any implementations or configurations using the old interface names.

## Related Issue
https://github.com/giselles-ai/giselle/pull/2183/files#r2527660055
https://github.com/giselles-ai/giselle/pull/2183/files#r2527674248
https://github.com/giselles-ai/giselle/pull/2183/files#r2527660023

## Changes

### ⚠️ Breaking Changes
- **Renamed interface:** `GitHubInstalltionAppAuthResolver` → `GitHubInstallationAppAuthResolver`
- **Renamed method:** `installtionIds()` → `installationIds()`

### Code Updates
- Fixed typo in the public resolver interface name
- Updated internal repository fetching logic to use the corrected `resolver.installationIds()` method
- Modified example app configurations (playground and studio) to use the new method name
- No functional or behavioral changes - the resolver contract and semantics remain unchanged

## Testing

- Verified that the renamed interface and methods are properly referenced throughout the codebase
- Tested example applications (playground and studio) with the updated resolver configuration
- Confirmed that `getGitHubRepositories` correctly calls the renamed `installationIds()` method

## Review Notes

- **Migration Impact:** Please review the breaking changes carefully. Any existing implementations of the resolver interface will need to be updated
- **Documentation:** Confirm if any documentation updates are needed for this interface rename
- **Version Bump:** Consider if this breaking change warrants a major version bump per semver

## Related Issues

_No specific issues referenced - this is a proactive fix for naming consistency_