### PR TITLE
fix: show Running status label when status is running

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx
@@ -309,13 +309,12 @@ function EmbeddingModelCard({
 														: "text-text-muted"
 												}`}
 											>
-												{isIngesting && blobStatus.enabled
+												{(isIngesting && blobStatus.enabled) ||
+												blobStatus.status === "running"
 													? "Running"
-													: blobStatus.status === "running"
-														? "Running"
-														: blobStatus.status === "idle"
-															? "Idle"
-															: "Error"}
+													: blobStatus.status === "idle"
+														? "Idle"
+														: "Error"}
 											</span>
 										</div>
 										{blobStatus?.status === "failed" &&
@@ -404,13 +403,12 @@ function EmbeddingModelCard({
 														: "text-text-muted"
 												}`}
 											>
-												{isIngesting && issueStatus.enabled
+												{(isIngesting && issueStatus.enabled) ||
+												issueStatus.status === "running"
 													? "Running"
-													: issueStatus.status === "running"
-														? "Running"
-														: issueStatus.status === "idle"
-															? "Idle"
-															: "Error"}
+													: issueStatus.status === "idle"
+														? "Idle"
+														: "Error"}
 											</span>
 										</div>
 										{issueStatus?.status === "failed" &&
@@ -500,13 +498,12 @@ function EmbeddingModelCard({
 														: "text-text-muted"
 												}`}
 											>
-												{isIngesting && pullRequestStatus.enabled
+												{(isIngesting && pullRequestStatus.enabled) ||
+												pullRequestStatus.status === "running"
 													? "Running"
-													: pullRequestStatus.status === "running"
-														? "Running"
-														: pullRequestStatus.status === "idle"
-															? "Idle"
-															: "Error"}
+													: pullRequestStatus.status === "idle"
+														? "Idle"
+														: "Error"}
 											</span>
 										</div>
 										{pullRequestStatus?.status === "failed" &&


### PR DESCRIPTION
### **User description**
### Summary
Fix the status label display logic in the vector store repository settings. Previously, when `status === "running"` but `isIngesting` was false, the label incorrectly showed "Idle" instead of "Running".

### Related Issue
N/A

### Changes
- Added check for `status === "running"` before checking for `"idle"` in the ternary conditions
- Applied the fix to all three status displays: blob, issue, and pull request

### Testing
Verify that the status label shows "Running" when `blobStatus.status`, `issueStatus.status`, or `pullRequestStatus.status` is `"running"`, regardless of the `isIngesting` flag.

### Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Fix status label display logic in vector store repository settings

- Check for "running" status before "idle" in ternary conditions

- Applied fix to blob, issue, and pull request status displays

- Ensures "Running" label shows when status is running, regardless of isIngesting flag


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Status Check Logic"] -->|isIngesting && enabled| B["Show Running"]
  A -->|status === running| B
  A -->|status === idle| C["Show Idle"]
  A -->|other| D["Show Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repository-item.tsx</strong><dd><code>Reorder status checks to prioritize running state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx

<ul><li>Reordered ternary condition to check <code>status === "running"</code> before <br><code>status === "idle"</code><br> <li> Applied fix to three status display sections: blob, issue, and pull <br>request<br> <li> Ensures "Running" label displays correctly when status is running but <br>isIngesting is false<br> <li> Maintains existing error and idle status handling logic</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2271/files#diff-7081ecafde073350a2fc722beae87dd986b2f8d55ca73cd48ffdfe62908296c6">+15/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected status display for vector store content blocks (blob, issue, pull_request): the UI now shows "Running" when the underlying status is running even if ingestion isn't actively occurring, while preserving Idle, Completed, and Failed displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure "Running" is shown when status is running, regardless of `isIngesting`, across blob, issue, and pull request sections.
> 
> - **Frontend**
>   - `apps/studio.giselles.ai/app/(main)/settings/team/vector-stores/repository-item.tsx`:
>     - Adjust status label logic to show "Running" when `(isIngesting && enabled) || status === "running"`.
>     - Applied to `blobStatus`, `issueStatus`, and `pullRequestStatus` sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afa97ca09c87b9f4c64edc34bde133348ffd1afa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->