### PR TITLE
Manage tool addition in properties panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx
@@ -108,7 +108,19 @@ export function ContentGenerationNodePropertiesPanel({
 	);
 
 	const handleToolSelect = (_e: unknown, item: { value: string }) => {
-		setSelectedToolName(item.value);
+		const toolName = item.value;
+		const tool = languageModelTools.find(
+			(t: LanguageModelTool) => t.name === toolName,
+		);
+
+		// If tool has no configuration options, add it immediately without dialog
+		if (tool && Object.keys(tool.configurationOptions).length === 0) {
+			handleToolConfigSubmit({}, toolName);
+			return;
+		}
+
+		// Otherwise, open dialog for configuration
+		setSelectedToolName(toolName);
 		setSelectedToolConfig(null);
 		setToolDialogOpen(true);
 	};
@@ -139,14 +151,18 @@ export function ContentGenerationNodePropertiesPanel({
 		});
 	};
 
-	const handleToolConfigSubmit = (config: Record<string, unknown>) => {
-		if (!selectedToolName) {
+	const handleToolConfigSubmit = (
+		config: Record<string, unknown>,
+		toolNameOverride?: string,
+	) => {
+		const toolName = toolNameOverride ?? selectedToolName;
+		if (!toolName) {
 			return;
 		}
 
 		// Transform to content-generation.ts tools format
 		const toolEntry = {
-			name: selectedToolName,
+			name: toolName,
 			configuration: config,
 		};
 
@@ -156,7 +172,7 @@ export function ContentGenerationNodePropertiesPanel({
 
 		// Check if tool already exists, update it; otherwise add new one
 		const toolIndex = existingTools.findIndex(
-			(tool: typeof toolEntry) => tool.name === selectedToolName,
+			(tool: typeof toolEntry) => tool.name === toolName,
 		);
 
 		const updatedTools =


### PR DESCRIPTION
## Summary
Allows tools without configuration options (e.g., Google Web Search) to be added immediately without displaying a configuration dialog.

## Related Issue
N/A

## Changes
- Modified `handleToolSelect` to check if a selected tool has empty `configurationOptions`. If so, it directly calls `handleToolConfigSubmit` to add the tool.
- Updated `handleToolConfigSubmit` to accept an optional `toolNameOverride` parameter, allowing it to be called directly without relying on `selectedToolName` state.

## Testing
- Verified that tools with no configuration options are added instantly.
- Verified that tools with configuration options still open the dialog.
- Ran format, type checks, and linting.

## Other Information
This change improves the user experience for tools like Google Web Search, which do not require any setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-09c21b92-2f7e-45d0-a4a7-86da494b8ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09c21b92-2f7e-45d0-a4a7-86da494b8ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

