### PR TITLE
Hide configured tools in dropdown menu

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx
@@ -84,34 +84,35 @@ export function ContentGenerationNodePropertiesPanel({
 		});
 	}, [node.content]);
 
-	const toolsGroupByProvider = useMemo(
-		() => [
+	const configuredToolNames = useMemo(
+		() => new Set(configuredTools.map((tool) => tool.name)),
+		[configuredTools],
+	);
+	const toolsGroupByProvider = useMemo(() => {
+		const makeItems = (provider: string) =>
+			languageModelTools
+				.filter(
+					(tool: LanguageModelTool) =>
+						tool.provider === provider && !configuredToolNames.has(tool.name),
+				)
+				.map((tool: LanguageModelTool) => ({
+					value: tool.name,
+					label: tool?.title ?? tool.name,
+				}));
+
+		return [
 			{
 				groupId: "giselle",
 				groupLabel: "Hosted",
-				items: languageModelTools
-					.filter((tool: LanguageModelTool) => tool.provider === "giselle")
-					.map((tool: LanguageModelTool) => ({
-						value: tool.name,
-						label: tool?.title ?? tool.name,
-					})),
+				items: makeItems("giselle"),
 			},
 			{
 				groupId: languageModel.provider,
 				groupLabel: `${titleCase(languageModel.provider)} Provides`,
-				items: languageModelTools
-					.filter(
-						(tool: LanguageModelTool) =>
-							tool.provider === languageModel.provider,
-					)
-					.map((tool: LanguageModelTool) => ({
-						value: tool.name,
-						label: tool?.title ?? tool.name,
-					})),
+				items: makeItems(languageModel.provider),
 			},
-		],
-		[languageModel.provider],
-	);
+		].filter((group) => group.items.length > 0);
+	}, [configuredToolNames, languageModel.provider]);
 
 	const handleToolSelect = (_e: unknown, item: { value: string }) => {
 		const toolName = item.value;


### PR DESCRIPTION
### **User description**
## Summary
Filters the tool selection dropdown to only display tools that have not yet been configured, improving user experience and preventing duplicate entries.

## Related Issue
N/A

## Changes
- Introduced a memoized set (`configuredToolNames`) to track currently configured tools.
- Modified the `toolsGroupByProvider` to filter out tools that are already configured.
- Ensured that tool provider groups with no available (unconfigured) tools are not displayed.

## Testing
All automated tests passed (`pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, `pnpm test`). Manual visual confirmation is recommended.

## Other Information
This change directly addresses the user request to prevent already configured tools from appearing in the dropdown, making the UI clearer and more intuitive for selecting new tools.

---
<a href="https://cursor.com/background-agent?bcId=bc-be49ae7d-24f3-4420-a934-5d8e9aef6103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be49ae7d-24f3-4420-a934-5d8e9aef6103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Enhancement


___

### **Description**
- Filter configured tools from dropdown selection menu

- Create memoized set tracking currently configured tool names

- Hide empty tool provider groups with no available tools

- Refactor tool filtering logic into reusable helper function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configured Tools"] --> B["configuredToolNames Set"]
  B --> C["Filter languageModelTools"]
  C --> D["makeItems Helper"]
  D --> E["Tool Groups"]
  E --> F["Remove Empty Groups"]
  F --> G["Filtered Dropdown Menu"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>content-generation-node-properties-panel.tsx</strong><dd><code>Refactor tool filtering to hide configured tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx

<ul><li>Added <code>configuredToolNames</code> memoized Set to track already configured <br>tools<br> <li> Introduced <code>makeItems</code> helper function to filter tools by provider and <br>exclude configured ones<br> <li> Modified <code>toolsGroupByProvider</code> to filter out configured tools from each <br>provider group<br> <li> Added filter to remove empty tool provider groups from the dropdown<br> <li> Updated dependency array to include <code>configuredToolNames</code> for proper <br>memoization</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2298/files#diff-b37464f40d374545b1bd956acf7fbf08c71fd180d6a0f1f5fbd3e4799239d32c">+21/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool group generation to exclude already-configured tools, preventing duplicate selections
  * Improved UI by filtering out empty tool groups from the interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->