### PR TITLE
Remove gpt-5 codex fallback

### DIFF
--- a/packages/language-model/src/openai.test.ts
+++ b/packages/language-model/src/openai.test.ts
@@ -11,7 +11,7 @@ describe("openai llm", () => {
 				"gpt-5.1-codex",
 			);
 			expect(OpenAILanguageModelId.parse("gpt-5")).toBe("gpt-5");
-			expect(OpenAILanguageModelId.parse("gpt-5-codex")).toBe("gpt-5-codex");
+			expect(OpenAILanguageModelId.parse("gpt-5-codex")).toBe("gpt-5.1-codex");
 			expect(OpenAILanguageModelId.parse("gpt-5-mini")).toBe("gpt-5-mini");
 			expect(OpenAILanguageModelId.parse("gpt-5-nano")).toBe("gpt-5-nano");
 		});
@@ -24,7 +24,7 @@ describe("openai llm", () => {
 				"gpt-5.1-codex",
 			);
 			expect(OpenAILanguageModelId.parse("gpt-5-codex-20250915")).toBe(
-				"gpt-5-codex",
+				"gpt-5.1-codex",
 			);
 
 			// Fallback to gpt-5

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -32,7 +32,6 @@ export const OpenAILanguageModelId = z
 		"gpt-5.1-thinking",
 		"gpt-5.1-codex",
 		"gpt-5",
-		"gpt-5-codex",
 		"gpt-5-mini",
 		"gpt-5-nano",
 	])
@@ -51,7 +50,7 @@ export const OpenAILanguageModelId = z
 		}
 
 		if (/^gpt-5-codex(?:-.+)?$/.test(v)) {
-			return "gpt-5-codex";
+			return "gpt-5.1-codex";
 		}
 
 		// Fallback to gpt-5
@@ -129,18 +128,6 @@ const gpt5: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-const gpt5codex: OpenAILanguageModel = {
-	provider: "openai",
-	id: "gpt-5-codex",
-	capabilities:
-		Capability.ImageFileInput |
-		Capability.TextGeneration |
-		Capability.OptionalSearchGrounding |
-		Capability.Reasoning,
-	tier: Tier.enum.pro,
-	configurations: defaultConfigurations,
-};
-
 const gpt5mini: OpenAILanguageModel = {
 	provider: "openai",
 	id: "gpt-5-mini",
@@ -164,14 +151,7 @@ const gpt5nano: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-export const models = [
-	gpt51Thinking,
-	gpt51codex,
-	gpt5,
-	gpt5codex,
-	gpt5mini,
-	gpt5nano,
-];
+export const models = [gpt51Thinking, gpt51codex, gpt5, gpt5mini, gpt5nano];
 
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;

--- a/packages/node-registry/src/node-conversion.ts
+++ b/packages/node-registry/src/node-conversion.ts
@@ -15,9 +15,11 @@ import {
 
 // Legacy model IDs that are no longer in the current schema but may exist in stored data
 type LegacyAnthropicModelId = "claude-opus-4-1-20250805";
+type LegacyOpenAiModelId = "gpt-5-codex";
 type TextGenerationModelIdWithLegacy =
 	| TextGenerationNode["content"]["llm"]["id"]
-	| LegacyAnthropicModelId;
+	| LegacyAnthropicModelId
+	| LegacyOpenAiModelId;
 
 function convertTextGenerationLanguageModelIdToContentGenerationLanguageModelId(
 	from: TextGenerationModelIdWithLegacy,
@@ -47,7 +49,7 @@ function convertTextGenerationLanguageModelIdToContentGenerationLanguageModelId(
 		case "gpt-5.1-codex":
 			return "openai/gpt-5.1-codex";
 		case "gpt-5-codex":
-			return "openai/gpt-5-codex";
+			return "openai/gpt-5.1-codex";
 		case "gpt-5-nano":
 			return "openai/gpt-5-nano";
 		case "sonar":
@@ -89,7 +91,7 @@ function convertContentGenerationLanguageModelIdToTextGenerationLanguageModelId(
 		case "openai/gpt-5.1-codex":
 			return "gpt-5.1-codex";
 		case "openai/gpt-5-codex":
-			return "gpt-5-codex";
+			return "gpt-5.1-codex";
 		case "openai/gpt-5-nano":
 			// When converting back, use gpt-5-nano (not sonar/sonar-pro)
 			// as we cannot determine the original source


### PR DESCRIPTION
## Summary
Removes the unsupported `gpt-5-codex` model and implements a fallback mechanism to `gpt-5.1-codex` to prevent errors for existing users.

## Related Issue
N/A

## Changes
*   **`packages/language-model/src/openai.ts`**:
    *   Removed `gpt-5-codex` from the `OpenAILanguageModelId` enum and `models` list.
    *   Added a fallback to `gpt-5.1-codex` for any requests using `gpt-5-codex`.
*   **`packages/node-registry/src/node-conversion.ts`**:
    *   Marked `gpt-5-codex` as a `LegacyOpenAiModelId`.
    *   Updated conversion functions to map `gpt-5-codex` to `gpt-5.1-codex` for stored nodes.
*   **`packages/language-model/src/openai.test.ts`**:
    *   Updated tests to reflect the new fallback behavior for `gpt-5-codex`.

## Testing
*   `pnpm format`
*   `pnpm build-sdk`
*   `pnpm check-types`
*   `pnpm tidy`
*   `pnpm test`

## Other Information
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-90fb6112-f429-4296-992f-c4654d17d568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90fb6112-f429-4296-992f-c4654d17d568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `gpt-5-codex` and redirects all references/conversions to `gpt-5.1-codex`, updating schemas, mappings, and tests.
> 
> - **Language Model (OpenAI)**:
>   - Remove `gpt-5-codex` from `OpenAILanguageModelId` and `models`.
>   - Add fallback to map `gpt-5-codex*` variants to `gpt-5.1-codex`.
> - **Node Registry**:
>   - Add legacy type `"gpt-5-codex"` and map it to `openai/gpt-5.1-codex` in both conversion directions.
> - **Tests**:
>   - Update expectations to assert fallback from `gpt-5-codex` (and dated variants) to `gpt-5.1-codex`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d2498c41694f1e91ab39892849531eb01fd4db0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the "gpt-5-codex" model; all references now automatically map to "gpt-5.1-codex".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->