### PR TITLE
feat: add stripe-v2 feature flag

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -193,3 +193,22 @@ export const generateContentNodeFlag = flag<boolean>({
 		{ value: true, label: "Enable" },
 	],
 });
+
+export const stripeV2Flag = flag<boolean>({
+	key: "stripe-v2",
+	async decide() {
+		if (process.env.NODE_ENV === "development") {
+			return takeLocalEnv("STRIPE_V2_FLAG");
+		}
+		const edgeConfig = await get(`flag__${this.key}`);
+		if (edgeConfig === undefined) {
+			return false;
+		}
+		return edgeConfig === true || edgeConfig === "true";
+	},
+	description: "Enable Stripe V2",
+	options: [
+		{ value: false, label: "disable" },
+		{ value: true, label: "Enable" },
+	],
+});


### PR DESCRIPTION
### **User description**
Add stripeV2Flag to control Stripe V2 integration rollout. 
Configurable via STRIPE_V2_FLAG env var (local) or Edge Config (production).


### Related Issues

Part of https://github.com/giselles-ai/giselle/issues/2061, https://github.com/giselles-ai/giselle/issues/2233


___

### **PR Type**
Enhancement


___

### **Description**
- Add `stripeV2Flag` feature flag for Stripe V2 integration rollout

- Support environment variable configuration in development mode

- Support Edge Config-based configuration in production mode

- Provide UI options to enable or disable the flag


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stripeV2Flag"] --> B{"NODE_ENV"}
  B -->|development| C["STRIPE_V2_FLAG env var"]
  B -->|production| D["Edge Config flag__stripe-v2"]
  C --> E["Boolean decision"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Add Stripe V2 feature flag implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Added new <code>stripeV2Flag</code> feature flag export with key <code>stripe-v2</code><br> <li> Implemented decision logic checking NODE_ENV for development vs <br>production<br> <li> Development mode reads from <code>STRIPE_V2_FLAG</code> environment variable<br> <li> Production mode reads from Edge Config with fallback to false<br> <li> Included UI options for flag management (disable/Enable)</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2258/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `stripeV2Flag` to control Stripe V2 via `STRIPE_V2_FLAG` (dev) or Edge Config in production.
> 
> - **Flags**:
>   - **New** `stripeV2Flag` (`key: "stripe-v2"`)
>     - Decision: `STRIPE_V2_FLAG` in development; `edge-config` key `flag__stripe-v2` otherwise.
>     - Includes description and enable/disable options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd8af3cbffef18e692e51073cd76d6b645bab781. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->