### PR TITLE
Set initial app options

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
@@ -319,11 +319,14 @@ function ChatInputArea({
 	const [isDragActive, setIsDragActive] = useState(false);
 	const [attachedFiles, setAttachedFiles] = useState<FileData[]>([]);
 
-	const appOptions: SelectOption[] = apps.map((app) => ({
-		value: app.id,
-		label: app.name,
-		icon: <DynamicIcon name={app.iconName} className="h-4 w-4" />,
-	}));
+	const appOptions = apps.map(
+		(app) =>
+			({
+				value: app.id,
+				label: app.name,
+				icon: <DynamicIcon name={app.iconName} className="h-4 w-4" />,
+			}) satisfies SelectOption,
+	);
 	const firstAppOptionValue = appOptions[0]?.value;
 
 	useEffect(() => {


### PR DESCRIPTION
### **User description**
## Summary
Sets the initial selected app in the `ChatInputArea`'s app selection dropdown to the first available option.

## Related Issue
N/A

## Changes
-   Introduced `firstAppOptionValue` to capture the ID of the first available app option.
-   Added a `useEffect` hook to automatically call `onAppSelect` with `firstAppOptionValue` if no app is currently selected, ensuring the parent state is synchronized with the default.
-   Modified the `Select` component's `value` prop to fall back to `firstAppOptionValue` if `selectedApp?.id` is undefined, providing immediate UI reflection of the default.

## Testing
Manual UI verification.

## Other Information
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-bb46a573-44c1-4d93-8f86-8d6de0d53aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb46a573-44c1-4d93-8f86-8d6de0d53aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Enhancement


___

### **Description**
- Auto-select first available app on initial load

- Add type safety to app options with `satisfies` operator

- Synchronize parent state with default app selection via useEffect

- Fallback to first app value in Select component display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App Options Array"] -->|"map with satisfies"| B["Type-safe SelectOption[]"]
  B -->|"extract first value"| C["firstAppOptionValue"]
  C -->|"useEffect on mount"| D["Call onAppSelect"]
  D -->|"sync parent state"| E["selectedApp updated"]
  E -->|"fallback in Select"| F["UI reflects selection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.client.tsx</strong><dd><code>Auto-select first app with type-safe options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/playground/page.client.tsx

<ul><li>Added <code>useEffect</code> import to React hooks<br> <li> Refactored <code>appOptions</code> mapping with <code>satisfies SelectOption</code> for type <br>safety<br> <li> Extracted <code>firstAppOptionValue</code> from first app option<br> <li> Implemented <code>useEffect</code> hook to auto-select first app when none selected<br> <li> Updated Select component <code>value</code> prop to fallback to <code>firstAppOptionValue</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2442/files#diff-bee7c505d563c48e3d29a449cdcec06f7018b455056f0594073521829583703f">+17/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app selection stability in the playground by automatically selecting the first available app when none is currently active, with enhanced fallback handling to ensure consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->