### PR TITLE
Breaking: Centralize billing identifiers on teams table, remove subscription joins

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/join/[token]/invitation.ts
+++ b/apps/studio.giselles.ai/app/(auth)/join/[token]/invitation.ts
@@ -6,7 +6,6 @@ import {
 	db,
 	db as dbInstance,
 	invitations,
-	subscriptions,
 	supabaseUserMappings,
 	type TeamRole,
 	teamMemberships,
@@ -85,16 +84,10 @@ async function fetchTeamWithSubscription(
 			name: teams.name,
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
-			activeSubscriptionId: subscriptions.id,
+			activeSubscriptionId: teams.activeSubscriptionId,
+			activeCustomerId: teams.activeCustomerId,
 		})
 		.from(teams)
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(teams.dbId, subscriptions.teamDbId),
-				eq(subscriptions.status, "active"),
-			),
-		)
 		.where(eq(teams.dbId, teamDbId));
 
 	if (!team) {
@@ -108,6 +101,7 @@ async function fetchTeamWithSubscription(
 		avatarUrl: team.avatarUrl,
 		plan: team.plan,
 		activeSubscriptionId: team.activeSubscriptionId,
+		activeCustomerId: team.activeCustomerId,
 	};
 }
 

--- a/apps/studio.giselles.ai/packages/lib/fetch-usage-limits.ts
+++ b/apps/studio.giselles.ai/packages/lib/fetch-usage-limits.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceId } from "@giselles-ai/protocol";
-import { and, eq } from "drizzle-orm";
-import { agents, db, subscriptions, teams } from "@/db";
+import { eq } from "drizzle-orm";
+import { agents, db, teams } from "@/db";
 import { getUsageLimitsForTeam } from "./usage-limits";
 
 export async function fetchUsageLimits(workspaceId: WorkspaceId) {
@@ -10,17 +10,11 @@ export async function fetchUsageLimits(workspaceId: WorkspaceId) {
 			dbId: teams.dbId,
 			name: teams.name,
 			plan: teams.plan,
-			activeSubscriptionId: subscriptions.id,
+			activeSubscriptionId: teams.activeSubscriptionId,
+			activeCustomerId: teams.activeCustomerId,
 		})
 		.from(teams)
 		.innerJoin(agents, eq(agents.workspaceId, workspaceId))
-		.leftJoin(
-			subscriptions,
-			and(
-				eq(subscriptions.teamDbId, teams.dbId),
-				eq(subscriptions.status, "active"),
-			),
-		)
 		.where(eq(teams.dbId, agents.teamDbId))
 		.limit(1);
 

--- a/apps/studio.giselles.ai/services/teams/fetch-current-team.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-current-team.ts
@@ -39,6 +39,7 @@ async function fetchTeam(teamId: TeamId, supabaseUserId: string) {
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
 			activeSubscriptionId: teams.activeSubscriptionId,
+			activeCustomerId: teams.activeCustomerId,
 		})
 		.from(teams)
 		// join teamMemberships and supabaseUserMappings to check user's membership
@@ -68,6 +69,7 @@ async function fetchFirstTeam(supabaseUserId: string) {
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
 			activeSubscriptionId: teams.activeSubscriptionId,
+			activeCustomerId: teams.activeCustomerId,
 		})
 		.from(teams)
 		.innerJoin(teamMemberships, eq(teams.dbId, teamMemberships.teamDbId))

--- a/apps/studio.giselles.ai/services/teams/fetch-team.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-team.ts
@@ -14,6 +14,7 @@ export async function fetchTeamByDbId(
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
 			activeSubscriptionId: teams.activeSubscriptionId,
+			activeCustomerId: teams.activeCustomerId,
 		})
 		.from(teams)
 		.where(eq(teams.dbId, dbId));

--- a/apps/studio.giselles.ai/services/teams/fetch-user-teams.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-user-teams.ts
@@ -16,6 +16,7 @@ export async function fetchUserTeams() {
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
 			activeSubscriptionId: teams.activeSubscriptionId,
+			activeCustomerId: teams.activeCustomerId,
 			role: teamMemberships.role,
 		})
 		.from(teams)

