### PR TITLE
Remove text generation expansion support and disable generateContentNode flag

### DIFF
--- a/apps/playground/app/workspaces/[workspaceId]/page.client.tsx
+++ b/apps/playground/app/workspaces/[workspaceId]/page.client.tsx
@@ -20,7 +20,7 @@ export function Page({ dataLoader }: Props) {
 				aiGateway: true,
 				aiGatewayUnsupportedModels: false,
 				googleUrlContext: false,
-				generateContentNode: true,
+				generateContentNode: false,
 			}}
 			usageLimits={{
 				featureTier: "pro",

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx
@@ -90,14 +90,10 @@ export function PromptPanel({
 	node,
 	sections,
 	slots,
-	onExpand,
-	editorVersion,
 }: {
 	node: TextGenerationNode;
 	sections?: PromptPanelSections;
 	slots?: PromptPanelSlots;
-	onExpand?: () => void;
-	editorVersion?: number;
 }) {
 	const updateNodeDataContent = useWorkflowDesignerStore(
 		(s) => s.updateNodeDataContent,
@@ -371,7 +367,7 @@ export function PromptPanel({
 	return (
 		<>
 			<PromptEditor
-				key={`${editorVersion ?? 0}-${JSON.stringify(connectedSources.map((c) => c.node.id))}`}
+				key={JSON.stringify(connectedSources.map((c) => c.node.id))}
 				placeholder="Write your prompt... Use @ to reference other nodes"
 				value={node.content.prompt}
 				onValueChange={(value) => {
@@ -381,9 +377,7 @@ export function PromptPanel({
 				showToolbar={false}
 				variant="plain"
 				header={header}
-				showExpandIcon={true}
-				onExpand={onExpand}
-				expandIconPosition="right"
+				showExpandIcon={false}
 			/>
 			{resolvedSections.advancedOptions && advancedOptions}
 		</>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tab-content.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tab-content.tsx
@@ -7,26 +7,14 @@ import {
 
 interface TextGenerationTabContentProps {
 	node: TextGenerationNode;
-	onPromptExpand?: () => void;
 	sections?: PromptPanelSections;
 	slots?: PromptPanelSlots;
-	editorVersion?: number;
 }
 
 export function TextGenerationTabContent({
 	node,
-	onPromptExpand,
 	sections,
 	slots,
-	editorVersion,
 }: TextGenerationTabContentProps) {
-	return (
-		<PromptPanel
-			node={node}
-			onExpand={onPromptExpand}
-			sections={sections}
-			slots={slots}
-			editorVersion={editorVersion}
-		/>
-	);
+	return <PromptPanel node={node} sections={sections} slots={slots} />;
 }


### PR DESCRIPTION
### **User description**
## Overview

This PR simplifies the text generation node properties panel by removing the expanded/full-screen editing modes for both the prompt editor and generation output panel. The goal is to reduce UI complexity, eliminate synchronization issues between live prompt content and expanded editors, and create a more predictable inline-only editing experience.

Additionally, the `generateContentNode` feature flag has been disabled in the playground workspace page.

## Changes

- **Text Generation Node Properties Panel**
  - Removed support for expanding prompt editor into full-screen/overlay dialog
  - Removed support for expanding generation output panel into full-screen/overlay dialog
  - Eliminated related state management (`isPromptExpanded`, `isGenerationExpanded`, `editorVersion`, refs, overlay positioning)
  - Removed `useLivePrompt` and `useOverlayBottom` hooks
  - Simplified keyboard handling to only `Cmd/Ctrl + Enter` for running generation
  - `GenerationPanel` now always renders inline

- **Prompt Panel**
  - Removed `onExpand` callback and `editorVersion` props
  - `PromptEditor` no longer shows expand icon
  - Simplified component key to depend only on connected source node IDs

- **Tab Content Component**
  - Removed `onPromptExpand` and `editorVersion` prop forwarding from `TextGenerationTabContent`

- **Feature Flag**
  - Disabled `generateContentNode` feature flag in `workspaces/[workspaceId]/page.client.tsx`

## ⚠️ Breaking Changes

- Components no longer support expanded-mode API (`onPromptExpand`, `showExpandIcon`, `editorVersion`)
- External code relying on expanded dialog functionality will need to be updated

## Testing

- [ ] Verified prompt editing works correctly in inline mode
- [ ] Confirmed `Cmd/Ctrl + Enter` triggers generation
- [ ] Validated generation output displays properly without expansion
- [ ] Checked that `generateContentNode` is correctly hidden in playground workspace

## Review Notes

- Please verify the feature flag change aligns with the intended rollout/deprecation strategy
- Feedback welcome on whether any expansion functionality should be preserved for specific use cases

## Related Issues


___

### **PR Type**
Enhancement


___

### **Description**
- Disable `generateContentNode` feature flag in playground workspace

- Remove expanded/full-screen editing modes for prompt editor

- Remove expanded/full-screen editing modes for generation output panel

- Simplify state management by eliminating expansion-related hooks and refs

- Simplify keyboard shortcuts to only support `Cmd/Ctrl + Enter` for generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Text Generation Node<br/>Properties Panel"] -->|Remove expansion| B["Inline-only<br/>Editing Mode"]
  A -->|Remove state| C["Simplified State<br/>Management"]
  D["Feature Flag<br/>generateContentNode"] -->|Disable| E["Playground<br/>Workspace"]
  B --> F["Reduced UI<br/>Complexity"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.client.tsx</strong><dd><code>Disable generateContentNode feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/playground/app/workspaces/[workspaceId]/page.client.tsx

<ul><li>Changed <code>generateContentNode</code> feature flag from <code>true</code> to <code>false</code><br> <li> Disables the text generation node feature in the playground workspace</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2320/files#diff-f1a35f6348906887267d28e6bf511b9509135061388ced696b9139dec9ac4a51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove expansion dialogs and simplify state management</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/index.tsx

<ul><li>Removed expanded prompt editor dialog and related state <br>(<code>isPromptExpanded</code>, <code>editorVersion</code>)<br> <li> Removed expanded generation panel dialog and related state <br>(<code>isGenerationExpanded</code>)<br> <li> Removed custom hooks: <code>useLivePrompt</code>, <code>useOverlayBottom</code>, <code>useElementTopPx</code><br> <li> Removed refs and overlay positioning logic (<code>promptEditorRef</code>, <br><code>generationPanelRef</code>, <code>generateCtaRef</code>)<br> <li> Simplified keyboard handling to only support <code>Cmd/Ctrl + Enter</code> for <br>generation<br> <li> Removed <code>Escape</code> key handler for closing expanded editors<br> <li> Removed <code>updateNodeDataContent</code> store subscription and <code>currentGeneration</code> <br>tracking<br> <li> Removed <code>connections</code> variable from <code>useConnectedOutputs</code> hook usage</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2320/files#diff-b1f2287bb552bf4b22b33e8ad29c9c365a3e751e24ee9b8f29eb16687aba37d6">+15/-174</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prompt-panel.tsx</strong><dd><code>Remove expand icon and simplify prompt panel props</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/prompt-panel.tsx

<ul><li>Removed <code>onExpand</code> callback prop<br> <li> Removed <code>editorVersion</code> prop<br> <li> Removed <code>showExpandIcon</code> prop from <code>PromptEditor</code> (set to <code>false</code>)<br> <li> Removed <code>onExpand</code> and <code>expandIconPosition</code> props from <code>PromptEditor</code><br> <li> Simplified component key to depend only on connected source node IDs</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2320/files#diff-b948e855ed4caae9a25e3a70cdf48c528051a145191609c3acff7fad495ae4bf">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tab-content.tsx</strong><dd><code>Remove expansion props from tab content component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/tab-content.tsx

<ul><li>Removed <code>onPromptExpand</code> prop from component interface<br> <li> Removed <code>editorVersion</code> prop from component interface<br> <li> Removed prop forwarding to <code>PromptPanel</code> for expansion-related callbacks<br> <li> Simplified component to pass only essential props to <code>PromptPanel</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2320/files#diff-9e1ad2767829edae07856e70b4d219bec56c2970ca788e6edb694ccf777103e0">+1/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove expanded/full-screen modes from text-generation node and disable `generateContentNode`, simplifying to inline editing with Cmd/Ctrl+Enter to run.
> 
> - **Workflow Designer UI – Text Generation Node**
>   - Removed expanded/full-screen dialogs for prompt editor and generation output; now inline-only via `GenerationPanel` and `PromptEditor`.
>   - Deleted related state/refs and hooks: `isPromptExpanded`, `isGenerationExpanded`, `editorVersion`, overlay/backdrop elements, `useLivePrompt`, `useOverlayBottom`, `useElementTopPx`, `Minimize2`.
>   - Simplified keyboard handling to only `Cmd/Ctrl + Enter` for generation; adjusted `useNodeGenerations` usage and removed `currentGeneration`/`connections` where unused.
>   - `TextGenerationTabContent` and `PromptPanel` props streamlined (removed `onPromptExpand`, `editorVersion`); `PromptEditor` no longer shows expand icon and uses a simplified `key`.
> - **Playground**
>   - Disabled feature flag `generateContentNode` in `apps/playground/app/workspaces/[workspaceId]/page.client.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e61227c3070cf5f9318beec64a9200b198be7737. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Disabled content generation node feature flag
  * Streamlined text generation panel interface by removing expandable editor sections and simplifying the layout

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->