### PR TITLE
fix: Handle GitHub App installation 404 errors as DocumentLoaderError

### DIFF
--- a/packages/github-tool/src/document-loaders/issues/loader.ts
+++ b/packages/github-tool/src/document-loaders/issues/loader.ts
@@ -3,10 +3,10 @@ import {
 	type DocumentLoader,
 	DocumentLoaderError,
 } from "@giselles-ai/rag";
-import { RequestError } from "@octokit/request-error";
 import { type Client, CombinedError } from "urql";
 import { graphql } from "../../client";
 import type { GitHubAuthConfig } from "../../types";
+import { handleGitHubClientError } from "../utils";
 import { getCache, issueDetailsCache, setCache } from "./cache";
 import {
 	type FetchContext,
@@ -87,22 +87,7 @@ export function createGitHubIssuesLoader(
 			try {
 				graphqlClient = await graphql(authConfig);
 			} catch (error) {
-				if (error instanceof RequestError && error.status === 404) {
-					const installationId =
-						authConfig.strategy === "app-installation"
-							? authConfig.installationId
-							: "unknown";
-					throw DocumentLoaderError.notFound(
-						`/app/installations/${installationId}/access_tokens`,
-						error,
-						{
-							source: "github",
-							resourceType: "AppInstallation",
-							statusCode: 404,
-						},
-					);
-				}
-				throw error;
+				handleGitHubClientError(error, authConfig);
 			}
 		}
 		return graphqlClient;

--- a/packages/github-tool/src/document-loaders/utils.ts
+++ b/packages/github-tool/src/document-loaders/utils.ts
@@ -1,5 +1,29 @@
 import { DocumentLoaderError } from "@giselles-ai/rag";
 import { RequestError } from "@octokit/request-error";
+import type { GitHubAuthConfig } from "../types";
+
+/**
+ * Handle GitHub client initialization errors
+ */
+export function handleGitHubClientError(
+	error: unknown,
+	authConfig: GitHubAuthConfig,
+): never {
+	if (authConfig.strategy === "app-installation") {
+		if (error instanceof RequestError && error.status === 404) {
+			throw DocumentLoaderError.notFound(
+				`/app/installations/${authConfig.installationId}/access_tokens`,
+				error,
+				{
+					source: "github",
+					resourceType: "AppInstallation",
+					statusCode: 404,
+				},
+			);
+		}
+	}
+	throw error;
+}
 
 /**
  * Execute a GitHub REST API request with retry logic and error handling


### PR DESCRIPTION
### **User description**
### Summary
When a GitHub App installation is deleted or becomes invalid, the authentication request returns a 404 error. Previously, this error was caught by the pipeline's generic error handler and converted to `OperationError`. However, since `OperationError` is a subclass of `RagError`, the error handling in `extractErrorInfo()` fell through to the `RagError` case, which sets `retryAfter: new Date()`. This caused infinite retry loops with continuous errors. This PR properly converts the 404 error to `DocumentLoaderError.notFound`, which sets `retryAfter: null` and stops the retry loop.

### Related Issue
N/A

### Changes
- Add error handling in `getGraphQLClient()` for issues and pull-requests document loaders
- Convert GitHub API 404 errors (from `@octokit/request-error`) to `DocumentLoaderError.notFound`
- Include helpful context: source, resourceType, and statusCode

### Testing


### Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Handle GitHub App installation 404 errors as DocumentLoaderError.notFound

- Prevent infinite retry loops by setting retryAfter to null

- Add error handling in getGraphQLClient() for both issues and pull-requests loaders

- Include helpful context (source, resourceType, statusCode) in error details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub API 404 Error"] -->|RequestError caught| B["Convert to DocumentLoaderError.notFound"]
  B -->|retryAfter: null| C["Stop retry loop"]
  A -->|Other errors| D["Re-throw error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loader.ts</strong><dd><code>Add 404 error handling for issues loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/document-loaders/issues/loader.ts

<ul><li>Import RequestError from @octokit/request-error<br> <li> Wrap graphql() call in try-catch block in getGraphQLClient()<br> <li> Detect 404 status errors and convert to DocumentLoaderError.notFound<br> <li> Include installation ID and metadata (source, resourceType, <br>statusCode) in error context</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2262/files#diff-28cd78a568ee1c4e4d0d8d6f0a0155906b9e3cee5041ad10c75465d302ee0c52">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>loader.ts</strong><dd><code>Add 404 error handling for pull-requests loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/github-tool/src/document-loaders/pull-requests/loader.ts

<ul><li>Import RequestError from @octokit/request-error<br> <li> Wrap graphql() call in try-catch block in getGraphQLClient()<br> <li> Detect 404 status errors and convert to DocumentLoaderError.notFound<br> <li> Include installation ID and metadata (source, resourceType, <br>statusCode) in error context</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2262/files#diff-e8fb2638bc550eff8a1971a4b47b8338c7bbfb9645c256fd09ef2301fe7f2d01">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub document loader error handling: failures to initialize the GitHub client (including missing App installation access) now produce clearer, contextual "not found" errors with metadata to aid troubleshooting, instead of unhandled exceptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a shared handler that converts GitHub App installation 404s to `DocumentLoaderError.notFound` and applies it to GraphQL client initialization in issues and pull-requests loaders.
> 
> - **Error handling**:
>   - **New utility**: `packages/github-tool/src/document-loaders/utils.ts`
>     - `handleGitHubClientError` converts GitHub App installation 404s (`@octokit/request-error`) to `DocumentLoaderError.notFound` with context (`source`, `resourceType`, `statusCode`).
>   - **Loaders**:
>     - `packages/github-tool/src/document-loaders/issues/loader.ts`
>       - Wrap `graphql(authConfig)` in try/catch and route to `handleGitHubClientError` during client initialization.
>     - `packages/github-tool/src/document-loaders/pull-requests/loader.ts`
>       - Same handling for GraphQL client initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1928eab68c270f30e37a51311f04f47702a459c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->