### PR TITLE
feat: Convert app-entry-node-icon to Client Component for useGiselle hook support

### DIFF
--- a/internal-packages/workflow-designer-ui/src/icons/node/app-entry-node-icon.tsx
+++ b/internal-packages/workflow-designer-ui/src/icons/node/app-entry-node-icon.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { isIconName } from "@giselle-internal/ui/utils";
 import type { AppEntryNode, AppId } from "@giselles-ai/protocol";
 import { useGiselle } from "@giselles-ai/react";


### PR DESCRIPTION
## Overview

This PR converts the `app-entry-node-icon.tsx` component to a Next.js Client Component to support the use of React hooks, specifically `useGiselle`. This change is necessary as hooks require client-side runtime execution and cannot run in Server Components.

## Changes

- Added `"use client"` directive to `app-entry-node-icon.tsx` to designate it as a Client Component
- Component now runs exclusively in the browser environment to support React hook usage

## ⚠️ Breaking Changes

- **Server Component Compatibility**: This component can no longer be imported directly into Server Components
- Any existing Server Component imports of this icon will need to be:
  - Moved to Client Component boundaries, or
  - Wrapped in a Client Component wrapper

## Testing

- Verified the component renders correctly in the client environment
- Confirmed `useGiselle` hook functions as expected
- Checked existing usages for compatibility with the Client Component designation

## Review Notes

- Please verify all existing imports of this component to ensure they are compatible with the Client Component change
- Consider whether any Server Components currently depend on this icon and need refactoring
- Confirm this aligns with the broader architecture strategy for icon components in the application

## Related Issues

_No specific issues referenced - this change supports the integration of the `useGiselle` hook functionality_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Technical update to component configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->