### PR TITLE
feat: Enable incremental content rendering during generation (removes global spinner)

### DIFF
--- a/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/ui/generation-view.tsx
@@ -169,6 +169,8 @@ export function GenerationView({ generation }: { generation: Generation }) {
 					{message.parts.map((part, index) => {
 						const lastPart = message.parts.length === index + 1;
 						switch (part.type) {
+							case "step-start":
+								return null;
 							case "reasoning":
 								if (lastPart) {
 									return (


### PR DESCRIPTION
### **User description**
## Overview

This PR modifies the `GenerationView` component to support incremental content rendering during generation. Previously, a global spinner was displayed while `generation.status === "running"`, blocking all content. This change removes that blocking behavior, allowing step-based content (such as individual image placeholders) to appear progressively as the generation proceeds.

## Changes

- **Removed blocking spinner**: Eliminated the global `Spinner` component that was rendered when `generation.status === "running"`
- **Added step-start message handling**: Introduced recognition for a new "step-start" message part type (currently not rendered but no longer triggers warnings)
- **Enhanced debugging**: Console warnings for unsupported part types now include the actual part object for easier troubleshooting

## ⚠️ Breaking Changes

Tests or integrations that relied on detecting the spinner element to determine if generation is running will need to be updated to check `generation.status` directly instead.

## Testing

- Verified that content renders incrementally during generation instead of being blocked by a spinner
- Confirmed that "step-start" message parts are handled without console warnings
- Tested that unsupported part types still trigger warnings with improved diagnostic information

## Review Notes

- Please verify that the removal of the blocking spinner doesn't negatively impact user experience in scenarios where no incremental content is available
- Consider whether we should add a loading indicator at a more granular level (e.g., per-step) rather than removing loading feedback entirely

## Related Issues

_No specific issues referenced - please add if applicable_


___

### **PR Type**
Enhancement


___

### **Description**
- Removes blocking spinner during generation to enable incremental content rendering

- Adds support for "step-start" message part type by returning null

- Improves debugging by including part object in unsupported type warnings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generation Running"] -->|"Previously"| B["Show Blocking Spinner"]
  A -->|"Now"| C["Render Content Incrementally"]
  D["Message Parts"] -->|"step-start"| E["Return null"]
  D -->|"Other types"| F["Enhanced Warning Logs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generation-view.tsx</strong><dd><code>Remove spinner and add step-start handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/ui/generation-view.tsx

<ul><li>Removed the blocking spinner that displayed when <code>generation.status === </code><br><code>"running"</code><br> <li> Added case handler for "step-start" message part type that returns <br>null<br> <li> Enhanced console warning for unsupported part types to include the <br>actual part object for better debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2216/files#diff-7e1e868389c8152e3a617fb188f0955cc9d4c3bd4cb5c9f367b57db2de1f0a40">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the blocking spinner during `running`, renders content incrementally, ignores `step-start` parts, and improves unsupported-part logging.
> 
> - **UI (`generation-view.tsx`)**:
>   - **Incremental rendering**: Remove global spinner for `generation.status === "running"`; show spinner only when not `completed/cancelled` and no `reasoning` parts are present.
>   - **Message handling**: Add support for `step-start` parts (ignored/no-op) to prevent warnings.
>   - **Logging**: Expand unsupported-part warning to include the full `part` object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 839a011737157f984590f86d2f13807c3bb978aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the generation status indicator behavior to display appropriately during workflow generation

* **Refactor**
  * Enhanced generation step handling and improved diagnostic logging for better error visibility when encountering unsupported step types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->