### PR TITLE
Add reference to OpenAI reasoning effort API docs

### DIFF
--- a/packages/language-model-registry/src/openai.ts
+++ b/packages/language-model-registry/src/openai.ts
@@ -10,6 +10,11 @@ const reasoningEffortDescription =
 const textVerbosityDescription =
 	"Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values";
 
+/**
+ * `reasoningEffort` configuration for OpenAI models.
+ * Default values follow OpenAI's official defaults for each model.
+ * @see https://platform.openai.com/docs/api-reference/responses/create#responses_create-reasoning-effort
+ */
 export const openai = {
 	"openai/gpt-5.1-thinking": defineLanguageModel({
 		provider: "openai",


### PR DESCRIPTION
### **User description**
## Summary
Document that default reasoning effort values follow OpenAI's official defaults for each model.

## Related Issue
https://github.com/giselles-ai/giselle/pull/2366#issuecomment-3611912002

## Other Information
https://platform.openai.com/docs/api-reference/responses/create#responses_create-reasoning-effort


___

### **PR Type**
Documentation


___

### **Description**
- Add JSDoc comment documenting `reasoningEffort` configuration

- Reference OpenAI's official API documentation for reasoning effort defaults

- Clarify that default values follow OpenAI's model-specific standards


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["openai.ts file"] -- "Add JSDoc comment" --> B["Document reasoningEffort config"]
  B -- "Reference OpenAI docs" --> C["Link to official API reference"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Add JSDoc documentation for reasoningEffort configuration</code></dd></summary>
<hr>

packages/language-model-registry/src/openai.ts

<ul><li>Add JSDoc comment block above <code>openai</code> export<br> <li> Document that <code>reasoningEffort</code> defaults follow OpenAI's official <br>model-specific defaults<br> <li> Include <code>@see</code> tag linking to OpenAI's API reference documentation<br> <li> Provide context about reasoning effort configuration purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2367/files#diff-e6017504117029db5da4178595c2dea30f4436d59fa5e293cf2c4d43998db98d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a JSDoc comment noting reasoningEffort defaults follow OpenAI’s official defaults and links to the API docs.
> 
> - **Docs**:
>   - Add JSDoc above `openai` in `packages/language-model-registry/src/openai.ts` explaining `reasoningEffort` defaults and linking to OpenAI API reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3803fbb98f2e49ff8e7505d180fc604ca4ce2a67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->