### PR TITLE
Check and fix types

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/stage/(depreacted)/helpers.ts
+++ b/apps/studio.giselles.ai/app/(main)/stage/(depreacted)/helpers.ts
@@ -1,8 +1,8 @@
 import type {
-	FileData,
 	FileId,
 	ParameterItem,
 	Trigger,
+	UploadedFileData,
 	WorkspaceId,
 } from "@giselles-ai/protocol";
 import {
@@ -150,7 +150,7 @@ export async function toParameterItems(
 					);
 				}
 
-				const uploadedFiles: FileData[] = [];
+				const uploadedFiles: UploadedFileData[] = [];
 				for (const file of value) {
 					const uploadingFileData = createUploadingFileData({
 						name: file.name,

--- a/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
@@ -6,7 +6,7 @@ import {
 	type AppEntryNode,
 	createUploadedFileData,
 	createUploadingFileData,
-	type FileData,
+	type UploadedFileData,
 	type GenerationContextInput,
 } from "@giselles-ai/protocol";
 import { useGiselle } from "@giselles-ai/react";
@@ -102,7 +102,7 @@ export function AppEntryInputDialog({
 
 			const formData = new FormData(e.currentTarget);
 			const errors: Record<string, string> = {};
-			const values: Record<string, string | number | FileData[]> = {};
+			const values: Record<string, string | number | UploadedFileData[]> = {};
 
 			for (const parameter of app.parameters) {
 				switch (parameter.type) {
@@ -168,7 +168,7 @@ export function AppEntryInputDialog({
 							continue;
 						}
 
-						const uploadedFiles: FileData[] = [];
+						const uploadedFiles: UploadedFileData[] = [];
 
 						for (const file of files) {
 							const uploadingFileData = createUploadingFileData({


### PR DESCRIPTION
## Summary
Resolves a TypeError by standardizing file input types to `UploadedFileData[]` across the application, ensuring correct data schema adherence for file uploads.

## Related Issue
N/A

## Changes
- Replaced `FileData` with `UploadedFileData` for file input types in `AppEntryInputDialog` to correctly track uploaded files.
- Updated deprecated stage helpers to use `UploadedFileData[]` for file parameters, ensuring consistency with newer flows.

## Testing
- `pnpm build-sdk`
- `pnpm check-types` (passed)

## Other Information
This change prevents type mismatches when constructing `GenerationContextInput` and `ParameterItem`s, ensuring that the generated parameter payload always satisfies the expected schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-d478c376-c44c-45d4-add2-2ebf0b4defdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d478c376-c44c-45d4-add2-2ebf0b4defdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

