### PR TITLE
feat: add Stripe v2 billing history tables

### DIFF
--- a/apps/studio.giselles.ai/db/migrate/0069_shocking_shooting_star.sql
+++ b/apps/studio.giselles.ai/db/migrate/0069_shocking_shooting_star.sql
@@ -1,0 +1,55 @@
+CREATE TABLE "stripe_billing_cadence_histories" (
+	"db_id" serial PRIMARY KEY NOT NULL,
+	"team_db_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"id" text NOT NULL,
+	"customer_id" text NOT NULL,
+	"billing_profile_id" text NOT NULL,
+	"payer_type" text NOT NULL,
+	"billing_cycle_type" text NOT NULL,
+	"billing_cycle_interval_count" integer NOT NULL,
+	"billing_cycle_day_of_month" integer,
+	"billing_cycle_month_of_year" integer,
+	"billing_cycle_time_hour" integer NOT NULL,
+	"billing_cycle_time_minute" integer NOT NULL,
+	"billing_cycle_time_second" integer NOT NULL,
+	"next_billing_date" timestamp NOT NULL,
+	"status" text NOT NULL,
+	"bill_settings_id" text,
+	"created" timestamp NOT NULL,
+	"metadata" jsonb,
+	"lookup_key" text
+);
+--> statement-breakpoint
+CREATE TABLE "stripe_pricing_plan_subscription_histories" (
+	"db_id" serial PRIMARY KEY NOT NULL,
+	"team_db_id" integer NOT NULL,
+	"billing_cadence_db_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"id" text NOT NULL,
+	"billing_cadence_id" text NOT NULL,
+	"pricing_plan_id" text NOT NULL,
+	"pricing_plan_version_id" text NOT NULL,
+	"servicing_status" text NOT NULL,
+	"collection_status" text NOT NULL,
+	"activated_at" timestamp,
+	"canceled_at" timestamp,
+	"paused_at" timestamp,
+	"collection_current_at" timestamp,
+	"collection_past_due_at" timestamp,
+	"collection_paused_at" timestamp,
+	"collection_unpaid_at" timestamp,
+	"collection_awaiting_customer_action_at" timestamp,
+	"created" timestamp NOT NULL,
+	"metadata" jsonb
+);
+--> statement-breakpoint
+ALTER TABLE "stripe_billing_cadence_histories" ADD CONSTRAINT "stripe_billing_cadence_histories_team_db_id_teams_db_id_fk" FOREIGN KEY ("team_db_id") REFERENCES "public"."teams"("db_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stripe_pricing_plan_subscription_histories" ADD CONSTRAINT "stripe_pricing_plan_subscription_histories_team_db_id_teams_db_id_fk" FOREIGN KEY ("team_db_id") REFERENCES "public"."teams"("db_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stripe_pricing_plan_subscription_histories" ADD CONSTRAINT "stripe_pricing_plan_subscription_histories_billing_cadence_db_id_stripe_billing_cadence_histories_db_id_fk" FOREIGN KEY ("billing_cadence_db_id") REFERENCES "public"."stripe_billing_cadence_histories"("db_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "stripe_cadence_hist_id_idx" ON "stripe_billing_cadence_histories" USING btree ("id");--> statement-breakpoint
+CREATE INDEX "stripe_cadence_hist_team_db_id_idx" ON "stripe_billing_cadence_histories" USING btree ("team_db_id");--> statement-breakpoint
+CREATE INDEX "stripe_cadence_hist_customer_id_idx" ON "stripe_billing_cadence_histories" USING btree ("customer_id");--> statement-breakpoint
+CREATE INDEX "stripe_pps_hist_id_idx" ON "stripe_pricing_plan_subscription_histories" USING btree ("id");--> statement-breakpoint
+CREATE INDEX "stripe_pps_hist_team_db_id_idx" ON "stripe_pricing_plan_subscription_histories" USING btree ("team_db_id");--> statement-breakpoint
+CREATE INDEX "stripe_pps_hist_billing_cadence_db_id_idx" ON "stripe_pricing_plan_subscription_histories" USING btree ("billing_cadence_db_id");

--- a/apps/studio.giselles.ai/db/migrate/meta/0069_snapshot.json
+++ b/apps/studio.giselles.ai/db/migrate/meta/0069_snapshot.json
@@ -1,0 +1,3621 @@
+{
+  "id": "3c0311e2-45b1-418c-ac55-8c88fe4d0cf1",
+  "prevId": "fd3022c8-71fb-4408-9469-981b59bca5c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.acts": {
+      "name": "acts",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "director_db_id": {
+          "name": "director_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_workspace_id": {
+          "name": "sdk_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_flow_trigger_id": {
+          "name": "sdk_flow_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_act_id": {
+          "name": "sdk_act_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "acts_team_db_id_index": {
+          "name": "acts_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acts_sdk_workspace_id_index": {
+          "name": "acts_sdk_workspace_id_index",
+          "columns": [
+            {
+              "expression": "sdk_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acts_sdk_flow_trigger_id_index": {
+          "name": "acts_sdk_flow_trigger_id_index",
+          "columns": [
+            {
+              "expression": "sdk_flow_trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acts_sdk_act_id_index": {
+          "name": "acts_sdk_act_id_index",
+          "columns": [
+            {
+              "expression": "sdk_act_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acts_team_db_id_teams_db_id_fk": {
+          "name": "acts_team_db_id_teams_db_id_fk",
+          "tableFrom": "acts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acts_director_db_id_users_db_id_fk": {
+          "name": "acts_director_db_id_users_db_id_fk",
+          "tableFrom": "acts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "director_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_activities": {
+      "name": "agent_activities",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_report_db_id": {
+          "name": "usage_report_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_activities_agent_db_id_index": {
+          "name": "agent_activities_agent_db_id_index",
+          "columns": [
+            {
+              "expression": "agent_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activities_ended_at_index": {
+          "name": "agent_activities_ended_at_index",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_activities_agent_db_id_agents_db_id_fk": {
+          "name": "agent_activities_agent_db_id_agents_db_id_fk",
+          "tableFrom": "agent_activities",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk": {
+          "name": "agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk",
+          "tableFrom": "agent_activities",
+          "tableTo": "agent_time_usage_reports",
+          "columnsFrom": [
+            "usage_report_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_time_restrictions": {
+      "name": "agent_time_restrictions",
+      "schema": "",
+      "columns": {
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_time_restrictions_team_db_id_index": {
+          "name": "agent_time_restrictions_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_time_restrictions_team_db_id_teams_db_id_fk": {
+          "name": "agent_time_restrictions_team_db_id_teams_db_id_fk",
+          "tableFrom": "agent_time_restrictions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_time_usage_reports": {
+      "name": "agent_time_usage_reports",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accumulated_duration_ms": {
+          "name": "accumulated_duration_ms",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_increment": {
+          "name": "minutes_increment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_event_id": {
+          "name": "stripe_meter_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_time_usage_reports_team_db_id_index": {
+          "name": "agent_time_usage_reports_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_time_usage_reports_created_at_index": {
+          "name": "agent_time_usage_reports_created_at_index",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_time_usage_reports_stripe_meter_event_id_index": {
+          "name": "agent_time_usage_reports_stripe_meter_event_id_index",
+          "columns": [
+            {
+              "expression": "stripe_meter_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_time_usage_reports_team_db_id_teams_db_id_fk": {
+          "name": "agent_time_usage_reports_team_db_id_teams_db_id_fk",
+          "tableFrom": "agent_time_usage_reports",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_url": {
+          "name": "graph_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_db_id": {
+          "name": "creator_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"sample\":false}'::jsonb"
+        }
+      },
+      "indexes": {
+        "agents_team_db_id_index": {
+          "name": "agents_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_team_db_id_teams_db_id_fk": {
+          "name": "agents_team_db_id_teams_db_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_creator_db_id_users_db_id_fk": {
+          "name": "agents_creator_db_id_users_db_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_id_unique": {
+          "name": "agents_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_entry_node_id": {
+          "name": "app_entry_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_db_id": {
+          "name": "workspace_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "apps_team_db_id_index": {
+          "name": "apps_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apps_team_db_id_teams_db_id_fk": {
+          "name": "apps_team_db_id_teams_db_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "apps_workspace_db_id_workspaces_db_id_fk": {
+          "name": "apps_workspace_db_id_workspaces_db_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apps_id_unique": {
+          "name": "apps_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "apps_app_entry_node_id_unique": {
+          "name": "apps_app_entry_node_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_entry_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_embedding_profiles": {
+      "name": "document_embedding_profiles",
+      "schema": "",
+      "columns": {
+        "document_vector_store_db_id": {
+          "name": "document_vector_store_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doc_vs_emb_profiles_store_fk": {
+          "name": "doc_vs_emb_profiles_store_fk",
+          "tableFrom": "document_embedding_profiles",
+          "tableTo": "document_vector_stores",
+          "columnsFrom": [
+            "document_vector_store_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "doc_vs_emb_profiles_pk": {
+          "name": "doc_vs_emb_profiles_pk",
+          "columns": [
+            "document_vector_store_db_id",
+            "embedding_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_embeddings": {
+      "name": "document_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_vector_store_db_id": {
+          "name": "document_vector_store_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_vector_store_source_db_id": {
+          "name": "document_vector_store_source_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_key": {
+          "name": "document_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_embs_embedding_1536_idx": {
+          "name": "doc_embs_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::vector(1536)) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"document_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "doc_embs_embedding_3072_idx": {
+          "name": "doc_embs_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::halfvec(3072)) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"document_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "doc_embs_store_idx": {
+          "name": "doc_embs_store_idx",
+          "columns": [
+            {
+              "expression": "document_vector_store_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_embeddings_document_vector_store_db_id_document_vector_stores_db_id_fk": {
+          "name": "document_embeddings_document_vector_store_db_id_document_vector_stores_db_id_fk",
+          "tableFrom": "document_embeddings",
+          "tableTo": "document_vector_stores",
+          "columnsFrom": [
+            "document_vector_store_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_embeddings_document_vector_store_source_db_id_document_vector_store_sources_db_id_fk": {
+          "name": "document_embeddings_document_vector_store_source_db_id_document_vector_store_sources_db_id_fk",
+          "tableFrom": "document_embeddings",
+          "tableTo": "document_vector_store_sources",
+          "columnsFrom": [
+            "document_vector_store_source_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doc_embs_src_prof_doc_chunk_unique": {
+          "name": "doc_embs_src_prof_doc_chunk_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_vector_store_source_db_id",
+            "embedding_profile_id",
+            "document_key",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_vector_store_sources": {
+      "name": "document_vector_store_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_vector_store_db_id": {
+          "name": "document_vector_store_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_checksum": {
+          "name": "file_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "upload_error_code": {
+          "name": "upload_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_status": {
+          "name": "ingest_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "ingest_error_code": {
+          "name": "ingest_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "doc_vs_src_upload_status_idx": {
+          "name": "doc_vs_src_upload_status_idx",
+          "columns": [
+            {
+              "expression": "upload_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_vs_src_ingest_status_idx": {
+          "name": "doc_vs_src_ingest_status_idx",
+          "columns": [
+            {
+              "expression": "ingest_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_vector_store_sources_document_vector_store_db_id_document_vector_stores_db_id_fk": {
+          "name": "document_vector_store_sources_document_vector_store_db_id_document_vector_stores_db_id_fk",
+          "tableFrom": "document_vector_store_sources",
+          "tableTo": "document_vector_stores",
+          "columnsFrom": [
+            "document_vector_store_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doc_vs_src_id_unique": {
+          "name": "doc_vs_src_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "doc_vs_src_storage_unique": {
+          "name": "doc_vs_src_storage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_vector_store_db_id",
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_vector_stores": {
+      "name": "document_vector_stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_vs_team_db_id_idx": {
+          "name": "doc_vs_team_db_id_idx",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_vector_stores_team_db_id_teams_db_id_fk": {
+          "name": "document_vector_stores_team_db_id_teams_db_id_fk",
+          "tableFrom": "document_vector_stores",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doc_vs_id_unique": {
+          "name": "doc_vs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flow_triggers": {
+      "name": "flow_triggers",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staged": {
+          "name": "staged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_trigger_id": {
+          "name": "flow_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flow_triggers_flow_trigger_id_index": {
+          "name": "flow_triggers_flow_trigger_id_index",
+          "columns": [
+            {
+              "expression": "flow_trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flow_triggers_team_db_id_index": {
+          "name": "flow_triggers_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flow_triggers_staged_index": {
+          "name": "flow_triggers_staged_index",
+          "columns": [
+            {
+              "expression": "staged",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flow_triggers_team_db_id_teams_db_id_fk": {
+          "name": "flow_triggers_team_db_id_teams_db_id_fk",
+          "tableFrom": "flow_triggers",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integration_settings": {
+      "name": "github_integration_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_sign": {
+          "name": "call_sign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_node_mappings": {
+          "name": "event_node_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_integration_settings_agent_db_id_agents_db_id_fk": {
+          "name": "github_integration_settings_agent_db_id_agents_db_id_fk",
+          "tableFrom": "github_integration_settings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_integration_settings_id_unique": {
+          "name": "github_integration_settings_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_content_status": {
+      "name": "github_repository_content_status",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gh_content_status_query_idx": {
+          "name": "gh_content_status_query_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_content_status_repo_idx_fk": {
+          "name": "gh_content_status_repo_idx_fk",
+          "tableFrom": "github_repository_content_status",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_content_status_unique": {
+          "name": "gh_content_status_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "content_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_embedding_profiles": {
+      "name": "github_repository_embedding_profiles",
+      "schema": "",
+      "columns": {
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_repo_emb_profiles_repo_idx_fk": {
+          "name": "gh_repo_emb_profiles_repo_idx_fk",
+          "tableFrom": "github_repository_embedding_profiles",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_repo_emb_profiles_pk": {
+          "name": "gh_repo_emb_profiles_pk",
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_embeddings": {
+      "name": "github_repository_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_sha": {
+          "name": "file_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_embeddings_embedding_1536_idx": {
+          "name": "github_repository_embeddings_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::vector(1536) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "github_repository_embeddings_embedding_3072_idx": {
+          "name": "github_repository_embeddings_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::halfvec(3072) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_embeddings_repository_index_db_id_github_repository_index_db_id_fk": {
+          "name": "github_repository_embeddings_repository_index_db_id_github_repository_index_db_id_fk",
+          "tableFrom": "github_repository_embeddings",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_repo_emb_unique": {
+          "name": "gh_repo_emb_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "path",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_index": {
+      "name": "github_repository_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ingested_commit_sha": {
+          "name": "last_ingested_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_index_team_db_id_index": {
+          "name": "github_repository_index_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_index_status_index": {
+          "name": "github_repository_index_status_index",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_index_team_db_id_teams_db_id_fk": {
+          "name": "github_repository_index_team_db_id_teams_db_id_fk",
+          "tableFrom": "github_repository_index",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_repository_index_id_unique": {
+          "name": "github_repository_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "github_repository_index_owner_repo_team_db_id_unique": {
+          "name": "github_repository_index_owner_repo_team_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "repo",
+            "team_db_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_issue_embeddings": {
+      "name": "github_repository_issue_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_state": {
+          "name": "issue_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_state_reason": {
+          "name": "issue_state_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_updated_at": {
+          "name": "issue_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_closed_at": {
+          "name": "issue_closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_key": {
+          "name": "document_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_created_at": {
+          "name": "content_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_edited_at": {
+          "name": "content_edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_version": {
+          "name": "metadata_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gh_issue_embeddings_embedding_1536_idx": {
+          "name": "gh_issue_embeddings_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::vector(1536)) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_issue_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_issue_embeddings_embedding_3072_idx": {
+          "name": "gh_issue_embeddings_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::halfvec(3072)) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_issue_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_issue_emb_repo_doc_idx": {
+          "name": "gh_issue_emb_repo_doc_idx",
+          "columns": [
+            {
+              "expression": "repository_index_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_issue_embeddings_repo_idx_fk": {
+          "name": "gh_issue_embeddings_repo_idx_fk",
+          "tableFrom": "github_repository_issue_embeddings",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_issue_emb_unique": {
+          "name": "gh_issue_emb_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "issue_number",
+            "content_type",
+            "content_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_pull_request_embeddings": {
+      "name": "github_repository_pull_request_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_key": {
+          "name": "document_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gh_pr_embeddings_embedding_1536_idx": {
+          "name": "gh_pr_embeddings_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::vector(1536) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_pull_request_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_pr_embeddings_embedding_3072_idx": {
+          "name": "gh_pr_embeddings_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::halfvec(3072) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_pull_request_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_pr_emb_repo_doc_idx": {
+          "name": "gh_pr_emb_repo_doc_idx",
+          "columns": [
+            {
+              "expression": "repository_index_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_embeddings_repo_idx_fk": {
+          "name": "gh_pr_embeddings_repo_idx_fk",
+          "tableFrom": "github_repository_pull_request_embeddings",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_pr_emb_unique": {
+          "name": "gh_pr_emb_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "pr_number",
+            "content_type",
+            "content_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_db_id": {
+          "name": "inviter_user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitations_team_db_id_revoked_at_index": {
+          "name": "invitations_team_db_id_revoked_at_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_team_db_id_teams_db_id_fk": {
+          "name": "invitations_team_db_id_teams_db_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_user_db_id_users_db_id_fk": {
+          "name": "invitations_inviter_user_db_id_users_db_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_credentials_user_id_users_db_id_fk": {
+          "name": "oauth_credentials_user_id_users_db_id_fk",
+          "tableFrom": "oauth_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_credentials_user_id_provider_provider_account_id_unique": {
+          "name": "oauth_credentials_user_id_provider_provider_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_billing_cadence_histories": {
+      "name": "stripe_billing_cadence_histories",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_profile_id": {
+          "name": "billing_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_type": {
+          "name": "payer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_type": {
+          "name": "billing_cycle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_interval_count": {
+          "name": "billing_cycle_interval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_day_of_month": {
+          "name": "billing_cycle_day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_month_of_year": {
+          "name": "billing_cycle_month_of_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_time_hour": {
+          "name": "billing_cycle_time_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_time_minute": {
+          "name": "billing_cycle_time_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_time_second": {
+          "name": "billing_cycle_time_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_settings_id": {
+          "name": "bill_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lookup_key": {
+          "name": "lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_cadence_hist_id_idx": {
+          "name": "stripe_cadence_hist_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_cadence_hist_team_db_id_idx": {
+          "name": "stripe_cadence_hist_team_db_id_idx",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_cadence_hist_customer_id_idx": {
+          "name": "stripe_cadence_hist_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_billing_cadence_histories_team_db_id_teams_db_id_fk": {
+          "name": "stripe_billing_cadence_histories_team_db_id_teams_db_id_fk",
+          "tableFrom": "stripe_billing_cadence_histories",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_pricing_plan_subscription_histories": {
+      "name": "stripe_pricing_plan_subscription_histories",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cadence_db_id": {
+          "name": "billing_cadence_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cadence_id": {
+          "name": "billing_cadence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_plan_id": {
+          "name": "pricing_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_plan_version_id": {
+          "name": "pricing_plan_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servicing_status": {
+          "name": "servicing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_status": {
+          "name": "collection_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_current_at": {
+          "name": "collection_current_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_past_due_at": {
+          "name": "collection_past_due_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_paused_at": {
+          "name": "collection_paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_unpaid_at": {
+          "name": "collection_unpaid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_awaiting_customer_action_at": {
+          "name": "collection_awaiting_customer_action_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_pps_hist_id_idx": {
+          "name": "stripe_pps_hist_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_pps_hist_team_db_id_idx": {
+          "name": "stripe_pps_hist_team_db_id_idx",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_pps_hist_billing_cadence_db_id_idx": {
+          "name": "stripe_pps_hist_billing_cadence_db_id_idx",
+          "columns": [
+            {
+              "expression": "billing_cadence_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_pricing_plan_subscription_histories_team_db_id_teams_db_id_fk": {
+          "name": "stripe_pricing_plan_subscription_histories_team_db_id_teams_db_id_fk",
+          "tableFrom": "stripe_pricing_plan_subscription_histories",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stripe_pricing_plan_subscription_histories_billing_cadence_db_id_stripe_billing_cadence_histories_db_id_fk": {
+          "name": "stripe_pricing_plan_subscription_histories_billing_cadence_db_id_stripe_billing_cadence_histories_db_id_fk",
+          "tableFrom": "stripe_pricing_plan_subscription_histories",
+          "tableTo": "stripe_billing_cadence_histories",
+          "columnsFrom": [
+            "billing_cadence_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_histories": {
+      "name": "subscription_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_start": {
+          "name": "trial_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sub_hist_id_created_at_idx": {
+          "name": "sub_hist_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sub_hist_team_db_id_created_at_idx": {
+          "name": "sub_hist_team_db_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sub_hist_id_team_db_id_created_at_idx": {
+          "name": "sub_hist_id_team_db_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_histories_team_db_id_teams_db_id_fk": {
+          "name": "subscription_histories_team_db_id_teams_db_id_fk",
+          "tableFrom": "subscription_histories",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supabase_user_mappings": {
+      "name": "supabase_user_mappings",
+      "schema": "",
+      "columns": {
+        "user_db_id": {
+          "name": "user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supabase_user_mappings_user_db_id_users_db_id_fk": {
+          "name": "supabase_user_mappings_user_db_id_users_db_id_fk",
+          "tableFrom": "supabase_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supabase_user_mappings_user_db_id_unique": {
+          "name": "supabase_user_mappings_user_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_db_id"
+          ]
+        },
+        "supabase_user_mappings_supabase_user_id_unique": {
+          "name": "supabase_user_mappings_supabase_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_db_id": {
+          "name": "app_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_team_db_id_index": {
+          "name": "tasks_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_team_db_id_teams_db_id_fk": {
+          "name": "tasks_team_db_id_teams_db_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_app_db_id_apps_db_id_fk": {
+          "name": "tasks_app_db_id_apps_db_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasks_id_unique": {
+          "name": "tasks_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_db_id": {
+          "name": "user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_memberships_user_db_id_users_db_id_fk": {
+          "name": "team_memberships_user_db_id_users_db_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_team_db_id_teams_db_id_fk": {
+          "name": "team_memberships_team_db_id_teams_db_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_memberships_user_db_id_team_db_id_unique": {
+          "name": "team_memberships_user_db_id_team_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_db_id",
+            "team_db_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "active_subscription_id": {
+          "name": "active_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_customer_id": {
+          "name": "active_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_id_unique": {
+          "name": "teams_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_seat_usage_reports": {
+      "name": "user_seat_usage_reports",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_db_id_list": {
+          "name": "user_db_id_list",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_event_id": {
+          "name": "stripe_meter_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_seat_usage_reports_team_db_id_index": {
+          "name": "user_seat_usage_reports_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_seat_usage_reports_created_at_index": {
+          "name": "user_seat_usage_reports_created_at_index",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_seat_usage_reports_stripe_meter_event_id_index": {
+          "name": "user_seat_usage_reports_stripe_meter_event_id_index",
+          "columns": [
+            {
+              "expression": "stripe_meter_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_seat_usage_reports_team_db_id_teams_db_id_fk": {
+          "name": "user_seat_usage_reports_team_db_id_teams_db_id_fk",
+          "tableFrom": "user_seat_usage_reports",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_db_id": {
+          "name": "creator_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"sample\":false}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_team_db_id_teams_db_id_fk": {
+          "name": "workspaces_team_db_id_teams_db_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_creator_db_id_users_db_id_fk": {
+          "name": "workspaces_creator_db_id_users_db_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspaces_id_unique": {
+          "name": "workspaces_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/studio.giselles.ai/db/migrate/meta/_journal.json
+++ b/apps/studio.giselles.ai/db/migrate/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1764222491592,
       "tag": "0068_warm_vector",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1764256980624,
+      "tag": "0069_shocking_shooting_star",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/studio.giselles.ai/db/schema.ts
+++ b/apps/studio.giselles.ai/db/schema.ts
@@ -106,6 +106,158 @@ export const subscriptionHistoryRelations = relations(
 	}),
 );
 
+/**
+ * Stripe v2 Billing Cadence history table
+ *
+ * Stores snapshots of billing cadence data from Stripe v2 API.
+ * Each webhook event creates a new history record.
+ *
+ * @see https://docs.stripe.com/api/v2/billing-cadences/object?api-version=2025-11-17.preview
+ */
+export const stripeBillingCadenceHistories = pgTable(
+	"stripe_billing_cadence_histories",
+	{
+		// Giselle fields
+		dbId: serial("db_id").primaryKey(),
+		teamDbId: integer("team_db_id")
+			.notNull()
+			.references(() => teams.dbId, { onDelete: "cascade" }),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+
+		// Stripe cadence ID (bc_xxx) - not unique, can have multiple records
+		id: text("id").notNull(),
+
+		// Payer info
+		customerId: text("customer_id").notNull(), // cus_xxx
+		billingProfileId: text("billing_profile_id").notNull(), // bilp_xxx
+		payerType: text("payer_type").notNull(), // "customer"
+
+		// Billing cycle
+		billingCycleType: text("billing_cycle_type").notNull(), // "month" | "year"
+		billingCycleIntervalCount: integer(
+			"billing_cycle_interval_count",
+		).notNull(),
+		billingCycleDayOfMonth: integer("billing_cycle_day_of_month"),
+		billingCycleMonthOfYear: integer("billing_cycle_month_of_year"),
+		billingCycleTimeHour: integer("billing_cycle_time_hour").notNull(),
+		billingCycleTimeMinute: integer("billing_cycle_time_minute").notNull(),
+		billingCycleTimeSecond: integer("billing_cycle_time_second").notNull(),
+
+		// Billing dates
+		nextBillingDate: timestamp("next_billing_date").notNull(),
+
+		// Status
+		status: text("status").notNull(), // "active" | etc.
+
+		// Settings
+		billSettingsId: text("bill_settings_id"), // bblset_xxx
+
+		// Timestamps from Stripe
+		created: timestamp("created").notNull(), // cadence.created
+
+		// Metadata
+		metadata: jsonb("metadata"),
+		lookupKey: text("lookup_key"),
+
+		// Note: livemode is available in Stripe response but omitted here as it's self-evident from the environment
+	},
+	(table) => [
+		index("stripe_cadence_hist_id_idx").on(table.id),
+		index("stripe_cadence_hist_team_db_id_idx").on(table.teamDbId),
+		index("stripe_cadence_hist_customer_id_idx").on(table.customerId),
+	],
+);
+
+export const stripeBillingCadenceHistoryRelations = relations(
+	stripeBillingCadenceHistories,
+	({ one }) => ({
+		team: one(teams, {
+			fields: [stripeBillingCadenceHistories.teamDbId],
+			references: [teams.dbId],
+		}),
+	}),
+);
+
+/**
+ * Stripe v2 Pricing Plan Subscription history table
+ *
+ * Stores snapshots of pricing plan subscription data from Stripe v2 API.
+ * Each webhook event creates a new history record.
+ *
+ * @see https://docs.stripe.com/api/v2/pricing-plan-subscriptions/object?api-version=2025-11-17.preview
+ */
+export const stripePricingPlanSubscriptionHistories = pgTable(
+	"stripe_pricing_plan_subscription_histories",
+	{
+		// Giselle fields
+		dbId: serial("db_id").primaryKey(),
+		teamDbId: integer("team_db_id")
+			.notNull()
+			.references(() => teams.dbId, { onDelete: "cascade" }),
+		billingCadenceDbId: integer("billing_cadence_db_id")
+			.notNull()
+			.references(() => stripeBillingCadenceHistories.dbId, {
+				onDelete: "cascade",
+			}),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+
+		// Stripe subscription ID (bpps_xxx) - not unique, can have multiple records
+		id: text("id").notNull(),
+
+		// Stripe IDs
+		billingCadenceId: text("billing_cadence_id").notNull(), // bc_xxx
+		pricingPlanId: text("pricing_plan_id").notNull(), // bpp_xxx
+		pricingPlanVersionId: text("pricing_plan_version_id").notNull(), // bppv_xxx
+
+		// Status fields
+		servicingStatus: text("servicing_status").notNull(), // "active" | "canceled" | "paused" | "pending"
+		collectionStatus: text("collection_status").notNull(), // "current" | "past_due" | "paused" | "unpaid" | "awaiting_customer_action"
+
+		// Servicing status transitions
+		activatedAt: timestamp("activated_at"),
+		canceledAt: timestamp("canceled_at"),
+		pausedAt: timestamp("paused_at"),
+
+		// Collection status transitions
+		collectionCurrentAt: timestamp("collection_current_at"),
+		collectionPastDueAt: timestamp("collection_past_due_at"),
+		collectionPausedAt: timestamp("collection_paused_at"),
+		collectionUnpaidAt: timestamp("collection_unpaid_at"),
+		collectionAwaitingCustomerActionAt: timestamp(
+			"collection_awaiting_customer_action_at",
+		),
+
+		// Timestamps from Stripe
+		created: timestamp("created").notNull(), // subscription.created
+
+		// Metadata
+		metadata: jsonb("metadata"),
+
+		// Note: livemode is available in Stripe response but omitted here as it's self-evident from the environment
+	},
+	(table) => [
+		index("stripe_pps_hist_id_idx").on(table.id),
+		index("stripe_pps_hist_team_db_id_idx").on(table.teamDbId),
+		index("stripe_pps_hist_billing_cadence_db_id_idx").on(
+			table.billingCadenceDbId,
+		),
+	],
+);
+
+export const stripePricingPlanSubscriptionHistoryRelations = relations(
+	stripePricingPlanSubscriptionHistories,
+	({ one }) => ({
+		team: one(teams, {
+			fields: [stripePricingPlanSubscriptionHistories.teamDbId],
+			references: [teams.dbId],
+		}),
+		billingCadence: one(stripeBillingCadenceHistories, {
+			fields: [stripePricingPlanSubscriptionHistories.billingCadenceDbId],
+			references: [stripeBillingCadenceHistories.dbId],
+		}),
+	}),
+);
+
 export type TeamPlan = "free" | "pro" | "team" | "enterprise" | "internal";
 export const teams = pgTable("teams", {
 	id: text("id").$type<TeamId>().notNull().unique(),


### PR DESCRIPTION
### **User description**
## Summary
Add database schema for Stripe v2 Pricing Plans API:
- stripe_billing_cadence_histories: billing cycle configuration
- stripe_pricing_plan_subscription_histories: subscription state

These tables store webhook event snapshots for activated/canceled events.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Other Information
- https://docs.stripe.com/api/v2/billing-cadences/object?api-version=2025-11-17.preview
- https://docs.stripe.com/api/v2/pricing-plan-subscriptions/object?api-version=2025-11-17.preview


___

### **PR Type**
Enhancement


___

### **Description**
- Added two new database tables for Stripe v2 Pricing Plans API integration:
  - `stripe_billing_cadence_histories`: stores billing cycle configuration snapshots with payer information and status tracking
  - `stripe_pricing_plan_subscription_histories`: stores subscription state snapshots with servicing and collection status fields

- Established database relationships between the new tables and existing `teams` table with cascade delete constraints

- Created foreign key linking subscription histories to billing cadence histories for data integrity

- Added 6 indexes on frequently queried fields (`id`, `team_db_id`, `customer_id`, `billing_cadence_db_id`) for query performance

- Generated complete migration SQL and updated database schema metadata and journal entries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  teams["teams"]
  cadence["stripe_billing_cadence_histories"]
  subscription["stripe_pricing_plan_subscription_histories"]
  
  teams -- "1:N" --> cadence
  teams -- "1:N" --> subscription
  cadence -- "1:N" --> subscription
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.ts</strong><dd><code>Add Stripe v2 billing history database tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/db/schema.ts

<ul><li>Added <code>stripeBillingCadenceHistories</code> table to store Stripe v2 billing <br>cadence snapshots with fields for billing cycle configuration, payer <br>info, and status<br> <li> Added <code>stripeBillingCadenceHistoryRelations</code> to establish relationship <br>between billing cadence history and teams table<br> <li> Added <code>stripePricingPlanSubscriptionHistories</code> table to store Stripe v2 <br>pricing plan subscription snapshots with servicing and collection <br>status fields<br> <li> Added <code>stripePricingPlanSubscriptionHistoryRelations</code> to establish <br>relationships with teams and billing cadence history tables</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2290/files#diff-dde376759ce503306024865f21ff81ba647ff3c38db203c2aafe88e8d4cc3b8c">+152/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Database migration</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0069_shocking_shooting_star.sql</strong><dd><code>Create Stripe v2 billing history migration SQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/db/migrate/0069_shocking_shooting_star.sql

<ul><li>Created <code>stripe_billing_cadence_histories</code> table with 20 columns <br>including billing cycle configuration and Stripe metadata<br> <li> Created <code>stripe_pricing_plan_subscription_histories</code> table with 23 <br>columns for subscription state tracking<br> <li> Added foreign key constraints linking both tables to <code>teams</code> table with <br>cascade delete<br> <li> Added foreign key constraint linking subscription histories to billing <br>cadence histories with cascade delete<br> <li> Created 6 indexes for efficient querying on <code>id</code>, <code>team_db_id</code>, <br><code>customer_id</code>, and <code>billing_cadence_db_id</code> fields</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2290/files#diff-3186555c197b1771556d4777f90cc9e526c65bb96742b8a5f1f89dfc6ce63091">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0069_snapshot.json</strong><dd><code>Update database schema snapshot metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/db/migrate/meta/0069_snapshot.json

<ul><li>Generated complete database schema snapshot including the two new <br>Stripe v2 billing history tables<br> <li> Documented all table structures, indexes, foreign keys, and <br>constraints for the new tables<br> <li> Updated schema metadata with full column definitions and relationships</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2290/files#diff-3d515c22c526c64b602a7fc47349e79c3e8307522698e4954e76b4efa8fb345c">+3621/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_journal.json</strong><dd><code>Record migration journal entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/db/migrate/meta/_journal.json

<ul><li>Added migration journal entry for version 0069 with tag <br><code>0069_shocking_shooting_star</code><br> <li> Recorded migration timestamp and breakpoints configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2290/files#diff-b774219e34219c43212d2ca3bdaedf130b8b234365320d96920b057f645c178f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `stripe_billing_cadence_histories` and `stripe_pricing_plan_subscription_histories` tables, their indexes/foreign-keys, and corresponding Drizzle schema/relations.
> 
> - **Database (Postgres)**:
>   - **New Tables**:
>     - `stripe_billing_cadence_histories`: cadence snapshots with payer/billing-cycle fields; FK `team_db_id -> teams.db_id`; indexes on `id`, `team_db_id`, `customer_id`.
>     - `stripe_pricing_plan_subscription_histories`: pricing plan subscription snapshots; FK `team_db_id -> teams.db_id`, `billing_cadence_db_id -> stripe_billing_cadence_histories.db_id`; indexes on `id`, `team_db_id`, `billing_cadence_db_id`.
>   - **Migrations/Metadata**: add migration `0069_shocking_shooting_star.sql`; update `meta/0069_snapshot.json` and `_journal.json`.
> - **ORM (Drizzle schema)**:
>   - Define `stripeBillingCadenceHistories` and `stripePricingPlanSubscriptionHistories` tables with relations to `teams` and each other.
>   - Add related indices and relation objects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26dbee894ed3c8d2f14dc52c242178e5488a4003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added infrastructure for tracking billing history and subscription data snapshots to improve billing data management and audit capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->