### PR TITLE
fix: resolve pdfium.wasm loading error with Turbopack on Vercel

### DIFF
--- a/apps/studio.giselles.ai/next.config.ts
+++ b/apps/studio.giselles.ai/next.config.ts
@@ -28,6 +28,7 @@ const pdfiumTracingConfig = {
 		"/api/vector-stores/document/[documentVectorStoreId]/documents": [
 			pdfiumWasmInclude,
 		],
+		"/api/vector-stores/cron/document/ingest": [pdfiumWasmInclude],
 	},
 };
 


### PR DESCRIPTION
## Summary
- Fix wasm module resolution error when using Turbopack instead of Webpack
- Make wasm path resolution lazy to avoid Turbopack's static analysis
- Add fallback path resolution for Vercel serverless environment
- Add cron endpoint to `outputFileTracingIncludes`

## Background
After switching from Webpack to Turbopack, PDF processing failed with:

```
Error: Cannot find module '@embedpdf/pdfium/pdfium.wasm'
```

This occurred due to two issues:
1. Turbopack statically analyzes `createRequire().resolve()` at build time
2. Vercel serverless functions have a different file structure than local development

## Solution

### Lazy path resolution
Move wasm path resolution from module top-level into a function to bypass Turbopack's static analysis.

### Fallback path strategy
Search multiple locations for the wasm file:
- Standard `createRequire().resolve()`
- `process.cwd()/node_modules/...` (Vercel)
- `__dirname/../node_modules/...`
- `.next/server/node_modules/...`

### Use wasmBinary option
Read wasm file directly with `fs.readFileSync` and pass as `wasmBinary` option instead of using `locateFile` callback.

## Related issues
- https://github.com/vercel/next.js/issues/84972
- https://github.com/vercel/next.js/issues/65406

## Test plan
- [x] Verify PDF processing works in development mode with Turbopack
- [x] Verify PDF upload and text extraction on Vercel deployment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `pdfium.wasm` loading resilient under Turbopack/Vercel via lazy multi-path resolution and `wasmBinary` init; add cron ingest route to `outputFileTracingIncludes`.
> 
> - **PDF processing (`packages/document-preprocessor/src/internal/pdfium.ts`)**
>   - Lazily resolve `pdfium.wasm` path to avoid Turbopack static analysis.
>   - Implement multi-path search for `pdfium.wasm` (standard `node_modules`, `process.cwd()`, `__dirname`, `.next/server/node_modules`).
>   - Load wasm via `fs.readFileSync` and pass as `wasmBinary` to `initPdfium`; remove `locateFile` usage.
>   - Cache resolved wasm path and module initialization.
> - **Next.js config (`apps/studio.giselles.ai/next.config.ts`)**
>   - Add `"/api/vector-stores/cron/document/ingest"` to `outputFileTracingIncludes` to include `pdfium.wasm`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36221711ae27e1cc67fd448cfd2ecaae17f1bf25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved PDF processing reliability across different deployment environments, including serverless platforms, through enhanced file resolution with intelligent multi-path discovery and caching mechanisms.
  * Extended PDF processing support to additional API routes for document vector store operations and automated document ingestion tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->