### PR TITLE
Adjust playground textarea footer text to show only 'to send' hint

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
@@ -638,19 +638,6 @@ function ChatInputArea({
 					</div>
 					<span className="leading-none">to send</span>
 				</div>
-				<div className="flex items-center gap-[6px]">
-					<div className="flex h-[18px] w-[18px] items-center justify-center rounded-[6px] border border-blue-muted/40 bg-blue-muted/10">
-						<span className="text-[10px] leading-none tracking-[0.08em]">
-							⇧
-						</span>
-					</div>
-					<div className="flex h-[18px] w-[18px] items-center justify-center rounded-[6px] border border-blue-muted/40 bg-blue-muted/10">
-						<span className="text-[10px] leading-none tracking-[0.08em]">
-							↵
-						</span>
-					</div>
-					<span className="leading-none">for newline</span>
-				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
### **User description**
## Summary
Adjust the playground textarea footer text to show only the Enter key hint for sending messages.

## Changes
- Remove Shift+Enter hint from textarea footer
- Keep only Enter key hint ("to send") for sending messages

## Design Rationale
Based on the design feedback, we simplified the keyboard shortcut hints to show only the primary action (Enter to send), making the UI cleaner and less cluttered.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove Shift+Enter newline hint from textarea footer

- Simplify UI by showing only Enter key hint

- Reduce visual clutter in playground chat input


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Textarea Footer"] -->|Remove| B["Shift+Enter Hint"]
  A -->|Keep| C["Enter to Send Hint"]
  C -->|Result| D["Cleaner UI"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.client.tsx</strong><dd><code>Remove Shift+Enter hint from textarea footer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/playground/page.client.tsx

<ul><li>Removed the Shift+Enter keyboard shortcut hint section from textarea <br>footer<br> <li> Kept only the Enter key hint displaying "to send"<br> <li> Reduced footer UI complexity by eliminating redundant keyboard hint</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2432/files#diff-bee7c505d563c48e3d29a449cdcec06f7018b455056f0594073521829583703f">+0/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies the playground textarea footer to show only the Enter “to send” hint, removing the Shift+Enter “for newline” hint.
> 
> - **UI**:
>   - Simplify keyboard shortcut hints in `apps/studio.giselles.ai/app/(main)/playground/page.client.tsx` footer: remove `Shift+Enter` “for newline”, keep `Enter` “to send`.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dd45065dfd3131966cc8e2df095df7cbd3165d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Streamlined the chat input interface by removing secondary keyboard shortcut hint displays from the playground area. The primary send command indicator has been retained. This change reduces visual clutter and improves interface clarity while preserving the complete functionality of all keyboard shortcuts and input commands available to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->