### PR TITLE
Fix ime enter submit

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
@@ -534,6 +534,12 @@ function ChatInputArea({
 			return;
 		}
 
+		const nativeEvent = event.nativeEvent;
+		if (nativeEvent.isComposing || nativeEvent.keyCode === 229) {
+			// Skip submit while IME composition (e.g., Japanese) is active
+			return;
+		}
+
 		if (event.shiftKey) {
 			event.preventDefault();
 			const textarea = textareaRef.current;


### PR DESCRIPTION
## Summary
Prevents accidental form submission when pressing Enter during IME (e.g., Japanese) text composition.

## Related Issue
N/A

## Changes
Modified the `handleKeyDown` function in `ChatInputArea` to check `event.nativeEvent.isComposing` and `event.nativeEvent.keyCode === 229`. If either is true, the submit action is skipped.

## Testing
Manual testing with a Japanese IME is recommended to confirm that Enter now confirms text composition without submitting the message.

## Other Information
This change improves the user experience for users of IMEs by allowing them to confirm text without prematurely sending their message.

---
<a href="https://cursor.com/background-agent?bcId=bc-1139a552-3587-4b60-b63c-ba83579185dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1139a552-3587-4b60-b63c-ba83579185dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

