### PR TITLE
Update OpenAI reasoning effort values

### DIFF
--- a/packages/language-model-registry/src/openai.ts
+++ b/packages/language-model-registry/src/openai.ts
@@ -58,7 +58,7 @@ export const openai = {
 		configurationOptions: {
 			reasoningEffort: {
 				description: reasoningEffortDescription,
-				schema: z.enum(["minimal", "low", "medium", "high"]),
+				schema: z.enum(["none", "low", "medium", "high"]),
 			},
 			textVerbosity: {
 				description: textVerbosityDescription,
@@ -66,7 +66,7 @@ export const openai = {
 			},
 		},
 		defaultConfiguration: {
-			reasoningEffort: "minimal",
+			reasoningEffort: "none",
 			textVerbosity: "medium",
 		},
 		url: "https://platform.openai.com/docs/models/gpt-5.1-codex",
@@ -97,7 +97,7 @@ export const openai = {
 			},
 		},
 		defaultConfiguration: {
-			reasoningEffort: "minimal",
+			reasoningEffort: "medium",
 			textVerbosity: "medium",
 		},
 		url: "https://platform.openai.com/docs/models/gpt-5",


### PR DESCRIPTION
### **User description**
Change "minimal" to "none" for GPT5.1-Codex model and update GPT-5 default from "minimal" to "medium".


___

### **PR Type**
Enhancement


___

### **Description**
- Update GPT-5.1-Codex reasoning effort from "minimal" to "none"

- Change reasoning effort schema to exclude "minimal" option

- Update GPT-5 default reasoning effort to "medium"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GPT-5.1-Codex<br/>reasoningEffort"] -->|"Change from<br/>minimal to none"| B["Updated Schema<br/>none, low, medium, high"]
  C["GPT-5<br/>reasoningEffort"] -->|"Change from<br/>minimal to medium"| D["Updated Default<br/>medium"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Update reasoning effort values for OpenAI models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model-registry/src/openai.ts

<ul><li>Updated GPT-5.1-Codex <code>reasoningEffort</code> schema to replace "minimal" with <br>"none"<br> <li> Changed GPT-5.1-Codex default <code>reasoningEffort</code> from "minimal" to "none"<br> <li> Updated GPT-5 default <code>reasoningEffort</code> from "minimal" to "medium"</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2366/files#diff-e6017504117029db5da4178595c2dea30f4436d59fa5e293cf2c4d43998db98d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust reasoningEffort schema/defaults: use "none" for GPT‑5.1 Codex and set GPT‑5 default to "medium".
> 
> - **Language model registry (OpenAI)**:
>   - `openai/gpt-5.1-codex`:
>     - Update `configurationOptions.reasoningEffort.schema` to use `"none"` instead of `"minimal"`.
>     - Set `defaultConfiguration.reasoningEffort` to `"none"`.
>   - `openai/gpt-5`:
>     - Set `defaultConfiguration.reasoningEffort` to `"medium"` (was `"minimal"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb3b1d18d9d043c33e812a825e9b55e15821c8fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Model Updates**
  * Updated OpenAI model configurations with expanded reasoning effort options for GPT-5 series models.
  * Adjusted default reasoning effort settings to optimize performance across affected models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->