### PR TITLE
feat!: Add workspace validation and team-based access control to task creation

### DIFF
--- a/apps/studio.giselles.ai/app/v2/stage/action.ts
+++ b/apps/studio.giselles.ai/app/v2/stage/action.ts
@@ -1,9 +1,42 @@
 "use server";
 
 import type { CreateAndStartTaskInputs } from "@giselles-ai/giselle";
+import {
+	type WorkspaceId,
+	WorkspaceId as WorkspaceIdSchema,
+} from "@giselles-ai/protocol";
 import { giselle } from "@/app/giselle";
+import { db } from "@/db";
+import { fetchCurrentUser } from "@/services/accounts";
+import { isMemberOfTeam } from "@/services/teams";
 
 export async function createAndStartTask(input: CreateAndStartTaskInputs) {
+	let workspaceId: WorkspaceId;
+	try {
+		workspaceId = WorkspaceIdSchema.schema.parse(input.workspaceId);
+	} catch {
+		throw new Error("Workspace ID is required");
+	}
+
+	const [user, workspace] = await Promise.all([
+		fetchCurrentUser(),
+		db.query.workspaces.findFirst({
+			where: (workspaceTable, { eq }) => eq(workspaceTable.id, workspaceId),
+			columns: {
+				teamDbId: true,
+			},
+		}),
+	]);
+
+	if (!workspace) {
+		throw new Error("Workspace not found");
+	}
+
+	const hasAccess = await isMemberOfTeam(user.dbId, workspace.teamDbId);
+	if (!hasAccess) {
+		throw new Error("You are not authorized to run tasks for this workspace");
+	}
+
 	const { task } = await giselle.createTask(input);
 	await giselle.startTask({ taskId: task.id, generationOriginType: "stage" });
 	return task.id;


### PR DESCRIPTION
## Overview

This PR adds critical security controls to the `createAndStartTask` function by implementing workspace validation and team membership verification. Previously, tasks could be created without proper authorization checks, potentially allowing unauthorized users to create tasks in any workspace. This change ensures that only authenticated users who are members of the workspace's team can create and start tasks.

## Changes

- **Added workspace ID validation**: Validates `workspaceId` against the schema from `@giselles-ai/protocol` before processing
- **Implemented access control**: Verifies that the current user is a member of the workspace's team before allowing task creation
- **Enhanced error handling**: Provides clear, specific error messages for:
  - Missing workspace ID
  - Non-existent workspace
  - Unauthorized access attempts
- **Performance optimization**: User and workspace data are now fetched in parallel to reduce latency
- **Maintained API compatibility**: No changes to function signature; only behavioral enforcement is stricter

## ⚠️ Breaking Changes

- **Workspace ID is now mandatory**: The function will throw an error if called without a valid `workspaceId`
- **Team membership required**: Users must be authenticated and be members of the workspace's team to create tasks
- **Existing integrations may break** if they:
  - Create tasks without providing a workspace ID
  - Attempt to create tasks while unauthenticated
  - Create tasks in workspaces where they lack team membership

## Testing

- Verified that valid workspace IDs pass schema validation
- Confirmed that invalid or missing workspace IDs trigger appropriate errors
- Tested access control with both team members and non-members
- Validated error messages are clear and actionable
- Ensured parallel fetching of user and workspace data works correctly

## Review Notes

- Please pay special attention to the breaking changes and their potential impact on existing workflows
- The parallel fetch implementation (`Promise.all`) should be reviewed for any edge cases
- Consider if we need to add migration documentation for existing users affected by these changes

## Related Issues

_No specific issues linked - this is a security enhancement initiative_