### PR TITLE
Add description and icon forms

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx
@@ -1,45 +1,18 @@
-import type { AppEntryNode, AppId } from "@giselles-ai/protocol";
+import type { App, AppEntryNode } from "@giselles-ai/protocol";
 import { AppParameterId } from "@giselles-ai/protocol";
-import { useGiselle } from "@giselles-ai/react";
-import { useEffect, useState } from "react";
-import useSWR from "swr";
+import { useState } from "react";
 import { SettingDetail, SettingLabel } from "../ui/setting-label";
 import { AppIconSelect } from "./app-icon-select";
 
 export function AppEntryConfiguredView({
 	node,
-	appId,
+	app,
 }: {
 	node: AppEntryNode;
-	appId: AppId;
+	app: App;
 }) {
-	const giselle = useGiselle();
-	const { data, isLoading } = useSWR(`getApp/${appId}`, () =>
-		giselle.getApp({ appId }),
-	);
-	const [appDescription, setAppDescription] = useState("");
-	const [selectedIconName, setSelectedIconName] = useState("");
-	const appDescriptionFromServer = data?.app.description ?? "";
-	const appIconNameFromServer = data?.app.iconName ?? "";
-	const appIdFromServer = data?.app.id;
-
-	useEffect(() => {
-		if (appIdFromServer === undefined) {
-			return;
-		}
-
-		setAppDescription(appDescriptionFromServer);
-		setSelectedIconName(appIconNameFromServer);
-	}, [appIdFromServer, appDescriptionFromServer, appIconNameFromServer]);
-
-	if (isLoading) {
-		return null;
-	}
-
-	if (data === undefined) {
-		console.warn("App data is undefined");
-		return null;
-	}
+	const [appDescription, setAppDescription] = useState(app.description);
+	const [selectedIconName, setSelectedIconName] = useState(app.iconName);
 
 	return (
 		<div className="flex flex-col gap-[16px] p-0 px-1 overflow-y-auto">
@@ -82,9 +55,7 @@ export function AppEntryConfiguredView({
 									output.accessor,
 								);
 								const parameter = parameterIdResult.success
-									? data.app.parameters.find(
-											(p) => p.id === parameterIdResult.data,
-										)
+									? app.parameters.find((p) => p.id === parameterIdResult.data)
 									: undefined;
 
 								return (

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-node-properties-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-node-properties-panel.tsx
@@ -1,7 +1,8 @@
 import type { AppEntryNode } from "@giselles-ai/protocol";
-import { useWorkflowDesigner } from "@giselles-ai/react";
+import { useGiselle, useWorkflowDesigner } from "@giselles-ai/react";
 import clsx from "clsx/lite";
 import { useState } from "react";
+import useSWR from "swr";
 import {
 	NodePanelHeader,
 	PropertiesPanelContent,
@@ -12,6 +13,14 @@ import { AppEntryConfiguredView } from "./app-entry-configured-view";
 export function AppEntryNodePropertiesPanel({ node }: { node: AppEntryNode }) {
 	const { updateNodeData, deleteNode } = useWorkflowDesigner();
 	const [scrollMode] = useState<"limited" | "full">("full");
+
+	const giselle = useGiselle();
+	const { data, isLoading } = useSWR(
+		node.content.status !== "configured"
+			? null
+			: { namespace: "getApp", appId: node.content.appId },
+		({ appId }) => giselle.getApp({ appId }),
+	);
 
 	return (
 		<PropertiesPanelRoot>
@@ -29,8 +38,9 @@ export function AppEntryNodePropertiesPanel({ node }: { node: AppEntryNode }) {
 						scrollMode === "limited" ? "max-h-[560px]" : "h-full flex-1",
 					)}
 				>
-					{node.content.status === "configured" && (
-						<AppEntryConfiguredView node={node} appId={node.content.appId} />
+					{isLoading && <div>Loading...</div>}
+					{data !== undefined && (
+						<AppEntryConfiguredView node={node} app={data.app} />
 					)}
 				</div>
 			</PropertiesPanelContent>


### PR DESCRIPTION
### **User description**
## Summary
Adds UI elements for editing the app's description and icon within the `AppEntryConfiguredView`, as requested.

## Related Issue
N/A

## Changes
- Integrated `AppIconSelect` component for app icon editing.
- Added a `textarea` for editing the app description, styled as specified.
- Implemented local state for description and icon, initialized from the fetched app data, to support UI interaction without backend persistence.

## Testing
- `pnpm format`
- `pnpm build-sdk`
- `pnpm check-types`
- `pnpm tidy`
- `pnpm test`

## Other Information
These changes are UI-only. The forms currently manage local state, and no update API is wired up for persistence. This will be addressed in a subsequent task.

---
<a href="https://cursor.com/background-agent?bcId=bc-556a7838-8e9a-4681-a3b1-8eecbb80b4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-556a7838-8e9a-4681-a3b1-8eecbb80b4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor app data fetching to parent component for better state management

- Add app icon selection UI with `AppIconSelect` component integration

- Add textarea for editing app description with local state management

- Implement local state for icon and description without backend persistence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Parent["AppEntryNodePropertiesPanel<br/>(Fetch app data)"]
  Child["AppEntryConfiguredView<br/>(Receive app prop)"]
  IconForm["AppIconSelect<br/>(Icon editing)"]
  DescForm["Textarea<br/>(Description editing)"]
  Parent -- "app prop" --> Child
  Child -- "uses" --> IconForm
  Child -- "uses" --> DescForm
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app-entry-configured-view.tsx</strong><dd><code>Add icon and description editing forms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx

<ul><li>Changed prop from <code>appId</code> to <code>app</code> object for direct data access<br> <li> Added local state for <code>appDescription</code> and <code>selectedIconName</code> using <br><code>useState</code><br> <li> Integrated <code>AppIconSelect</code> component with icon selection UI<br> <li> Added textarea form for editing app description with custom styling<br> <li> Removed SWR hook and loading state logic (moved to parent)<br> <li> Updated parameter lookup to use <code>app</code> prop instead of fetched data</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2408/files#diff-dc9401c79d3938de9e1da98aef235616c7a56fc9ab3d45b658e605e6140a79ab">+37/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app-entry-node-properties-panel.tsx</strong><dd><code>Lift app data fetching to parent component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-node-properties-panel.tsx

<ul><li>Added <code>useGiselle</code> hook import for API access<br> <li> Implemented SWR hook to fetch app data based on node status<br> <li> Moved app data fetching logic from child to parent component<br> <li> Added loading state UI display<br> <li> Pass fetched <code>app</code> object as prop to <code>AppEntryConfiguredView</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2408/files#diff-87116dc960009e9423dc1f472f72e2c22e6f7b25e37e3eeae60d4b47fefdb70b">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds icon and description editors to the app entry view and moves app fetching to the parent properties panel with a loading state.
> 
> - **Frontend UI**
>   - `app-entry-node-properties-panel.tsx`
>     - Fetches app via `useSWR`/`useGiselle` when node is configured; shows loading; passes `data.app` to child.
>   - `app-entry-configured-view.tsx`
>     - Accepts `app: App` (replaces `appId`); removes internal fetching.
>     - Adds icon selector (`AppIconSelect`) and description textarea with local state.
>     - Resolves output parameter metadata via `app.parameters`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bfa7b926e2a878c0329c93be53abff6b79371bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced app icon selection interface in the application configuration panel
  * Added editable app description field for enhanced app customization

* **Improvements**
  * Enhanced data loading with improved state management during app configuration
  * Optimized app data retrieval for better performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->