### PR TITLE
Tweak header Upgrade button styling

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/ui/header/upgrade-button.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/header/upgrade-button.tsx
@@ -8,6 +8,7 @@ export async function getUpgradeButtonContext() {
 
 	return { isProPlan: isProPlan(currentTeam) };
 }
+
 type UpgradeButtonContext = Awaited<ReturnType<typeof getUpgradeButtonContext>>;
 export function UpgradeButton({
 	getUpgradeButtonContextPromise,
@@ -23,7 +24,7 @@ export function UpgradeButton({
 	return (
 		<form className="flex items-center">
 			<Button
-				className="px-4 py-2 text-sm font-medium text-white bg-primary-900 hover:bg-primary-900/80 rounded-lg transition-colors"
+				className="relative inline-flex items-center justify-center gap-2 duration-300 focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--color-focused)] border border-primary-400 shadow-[inset_0_0_12px_rgba(255,255,255,0.08)] hover:shadow-[inset_0_0_16px_rgba(255,255,255,0.12)] px-4 py-1 text-sm font-medium text-white bg-primary-400 hover:bg-primary-400/90 rounded-full transition-colors"
 				formAction={upgradeCurrentTeam}
 			>
 				Upgrade


### PR DESCRIPTION
### **User description**
<img width="1159" height="54" alt="スクリーンショット 2025-12-08 18 09 56" src="https://github.com/user-attachments/assets/528e9ba7-110b-4714-817c-7ed9ffff6bd9" />

## Summary
- Adjust the header Upgrade button's vertical padding to better match the new, slimmer header menu height.
- Change the Upgrade button shape to a pill-style button so it feels more consistent with the compact header controls.

## Details
- Vertical padding is reduced from `py-2` to `py-1` to align with the thinner menu.
- Border radius is updated to `rounded-full` so the button reads as a pill-shaped primary CTA.
- Adjusted the color to match the “Pro” label blue.

## Test plan
- Open Studio in this branch and confirm the Upgrade button appears only for non‑Pro plans (behavior unchanged).
- Verify the button height aligns with the new compact header and does not overflow vertically.
- Check hover and focus states still look correct and remain readable on the dark header background.


___

### **PR Type**
Enhancement


___

### **Description**
- Redesigned Upgrade button with pill shape and Pro blue styling

- Reduced vertical padding from `py-2` to `py-1` for compact header

- Added inset shadow and border for modern glass-morphism effect

- Enhanced focus states with outline shadow for accessibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Button<br/>bg-primary-900<br/>rounded-lg<br/>py-2"] -- "Redesign" --> B["New Button<br/>bg-primary-400<br/>rounded-full<br/>py-1<br/>Inset shadow"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upgrade-button.tsx</strong><dd><code>Upgrade button styling with pill shape and Pro blue color</code></dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/ui/header/upgrade-button.tsx

<ul><li>Updated button className with new color scheme from <code>bg-primary-900</code> to <br><code>bg-primary-400</code><br> <li> Changed border radius from <code>rounded-lg</code> to <code>rounded-full</code> for pill-shaped <br>appearance<br> <li> Reduced vertical padding from <code>py-2</code> to <code>py-1</code> to match compact header <br>height<br> <li> Added inset shadow effects and border styling for modern <br>glass-morphism design<br> <li> Enhanced focus states with <code>focus-visible:shadow</code> for better <br>accessibility<br> <li> Added <code>relative inline-flex</code> layout utilities and <code>gap-2</code> spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2388/files#diff-1d7943f2dd2d65e094df9b97d2ed6074d71610bff49274289e562f92f031cdb6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restyles the header Upgrade button to a slimmer pill with updated color, border, shadows, and focus/hover states; no behavior changes.
> 
> - **UI**
>   - **Upgrade button** in `apps/studio.giselles.ai/app/(main)/ui/header/upgrade-button.tsx`:
>     - Reduce vertical padding (`py-2` → `py-1`) and switch to pill shape (`rounded-full`).
>     - Update color (`bg-primary-900` → `bg-primary-400`) and add `border-primary-400`.
>     - Add inset shadows, refined hover shadow, and focus-visible outline; keep logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a5102b04744fc9c472bd6a05d268b7a6bf1dbea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the upgrade button, including adjustments to padding and border appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->