### PR TITLE
refactor: improve EditableText component styling and React 19 patterns

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/editable-text.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/editable-text.tsx
@@ -2,7 +2,6 @@
 
 import clsx from "clsx/lite";
 import {
-	forwardRef,
 	useCallback,
 	useEffect,
 	useImperativeHandle,
@@ -14,20 +13,25 @@ export interface EditableTextRef {
 	triggerEdit: () => void;
 }
 
-export const EditableText = forwardRef<
-	EditableTextRef,
-	{
-		value?: string;
-		fallbackValue: string;
-		onChange?: (value?: string) => void;
-		size?: "medium" | "large";
-		ariaLabel?: string;
-		className?: string;
-	}
->(function EditableText(
-	{ value, fallbackValue, onChange, size = "medium", ariaLabel, className },
+interface EditableTextProps {
+	value?: string;
+	fallbackValue: string;
+	onChange?: (value?: string) => void;
+	size?: "medium" | "large";
+	ariaLabel?: string;
+	className?: string;
+	ref?: React.Ref<EditableTextRef>;
+}
+
+export function EditableText({
+	value,
+	fallbackValue,
+	onChange,
+	size = "medium",
+	ariaLabel,
+	className,
 	ref,
-) {
+}: EditableTextProps) {
 	const [edit, setEdit] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -66,7 +70,7 @@ export const EditableText = forwardRef<
 				type="text"
 				aria-label={ariaLabel}
 				className={clsx(
-					"w-full min-w-[200px] hidden data-[editing=true]:block",
+					"w-full min-w-[300px] hidden data-[editing=true]:block",
 					"outline-none border border-[color-mix(in_srgb,var(--color-text-inverse,#fff)_20%,transparent)] focus:border-[color-mix(in_srgb,var(--color-text-inverse,#fff)_30%,transparent)]",
 					"rounded-[8px] bg-[color-mix(in_srgb,var(--color-text-inverse,#fff)_5%,transparent)]",
 					"!pt-[2px] !pr-[8px] !pb-[2px] !pl-[12px]",
@@ -92,7 +96,7 @@ export const EditableText = forwardRef<
 				className={clsx(
 					"rounded-[8px] data-[editing=true]:hidden text-left",
 					"hover:bg-bg-900/20 group-hover:bg-bg-900/10",
-					"bg-[color-mix(in_srgb,var(--color-text-inverse,#fff)_5%,transparent)] !pt-[2px] !pr-[8px] !pb-[2px] !pl-[12px]",
+					"!pt-[2px] !pr-[8px] !pb-[2px] !pl-[12px]",
 					"data-[size=medium]:text-[14px] data-[size=large]:text-[16px]",
 					"cursor-default w-full overflow-hidden text-ellipsis whitespace-nowrap",
 					!className && "text-inverse",
@@ -106,4 +110,4 @@ export const EditableText = forwardRef<
 			</button>
 		</>
 	);
-});
+}

--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-header.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-header.tsx
@@ -65,7 +65,7 @@ export function V2Header({
 						</span>
 					)}
 					{/* app name editable */}
-					<div className="max-w-[200px]">
+					<div className="max-w-[300px]">
 						<EditableText
 							key={data.id}
 							ref={editableTextRef}


### PR DESCRIPTION
### **User description**
## Overview
Improved EditableText component styling and refactored to follow React 19 patterns.

## Changes
- Remove background color from non-editing state button for cleaner appearance
- Increase workspace name max width from 200px to 300px for better readability
- Increase edit mode input min width from 200px to 300px
- Refactor to remove forwardRef and use React 19 pattern with ref as prop

## Technical Details
- Removed `bg-[color-mix(in_srgb,var(--color-text-inverse,#fff)_5%,transparent)]` from button element
- Updated `max-w-[200px]` to `max-w-[300px]` in v2-header.tsx
- Updated `min-w-[200px]` to `min-w-[300px]` in editable-text.tsx
- Replaced forwardRef with regular function component accepting ref as prop


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor EditableText to use React 19 ref pattern

- Remove forwardRef wrapper for cleaner component structure

- Increase workspace name max width to 300px

- Increase edit mode input min width to 300px

- Remove background color from non-editing button state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EditableText Component"] -->|"Remove forwardRef"| B["Regular Function Component"]
  B -->|"Accept ref as prop"| C["React 19 Pattern"]
  D["Button Styling"] -->|"Remove bg color"| E["Cleaner Appearance"]
  F["Width Values"] -->|"200px to 300px"| G["Better Readability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>editable-text.tsx</strong><dd><code>Refactor to React 19 ref pattern and improve styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/editable-text.tsx

<ul><li>Removed <code>forwardRef</code> import and wrapper, converted to regular function <br>component<br> <li> Added <code>EditableTextProps</code> interface with <code>ref</code> as optional prop<br> <li> Increased edit mode input <code>min-w</code> from <code>200px</code> to <code>300px</code><br> <li> Removed background color from non-editing button state for cleaner <br>appearance</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2240/files#diff-71f8b29b55e359b7218a65a9157e44debf5fac62eefc9c468012379cdbbbdf86">+21/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>v2-header.tsx</strong><dd><code>Increase workspace name max width for readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/v2/components/v2-header.tsx

<ul><li>Increased workspace name container <code>max-w</code> from <code>200px</code> to <code>300px</code><br> <li> Improves readability for longer workspace names</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2240/files#diff-b4ce09a73f46d0c917223c0a2ef342dc2fbe3c3a95bc3e6899094fd962573462">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors `EditableText` to use React 19 ref-as-prop and updates styling/widths (300px) while removing view-mode button background.
> 
> - **UI**
>   - Increase editable name field widths to 300px:
>     - `min-w-[300px]` for input in `editor/properties-panel/ui/editable-text.tsx`.
>     - `max-w-[300px]` for app name container in `editor/v2/components/v2-header.tsx`.
>   - Remove non-editing button background (`bg-[color-mix(...)]`) in `EditableText` for cleaner view state.
> - **Refactor**
>   - Convert `EditableText` from `forwardRef` to a function component using React 19 ref-as-prop, retaining `useImperativeHandle` API (`triggerEdit`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 794dda075013ba6e77da8887885f8a767fb18c1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Increased editable text component input width from 200px to 300px for improved visibility of longer content
  * Extended app name display area in the header to better accommodate longer names
  * Simplified styling by removing unnecessary background styling from input elements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->