### PR TITLE
Restrict toolbar triggers to GitHub and hide placeholder items

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -314,20 +314,25 @@ export function Toolbar() {
 														<p className="text-[14px]">App Entry Node</p>
 													</ToggleGroup.Item>
 												)}
-												{triggerRegistry.map((triggerEntry) => (
-													<ToggleGroup.Item
-														key={triggerEntry.provider}
-														value={triggerEntry.provider}
-														data-tool
-													>
-														{triggerEntry.provider === "github" && (
-															<GitHubIcon className="size-[20px] shrink-0" />
-														)}
-														<p className="text-[14px]">
-															{triggerNodeDefaultName(triggerEntry.provider)}
-														</p>
-													</ToggleGroup.Item>
-												))}
+												{triggerRegistry
+													.filter(
+														(triggerEntry) =>
+															triggerEntry.provider === "github",
+													)
+													.map((triggerEntry) => (
+														<ToggleGroup.Item
+															key={triggerEntry.provider}
+															value={triggerEntry.provider}
+															data-tool
+														>
+															{triggerEntry.provider === "github" && (
+																<GitHubIcon className="size-[20px] shrink-0" />
+															)}
+															<p className="text-[14px]">
+																{triggerNodeDefaultName(triggerEntry.provider)}
+															</p>
+														</ToggleGroup.Item>
+													))}
 											</ToggleGroup.Root>
 										</div>
 									</Popover.Content>


### PR DESCRIPTION
## Overview

This PR restricts the workflow designer toolbar to only display GitHub triggers and removes placeholder UI elements for features that are not yet available. The goal is to simplify the user experience by focusing on currently supported functionality and eliminating confusion around non-functional options.

## Changes

- **Filtered trigger registry to GitHub only**: Modified the trigger selection logic to explicitly filter for `provider === "github"`, removing any other trigger types (e.g., manual) from the toolbar UI
- **Removed "Coming soon" placeholders**: Commented out the "Stage (Coming soon)" and "Widget (Coming soon)" toolbar items that were previously visible but non-functional

## ⚠️ Breaking Changes

- Users who previously relied on non-GitHub trigger options in the workflow designer will no longer have access to those triggers through the UI
- Any existing workflows using alternative trigger types configured via the designer may need to be managed differently going forward

## Testing

- [ ] Verified toolbar only displays GitHub trigger options
- [ ] Confirmed "Stage" and "Widget" items are no longer visible in the UI
- [ ] Tested that GitHub trigger selection and configuration works as expected

## Review Notes

- Please verify this aligns with the product direction for trigger support
- Feedback welcome on whether the commented-out code should be fully removed or kept for future re-enablement

## Related Issues

<!-- Link any related issues or tasks here -->