### PR TITLE
Add file attachment ui

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/stage/tasks/[taskId]/ui/task-input.tsx
+++ b/apps/studio.giselles.ai/app/(main)/stage/tasks/[taskId]/ui/task-input.tsx
@@ -3,6 +3,7 @@ import type {
 	TaskId,
 	UploadedFileData,
 } from "@giselles-ai/protocol";
+import { Check } from "lucide-react";
 import { use } from "react";
 import { giselle } from "@/app/giselle";
 import { logger } from "@/lib/logger";
@@ -42,16 +43,67 @@ export async function getTaskInput(taskId: TaskId) {
 }
 type TaskInput = Awaited<ReturnType<typeof getTaskInput>>;
 
+function formatFileSize(bytes?: number) {
+	const safeBytes = Number.isFinite(bytes) ? (bytes as number) : 0;
+	if (safeBytes <= 0) {
+		return "0 B";
+	}
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	const exponent = Math.min(
+		Math.floor(Math.log(safeBytes) / Math.log(1024)),
+		units.length - 1,
+	);
+	const value = safeBytes / 1024 ** exponent;
+	const decimals = value >= 10 || exponent === 0 ? 0 : 1;
+	return `${value.toFixed(decimals)} ${units[exponent]}`;
+}
+
 function TaskInputItemFile({ file }: { file: UploadedFileData }) {
-	return <p>{file.name}</p>;
+	const sizeLabel = formatFileSize(file.size);
+
+	return (
+		<div className="flex items-start gap-3 rounded-xl border border-white/5 bg-white/5 px-3 py-2 text-left">
+			<div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-white/10">
+				<Check className="h-4 w-4 text-emerald-300" aria-hidden />
+			</div>
+			<div className="flex min-w-0 flex-1 flex-col gap-1">
+				<p className="truncate text-[13px] text-white">{file.name}</p>
+				<p className="text-[11px] text-blue-muted/70">{sizeLabel} · Ready</p>
+			</div>
+		</div>
+	);
+}
+
+function TaskInputFiles({
+	files,
+	label,
+}: {
+	files: UploadedFileData[];
+	label?: string;
+}) {
+	if (files.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="mt-3 space-y-2" aria-live="polite">
+			<div className="flex items-center justify-between px-1 text-[11px] text-blue-muted/70">
+				<span>{label || "Attachments"}</span>
+				<span>
+					{files.length}/{files.length} ready
+				</span>
+			</div>
+			{files.map((file) => (
+				<TaskInputItemFile key={file.id} file={file} />
+			))}
+		</div>
+	);
 }
 
 function TaskInputItem({ item }: { item: ParameterItem }) {
 	switch (item.type) {
 		case "files":
-			return item.value.map((file) => (
-				<TaskInputItemFile key={file.id} file={file} />
-			));
+			return <TaskInputFiles files={item.value} label={item.name} />;
 		case "number":
 			return <p>{item.value}</p>;
 		case "string":


### PR DESCRIPTION
### **User description**
## Summary
Updated the UI for file attachments in `TaskInputItemFile` to match the visual style of `file-attachments.tsx`, providing a more consistent and informative display for attached files.

## Related Issue
N/A

## Changes
- Introduced `formatFileSize` utility function for displaying file sizes.
- Refactored `TaskInputItemFile` to render files with an icon, truncated name, formatted size, and "Ready" status.
- Added `TaskInputFiles` component to group and display multiple file attachments with a header indicating the number of attachments and their status.
- Modified `TaskInputItem` to utilize the new `TaskInputFiles` component for `files` type parameters.
- Imported `Check` icon from `lucide-react`.

## Testing
The following commands were executed successfully:
- `pnpm exec biome check --write apps/studio.giselles.ai/app/(main)/stage/tasks/[taskId]/ui/task-input.tsx`
- `pnpm build-sdk`
- `pnpm check-types`
- `pnpm tidy`
- `pnpm test`

## Other Information
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-67d20d17-951a-46b1-93e8-6e79d4297d53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67d20d17-951a-46b1-93e8-6e79d4297d53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Enhancement


___

### **Description**
- Added `formatFileSize` utility for human-readable file size display

- Enhanced `TaskInputItemFile` with icon, truncated name, size, and status

- Created `TaskInputFiles` component to group attachments with header

- Updated `TaskInputItem` to use new `TaskInputFiles` component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["formatFileSize utility"] --> B["TaskInputItemFile component"]
  B --> C["TaskInputFiles component"]
  C --> D["TaskInputItem integration"]
  E["Check icon from lucide-react"] --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-input.tsx</strong><dd><code>Enhanced file attachment display with formatting and grouping</code></dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/stage/tasks/[taskId]/ui/task-input.tsx

<ul><li>Added <code>formatFileSize</code> utility function to convert bytes to <br>human-readable format<br> <li> Refactored <code>TaskInputItemFile</code> to display file icon, truncated name, <br>formatted size, and "Ready" status with improved styling<br> <li> Created new <code>TaskInputFiles</code> component to group multiple attachments <br>with header showing count and status<br> <li> Updated <code>TaskInputItem</code> to use <code>TaskInputFiles</code> component for files type <br>parameters<br> <li> Imported <code>Check</code> icon from <code>lucide-react</code> for visual feedback</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2438/files#diff-81291069b0893da8decc8a6482e96f2f3148313634d8c477cbb33d072b2e2769">+56/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved file attachment display with human-readable file sizes, visual indicators, and status labels.
  * File input section now shows total attachment count and readiness status for better visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->