### PR TITLE
fix: Make entire Log Out menu item clickable

### DIFF
--- a/apps/studio.giselles.ai/app/stage/ui/navigation-rail/navigation-rail-footer-menu.tsx
+++ b/apps/studio.giselles.ai/app/stage/ui/navigation-rail/navigation-rail-footer-menu.tsx
@@ -224,7 +224,7 @@ export function NavigationRailFooterMenu({
 
 						{/* Logout */}
 						<DropdownMenuPrimitive.Item className={MENU_ITEM_CLASS} asChild>
-							<SignOutButton className="text-[14px] w-full text-left">
+							<SignOutButton className="w-full text-left">
 								Log Out
 							</SignOutButton>
 						</DropdownMenuPrimitive.Item>


### PR DESCRIPTION
### **User description**
## Summary
Fixed the Log Out menu item so that clicking anywhere on the item triggers sign out, not just the text.

## Related Issue
N/A

## Changes
- Added `asChild` prop to `DropdownMenuPrimitive.Item` wrapping the `SignOutButton`
- Added `w-full` and `text-left` classes to `SignOutButton` to extend the clickable area to full width while keeping text left-aligned

## Testing
1. Open the navigation rail footer menu by clicking on the user avatar
2. Click anywhere on the "Log Out" menu item (not just the text)
3. Verify that sign out action is triggered


## Other Information
Previously, only clicking directly on the "Log Out" text would trigger sign out. With `asChild`, the `SignOutButton` now spans the full width of the menu item, making the entire row clickable for better UX consistency with other menu items.


___

### **PR Type**
Bug fix


___

### **Description**
- Made entire Log Out menu item clickable by adding `asChild` prop

- Extended SignOutButton to full width with `w-full` class

- Aligned text left while maintaining full clickable area


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DropdownMenuPrimitive.Item"] -->|"asChild prop added"| B["SignOutButton"]
  B -->|"w-full text-left classes"| C["Full width clickable area"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation-rail-footer-menu.tsx</strong><dd><code>Expand Log Out button clickable area to full width</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/stage/ui/navigation-rail/navigation-rail-footer-menu.tsx

<ul><li>Added <code>asChild</code> prop to <code>DropdownMenuPrimitive.Item</code> wrapping <br><code>SignOutButton</code><br> <li> Added <code>w-full</code> and <code>text-left</code> CSS classes to <code>SignOutButton</code> element<br> <li> Ensures entire menu item row is clickable for sign out action</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2259/files#diff-a0516a4b8e699a7fb52a4036a4126ccb5f9e836d13a5b55002b9d82b9e221e90">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Wraps the logout menu item with `asChild` and makes `SignOutButton` full-width/left-aligned so the entire row triggers sign out.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b65330edccf87d0aaf450f3129ec0c50a0c7df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the logout item in the navigation footer to a full-width, left-aligned button, expanding its clickable area for improved usability and clearer visual alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->