### PR TITLE
Fix stripe customer ID warning to only log for pro/team plans

### DIFF
--- a/apps/studio.giselles.ai/app/giselle.ts
+++ b/apps/studio.giselles.ai/app/giselle.ts
@@ -362,6 +362,9 @@ export const giselle = NextGiselle({
 			const stripeCustomerId = parsedMetadata.success
 				? (parsedMetadata.data.team.activeCustomerId ?? undefined)
 				: undefined;
+			const teamPlan = parsedMetadata.success
+				? parsedMetadata.data.team.plan
+				: undefined;
 			const aiGatewayHeaders: AiGatewayHeaders = {
 				"http-referer":
 					process.env.AI_GATEWAY_HTTP_REFERER ?? "https://giselles.ai",
@@ -369,7 +372,7 @@ export const giselle = NextGiselle({
 			};
 			if (stripeCustomerId !== undefined) {
 				aiGatewayHeaders["stripe-customer-id"] = stripeCustomerId;
-			} else {
+			} else if (teamPlan === "pro" || teamPlan === "team") {
 				logger.warn(
 					`Stripe customer ID not found for generation ${generation.id}`,
 				);


### PR DESCRIPTION
### **User description**
The warning was being logged for all plans when stripeCustomerId was undefined, but this value is only expected to exist for pro or team plans. 
This change suppresses unnecessary warnings for free, enterprise,and internal plans.

### Related Issues

Part of https://github.com/giselles-ai/giselle/issues/2233

___

### **PR Type**
Bug fix


___

### **Description**
- Suppress stripe customer ID warning for non-billable plans

- Extract team plan from metadata for conditional logging

- Only warn when stripe ID missing on pro/team plans


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parse Metadata"] --> B["Extract stripeCustomerId"]
  A --> C["Extract teamPlan"]
  B --> D{stripeCustomerId defined?}
  D -->|Yes| E["Set stripe-customer-id header"]
  D -->|No| F{Plan is pro or team?}
  F -->|Yes| G["Log warning"]
  F -->|No| H["Skip warning"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>giselle.ts</strong><dd><code>Conditional stripe customer ID warning by plan type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/giselle.ts

<ul><li>Extract <code>teamPlan</code> from parsed metadata alongside <code>stripeCustomerId</code><br> <li> Modify warning condition to only log when plan is "pro" or "team"<br> <li> Prevents unnecessary warnings for free, enterprise, and internal plans</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2250/files#diff-8e743debdc9e9b9f0448ea18bac587bfcb323b47c7fb561fb6624ee722e062f0">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts the missing Stripe customer ID warning to pro/team plans by parsing team plan from metadata in buildAiGatewayHeaders.
> 
> - **Backend**
>   - **Logging behavior**: Update `buildAiGatewayHeaders` in `apps/studio.giselles.ai/app/giselle.ts` to log a warning about missing `stripe-customer-id` only when `team.plan` is `"pro"` or `"team"`.
>     - Parse `team.plan` from `GenerationMetadata` and use it to gate the warning.
>     - Preserve setting `stripe-customer-id` header when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 562989f983e42261fa31d9e43cb4d566c1e734b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging to ensure warnings are properly displayed in specific billing-related scenarios. Improved handling for edge cases involving team plans to ensure appropriate warnings are shown when necessary conditions are detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->