### PR TITLE
Fix biome errors and format

### DIFF
--- a/packages/node-registry/src/node-conversion.test.ts
+++ b/packages/node-registry/src/node-conversion.test.ts
@@ -162,6 +162,7 @@ describe("node-conversion", () => {
 			expect(result.content.languageModel.id).toBe(
 				"google/gemini-3-pro-preview",
 			);
+		});
 
 		it("should convert GPT-5.1 models", () => {
 			const modelIds: OpenAITextGenerationModelId[] = [
@@ -415,6 +416,19 @@ describe("node-conversion", () => {
 			const originalNode = createGoogleGeminiNode({
 				id: "gemini-3-pro-preview",
 			});
+			const contentGenerationNode =
+				convertTextGenerationToContentGeneration(originalNode);
+			const convertedBack = convertContentGenerationToTextGeneration(
+				contentGenerationNode,
+			);
+
+			expect(convertedBack.content.type).toBe(originalNode.content.type);
+			expect(convertedBack.content.llm?.provider).toBe(
+				originalNode.content.llm.provider,
+			);
+			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
+			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
+		});
 
 		it("should preserve data through round-trip conversion for GPT-5.1 models", () => {
 			const originalNode = createOpenAITextNode("gpt-5.1-thinking");


### PR DESCRIPTION
### **User description**
## Summary
Resolves Biome parse errors in `node-conversion.test.ts` by completing incomplete test blocks and adding missing round-trip assertions for Gemini/GPT-5.1 model conversions.

## Related Issue
N/A

## Changes
- Completed the `it` block for "should convert Google Gemini 3 Pro Preview model".
- Added round-trip assertions for "should preserve data through round-trip conversion with Google Gemini 3 Pro Preview".

## Testing
- `pnpm format` now runs successfully.
- `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, and `pnpm test` all passed after these changes.

## Other Information
These changes were made to address Biome errors and allow `pnpm format` to complete successfully, while also improving test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9013c8f-c483-4def-906a-bdb429e07a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9013c8f-c483-4def-906a-bdb429e07a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Complete incomplete test block for Google Gemini 3 Pro Preview model

- Add missing round-trip conversion assertions for Gemini model

- Fix Biome parse errors preventing formatter from running

- Improve test coverage for node conversion functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incomplete test blocks"] -->|"Add closing braces"| B["Valid test syntax"]
  C["Missing assertions"] -->|"Implement round-trip logic"| D["Complete test coverage"]
  B --> E["Biome formatter passes"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-conversion.test.ts</strong><dd><code>Complete Gemini test cases and fix syntax errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-registry/src/node-conversion.test.ts

<ul><li>Close incomplete <code>it</code> block for Google Gemini 3 Pro Preview model <br>conversion test<br> <li> Implement missing round-trip conversion assertions in Gemini test case<br> <li> Add assertions to verify data preservation through conversion cycle<br> <li> Ensure test syntax is valid for Biome formatter compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2397/files#diff-fad816ee78185427062fc426a731f13c32c058ad479da064750919217c29c400">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Completes the Gemini 3 Pro Preview conversion test and adds a round-trip conversion test ensuring provider, id, and prompt are preserved.
> 
> - **Tests** (`packages/node-registry/src/node-conversion.test.ts`):
>   - Complete `"should convert Google Gemini 3 Pro Preview model"` test block.
>   - Add round-trip test for `Google Gemini 3 Pro Preview`, verifying preservation of `provider`, `id`, and `prompt` after conversions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f54fe8df18fcf71bcb17decfa94ce94892cad439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->