### PR TITLE
Simplify Knip configuration by removing dynamic dependency discovery

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -1,30 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
 import type { KnipConfig } from "knip";
-
-function getDepsFor(workspaceRelPath: string): Set<string> {
-	const pkgPath = path.join(__dirname, workspaceRelPath, "package.json");
-	try {
-		const json = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as {
-			dependencies?: Record<string, string>;
-			devDependencies?: Record<string, string>;
-		};
-		return new Set([
-			...Object.keys(json.dependencies ?? {}),
-			...Object.keys(json.devDependencies ?? {}),
-		]);
-	} catch {
-		return new Set();
-	}
-}
-
-function filterExisting(
-	pkgs: string[] | undefined,
-	deps: Set<string>,
-): string[] {
-	if (!pkgs?.length) return [];
-	return pkgs.filter((name) => deps.has(name));
-}
 
 const config: KnipConfig = {
 	biome: false,
@@ -50,19 +24,15 @@ const config: KnipConfig = {
 				"trigger/investigate-private-key-job.ts",
 			],
 			// Ignore deps that are resolved dynamically in next.config or used only at build/runtime
-			ignoreDependencies: filterExisting(
-				[
-					"@embedpdf/pdfium",
-					"@opentelemetry/sdk-node",
-					"import-in-the-middle",
-					"require-in-the-middle",
-					"@aws-sdk/client-s3",
-					"pino-pretty",
-					"@react-email/preview-server",
-					"react-dom",
-				],
-				getDepsFor("apps/studio.giselles.ai"),
-			),
+			ignoreDependencies: [
+				"@aws-sdk/client-s3",
+				"@embedpdf/pdfium",
+				"@opentelemetry/sdk-node",
+				"import-in-the-middle",
+				"require-in-the-middle",
+				"@react-email/preview-server",
+				"pino-pretty",
+			],
 		},
 		"apps/ui.giselles.ai": {
 			ignoreDependencies: ["tailwindcss"],


### PR DESCRIPTION
### **User description**
## Overview

This PR reverts unnecessary changes from #2114 that broke Knip functionality and simplifies the Knip configuration by removing dynamic dependency discovery logic. The configuration is now static and more maintainable, though it may surface new findings in CI/local workflows.

## Changes

- **Simplified Knip configuration**: Removed dynamic dependency discovery that relied on reading `package.json` files
  - Dropped `fs` and `path` imports along with helper functions
  - Configuration is now static and easier to reason about

- **apps/studio.giselles.ai**:
  - Replaced dynamic `ignoreDependencies` filtering with a fixed list
  - ⚠️ Removed `react-dom` from the ignore list (will now be analyzed by Knip)
  - Retained ignores for dynamically resolved or build/runtime-only packages:
    - `@aws-sdk/client-s3`
    - `@embedpdf/pdfium`
    - `@opentelemetry/sdk-node`
    - `import/require-in-the-middle`
    - `@react-email/preview-server`
    - `pino-pretty`

- **apps/ui.giselles.ai**: No substantive changes; `tailwindcss` remains ignored

## Testing

- Verified that Knip runs successfully with the simplified configuration
- Confirmed that the static configuration produces expected results
- Checked that previously broken functionality from #2114 is restored

## Review Notes

- **Potential Impact**: CI or local developer workflows may see new Knip findings, particularly around `react-dom` usage in the studio app
- Please verify if `react-dom` should remain in the ignore list or if the new stricter checking is desired
- The simplified configuration makes the setup more predictable but may require adjustments to the ignore list based on actual usage patterns

## Related Issues

- Fixes regression introduced in #2114
- Addresses Knip configuration maintenance concerns


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Removed dynamic dependency discovery logic from Knip configuration

- Simplified `ignoreDependencies` to static lists for maintainability

- Deleted unused helper functions `getDepsFor` and `filterExisting`

- Removed `react-dom` from studio app ignore list for stricter analysis


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dynamic dependency discovery<br/>getDepsFor, filterExisting"] -->|Remove| B["Static ignoreDependencies<br/>configuration"]
  C["fs, path imports"] -->|Delete| B
  D["react-dom in ignore list"] -->|Remove| E["Stricter Knip analysis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>knip.ts</strong><dd><code>Replace dynamic dependency discovery with static configuration</code></dd></summary>
<hr>

knip.ts

<ul><li>Removed <code>fs</code> and <code>path</code> module imports used for dynamic file reading<br> <li> Deleted <code>getDepsFor()</code> function that read <code>package.json</code> files dynamically<br> <li> Deleted <code>filterExisting()</code> helper function that filtered packages <br>against actual dependencies<br> <li> Converted <code>ignoreDependencies</code> for <code>apps/studio.giselles.ai</code> from dynamic <br>filtering to static array<br> <li> Removed <code>react-dom</code> from the studio app's ignore list to enable stricter <br>checking<br> <li> Kept other ignored dependencies: <code>@aws-sdk/client-s3</code>, <code>@embedpdf/pdfium</code>, <br><code>@opentelemetry/sdk-node</code>, <code>import-in-the-middle</code>, <code>require-in-the-middle</code>, <br><code>@react-email/preview-server</code>, <code>pino-pretty</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2332/files#diff-a55fd3ab189e220a273770f57af40594369d9d7eb30d621d4d83fc78fd439288">+9/-39</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make Knip config static by removing dynamic dependency discovery and hardcoding ignoreDependencies for the studio app, excluding react-dom.
> 
> - **Knip Config**:
>   - Remove dynamic dependency discovery (drop `fs`/`path` imports and helper functions).
> - **apps/studio.giselles.ai**:
>   - Replace dynamic `ignoreDependencies` filtering with a fixed list for build/runtime-only deps.
>   - Remove `react-dom` from `ignoreDependencies`.
> - **Misc**:
>   - Keep existing workspace entries and ignores; no other behavioral changes noted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 188e7655e835bc1b2341c503f11d14b6f00cb0ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized dependency handling configuration by streamlining internal logic and reducing unnecessary filesystem operations for improved performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->