### PR TITLE
Select app list card

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
@@ -688,25 +688,30 @@ export function Page({
 		);
 	}, [appSearchQuery, data.apps]);
 
+	const selectableApps = useMemo(
+		() => [...data.sampleApps, ...data.apps],
+		[data.sampleApps, data.apps],
+	);
+
 	// Validate selectedAppId during render - if invalid, treat as undefined
 	const selectedApp = selectedAppId
-		? data.apps.find((app) => app.id === selectedAppId)
+		? selectableApps.find((app) => app.id === selectedAppId)
 		: undefined;
 
 	const handleAppSelect = useCallback(
 		(appId: string) => {
 			// Validate app exists before setting
-			if (data.apps.some((app) => app.id === appId)) {
+			if (selectableApps.some((app) => app.id === appId)) {
 				setSelectedAppId(appId);
 			} else {
 				setSelectedAppId(undefined);
 			}
 		},
-		[data.apps],
+		[selectableApps],
 	);
 
 	const runningApp = runningAppId
-		? data.apps.find((app) => app.id === runningAppId)
+		? selectableApps.find((app) => app.id === runningAppId)
 		: undefined;
 
 	const handleRunSubmit = useCallback(
@@ -780,6 +785,13 @@ export function Page({
 												/>
 											}
 											providers={sampleApp.llmProviders}
+											isSelected={
+												selectedAppId === sampleApp.id ||
+												runningAppId === sampleApp.id
+											}
+											onClick={() => {
+												handleAppSelect(sampleApp.id);
+											}}
 										/>
 									))}
 									{/*


### PR DESCRIPTION
## Summary
Enables selection of sample applications in the playground, mirroring the behavior of personal applications. Clicking a sample `AppListCard` now sets it as the `selectedApp`.

> [!NOTE]
> When selecting a sample app, there is a problem where it is not displayed in the Select UI in the text area, so we will address this separately.

## Related Issue
N/A

## Changes
*   Combined `data.sampleApps` and `data.apps` into a new `selectableApps` array.
*   Updated `selectedApp`, `handleAppSelect`, and `runningApp` logic to use `selectableApps` for consistent validation and selection across all app types.
*   Added `onClick` and `isSelected` props to `AppListCard` components for sample apps, allowing them to be selected and display their selection state.

## Testing
Logic-only change; no specific tests were run by the assistant. Manual verification in the UI is recommended.

## Other Information
During the session, `pnpm biome check --write` failed due to the `biome` binary not being found. Please ensure proper formatting and dependency checks are performed.

---
<a href="https://cursor.com/background-agent?bcId=bc-137cee09-3e56-44d6-92ba-0ffa5b061c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-137cee09-3e56-44d6-92ba-0ffa5b061c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables selecting and validating sample apps alongside personal apps, and makes sample app cards clickable with selection state.
> 
> - **Playground (`page.client.tsx`)**:
>   - **Selection logic**: Introduces `selectableApps = [...data.sampleApps, ...data.apps]` and updates `selectedApp`, `runningApp`, and `handleAppSelect` to validate against this combined list.
>   - **Sample app cards**: Wires `AppListCard` for samples with `onClick` to select and `isSelected` to reflect selection/running state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c847a773f324eec8e1e4915b6f35f01e8f4ddcfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sample apps can now be selected and run alongside regular apps
  * Added visual indicators showing which app is currently selected or running

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->