### PR TITLE
⚠️ Breaking: Change stage feature flag default from false to true when unconfigured

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -86,7 +86,7 @@ export const stageFlag = flag<boolean>({
 		}
 		const edgeConfig = await get(`flag__${this.key}`);
 		if (edgeConfig === undefined) {
-			return false;
+			return true;
 		}
 		return edgeConfig === true || edgeConfig === "true";
 	},


### PR DESCRIPTION
### **User description**
## Overview

This PR changes the default behavior of the stage feature flag to enable stage features by default when no remote configuration is found. This shifts from an opt-in model (features disabled unless explicitly enabled) to an opt-out model (features enabled unless explicitly disabled).

## Changes

- Modified stage flag evaluation logic in `apps/studio.giselles.ai/flags.ts`
- When Edge Config value is not found, the flag now defaults to `true` instead of `false`
- Stage-gated features will be active by default in environments without explicit flag configuration

## ⚠️ Breaking Changes

**This is a breaking change that may affect existing deployments:**
- Environments that previously relied on the default `false` value will now have stage features enabled
- Production environments without explicit Edge Config settings may unintentionally expose stage-only features
- **Action Required**: Ensure your production Edge Config explicitly sets the stage flag to maintain previous behavior

## Testing

- Verified flag evaluation behavior when Edge Config value is present
- Tested default behavior when Edge Config value is missing
- Confirmed stage features activate correctly with new default

## Review Notes

- Please pay special attention to the impact on production environments
- Consider whether we should add migration documentation or warnings for existing deployments
- Review if any additional safeguards are needed to prevent accidental feature exposure

## Related Issues

_No related issues linked_


___

### **PR Type**
Enhancement


___

### **Description**
- Change stage feature flag default from false to true

- Shifts from opt-in to opt-out model for stage features

- Stage features now enabled by default without explicit configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Edge Config Check"] -->|Value undefined| B["Return true<br/>Stage enabled"]
  A -->|Value defined| C["Evaluate config value"]
  C --> D["Return boolean result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Stage flag default value changed to true</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Modified <code>stageFlag</code> default return value from <code>false</code> to <code>true</code><br> <li> Changes flag behavior when Edge Config value is undefined<br> <li> Shifts stage feature flag from opt-in to opt-out model</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2304/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Change `stage` feature flag fallback to `true` when Edge Config value is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ab9962be68e80990b071d262eafd16afaad93f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->