### PR TITLE
Fix github tools configuration bug

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/tools/tool-provider/github/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/tools/tool-provider/github/index.tsx
@@ -428,6 +428,16 @@ function GitHubToolConfigurationDialogInternal({
 	currentSecretId: string | undefined;
 }) {
 	const { updateNodeDataContent } = useWorkflowDesigner();
+	const githubToolConfiguration = node.content.tools.find(
+		(tool) => tool.name === "github-api",
+	)?.configuration;
+	const configuredGitHubToolsRaw = githubToolConfiguration?.useTools as unknown;
+	const configuredGitHubTools = Array.isArray(configuredGitHubToolsRaw)
+		? configuredGitHubToolsRaw.filter(
+				(toolName): toolName is string => typeof toolName === "string",
+			)
+		: [];
+	const selectedGitHubTools = new Set<string>(configuredGitHubTools);
 
 	const updateAvailableTools = useCallback<
 		React.FormEventHandler<HTMLFormElement>
@@ -536,6 +546,7 @@ function GitHubToolConfigurationDialogInternal({
 												value={tool}
 												id={tool}
 												name="tools"
+												defaultChecked={selectedGitHubTools.has(tool)}
 											>
 												<Checkbox.Indicator className="text-background">
 													<CheckIcon className="size-[16px]" />

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/tools/tool-provider/use-tool-provider-connection.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/tools/tool-provider/use-tool-provider-connection.tsx
@@ -133,16 +133,18 @@ export function useToolProviderConnection<
 
 	const currentSecretId = useMemo(() => {
 		const tool = node.content.tools.find((tool) => tool.name === toolName);
-		if (!tool) return undefined;
-
-		if ("secretId" in tool && tool.configuration) {
-			const result = SecretId.safeParse(tool.secretId);
-			if (result.error) {
-				return undefined;
-			}
-			return result.data;
+		if (!tool || !tool.configuration) {
+			return undefined;
 		}
-		return undefined;
+		const secretIdValue = tool.configuration.secretId as unknown;
+		if (typeof secretIdValue !== "string") {
+			return undefined;
+		}
+		const result = SecretId.safeParse(secretIdValue);
+		if (!result.success) {
+			return undefined;
+		}
+		return result.data;
 	}, [node, toolName]);
 
 	return {


### PR DESCRIPTION
### **User description**
## Summary
Fixes two issues in the GitHub Tools configuration:
1.  Ensures selected GitHub tools are correctly displayed as checked when reopening the configuration dialog.
2.  Correctly displays the "Current PAT" badge and enables the "Update" button after a PAT is registered.

## Related Issue
N/A

## Changes
*   **Tool Selection Persistence**: The `GitHubToolConfigurationDialogInternal` component now reads the `useTools` array from the node's configuration and uses it to set the `defaultChecked` state for the tool selection checkboxes.
*   **PAT Display**: The `useToolProviderConnection` hook now correctly extracts and validates the `secretId` from the tool's `configuration` object, allowing the UI to display the current PAT.

## Testing
The following commands were run successfully:
*   `pnpm format`
*   `pnpm build-sdk`
*   `pnpm check-types`
*   `pnpm tidy`
*   `pnpm test`

Manual verification confirmed that previously selected tools are checked upon reopening the dialog and the PAT badge updates correctly.

## Other Information
Workspace dependencies were installed to facilitate running the necessary checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-615d1672-c475-47e1-a011-3a977c8c16ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-615d1672-c475-47e1-a011-3a977c8c16ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Bug fix


___

### **Description**
- Fix tool selection persistence by reading `useTools` from node configuration

- Correct PAT display by extracting `secretId` from tool configuration object

- Improve secret ID validation and type safety in both components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Tool Config"] -->|read useTools array| B["Set checkbox defaultChecked"]
  C["Tool Configuration"] -->|extract secretId| D["Validate and display PAT"]
  B -->|persist selection| E["Dialog reopens with selections"]
  D -->|enable Update button| F["PAT badge displays correctly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Persist GitHub tool selections in configuration dialog</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/tools/tool-provider/github/index.tsx

<ul><li>Extract <code>useTools</code> array from GitHub tool configuration on component <br>mount<br> <li> Filter and validate tool names to ensure only strings are included<br> <li> Set <code>defaultChecked</code> on checkboxes based on previously configured tools<br> <li> Restore tool selection state when reopening the configuration dialog</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2356/files#diff-3a3f31b142e23f93024eac100b0e25f7b0117b8f61f8e81566f7d9176bdb31ed">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-tool-provider-connection.tsx</strong><dd><code>Fix secret ID extraction from tool configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/tools/tool-provider/use-tool-provider-connection.tsx

<ul><li>Change <code>secretId</code> extraction from tool root to <code>tool.configuration</code> object<br> <li> Add type guard to validate <code>secretId</code> is a string before parsing<br> <li> Improve validation logic using <code>result.success</code> instead of <code>result.error</code><br> <li> Ensure proper null/undefined handling for configuration object</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2356/files#diff-51137a3894e05fa7a2e4850abd42d815fcb6d5cdb5b8ee744bc03bb8ce9a0116">+11/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub tool selections now persist correctly and automatically pre-populate the interface with your previously configured choices, ensuring the UI accurately reflects your current settings.

* **Refactor**
  * Enhanced the secret ID validation system with improved type-safety checks, stricter validation rules, and better error handling for more reliable configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->