### PR TITLE
Add copy-to-clipboard for Content Generation Node outputs and errors

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx
@@ -9,7 +9,13 @@ import {
 	languageModelTools,
 } from "@giselles-ai/language-model-registry";
 import { defaultName } from "@giselles-ai/node-registry";
-import { type ContentGenerationNode, Node } from "@giselles-ai/protocol";
+import {
+	type CompletedGeneration,
+	type ContentGenerationNode,
+	type FailedGeneration,
+	type Generation,
+	Node,
+} from "@giselles-ai/protocol";
 import { useNodeGenerations, useWorkflowDesigner } from "@giselles-ai/react";
 import { titleCase } from "@giselles-ai/utils";
 import clsx from "clsx/lite";
@@ -22,11 +28,55 @@ import {
 } from "lucide-react";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import { useCallback, useMemo, useState } from "react";
+import ClipboardButton from "../../../ui/clipboard-button";
 import { GenerationView } from "../../../ui/generation-view";
 import { NodePanelHeader, PropertiesPanelRoot } from "../ui";
 import { ConfigurationFormField, ModelPickerV2 } from "./language-model";
 import { useNodeContext } from "./node-context/use-node-context";
 import { ToolConfigurationDialog } from "./tool";
+
+// Helper function to extract text content from a generation
+function getGenerationTextContent(generation: Generation): string {
+	// For completed generations, use the outputs field
+	if (generation.status === "completed") {
+		const completedGeneration = generation as CompletedGeneration;
+		// Find all text outputs
+		const textOutputs = completedGeneration.outputs
+			.filter((output) => output.type === "generated-text")
+			.map((output) => (output.type === "generated-text" ? output.content : ""))
+			.join("\n\n");
+
+		if (textOutputs) {
+			return textOutputs;
+		}
+	}
+
+	// Fallback to extracting from messages if no outputs or not completed
+	const generatedMessages =
+		"messages" in generation
+			? (generation.messages?.filter((m) => m.role === "assistant") ?? [])
+			: [];
+
+	return generatedMessages
+		.map((message) =>
+			message.parts
+				?.filter((part) => part.type === "text")
+				.map((part) => (part.type === "text" ? part.text : ""))
+				.join("\n"),
+		)
+		.join("\n");
+}
+
+// Helper function to extract error content from a failed generation
+function getGenerationErrorContent(generation: Generation): string {
+	if (generation.status === "failed") {
+		const failedGeneration = generation as FailedGeneration;
+		const error = failedGeneration.error;
+		return `${error.name}: ${error.message}`;
+	}
+
+	return "";
+}
 
 export function ContentGenerationNodePropertiesPanel({
 	node,
@@ -563,9 +613,29 @@ export function ContentGenerationNodePropertiesPanel({
 						)}
 					</div>
 					<div className="flex flex-col w-1/2">
-						<SettingDetail size="md" className="text-text-muted mb-[6px]">
-							Output
-						</SettingDetail>
+						<div className="flex items-center justify-between mb-[6px]">
+							<SettingDetail size="md" className="text-text-muted">
+								Output
+							</SettingDetail>
+							{currentGeneration &&
+								(currentGeneration.status === "completed" ||
+									currentGeneration.status === "cancelled" ||
+									currentGeneration.status === "failed") && (
+									<ClipboardButton
+										text={
+											currentGeneration.status === "failed"
+												? getGenerationErrorContent(currentGeneration)
+												: getGenerationTextContent(currentGeneration)
+										}
+										tooltip={
+											currentGeneration.status === "failed"
+												? "Copy error to clipboard"
+												: "Copy to clipboard"
+										}
+										className="text-text-muted hover:text-text/60"
+									/>
+								)}
+						</div>
 						<div className="rounded-md bg-surface/70 w-full flex-1 p-[8px] overflow-y-auto">
 							{currentGeneration ? (
 								<GenerationView generation={currentGeneration} />


### PR DESCRIPTION
### **User description**
## Overview

This PR enhances the Content Generation Node properties panel by adding copy-to-clipboard functionality for generation outputs and errors. Users can now quickly copy generated content or error messages directly from the UI, improving the debugging and content-sharing experience.

## Changes

- **New helper functions for content extraction**
  - `getGenerationTextContent(generation)`: Extracts text from completed generations by preferring structured `outputs` of type `"generated-text"`, with fallback to assistant message text parts
  - `getGenerationErrorContent(generation)`: Formats failed generation errors as `"ErrorName: Error message"` for consistent display/copy

- **Copy-to-clipboard UI enhancement**
  - Added `ClipboardButton` to the Output section header
  - Button appears when generation status is `"completed"`, `"cancelled"`, or `"failed"`
  - Context-aware tooltip: "Copy error to clipboard" for failures, "Copy to clipboard" otherwise
  - Copies appropriate content based on generation status (error message vs. text output)

- **Improved type usage**
  - Now imports and uses specific protocol types (`Generation`, `CompletedGeneration`, `FailedGeneration`) for status-aware handling

- **Minor layout update**
  - Output label row converted to flex container to accommodate the new clipboard button

## Testing

- [ ] Verified copy functionality works for completed generations
- [ ] Verified copy functionality works for failed generations (copies formatted error)
- [ ] Verified copy functionality works for cancelled generations
- [ ] Verified button does not appear for in-progress or pending generations
- [ ] Verified tooltip text changes appropriately based on generation status

## Review Notes

- The helper functions centralize content extraction logic—please review for edge cases where `outputs` or `messages` might have unexpected shapes
- Would appreciate feedback on the tooltip text choices for clarity

## Related Issues


___

### **PR Type**
Enhancement


___

### **Description**
- Add copy-to-clipboard functionality for generation outputs and errors

- Extract text content from completed generations with fallback logic

- Display context-aware clipboard button in Output section header

- Import specific generation protocol types for status-aware handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generation Status"] -->|"completed/cancelled/failed"| B["Show ClipboardButton"]
  B -->|"failed status"| C["Copy Error Content"]
  B -->|"other status"| D["Copy Text Content"]
  C --> E["Display in UI"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>content-generation-node-properties-panel.tsx</strong><dd><code>Add clipboard button with content extraction helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/content-generation-node-properties-panel/content-generation-node-properties-panel.tsx

<ul><li>Added imports for <code>CompletedGeneration</code>, <code>FailedGeneration</code>, and <br><code>Generation</code> protocol types<br> <li> Implemented <code>getGenerationTextContent()</code> helper to extract text from <br>outputs or message parts<br> <li> Implemented <code>getGenerationErrorContent()</code> helper to format error <br>messages as "ErrorName: message"<br> <li> Added <code>ClipboardButton</code> component to Output section header with <br>conditional rendering<br> <li> Button displays only when generation status is "completed", <br>"cancelled", or "failed"<br> <li> Tooltip text changes based on generation status ("Copy error to <br>clipboard" vs "Copy to clipboard")<br> <li> Converted Output label row to flex container for button alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2309/files#diff-b37464f40d374545b1bd956acf7fbf08c71fd180d6a0f1f5fbd3e4799239d32c">+74/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard functionality for generated content and error messages. Users can now easily copy successful generation results or detailed error information directly to their clipboard with intelligent, context-aware buttons that automatically appear when a generation completes, fails, or is cancelled, enhancing workflow efficiency and error reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->