### PR TITLE
fix: Rename "webPage" display label to "Webpage" in UI

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -983,7 +983,7 @@ export function Toolbar() {
 												</ToggleGroup.Item>
 												<ToggleGroup.Item value="webPage" data-tool>
 													<WebPageFileIcon className="w-[20px] h-[20px]" />
-													<p className="text-[14px]">webPage</p>
+													<p className="text-[14px]">Webpage</p>
 												</ToggleGroup.Item>
 											</ToggleGroup.Root>
 										</div>

--- a/packages/node-registry/src/node-default-name.ts
+++ b/packages/node-registry/src/node-default-name.ts
@@ -101,6 +101,8 @@ export function defaultName(node: NodeLike) {
 						node.name ??
 						vectorStoreNodeDefaultName(node.content.source.provider)
 					);
+				case "webPage":
+					return node.name ?? "Webpage";
 				default:
 					return node.name ?? node.content.type;
 			}


### PR DESCRIPTION
### **User description**
- Update toolbar label from "webPage" to "Webpage"
- Add default name "Webpage" for webPage nodes in node-default-name.ts

#### Tool bar

<img width="285" height="168" alt="image" src="https://github.com/user-attachments/assets/6dd05cb2-9cc7-4d33-8f71-125447c06550" />

#### Node default name

<img width="278" height="168" alt="image" src="https://github.com/user-attachments/assets/4d13e97b-1c13-44a1-9bee-69c1bb7a309d" />

#### Node Property panel

<img width="419" height="263" alt="image" src="https://github.com/user-attachments/assets/9bbb3250-6c7e-44f6-9895-f06f97aa959f" />

___

### **PR Type**
Bug fix


___

### **Description**
- Update webPage toolbar label from "webPage" to "Webpage"

- Add default node name "Webpage" for webPage node type


___

### Diagram Walkthrough


```mermaid
flowchart LR
  toolbar["Toolbar Component"]
  nodeDefaults["Node Default Names"]
  toolbar -- "Update label text" --> webpageLabel["Webpage Label"]
  nodeDefaults -- "Add default name" --> webpageName["Webpage Default Name"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-default-name.ts</strong><dd><code>Add webPage default node name handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-registry/src/node-default-name.ts

<ul><li>Add case handler for "webPage" node type<br> <li> Return "Webpage" as default name when node.name is not provided</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2375/files#diff-70e8319c76ee6bdfff462b7250f469e33cb0d7b9ea7cd12c4cc976511535bfe1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolbar.tsx</strong><dd><code>Update webPage toolbar label capitalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx

<ul><li>Change webPage toolbar display label from "webPage" to "Webpage"<br> <li> Improve UI consistency with proper capitalization</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2375/files#diff-66d2626182bb02f543d898ac63a53bfe09b5ee215056b7810b6235686968ddf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes casing to "Webpage" in the toolbar and sets "Webpage" as the default name for `webPage` variable nodes.
> 
> - **UI (workflow designer)**:
>   - Update retrieval toolbar item label from `webPage` to "Webpage" in `internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx`.
> - **Node registry**:
>   - Add default name "Webpage" for `variable` nodes of type `webPage` in `packages/node-registry/src/node-default-name.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b11f113cdf49690490c390c4c9e999916a341a67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->