### PR TITLE
refactor: Remove unused subscription field from getWorkspaceTeam

### DIFF
--- a/apps/studio.giselles.ai/lib/workspaces/get-workspace-team.ts
+++ b/apps/studio.giselles.ai/lib/workspaces/get-workspace-team.ts
@@ -25,7 +25,6 @@ export async function getWorkspaceTeam(workspaceId: WorkspaceId) {
 
 	return {
 		...agent.team,
-		activeSubscriptionId: activeSubscription?.id || null,
-		subscription: activeSubscription || null,
+		activeSubscriptionId: activeSubscription?.id ?? null,
 	};
 }


### PR DESCRIPTION
The subscription field returned by getWorkspaceTeam was not used anywhere in the codebase. This commit removes it to simplify the return type and improve code clarity.

## Related Issue
Part of https://github.com/giselles-ai/giselle/issues/2231

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies getWorkspaceTeam by dropping the unused `subscription` field and using nullish coalescing for `activeSubscriptionId`.
> 
> - **Workspaces**:
>   - Update `apps/studio.giselles.ai/lib/workspaces/get-workspace-team.ts`:
>     - Remove unused `subscription` field from the returned object.
>     - Use `?? null` for `activeSubscriptionId` instead of `|| null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5879a6239b7922bbb7614ea6e8295364650ba889. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal workspace team data handling for better code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->