### PR TITLE
fix: double file selector trigger in document vector store settings

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/document-vector-store-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/document-vector-store-item.tsx
@@ -805,9 +805,7 @@ function DocumentVectorStoreConfigureDialog({
 									) : (
 										<div className="flex flex-col gap-[16px] justify-center items-center py-[16px]">
 											<ArrowUpFromLine className="size-[38px] text-text-muted" />
-											<label
-												className="text-center flex flex-col gap-[16px] text-inverse cursor-pointer"
-											>
+											<div className="text-center flex flex-col gap-[16px] text-inverse cursor-pointer">
 												<p>
 													Drop {SUPPORTED_FILE_TYPES_LABEL} files here to
 													upload.
@@ -818,7 +816,7 @@ function DocumentVectorStoreConfigureDialog({
 														Select files
 													</span>
 												</div>
-											</label>
+											</div>
 										</div>
 									)}
 									{isUploadingDocuments ? (


### PR DESCRIPTION
### **User description**
## Summary
Fixed an issue where the file selector dialog would open twice when clicking "Select files" in the document vector store settings. This was caused by a label element with an htmlFor attribute nested inside a button element that also had an onClick handler, triggering the file input event twice.

## Related Issue
N/A

## Changes
Removed the htmlFor attribute from the label element in apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/document-vector-store-item.tsx to prevent the double trigger.
Removed the unused id attribute from the corresponding input element.
## Testing
Manually verified that clicking the "Select files" button now opens the file selector dialog only once.
Confirmed that the drag-and-drop functionality and UI styling remain unaffected.

## Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Removed `htmlFor` attribute from label element preventing double file selector trigger

- Removed unused `id` attribute from file input element

- Fixed nested label-button interaction causing duplicate file dialog opens


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Button with onClick handler"] -->|"Previously nested with"| B["Label with htmlFor"]
  B -->|"Both triggered"| C["File input dialog"]
  D["Removed htmlFor and id"] -->|"Now only"| E["Button onClick triggers"]
  E -->|"Single open"| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>document-vector-store-item.tsx</strong><dd><code>Remove htmlFor and id attributes from file input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/document-vector-store-item.tsx

<ul><li>Removed <code>htmlFor={</code>file-input-${store.id}<code>}</code> attribute from label element<br> <li> Removed <code>id={</code>file-input-${store.id}<code>}</code> attribute from file input element<br> <li> Eliminated double trigger caused by nested label-button interaction</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2237/files#diff-d097c79daaa77364256fbbc819b624dc0bebeb9d35bd61b71698b130c4d5e21c">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the label/htmlFor link and input id in `document-vector-store-item.tsx` to stop the file selector from opening twice.
> 
> - **UI — Document Vector Store upload (`apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/document/document-vector-store-item.tsx`)**:
>   - Replace clickable `label` with `div` (remove `htmlFor`) inside the upload button to avoid duplicate file dialog triggers.
>   - Remove unused `id` from the hidden file `input`; click now solely triggered via `ref` on button action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 644c43357b541179d87e2bb7ef0213296bcd4af9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the document upload area: replaced the linked label/input pattern with a simplified interactive drop zone, adjusted on-screen prompt to "Drop ... files here to upload." with an inline emphasized "or Select files" cue, while preserving existing upload, validation, and UI behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->