### PR TITLE
Rename gemini-2.5-flash-image-preview to gemini-2.5-flash-image

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/model-defaults.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/model-defaults.ts
@@ -34,7 +34,7 @@ export function createDefaultModelData(
 		case "google":
 			return GoogleImageLanguageModelData.parse({
 				provider: "google",
-				id: "gemini-2.5-flash-image-preview",
+				id: "gemini-2.5-flash-image",
 				configurations: {
 					responseModalities: ["IMAGE"],
 				},

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -214,7 +214,7 @@ export const googleTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
-	"gemini-2.5-flash-image-preview": {
+	"gemini-2.5-flash-image": {
 		prices: [
 			{
 				validFrom: "2025-09-12T00:00:00Z",

--- a/packages/language-model/src/google-image.ts
+++ b/packages/language-model/src/google-image.ts
@@ -13,8 +13,8 @@ const defaultConfiguration: GoogleImageModelConfiguration = {
 };
 
 const GoogleImageLanguageModelId = z
-	.enum(["gemini-2.5-flash-image-preview"])
-	.catch("gemini-2.5-flash-image-preview");
+	.enum(["gemini-2.5-flash-image"])
+	.catch("gemini-2.5-flash-image");
 
 const GoogleImageLanguageModel = LanguageModelBase.extend({
 	id: GoogleImageLanguageModelId,
@@ -23,9 +23,9 @@ const GoogleImageLanguageModel = LanguageModelBase.extend({
 });
 type GoogleImageLanguageModel = z.infer<typeof GoogleImageLanguageModel>;
 
-const gemini25FlashImagePreview: GoogleImageLanguageModel = {
+const gemini25FlashImage: GoogleImageLanguageModel = {
 	provider: "google",
-	id: "gemini-2.5-flash-image-preview",
+	id: "gemini-2.5-flash-image",
 	capabilities:
 		Capability.ImageGeneration |
 		Capability.ImageFileInput |
@@ -34,7 +34,7 @@ const gemini25FlashImagePreview: GoogleImageLanguageModel = {
 	configurations: defaultConfiguration,
 };
 
-export const models = [gemini25FlashImagePreview];
+export const models = [gemini25FlashImage];
 
 export const LanguageModel = GoogleImageLanguageModel;
 export type LanguageModel = GoogleImageLanguageModel;

--- a/packages/react/src/workspace/utils/is-supported-connection.test.ts
+++ b/packages/react/src/workspace/utils/is-supported-connection.test.ts
@@ -284,7 +284,7 @@ describe("isSupportedConnection", () => {
 		test("should allow Image Generation Node as input for Google(Nano banana)", () => {
 			const outputNode = createImageGenerationNode(NodeId.generate());
 			const nanoBanana = googleImageLanguageModels.find(
-				(m) => m.id === "gemini-2.5-flash-image-preview",
+				(m) => m.id === "gemini-2.5-flash-image",
 			);
 			const inputNode = createImageGenerationNode(
 				NodeId.generate(),


### PR DESCRIPTION
### **User description**
## Summary
- Rename `gemini-2.5-flash-image-preview` to `gemini-2.5-flash-image` (stable release)
- The preview model will be discontinued on October 31, 2025

See: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image?hl=en


___

### **PR Type**
Enhancement


___

### **Description**
- Rename gemini-2.5-flash-image-preview to gemini-2.5-flash-image

- Update model ID across configuration, pricing, and type definitions

- Reflect stable release of Google's Gemini 2.5 Flash Image model


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gemini-2.5-flash-image-preview<br/>Preview Model"] -- "Rename to stable" --> B["gemini-2.5-flash-image<br/>Stable Release"]
  B -- "Updated in" --> C["Model Defaults"]
  B -- "Updated in" --> D["Pricing Table"]
  B -- "Updated in" --> E["Type Definitions"]
  B -- "Updated in" --> F["Tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-defaults.ts</strong><dd><code>Update Google image model ID in defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/model-defaults.ts

<ul><li>Updated Google image generation model ID from <br><code>gemini-2.5-flash-image-preview</code> to <code>gemini-2.5-flash-image</code><br> <li> Maintains all existing configuration properties</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2434/files#diff-20fba4c25261518f60ced367c4d41e02ea32e0f7a2f6bde6cb236db53146f488">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Update model pricing table key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Renamed pricing table key from <code>gemini-2.5-flash-image-preview</code> to <br><code>gemini-2.5-flash-image</code><br> <li> Preserves all pricing data and validity dates</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2434/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google-image.ts</strong><dd><code>Update model ID in type definitions and exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/google-image.ts

<ul><li>Updated Zod enum validation to accept <code>gemini-2.5-flash-image</code> instead <br>of preview version<br> <li> Renamed constant from <code>gemini25FlashImagePreview</code> to <code>gemini25FlashImage</code><br> <li> Updated model ID in constant definition and exports<br> <li> Changed fallback value in Zod catch clause to new model ID</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2434/files#diff-d471e5b4a53b66a407db3c42f82f06dd26e944d4636e08ebb5ec3850c5c1dfab">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>is-supported-connection.test.ts</strong><dd><code>Update model ID in test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/workspace/utils/is-supported-connection.test.ts

<ul><li>Updated test to reference new <code>gemini-2.5-flash-image</code> model ID<br> <li> Maintains test logic and assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2434/files#diff-7a5a1d45042d14175a02781a8e1e48c477f864e5a40dd85552c21396015d4b6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames Google image model `gemini-2.5-flash-image-preview` to `gemini-2.5-flash-image` and updates schema, defaults, pricing, and tests.
> 
> - **Language model (Google Image)**:
>   - Rename model id from `gemini-2.5-flash-image-preview` to `gemini-2.5-flash-image` in `packages/language-model/src/google-image.ts` (enum, default, exported model).
> - **Pricing**:
>   - Update pricing table key to `gemini-2.5-flash-image` in `packages/language-model/src/costs/model-prices.ts`.
> - **UI defaults**:
>   - Set Google default image model id to `gemini-2.5-flash-image` in `internal-packages/workflow-designer-ui/.../model-defaults.ts`.
> - **Tests**:
>   - Adjust test lookup to use `gemini-2.5-flash-image` in `packages/react/src/workspace/utils/is-supported-connection.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f77ec607fc5ee00add7befd5d8cc6b5170ac0c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Google image generation model and corresponding pricing configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->