### PR TITLE
Log giselle getapp errors

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/playground/data-loader.ts
+++ b/apps/studio.giselles.ai/app/(main)/playground/data-loader.ts
@@ -82,9 +82,22 @@ async function getAppsBySampleFlag(
 				);
 				return null;
 			}
-			const giselleApp = await giselle.getApp({
-				appId: dbWorkspace.app.id,
-			});
+			const giselleApp = await giselle
+				.getApp({
+					appId: dbWorkspace.app.id,
+				})
+				.catch((error) => {
+					logger.error(
+						{
+							err: error,
+							appId: dbWorkspace.app.id,
+							workspaceId: dbWorkspace.id,
+							appEntryNodeId: dbWorkspace.app.appEntryNodeId,
+						},
+						"Failed to load app via giselle.getApp",
+					);
+					throw error;
+				});
 			// Extract vector store / LLM metadata for this app
 			const githubRepositories: string[] = [];
 			const documentFiles: string[] = [];


### PR DESCRIPTION
## Summary
Adds error logging for failures when calling `giselle.getApp`.

## Related Issue
N/A

## Changes
Wrapped the `giselle.getApp` call in a `.catch()` block to log the error reason, `appId`, `workspaceId`, and `appEntryNodeId` if the call fails. The error is re-thrown after logging.

## Testing
No specific tests were run as this is a logging-only change.

## Other Information
Biome formatting was applied to the modified file.

---
<a href="https://cursor.com/background-agent?bcId=bc-b926bc4e-aed8-416d-ae0d-95d252bd36ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b926bc4e-aed8-416d-ae0d-95d252bd36ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

