### PR TITLE
fix: Open vector store setup links in new tab

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/document/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/document/index.tsx
@@ -326,6 +326,8 @@ export function DocumentVectorStoreNodePropertiesPanel({
 				<div className="flex justify-end pt-[8px]">
 					<Link
 						href={settingPath}
+						target="_blank"
+						rel="noopener noreferrer"
 						className="text-[14px] text-inverse underline hover:text-inverse"
 					>
 						Set Up Vector Store

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
@@ -293,6 +293,8 @@ export function GitHubVectorStoreNodePropertiesPanel({
 					<div className="pt-[8px] flex justify-end">
 						<Link
 							href={settingPath}
+							target="_blank"
+							rel="noopener noreferrer"
 							className="text-inverse hover:text-inverse text-[14px] underline"
 						>
 							Set Up Vector Store


### PR DESCRIPTION
### **User description**
### Summary
This PR adds `target="_blank"` and `rel="noopener noreferrer"` attributes to the "Set Up Vector Store" links in both the Document and GitHub vector store property panels. This ensures the links open in a new tab and follows security best practices.

### Related Issue
N/A

### Changes
- Added `target="_blank"` to open links in a new tab
- Added `rel="noopener noreferrer"` for security (prevents the new page from accessing `window.opener`)
- Applied to both Document and GitHub vector store panels

### Testing
Links in the vector store property panels now open in a new browser tab instead of navigating away from the current page.

### Other Information
N/A


___

### **PR Type**
Enhancement


___

### **Description**
- Add security attributes to vector store setup links

- Open links in new browser tab instead of navigating away

- Apply `target="_blank"` and `rel="noopener noreferrer"` to both panels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Vector Store Links"] --> B["Add target=_blank"]
  A --> C["Add rel=noopener noreferrer"]
  B --> D["Open in new tab"]
  C --> E["Prevent window.opener access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add security attributes to Document vector store link</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/document/index.tsx

<ul><li>Added <code>target="_blank"</code> attribute to Set Up Vector Store link<br> <li> Added <code>rel="noopener noreferrer"</code> attribute for security<br> <li> Ensures link opens in new tab with proper security practices</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2370/files#diff-53aa9c1027540da248f9a932e7f5542835f3a5029e128eaf162000a4a9b01f72">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add security attributes to GitHub vector store link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx

<ul><li>Added <code>target="_blank"</code> attribute to Set Up Vector Store link<br> <li> Added <code>rel="noopener noreferrer"</code> attribute for security<br> <li> Ensures link opens in new tab with proper security practices</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2370/files#diff-f211cde95d4ce69b93154909e24da0f2d6c4f672e4db0a273c3288e0cb3f0476">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Open “Set Up Vector Store” links in the Document and GitHub vector store panels in a new tab and add noopener/noreferrer for security.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf5f3fbc51aa6371f455114ad02b637f848841ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External links for vector store setup now open in new browser tabs.
  * Enhanced link handling throughout the vector store configuration interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->