### PR TITLE
Disable generateContentNodeFlag by default and support bidirectional node conversion

### DIFF
--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -183,7 +183,7 @@ export const generateContentNodeFlag = flag<boolean>({
 		}
 		const edgeConfig = await get(`flag__${this.key}`);
 		if (edgeConfig === undefined) {
-			return true;
+			return false;
 		}
 		return edgeConfig === true || edgeConfig === "true";
 	},

--- a/packages/giselle/src/workspaces/utils.ts
+++ b/packages/giselle/src/workspaces/utils.ts
@@ -1,5 +1,9 @@
-import { convertTextGenerationToContentGeneration } from "@giselles-ai/node-registry";
 import {
+	convertContentGenerationToTextGeneration,
+	convertTextGenerationToContentGeneration,
+} from "@giselles-ai/node-registry";
+import {
+	isContentGenerationNode,
 	isTextGenerationNode,
 	Node,
 	Workspace,
@@ -43,13 +47,19 @@ export async function getWorkspace({
 	const nodes = workspace.nodes
 		.map((node) => parseAndMod(Node, node))
 		.map((node) => {
-			if (!context.experimental_contentGenerationNode) {
-				return node;
+			if (
+				context.experimental_contentGenerationNode &&
+				isTextGenerationNode(node)
+			) {
+				return convertTextGenerationToContentGeneration(node);
 			}
-			if (!isTextGenerationNode(node)) {
-				return node;
+			if (
+				!context.experimental_contentGenerationNode &&
+				isContentGenerationNode(node)
+			) {
+				return convertContentGenerationToTextGeneration(node);
 			}
-			return convertTextGenerationToContentGeneration(node);
+			return node;
 		});
 	return {
 		...workspace,


### PR DESCRIPTION
### **User description**
## Overview

This PR changes the `generateContentNodeFlag` feature flag to default to `false` instead of `true` when no remote configuration is found. Additionally, it implements bidirectional conversion between text generation and content generation nodes, ensuring workspace consistency regardless of the experimental flag state.

The motivation is to make the experimental content generation node feature **opt-in** rather than on-by-default, reducing unintended exposure to experimental behavior in environments without explicit configuration.

## Changes

- **Feature flag default behavior:**
  - `generateContentNodeFlag` now returns `false` (instead of `true`) when edge configuration is unavailable
  - This makes the system more conservative, requiring explicit enablement

- **Bidirectional node conversion in workspace loading:**
  - Added import for `convertContentGenerationToTextGeneration` and `isContentGenerationNode` type guard
  - When `experimental_contentGenerationNode` is **enabled**: text generation nodes → content generation nodes
  - When `experimental_contentGenerationNode` is **disabled**: content generation nodes → text generation nodes
  - Ensures workspace node types stay consistent with the current flag state

## Testing

- [ ] Verified flag returns `false` when no edge configuration is present
- [ ] Tested workspace loading with experimental flag enabled (text nodes convert to content nodes)
- [ ] Tested workspace loading with experimental flag disabled (content nodes convert to text nodes)
- [ ] Confirmed no mixed node types remain after workspace normalization

## Review Notes

⚠️ **Breaking Change:** Environments that previously relied on the implicit `true` default for `generateContentNodeFlag` will now see the feature disabled unless explicitly configured.

Areas for review:
- Is the conservative default (`false`) the desired behavior for all deployment environments?
- Does the bidirectional conversion handle all edge cases for existing workspaces?

## Related Issues

<!-- Link any related issues here -->


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Change `generateContentNodeFlag` default from `true` to `false` for conservative behavior

- Implement bidirectional node conversion based on experimental flag state

- Convert text generation nodes to content nodes when flag enabled

- Convert content generation nodes to text nodes when flag disabled


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Feature Flag Default"] -->|Changed| B["false instead of true"]
  C["Workspace Loading"] -->|Bidirectional Conversion| D["Flag Enabled: Text→Content"]
  C -->|Bidirectional Conversion| E["Flag Disabled: Content→Text"]
  B --> F["Conservative Default Behavior"]
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Change feature flag default to false</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Changed <code>generateContentNodeFlag</code> default return value from <code>true</code> to <br><code>false</code><br> <li> Makes the experimental content generation node feature opt-in by <br>default<br> <li> Requires explicit remote configuration to enable the feature</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2323/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Implement bidirectional node conversion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/workspaces/utils.ts

<ul><li>Added import for <code>convertContentGenerationToTextGeneration</code> and <br><code>isContentGenerationNode</code> type guard<br> <li> Implemented bidirectional node conversion logic in <code>getWorkspace</code> <br>function<br> <li> When flag enabled: converts text generation nodes to content <br>generation nodes<br> <li> When flag disabled: converts content generation nodes to text <br>generation nodes<br> <li> Ensures workspace consistency regardless of experimental flag state</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2323/files#diff-1c038795527e5bfa5c8f615126f02d3a59fccb91038d002f4646c96bf6a253ca">+16/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set `generate-content-node` flag default to false when unset and normalize workspace nodes both directions based on the experimental flag.
> 
> - **Feature flags**
>   - `apps/studio.giselles.ai/flags.ts`: `generate-content-node` now returns `false` when `edgeConfig` is undefined.
> - **Workspaces**
>   - `packages/giselle/src/workspaces/utils.ts`:
>     - Add imports `convertContentGenerationToTextGeneration` and `isContentGenerationNode`.
>     - Normalize nodes on load based on `context.experimental_contentGenerationNode`:
>       - If enabled: convert `TextGeneration` → `ContentGeneration`.
>       - If disabled: convert `ContentGeneration` → `TextGeneration`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba777009d79bcaedf1017bd1615a34bab8a4adc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default flag behavior for content nodes when configuration is undefined.

* **Features**
  * Added experimental feature flag support for conditional content generation node handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->