### PR TITLE
feat: add tooltip to show truncated repository and file names

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx
+++ b/apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx
@@ -5,6 +5,7 @@ import { File, Zap } from "lucide-react";
 import Link from "next/link";
 import type { agents as dbAgents } from "@/db";
 import { GitHubIcon } from "../../../../../../internal-packages/workflow-designer-ui/src/icons";
+import { Tooltip } from "../../../../../../internal-packages/workflow-designer-ui/src/ui/tooltip";
 import { DeleteAgentButton } from "./delete-agent-button";
 import { DuplicateAgentButton } from "./duplicate-agent-button";
 import { formatExecutionCount } from "./format-execution-count";
@@ -115,9 +116,30 @@ export function AgentCard({ agent }: AgentCardProps) {
 																{repo}
 															</div>
 															{repos.length > 1 && (
-																<span className="font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted">
-																	+{repos.length - 1}
-																</span>
+																<Tooltip
+																	text={
+																		<div className="flex flex-col gap-1 bg-bg-900/30 rounded px-2 py-0.5 border border-white/20">
+																			{repos.slice(1).map((hiddenRepo) => (
+																				<span key={hiddenRepo}>
+																					{hiddenRepo}
+																				</span>
+																			))}
+																		</div>
+																	}
+																	variant="dark"
+																	side="top"
+																>
+																	<button
+																		type="button"
+																		className="relative z-50 font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted"
+																		onClick={(e) => {
+																			e.stopPropagation();
+																			e.preventDefault();
+																		}}
+																	>
+																		+{repos.length - 1}
+																	</button>
+																</Tooltip>
 															)}
 														</div>
 													));
@@ -144,9 +166,30 @@ export function AgentCard({ agent }: AgentCardProps) {
 																{fileName}
 															</div>
 															{files.length > 1 && (
-																<span className="font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted">
-																	+{files.length - 1}
-																</span>
+																<Tooltip
+																	text={
+																		<div className="flex flex-col gap-1 bg-bg-900/30 rounded px-2 py-0.5 border border-white/20">
+																			{files.slice(1).map((hiddenFile) => (
+																				<span key={hiddenFile}>
+																					{hiddenFile}
+																				</span>
+																			))}
+																		</div>
+																	}
+																	variant="dark"
+																	side="top"
+																>
+																	<button
+																		type="button"
+																		className="relative z-50 font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted"
+																		onClick={(e) => {
+																			e.stopPropagation();
+																			e.preventDefault();
+																		}}
+																	>
+																		+{files.length - 1}
+																	</button>
+																</Tooltip>
 															)}
 														</div>
 													));

--- a/apps/studio.giselles.ai/app/(main)/workspaces/components/app-list-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/workspaces/components/app-list-item.tsx
@@ -20,6 +20,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useState, useTransition } from "react";
 import type { AgentId } from "@/services/agents";
 import { GitHubIcon } from "../../../../../../internal-packages/workflow-designer-ui/src/icons";
+import { Tooltip } from "../../../../../../internal-packages/workflow-designer-ui/src/ui/tooltip";
 import { Button } from "../../settings/components/button";
 import { copyAgent, deleteAgent } from "../actions";
 import { formatExecutionCount } from "./format-execution-count";
@@ -134,9 +135,28 @@ export function AppListItem({
 											{repo}
 										</div>
 										{githubRepositories.length > 1 && (
-											<span className="font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted">
-												+{githubRepositories.length - 1}
-											</span>
+											<Tooltip
+												text={
+													<div className="flex flex-col gap-1 bg-bg-900/30 rounded px-2 py-0.5 border border-white/20">
+														{githubRepositories.slice(1).map((hiddenRepo) => (
+															<span key={hiddenRepo}>{hiddenRepo}</span>
+														))}
+													</div>
+												}
+												variant="dark"
+												side="top"
+											>
+												<button
+													type="button"
+													className="relative z-50 font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted"
+													onClick={(e) => {
+														e.stopPropagation();
+														e.preventDefault();
+													}}
+												>
+													+{githubRepositories.length - 1}
+												</button>
+											</Tooltip>
 										)}
 									</div>
 								))}
