### PR TITLE
Remove gpt-5-codex model

### DIFF
--- a/packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts
+++ b/packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts
@@ -14,7 +14,6 @@ export function transformGiselleLanguageModelToAiSdkLanguageModelCallOptions(
 	const languageModel = getEntry(content.languageModel.id);
 	switch (languageModel.id) {
 		case "openai/gpt-5":
-		case "openai/gpt-5-codex":
 		case "openai/gpt-5-mini":
 		case "openai/gpt-5-nano":
 		case "openai/gpt-5.1-codex":

--- a/packages/language-model-registry/src/openai.ts
+++ b/packages/language-model-registry/src/openai.ts
@@ -118,37 +118,6 @@ export const openai = {
 		url: "https://platform.openai.com/docs/models/gpt-5",
 	}),
 
-	"openai/gpt-5-codex": defineLanguageModel({
-		provider: openaiProvider,
-		id: "openai/gpt-5-codex",
-		name: "GPT-5-Codex",
-		description:
-			"GPT-5-Codex is a version of GPT-5 optimized for agentic coding tasks in Codex or similar environments.",
-		contextWindow: 400_000,
-		maxOutputTokens: 128_000,
-		knowledgeCutoff: new Date(2024, 8, 30).getTime(),
-		pricing: {
-			input: definePricing(1.25),
-			output: definePricing(10.0),
-		},
-		requiredTier: "pro",
-		configurationOptions: {
-			reasoningEffort: {
-				description: reasoningEffortDescription,
-				schema: z.enum(["minimal", "low", "medium", "high"]),
-			},
-			textVerbosity: {
-				description: textVerbosityDescription,
-				schema: z.enum(["low", "medium", "high"]),
-			},
-		},
-		defaultConfiguration: {
-			reasoningEffort: "medium",
-			textVerbosity: "medium",
-		},
-		url: "https://platform.openai.com/docs/models/gpt-5-codex",
-	}),
-
 	"openai/gpt-5-mini": defineLanguageModel({
 		provider: openaiProvider,
 		id: "openai/gpt-5-mini",

--- a/packages/language-model/src/costs/index.test.ts
+++ b/packages/language-model/src/costs/index.test.ts
@@ -47,19 +47,6 @@ describe("calculateDisplayCost", () => {
 		});
 	});
 
-	it("should calculate display cost for OpenAI gpt-5-codex model", async () => {
-		const result = await calculateDisplayCost("openai", "gpt-5-codex", {
-			inputTokens: 1000,
-			outputTokens: 500,
-		});
-
-		expect(result).toEqual({
-			inputCostForDisplay: 0.00125,
-			outputCostForDisplay: 0.005,
-			totalCostForDisplay: 0.00625,
-		});
-	});
-
 	it("should calculate display cost for OpenAI gpt-5.1-thinking model", async () => {
 		const result = await calculateDisplayCost("openai", "gpt-5.1-thinking", {
 			inputTokens: 1000,

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -55,21 +55,6 @@ export const openAiTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"gpt-5-codex": {
-		prices: [
-			{
-				validFrom: "2025-09-15T00:00:00Z",
-				price: {
-					input: {
-						costPerMegaToken: 1.25,
-					},
-					output: {
-						costPerMegaToken: 10.0,
-					},
-				},
-			},
-		],
-	},
 	"gpt-5-mini": {
 		prices: [
 			{

--- a/packages/language-model/src/openai.test.ts
+++ b/packages/language-model/src/openai.test.ts
@@ -11,7 +11,6 @@ describe("openai llm", () => {
 				"gpt-5.1-codex",
 			);
 			expect(OpenAILanguageModelId.parse("gpt-5")).toBe("gpt-5");
-			expect(OpenAILanguageModelId.parse("gpt-5-codex")).toBe("gpt-5-codex");
 			expect(OpenAILanguageModelId.parse("gpt-5-mini")).toBe("gpt-5-mini");
 			expect(OpenAILanguageModelId.parse("gpt-5-nano")).toBe("gpt-5-nano");
 		});
@@ -22,9 +21,6 @@ describe("openai llm", () => {
 			);
 			expect(OpenAILanguageModelId.parse("gpt-5.1-codex-20251001")).toBe(
 				"gpt-5.1-codex",
-			);
-			expect(OpenAILanguageModelId.parse("gpt-5-codex-20250915")).toBe(
-				"gpt-5-codex",
 			);
 
 			// Fallback to gpt-5

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -32,7 +32,6 @@ export const OpenAILanguageModelId = z
 		"gpt-5.1-thinking",
 		"gpt-5.1-codex",
 		"gpt-5",
-		"gpt-5-codex",
 		"gpt-5-mini",
 		"gpt-5-nano",
 	])
@@ -48,10 +47,6 @@ export const OpenAILanguageModelId = z
 
 		if (/^gpt-5\.1-codex(?:-.+)?$/.test(v)) {
 			return "gpt-5.1-codex";
-		}
-
-		if (/^gpt-5-codex(?:-.+)?$/.test(v)) {
-			return "gpt-5-codex";
 		}
 
 		// Fallback to gpt-5
@@ -129,18 +124,6 @@ const gpt5: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-const gpt5codex: OpenAILanguageModel = {
-	provider: "openai",
-	id: "gpt-5-codex",
-	capabilities:
-		Capability.ImageFileInput |
-		Capability.TextGeneration |
-		Capability.OptionalSearchGrounding |
-		Capability.Reasoning,
-	tier: Tier.enum.pro,
-	configurations: defaultConfigurations,
-};
-
 const gpt5mini: OpenAILanguageModel = {
 	provider: "openai",
 	id: "gpt-5-mini",
@@ -164,14 +147,7 @@ const gpt5nano: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-export const models = [
-	gpt51Thinking,
-	gpt51codex,
-	gpt5,
-	gpt5codex,
-	gpt5mini,
-	gpt5nano,
-];
+export const models = [gpt51Thinking, gpt51codex, gpt5, gpt5mini, gpt5nano];
 
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;

--- a/packages/node-registry/src/node-conversion.ts
+++ b/packages/node-registry/src/node-conversion.ts
@@ -41,8 +41,6 @@ function convertTextGenerationLanguageModelIdToContentGenerationLanguageModelId(
 			return "openai/gpt-5-mini";
 		case "gpt-5.1-codex":
 			return "openai/gpt-5.1-codex";
-		case "gpt-5-codex":
-			return "openai/gpt-5-codex";
 		case "gpt-5-nano":
 			return "openai/gpt-5-nano";
 		case "sonar":
@@ -85,8 +83,6 @@ function convertContentGenerationLanguageModelIdToTextGenerationLanguageModelId(
 			return "gpt-5-mini";
 		case "openai/gpt-5.1-codex":
 			return "gpt-5.1-codex";
-		case "openai/gpt-5-codex":
-			return "gpt-5-codex";
 		case "openai/gpt-5-nano":
 			// When converting back, use gpt-5-nano (not sonar/sonar-pro)
 			// as we cannot determine the original source


### PR DESCRIPTION
### **User description**
## Summary
Removes the `gpt-5-codex` model from the codebase as it is no longer supported.

## Related Issue
N/A

## Changes
- Removed `gpt-5-codex` from the OpenAI language model ID enum, model definitions, and fallback logic.
- Deleted associated pricing data and unit tests for `gpt-5-codex`.
- Updated all downstream consumers, including the language model registry, node conversion helpers, and AI SDK transform, to remove references to `gpt-5-codex`.

## Testing
- `pnpm format`
- `pnpm build-sdk`
- `pnpm check-types`
- `pnpm tidy`
- `pnpm test`

## Other Information
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-04abab8e-bec6-4379-89b2-40a5f4d382c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04abab8e-bec6-4379-89b2-40a5f4d382c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Bug fix


___

### **Description**
- Remove deprecated `gpt-5-codex` model from OpenAI language model enum

- Delete model definition, pricing data, and configuration

- Remove references from transform logic and node conversion helpers

- Clean up associated unit tests for removed model


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gpt-5-codex Model"] -->|removed from| B["OpenAI Enum"]
  A -->|removed from| C["Model Registry"]
  A -->|removed from| D["Pricing Table"]
  A -->|removed from| E["Transform Logic"]
  A -->|removed from| F["Node Conversion"]
  A -->|removed from| G["Unit Tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Remove gpt-5-codex from OpenAI model enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/openai.ts

<ul><li>Removed <code>gpt-5-codex</code> from <code>OpenAILanguageModelId</code> enum definition<br> <li> Deleted regex pattern matching for deprecated <code>gpt-5-codex-*</code> model <br>versions<br> <li> Removed <code>gpt5codex</code> model constant definition with capabilities and tier <br>configuration<br> <li> Updated <code>models</code> export array to exclude <code>gpt5codex</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2403/files#diff-1891a7f0ef98437d982f18296668e40c171f03da7e4b82d2dff4b3a2b3f791d8">+1/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Delete gpt-5-codex model definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model-registry/src/openai.ts

<ul><li>Deleted complete <code>openai/gpt-5-codex</code> model definition block<br> <li> Removed model metadata including name, description, context window, <br>and max output tokens<br> <li> Removed pricing configuration with input/output token costs<br> <li> Removed configuration options for reasoning effort and text verbosity</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2403/files#diff-e6017504117029db5da4178595c2dea30f4436d59fa5e293cf2c4d43998db98d">+0/-31</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Remove gpt-5-codex pricing data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Removed <code>gpt-5-codex</code> pricing entry from <code>openAiTokenPricing</code> table<br> <li> Deleted pricing data with effective date and cost per mega token <br>values</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2403/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+0/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-conversion.ts</strong><dd><code>Remove gpt-5-codex from node conversion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-registry/src/node-conversion.ts

<ul><li>Removed <code>gpt-5-codex</code> case from text-to-content generation model ID <br>conversion<br> <li> Removed <code>openai/gpt-5-codex</code> case from content-to-text generation model <br>ID conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2403/files#diff-d3a73003e50f7bd7c2d3edbd874ea5522dc9d8bcfcfc21a6f62126e3b7b0125f">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transform-giselle-to-ai-sdk.ts</strong><dd><code>Remove gpt-5-codex from AI SDK transform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts

<ul><li>Removed <code>openai/gpt-5-codex</code> case from switch statement in transform <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2403/files#diff-0a09de5e2c8b926e5c6fe97190e30c07afcc824bdad76066f6d54272a544c12f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.test.ts</strong><dd><code>Remove gpt-5-codex unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/openai.test.ts

<ul><li>Removed test case for parsing <code>gpt-5-codex</code> model ID<br> <li> Deleted fallback test for deprecated <code>gpt-5-codex-20250915</code> model <br>version</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2403/files#diff-8b4baea6439bfd13875b567662a0d76c43d0e4b7d123fdb889e1588866be2e42">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Remove gpt-5-codex cost calculation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/index.test.ts

<ul><li>Removed test case for calculating display cost for <code>gpt-5-codex</code> model<br> <li> Deleted assertions for input and output token cost calculations</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2403/files#diff-6fd7e573e447beb9ebe45517d1c5d56021b048d625859023e401b56b5fa6845e">+0/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the OpenAI `gpt-5-codex` model and deletes its pricing, tests, ID mappings, and conversion/transform references across packages.
> 
> - **OpenAI models**:
>   - Remove `gpt-5-codex` from `OpenAILanguageModelId`, model definitions, and fallback logic in `packages/language-model/src/openai.ts`.
> - **Costs/Pricing**:
>   - Delete `gpt-5-codex` entry from `openAiTokenPricing` in `packages/language-model/src/costs/model-prices.ts`.
> - **Tests**:
>   - Remove cost and ID parsing tests referencing `gpt-5-codex` in `costs/index.test.ts` and `openai.test.ts`.
> - **Registry**:
>   - Remove `openai/gpt-5-codex` model from `packages/language-model-registry/src/openai.ts`.
> - **Node conversion**:
>   - Drop `gpt-5-codex` mappings in `packages/node-registry/src/node-conversion.ts` (both directions).
> - **AI SDK transform**:
>   - Remove handling of `openai/gpt-5-codex` in `transform-giselle-to-ai-sdk.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7224634fd0d4ecdf834843980fdb9a5350c476b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removals**
  * Removed support for the OpenAI GPT-5-Codex language model variant. This model is no longer available for selection or usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->