### PR TITLE
Update context output display logic

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/node-context/use-node-context.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/node-context/use-node-context.ts
@@ -62,12 +62,24 @@ export function useNodeContext(node: ContentGenerationNode) {
 
 	const shouldShowOutputLabel = useCallback(
 		(nodeId: NodeId) => {
-			const countMap = new Map<string, number>();
+			let connectionCount = 0;
+			let hasMultipleOutputs = false;
+
 			for (const connection of connections) {
-				const currentCount = countMap.get(connection.outputNode.id) ?? 0;
-				countMap.set(connection.outputNode.id, currentCount + 1);
+				if (connection.outputNode.id !== nodeId) {
+					continue;
+				}
+				connectionCount += 1;
+				if (connection.outputNode.outputs.length > 1) {
+					hasMultipleOutputs = true;
+				}
+				if (connectionCount > 1) {
+					return true;
+				}
 			}
-			return (countMap.get(nodeId) ?? 0) > 1;
+
+			// Show labels when the source node exposes multiple outputs even with one connection.
+			return hasMultipleOutputs;
 		},
 		[connections],
 	);


### PR DESCRIPTION
## Summary
Updates the display condition for context labels in the content generation node properties panel. Labels will now show if the connected node has multiple outputs, even with a single connection, or if there are multiple connections to the node.

## Related Issue
N/A

## Changes
Modified the `shouldShowOutputLabel` function in `use-node-context.ts` to include an `OR` condition: display the output label if the source node has more than one output, or if there are multiple connections to the node.

## Testing
- Verified that context labels now render for nodes with multiple outputs (e.g., "On Pull Request Comment Created" showing "Pull request Comment") even with only one connection.
- Ran `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, and `pnpm test`.

## Other Information
Added a code comment to document the new logic for showing output labels.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4d2d4ff-a636-484c-98d1-301acab27ef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4d2d4ff-a636-484c-98d1-301acab27ef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

