### PR TITLE
[DO NOT MERGE] Sentry test endpoints for verification

### DIFF
--- a/apps/studio.giselles.ai/app/api/sentry-test/server/route.ts
+++ b/apps/studio.giselles.ai/app/api/sentry-test/server/route.ts
@@ -1,0 +1,16 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+	const error = new Error("Sentry server-side test error");
+	Sentry.captureException(error);
+	await Sentry.flush(2000);
+	return NextResponse.json({
+		message: "Server-side error sent to Sentry",
+		timestamp: new Date().toISOString(),
+	});
+}
+
+export function POST() {
+	throw new Error("Sentry server-side unhandled error test");
+}

--- a/apps/studio.giselles.ai/app/sentry-test/page.tsx
+++ b/apps/studio.giselles.ai/app/sentry-test/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useState } from "react";
+
+export default function SentryTestPage() {
+	const [status, setStatus] = useState<string>("");
+
+	const handleClientError = () => {
+		const error = new Error("Sentry client-side test error");
+		Sentry.captureException(error);
+		setStatus("Client-side error sent to Sentry");
+	};
+
+	const handleUnhandledError = () => {
+		throw new Error("Sentry client-side unhandled error test");
+	};
+
+	const handleServerError = async () => {
+		setStatus("Sending...");
+		const res = await fetch("/api/sentry-test/server");
+		const data = await res.json();
+		setStatus(`Server response: ${data.message}`);
+	};
+
+	const handleServerUnhandledError = async () => {
+		setStatus("Sending...");
+		try {
+			await fetch("/api/sentry-test/server", { method: "POST" });
+		} catch {
+			setStatus("Server unhandled error triggered");
+		}
+	};
+
+	return (
+		<div style={{ padding: "2rem" }}>
+			<h1>Sentry Test Page</h1>
+			<p>Use these buttons to test Sentry error reporting:</p>
+
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					gap: "1rem",
+					marginTop: "1rem",
+				}}
+			>
+				<button type="button" onClick={handleClientError}>
+					Trigger Client Error (captured)
+				</button>
+
+				<button type="button" onClick={handleUnhandledError}>
+					Trigger Client Unhandled Error
+				</button>
+
+				<button type="button" onClick={handleServerError}>
+					Trigger Server Error (captured)
+				</button>
+
+				<button type="button" onClick={handleServerUnhandledError}>
+					Trigger Server Unhandled Error
+				</button>
+			</div>
+
+			{status && (
+				<p
+					style={{ marginTop: "1rem", padding: "1rem", background: "#f0f0f0" }}
+				>
+					{status}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/apps/studio.giselles.ai/middleware.ts
+++ b/apps/studio.giselles.ai/middleware.ts
@@ -22,6 +22,6 @@ export default supabaseMiddleware(async (user, request) => {
 
 export const config = {
 	matcher: [
-		"/((?!_next/static|_next/image|.well-known|webhooks|legal|login|signup|join|pricing|password_reset|subscription|auth|api/giselle/github-webhook|api/vector-stores|robots\\.txt|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+		"/((?!_next/static|_next/image|.well-known|webhooks|legal|login|signup|join|pricing|password_reset|subscription|auth|api/giselle/github-webhook|api/vector-stores|api/sentry-test|sentry-test|robots\\.txt|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
 	],
 };


### PR DESCRIPTION
## ⚠️ DO NOT MERGE - For testing only

This PR adds test endpoints to verify Sentry error reporting after the v10 upgrade (#2362). **Do not merge.**

## Summary
- Add `/sentry-test` page for client-side error testing
- Add `/api/sentry-test/server` API endpoint for server-side error testing
- Both endpoints bypass authentication for easy testing

## How to test
1. Navigate to `/sentry-test`
2. Click each button and verify errors appear in the Sentry dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)