### PR TITLE
fix: team dropdown menu actions not navigating on account settings page

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/account/user-teams.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/account/user-teams.tsx
@@ -164,11 +164,11 @@ function UserTeamsItem({
 					align="end"
 					className="p-1 border-[0.25px] border-border rounded-[8px] min-w-[165px] bg-surface shadow-none"
 				>
-					<DropdownMenuItem className="p-0">
+					<DropdownMenuItem
+						className="p-0"
+						onSelect={(e) => e.preventDefault()}
+					>
 						<ChangeTeamAndAction
-							teamId={teamId}
-							userId={currentUserId}
-							role={role}
 							renderButton={(isPending) => (
 								<button
 									type="submit"
@@ -181,11 +181,11 @@ function UserTeamsItem({
 							action={() => navigateWithChangeTeam(teamId, "/workspaces")}
 						/>
 					</DropdownMenuItem>
-					<DropdownMenuItem className="p-0">
+					<DropdownMenuItem
+						className="p-0"
+						onSelect={(e) => e.preventDefault()}
+					>
 						<ChangeTeamAndAction
-							teamId={teamId}
-							userId={currentUserId}
-							role={role}
 							renderButton={(isPending) => (
 								<button
 									type="submit"
@@ -199,11 +199,11 @@ function UserTeamsItem({
 						/>
 					</DropdownMenuItem>
 					<div className="my-2 h-px bg-white/10" />
-					<DropdownMenuItem className="p-0">
+					<DropdownMenuItem
+						className="p-0"
+						onSelect={(e) => e.preventDefault()}
+					>
 						<ChangeTeamAndAction
-							teamId={teamId}
-							userId={currentUserId}
-							role={role}
 							renderButton={(isPending) => (
 								<button
 									type="submit"
@@ -223,9 +223,6 @@ function UserTeamsItem({
 }
 
 interface ChangeTeamAndActionProps {
-	teamId: string;
-	userId: string;
-	role: string;
 	renderButton: (isPending: boolean) => React.ReactNode;
 	action: () => Promise<void>;
 }


### PR DESCRIPTION
### **User description**
## Summary
Fixed an issue where clicking "Apps" or "Settings" from the team dropdown menu on `/settings/account` page did not navigate to the selected team.

## Related Issue
N/A

## Changes
- Added `onSelect={(e) => e.preventDefault()}` to `DropdownMenuItem` components to prevent the menu from closing before form submission completes
- Removed unused props (`teamId`, `userId`, `role`) from `ChangeTeamAndActionProps` interface

## Testing
1. Go to `/settings/account`
2. Click the three-dot menu on any team
3. Click "Apps" → Navigates to the team's workspaces page
4. Click "Settings" → Navigates to the team's settings page
5. Click "Leave team" → Shows confirmation or error toast

## Other Information
The root cause was that clicking a `DropdownMenuItem` closes the dropdown by default, which removes the form from the DOM before submission completes. This caused the error: "Form submission canceled because the form is not connected".


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed dropdown menu closing before form submission completes

- Added `onSelect` handler to prevent default dropdown behavior

- Removed unused props from `ChangeTeamAndActionProps` interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DropdownMenuItem clicked"] -->|"preventDefault() added"| B["Form submission completes"]
  B -->|"Navigation executes"| C["Team page loads"]
  D["Unused props removed"] -->|"Cleanup"| E["Cleaner interface"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-teams.tsx</strong><dd><code>Prevent dropdown closure and remove unused props</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/account/user-teams.tsx

<ul><li>Added <code>onSelect={(e) => e.preventDefault()}</code> to three <code>DropdownMenuItem</code> <br>components to prevent premature dropdown closure<br> <li> Removed unused props (<code>teamId</code>, <code>userId</code>, <code>role</code>) from <br><code>ChangeTeamAndActionProps</code> interface definition<br> <li> Removed prop passing for <code>teamId</code>, <code>userId</code>, and <code>role</code> from all three <br><code>ChangeTeamAndAction</code> component instances</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2257/files#diff-9d073f9ae4a8b35cb5ce15b10cc11ca52d8db23965b4cbbc5bf90ccf0e09a03a">+12/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevent dropdown auto-close to allow form submission-driven navigation and remove unused props in team menu on account settings page.
> 
> - **Account Settings › Team menu (`apps/.../user-teams.tsx`)**:
>   - Prevent dropdown auto-close on selection by adding `onSelect={(e) => e.preventDefault()}` to each `DropdownMenuItem` (for `Apps`, `Settings`, `Leave team`).
>   - Streamline `ChangeTeamAndAction` by removing unused props from its interface and call sites.
>   - Keep form submission via `useActionState` to perform navigation (`navigateWithChangeTeam`) and leave-team action reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68483535319cacab0ff572aeccd427f9ff7c8f47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown menu items in team settings to prevent unintended selection behavior.

* **Refactor**
  * Simplified component API for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->