### PR TITLE
refactor: Remove subscription joins in favor of teams.activeSubscriptionId field

### DIFF
--- a/apps/studio.giselles.ai/services/teams/fetch-current-team.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-current-team.ts
@@ -1,12 +1,6 @@
 import { and, asc, eq } from "drizzle-orm";
 import { cache } from "react";
-import {
-	db,
-	subscriptions,
-	supabaseUserMappings,
-	teamMemberships,
-	teams,
-} from "@/db";
+import { db, supabaseUserMappings, teamMemberships, teams } from "@/db";
 import { getGiselleSession } from "@/lib/giselle-session";
 import { getUser } from "@/lib/supabase";
 import type { CurrentTeam, TeamId } from "./types";
@@ -44,7 +38,7 @@ async function fetchTeam(teamId: TeamId, supabaseUserId: string) {
 			name: teams.name,
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
-			activeSubscriptionId: subscriptions.id,
+			activeSubscriptionId: teams.activeSubscriptionId,
 		})
 		.from(teams)
 		// join teamMemberships and supabaseUserMappings to check user's membership
@@ -52,13 +46,6 @@ async function fetchTeam(teamId: TeamId, supabaseUserId: string) {
 		.innerJoin(
 			supabaseUserMappings,
 			eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
-		)
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(subscriptions.teamDbId, teams.dbId),
-				eq(subscriptions.status, "active"),
-			),
 		)
 		.where(
 			and(
@@ -80,20 +67,13 @@ async function fetchFirstTeam(supabaseUserId: string) {
 			name: teams.name,
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
-			activeSubscriptionId: subscriptions.id,
+			activeSubscriptionId: teams.activeSubscriptionId,
 		})
 		.from(teams)
 		.innerJoin(teamMemberships, eq(teams.dbId, teamMemberships.teamDbId))
 		.innerJoin(
 			supabaseUserMappings,
 			eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
-		)
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(subscriptions.teamDbId, teams.dbId),
-				eq(subscriptions.status, "active"),
-			),
 		)
 		.where(eq(supabaseUserMappings.supabaseUserId, supabaseUserId))
 		.orderBy(asc(teams.dbId))

--- a/apps/studio.giselles.ai/services/teams/fetch-team.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-team.ts
@@ -1,6 +1,6 @@
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { subscriptions, teams } from "@/db/schema";
+import { teams } from "@/db/schema";
 import type { TeamWithSubscription } from "./types";
 
 export async function fetchTeamByDbId(
@@ -13,17 +13,10 @@ export async function fetchTeamByDbId(
 			name: teams.name,
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
-			activeSubscriptionId: subscriptions.id,
+			activeSubscriptionId: teams.activeSubscriptionId,
 		})
 		.from(teams)
-		.where(eq(teams.dbId, dbId))
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(subscriptions.teamDbId, teams.dbId),
-				eq(subscriptions.status, "active"),
-			),
-		);
+		.where(eq(teams.dbId, dbId));
 
 	if (result.length === 0) {
 		return null;

--- a/apps/studio.giselles.ai/services/teams/fetch-user-teams.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-user-teams.ts
@@ -1,11 +1,5 @@
-import { and, asc, eq } from "drizzle-orm";
-import {
-	db,
-	subscriptions,
-	supabaseUserMappings,
-	teamMemberships,
-	teams,
-} from "@/db";
+import { asc, eq } from "drizzle-orm";
+import { db, supabaseUserMappings, teamMemberships, teams } from "@/db";
 import { getUser } from "@/lib/supabase";
 
 /**
@@ -21,7 +15,7 @@ export async function fetchUserTeams() {
 			name: teams.name,
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
-			activeSubscriptionId: subscriptions.id,
+			activeSubscriptionId: teams.activeSubscriptionId,
 			role: teamMemberships.role,
 		})
 		.from(teams)
@@ -29,13 +23,6 @@ export async function fetchUserTeams() {
 		.innerJoin(
 			supabaseUserMappings,
 			eq(teamMemberships.userDbId, supabaseUserMappings.userDbId),
-		)
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(subscriptions.teamDbId, teams.dbId),
-				eq(subscriptions.status, "active"),
-			),
 		)
 		.where(eq(supabaseUserMappings.supabaseUserId, user.id))
 		.orderBy(asc(teams.dbId));

--- a/apps/studio.giselles.ai/services/teams/fetch-workspace-team.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-workspace-team.ts
@@ -1,5 +1,5 @@
-import { and, eq } from "drizzle-orm";
-import { db, subscriptions, teams } from "@/db";
+import { eq } from "drizzle-orm";
+import { db, teams } from "@/db";
 import type { CurrentTeam } from "@/services/teams";
 
 /**
@@ -15,16 +15,9 @@ export async function fetchWorkspaceTeam(
 			name: teams.name,
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
-			activeSubscriptionId: subscriptions.id,
+			activeSubscriptionId: teams.activeSubscriptionId,
 		})
 		.from(teams)
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(subscriptions.teamDbId, teams.dbId),
-				eq(subscriptions.status, "active"),
-			),
-		)
 		.where(eq(teams.dbId, workspaceTeamDbId))
 		.limit(1);
 


### PR DESCRIPTION
## Overview

This PR refactors team fetching queries to use the `activeSubscriptionId` field directly from the `teams` table instead of joining with the `subscriptions` table. This simplification reduces query complexity and improves performance by eliminating unnecessary joins and status filters across multiple service endpoints.

## Related Issue
Part of https://github.com/giselles-ai/giselle/issues/2231

## Changes

- **Removed subscription table joins** from 5 team fetching services:
  - `fetch-current-team`
  - `fetch-first-team`
  - `fetch-team-by-dbId`
  - `fetch-user-teams`
  - `fetch-workspace-team`
  
- **Updated queries** to select `activeSubscriptionId` directly from the `teams` table
- **Maintained API response shape** - endpoints continue to return `activeSubscriptionId` field with no changes to the public interface
- **Simplified query logic** by removing `subscriptions.status = 'active'` filtering

## ⚠️ Breaking Changes

**Database Migration Required:**
- This change requires `teams.activeSubscriptionId` to be populated and maintained
- Services will return `null` or stale subscription IDs if the migration hasn't been completed
- The system no longer validates subscription status at query time - correctness depends entirely on keeping `teams.activeSubscriptionId` synchronized

## Testing

- [ ] Verified all modified queries return the same response shape
- [ ] Confirmed `activeSubscriptionId` is correctly retrieved from teams table
- [ ] Tested with teams having active, inactive, and null subscription IDs
- [ ] Validated performance improvements with query analysis

## Review Notes

Please pay special attention to:
- **Data consistency assumptions** - This change assumes `teams.activeSubscriptionId` is always up-to-date
- **Migration strategy** - Ensure the database migration and backfill process is well-documented
- **Error handling** - Consider if additional validation is needed for null/invalid subscription IDs

## Related Issues

_No issues referenced_