### PR TITLE
Fix Stage menu visibility regression in sidebar

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from "lucide-react";
 import type { IconName } from "lucide-react/dynamic";
 import { Accordion } from "radix-ui";
+import { stageFlag } from "../../../../flags";
 import { CreateAppButton } from "./create-app-button";
 import { SidebarLink } from "./sidebar-link";
 
@@ -56,33 +57,34 @@ function SidebarItem({ part }: { part: SidebarPart }) {
 	}
 }
 
-const sidebarParts: SidebarPart[] = [
-	{
-		type: "linkGroup",
-		id: "stage",
-		label: "Stage - Run Apps",
-		icon: "sparkle",
-		links: [
-			{
-				id: "playground",
-				label: "Playground",
-				href: "/playground",
-				activeMatchPattern: "/playground",
-			},
-			{
-				id: "apps",
-				label: "Apps",
-				href: "/stage/showcase",
-				activeMatchPattern: "/stage/showcase",
-			},
-			{
-				id: "tasks",
-				label: "Task History",
-				href: "/tasks",
-				activeMatchPattern: "/tasks*",
-			},
-		],
-	},
+const stagePart: SidebarPart = {
+	type: "linkGroup",
+	id: "stage",
+	label: "Stage - Run Apps",
+	icon: "sparkle",
+	links: [
+		{
+			id: "playground",
+			label: "Playground",
+			href: "/playground",
+			activeMatchPattern: "/playground",
+		},
+		{
+			id: "apps",
+			label: "Apps",
+			href: "/stage/showcase",
+			activeMatchPattern: "/stage/showcase",
+		},
+		{
+			id: "tasks",
+			label: "Task History",
+			href: "/tasks",
+			activeMatchPattern: "/tasks*",
+		},
+	],
+};
+
+const baseSidebarParts: SidebarPart[] = [
 	{
 		type: "linkGroup",
 		id: "studio",
@@ -144,7 +146,12 @@ const sidebarParts: SidebarPart[] = [
 	},
 ];
 
-export function Sidebar() {
+export async function Sidebar() {
+	const isStageEnabled = await stageFlag();
+	const sidebarParts = isStageEnabled
+		? [stagePart, ...baseSidebarParts]
+		: baseSidebarParts;
+
 	return (
 		<div className="w-[240px]">
 			<div className="px-4">


### PR DESCRIPTION
### **User description**
The "Stage - Run Apps" menu was always visible in the sidebar regardless of the stageFlag setting. This was a regression from PR #2378 which refactored the navigation structure.

Now the Stage menu (Playground, Apps, Task History) only appears when stageFlag is enabled.

| stage flag: false | stage flag: true |
|--------|--------|
| <img width="246" height="426" alt="image" src="https://github.com/user-attachments/assets/bceafa02-39a6-4c0a-9561-678b632a2b81" /> | <img width="248" height="569" alt="image" src="https://github.com/user-attachments/assets/e4a64243-e7b0-4d29-9547-1d53fc91ee90" /> | 

___

### **PR Type**
Bug fix


___

### **Description**
- Fix Stage menu visibility regression in sidebar

- Stage menu now conditionally renders based on stageFlag setting

- Refactored sidebar parts structure for dynamic menu composition

- Convert Sidebar component to async for flag evaluation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stageFlag check"] -->|enabled| B["Include stagePart"]
  A -->|disabled| C["Exclude stagePart"]
  B --> D["sidebarParts with Stage menu"]
  C --> E["sidebarParts without Stage menu"]
  D --> F["Render Sidebar"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sidebar.tsx</strong><dd><code>Conditionally render Stage menu based on stageFlag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx

<ul><li>Import <code>stageFlag</code> from flags module for conditional rendering<br> <li> Extract Stage menu configuration into separate <code>stagePart</code> constant<br> <li> Rename static array to <code>baseSidebarParts</code> containing non-Stage menu <br>items<br> <li> Convert <code>Sidebar</code> component to async function that evaluates stageFlag <br>and conditionally includes Stage menu</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2398/files#diff-1b29a5b71ffeadb24999c5a893faa234976cd84967975907b7fba2bb44fc4395">+35/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Conditionally render the "Stage - Run Apps" sidebar group based on `stageFlag`, refactoring parts and making `Sidebar` async.
> 
> - **Sidebar behavior (`apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx`)**:
>   - Conditionally includes `stagePart` when `stageFlag()` is enabled; otherwise shows only `baseSidebarParts`.
>   - Refactors navigation structure: extracts `stagePart` and `baseSidebarParts` from a single `sidebarParts` array.
>   - Converts `Sidebar` to `async` to await `stageFlag()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2a724899fab473dce6bdcd76a64dbb3a848851d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Stage section to the sidebar, now dynamically displayed based on feature configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->