### PR TITLE
fix: Hide Setting label when no repository is selected

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx
@@ -303,7 +303,9 @@ export function GitHubVectorStoreNodePropertiesPanel({
 				)}
 
 				{/* Setting label below repository */}
-				<SettingLabel className="mt-[8px]">Setting</SettingLabel>
+				{selectedRepoKey && (
+					<SettingLabel className="mt-[8px]">Setting</SettingLabel>
+				)}
 
 				{/* Content Type Selection */}
 				{selectedRepoKey && (


### PR DESCRIPTION
### **User description**
### Summary
This PR fixes a UI issue where the "Setting" label was displayed even when no repository was selected in the GitHub vector store properties panel. The label is now conditionally rendered only when a repository has been selected.

### Related Issue
N/A

### Changes
- Added conditional rendering to the "Setting" label in the GitHub vector store properties panel
- The label now only appears when `selectedRepoKey` has a value

### Testing
Verified that the "Setting" label:
- Is hidden when no repository is selected
- Appears correctly when a repository is selected

<img width="880" height="504" alt="image" src="https://github.com/user-attachments/assets/02713e96-244a-4603-a476-90879019a725" />


### Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Hide "Setting" label when no repository selected

- Add conditional rendering based on selectedRepoKey


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Vector Store Panel"] -- "Check selectedRepoKey" --> B{"Repository Selected?"}
  B -- "Yes" --> C["Render Setting Label"]
  B -- "No" --> D["Hide Setting Label"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Conditionally render Setting label based on repository selection</code></dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/vector-store/github/index.tsx

<ul><li>Wrapped <code>SettingLabel</code> component with conditional rendering<br> <li> Label now only renders when <code>selectedRepoKey</code> has a value<br> <li> Prevents UI clutter when no repository is selected</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2374/files#diff-f211cde95d4ce69b93154909e24da0f2d6c4f672e4db0a273c3288e0cb3f0476">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Hide the "Setting" label in the GitHub vector store panel unless a repository (`selectedRepoKey`) is selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f26266db8cf89910f81593b3a784a8e5bee3de49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Settings" label in GitHub repository configuration to only display when a repository is selected, improving UI clarity and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->