### PR TITLE
Remove generation model info display

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/generation-panel.tsx
@@ -144,15 +144,7 @@ export function GenerationPanel({
 						<p data-header-text>Generating...</p>
 					)}
 					{currentGeneration.status === "completed" && (
-						<p data-header-text>
-							Result{" "}
-							<span className="text-[12px] font-normal">
-								from {(() => {
-									const modelInfo = getGenerationModelInfo(currentGeneration);
-									return `${getProviderDisplayName(modelInfo.provider)} ${modelInfo.modelId}`;
-								})()}
-							</span>
-						</p>
+						<p data-header-text>Result</p>
 					)}
 					{currentGeneration.status === "failed" && (
 						<p data-header-text>Error</p>


### PR DESCRIPTION
### **User description**
## Summary
Removes the display of model provider and ID from the "Result" header in the generation panel.

## Related Issue
N/A

## Changes
Removed the `<span>` element that displayed the generation model's provider and ID from the "completed" status header in `generation-panel.tsx`.

## Testing
- `pnpm biome check --write`
- `pnpm format`
- `pnpm build-sdk`
- `pnpm check-types`
- `pnpm tidy`
- `pnpm test`
All commands executed successfully.

## Other Information
The "completed" state header for text generation nodes will now display only "Result".

---
<a href="https://cursor.com/background-agent?bcId=bc-b3d8cd51-27e7-49c1-9b45-2e21b6e9cb28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3d8cd51-27e7-49c1-9b45-2e21b6e9cb28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Enhancement


___

### **Description**
- Simplifies generation result header by removing model provider and ID display

- Reduces visual clutter in the "Result" header for completed text generation nodes

- Removes unnecessary model information retrieval logic from the UI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generation Panel<br/>Completed State"] -- "Remove model info<br/>display logic" --> B["Simplified Result<br/>Header"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generation-panel.tsx</strong><dd><code>Remove model info from result header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/generation-panel.tsx

<ul><li>Removed <code><span></code> element displaying model provider and ID from completed <br>status header<br> <li> Simplified header text from "Result from [Provider] [ModelId]" to just <br>"Result"<br> <li> Eliminated calls to <code>getGenerationModelInfo()</code> and <br><code>getProviderDisplayName()</code> functions<br> <li> Reduced header markup complexity while maintaining functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2351/files#diff-8fdf8725caf8a55d885c2e6c296d079835d79be791ef7c779e7f650d4f93480f">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Hides provider and model ID from the "Result" header when a generation is completed.
> 
> - **UI (generation panel)**:
>   - In `generation-panel.tsx`, the completed state header now shows only `Result`, removing the provider/model ID span.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6de51a4efdef0a8058f7bdb5c53147d31ec37572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the text generation result header display to show a cleaner "Result" label instead of detailed provider and model information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->