@@ -153,9 +173,30 @@ export function AppListItem({
 											{fileName}
 										</div>
 										{documentVectorStoreFiles.length > 1 && (
-											<span className="font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted">
-												+{documentVectorStoreFiles.length - 1}
-											</span>
+											<Tooltip
+												text={
+													<div className="flex flex-col gap-1 bg-bg-900/30 rounded px-2 py-0.5 border border-white/20">
+														{documentVectorStoreFiles
+															.slice(1)
+															.map((hiddenFile) => (
+																<span key={hiddenFile}>{hiddenFile}</span>
+															))}
+													</div>
+												}
+												variant="dark"
+												side="top"
+											>
+												<button
+													type="button"
+													className="relative z-50 font-geist text-[11px] text-text/60 flex-shrink-0 px-1.5 py-0.5 rounded-lg border border-border-muted"
+													onClick={(e) => {
+														e.stopPropagation();
+														e.preventDefault();
+													}}
+												>
+													+{documentVectorStoreFiles.length - 1}
+												</button>
+											</Tooltip>
 										)}
 									</div>
 								))}


### PR DESCRIPTION

## Overview
Added tooltip functionality to display hidden repository and file names when hovering over the +N badge in workspace cards.

## Changes
- Added Tooltip component to display truncated repository/file names when hovering over +N badge
- Prevented Link navigation when clicking tooltip trigger button by adding stopPropagation and preventDefault
- Added subtle background color (`bg-bg-900/30`) and white border (`border-white/20`) to tooltip content
- Increased horizontal padding (`px-2`) in tooltip content for better readability
- Removed cursor-help class from tooltip trigger buttons

<img width="367" height="278" alt="スクリーンショット 2025-11-21 14 34 24" src="https://github.com/user-attachments/assets/f7bd6a25-00c0-4d16-b693-75e5b58e000e" />


## Behavior
- When hovering over the +N badge (e.g., +1, +2), a tooltip appears showing all hidden repository or file names
- Clicking the badge no longer navigates to the workspace page
- Tooltip content has a subtle background and white border for better visibility


___

### **PR Type**
Enhancement


___

### **Description**
- Add Tooltip component to display truncated repository and file names

- Replace static +N badges with interactive tooltip triggers

- Prevent navigation when clicking tooltip trigger buttons

- Apply dark styling with subtle background and white border


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Static +N Badge"] -->|"Replace with"| B["Tooltip Component"]
  B -->|"Shows on hover"| C["Hidden Items List"]
  B -->|"Prevents"| D["Link Navigation"]
  B -->|"Styled with"| E["Dark Background & Border"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent-card.tsx</strong><dd><code>Add tooltips for truncated repos and files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx

<ul><li>Import Tooltip component from workflow-designer-ui<br> <li> Wrap repository +N badge with Tooltip showing hidden repos<br> <li> Wrap file +N badge with Tooltip showing hidden files<br> <li> Add event handlers to prevent navigation on badge click<br> <li> Apply dark tooltip styling with bg-bg-900/30 and border-white/20</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2241/files#diff-82f10eeae9dd84bb7a03b100b9d17482d5744819ab7cb4073847832ecd63379a">+49/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app-list-item.tsx</strong><dd><code>Add tooltips for truncated items in app list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/workspaces/components/app-list-item.tsx

<ul><li>Import Tooltip component from workflow-designer-ui<br> <li> Wrap GitHub repositories +N badge with Tooltip<br> <li> Wrap document vector store files +N badge with Tooltip<br> <li> Add stopPropagation and preventDefault handlers to badge buttons<br> <li> Apply consistent dark tooltip styling across both sections</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2241/files#diff-75a0eccc6f835e1a790bdfa9abd64a2112b114a127b648361bee5e1e1ef3dc43">+47/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive tooltips that display hidden repositories and files when hovering over "+N" indicators, improving visibility of overflow items in workspace views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->