### PR TITLE
Improve prompt placeholder with @ reference hint

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx
@@ -184,7 +184,7 @@ export function PromptPanel({
 	return (
 		<PromptEditor
 			key={`${editorVersion ?? 0}-${JSON.stringify(nodes.map((n) => n.id))}`}
-			placeholder="Write your prompt here..."
+			placeholder="Write your prompt... Use @ to reference other nodes"
 			value={node.content.prompt}
 			onValueChange={(value) => {
 				updateNodeDataContent(node, { prompt: value });

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -372,7 +372,7 @@ export function PromptPanel({
 		<>
 			<PromptEditor
 				key={`${editorVersion ?? 0}-${JSON.stringify(connectedSources.map((c) => c.node.id))}`}
-				placeholder="Write your prompt here..."
+				placeholder="Write your prompt... Use @ to reference other nodes"
 				value={node.content.prompt}
 				onValueChange={(value) => {
 					updateNodeDataContent(node, { prompt: value });


### PR DESCRIPTION
### **User description**
## Summary
Add hint about using `@` to reference other nodes in the placeholder text to improve feature discoverability.

<img width="392" height="157" alt="image" src="https://github.com/user-attachments/assets/e4242aeb-fe25-43fd-bd9a-e1c04d0f9d29" />


## Reference
[Referencing other node outputs: If you want to insert the output of other nodes as variables within your prompt, you can click the @ key to display a suggestion list. From this list, you can select the outputs of other nodes that are connected to the current node’s input and insert them into your prompt.](https://docs.giselles.ai/en/glossary/generator-node#prompt-tab:~:text=Referencing%20other%20node%20outputs)
___

### **PR Type**
Enhancement


___

### **Description**
- Update prompt placeholder text with @ reference hint

- Improves feature discoverability for node referencing

- Applied to both image and text generation node panels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Prompt Placeholder Text"] -- "Add @ reference hint" --> B["Enhanced Placeholder with Node Reference Guide"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Add @ reference hint to image generation prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/prompt-panel.tsx

<ul><li>Updated placeholder text from "Write your prompt here..." to "Write <br>your prompt... Use @ to reference other nodes"<br> <li> Provides inline hint about @ syntax for referencing other nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2232/files#diff-a8e7545975c958bbc2f1b3b29e9a6bad5d8a0f4e6072c7cd04a3b2028974b6bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Add @ reference hint to text generation prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx

<ul><li>Updated placeholder text from "Write your prompt here..." to "Write <br>your prompt... Use @ to reference other nodes"<br> <li> Provides inline hint about @ syntax for referencing other nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2232/files#diff-b948e855ed4caae9a25e3a70cdf48c528051a145191609c3acff7fad495ae4bf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update PromptEditor placeholder to mention using @ to reference other nodes in text and image generation prompt panels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fee962bb4f489cf046bfdbb6444b9c52d333dce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prompt editor placeholder text to include information about referencing other nodes using the @ symbol.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->