--- a/apps/studio.giselles.ai/services/teams/fetch-workspace-team.ts
+++ b/apps/studio.giselles.ai/services/teams/fetch-workspace-team.ts
@@ -16,6 +16,7 @@ export async function fetchWorkspaceTeam(
 			avatarUrl: teams.avatarUrl,
 			plan: teams.plan,
 			activeSubscriptionId: teams.activeSubscriptionId,
+			activeCustomerId: teams.activeCustomerId,
 		})
 		.from(teams)
 		.where(eq(teams.dbId, workspaceTeamDbId))

--- a/apps/studio.giselles.ai/services/teams/member-change.ts
+++ b/apps/studio.giselles.ai/services/teams/member-change.ts
@@ -1,4 +1,3 @@
-import { getLatestSubscription } from "@/services/subscriptions/get-latest-subscription";
 import { reportUserSeatUsage } from "@/services/usage-based-billing";
 import type { CurrentTeam } from "./types";
 
@@ -8,18 +7,10 @@ import type { CurrentTeam } from "./types";
  */
 export async function handleMemberChange(currentTeam: CurrentTeam) {
 	const subscriptionId = currentTeam.activeSubscriptionId;
-	if (subscriptionId == null) {
+	const customerId = currentTeam.activeCustomerId;
+	if (subscriptionId == null || customerId == null) {
 		// No active subscription, nothing to do
 		return;
 	}
-	const customerId = await fetchCustomerId(subscriptionId);
 	await reportUserSeatUsage(subscriptionId, customerId);
-}
-
-async function fetchCustomerId(subscriptionId: string) {
-	const subscription = await getLatestSubscription(subscriptionId);
-	if (!subscription) {
-		throw new Error(`Subscription ${subscriptionId} not found`);
-	}
-	return subscription.customerId;
 }

--- a/apps/studio.giselles.ai/services/teams/types.ts
+++ b/apps/studio.giselles.ai/services/teams/types.ts
@@ -12,6 +12,7 @@ export type CurrentTeam = {
 	avatarUrl?: typeof teams.$inferSelect.avatarUrl;
 	plan: typeof teams.$inferSelect.plan;
 	activeSubscriptionId: typeof subscriptions.$inferInsert.id | null;
+	activeCustomerId: typeof teams.$inferSelect.activeCustomerId;
 };
 
 export type TeamWithSubscription = CurrentTeam;


### PR DESCRIPTION
## Overview

This PR centralizes billing identifiers directly on the teams table, eliminating the need for subscription table joins throughout the codebase. By adding `activeCustomerId` to teams and relying on the existing `activeSubscriptionId`, we simplify queries and reduce complexity in billing-related operations.

**Motivation:** The previous approach required frequent joins with the subscriptions table to retrieve billing information, adding unnecessary query complexity and potential performance overhead. This change consolidates billing data where it's most frequently accessed - directly on the team entity.

## Related Issue
Part of https://github.com/giselles-ai/giselle/issues/2231

## Changes

### Breaking Changes ⚠️
- **Type contract change:** `CurrentTeam` now requires an `activeCustomerId` field
- **Behavioral change:** Seat usage reporting no longer throws when billing data is missing; instead silently skips reporting
- **Query simplification:** Removed subscription status filtering - now relies solely on `teams.activeSubscriptionId` being set

### Key Modifications
- Added `activeCustomerId` field to teams table and all team-fetching services:
  - `getCurrentTeam`
  - `getFirstTeam`
  - `getTeamByDatabaseId`
  - `getUserTeams`
  - `getWorkspaceTeam`
- Simplified member seat usage reporting by removing `getLatestSubscription` dependency
- Removed subscriptions table joins from invitation flows and usage limit fetching
- Reduced imports and query complexity across billing-related modules

## Testing

- [ ] Verified all team-fetching services return `activeCustomerId`
- [ ] Tested invitation flow works without subscription joins
- [ ] Confirmed seat usage reporting handles null billing data gracefully
- [ ] Validated usage limits are correctly fetched using team fields

## Review Notes

Please pay special attention to:

1. **Data consistency:** This assumes `teams.activeCustomerId` is populated and kept in sync with `activeSubscriptionId`. Any existing data migration needs should be addressed.

2. **Error handling change:** The seat usage reporting now silently skips when billing data is missing rather than throwing. Is this the desired behavior for production monitoring?

3. **Subscription status filtering:** We no longer filter by `status="active"` from subscriptions table. Confirm this won't affect any critical billing workflows.

## Related Issues

_No issues linked_