### PR TITLE
Auto-fit viewport on workspace open

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -159,6 +159,14 @@ function V2NodeCanvas() {
 		if (didInitialFitViewRef.current) {
 			return;
 		}
+		// Respect the last saved viewport. Only auto-fit when the viewport is still the default.
+		const isDefaultViewport =
+			Math.abs(data.viewport.x) < 1 &&
+			Math.abs(data.viewport.y) < 1 &&
+			Math.abs(data.viewport.zoom - 1) < 0.001;
+		if (!isDefaultViewport) {
+			return;
+		}
 		if (nodes.length === 0) {
 			return;
 		}
@@ -169,7 +177,13 @@ function V2NodeCanvas() {
 				duration: 400,
 			});
 		});
-	}, [nodes.length, reactFlowInstance]);
+	}, [
+		data.viewport.x,
+		data.viewport.y,
+		data.viewport.zoom,
+		nodes.length,
+		reactFlowInstance,
+	]);
 
 	const handleConnect = useCallback(
 		(connection: Connection) => {
@@ -390,7 +404,7 @@ function V2NodeCanvas() {
 			zoomOnScroll={false}
 			zoomOnPinch={true}
 			tabIndex={0}
-			onMoveEnd={(_, viewport) => setUiViewport(viewport)}
+			onMoveEnd={(_, viewport) => setUiViewport(viewport, { save: true })}
 			onNodesChange={handleNodesChange}
 			onNodeClick={handleNodeClick}
 			onPaneClick={handlePanelClick}


### PR DESCRIPTION
## Summary
- Auto-fit the canvas viewport to existing nodes when a workspace opens, so users don't start on an empty-looking area.

## Test plan
- Open an existing workspace with nodes and confirm the viewport automatically centers/zooms to show them.
- Open an empty workspace and confirm the viewport does not jump unexpectedly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-fits the canvas to existing nodes on first load and persists viewport after user pan/zoom.
> 
> - **Canvas behavior (`internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx`)**:
>   - Auto-fit on first open: when the saved viewport is at default and nodes exist, call `reactFlowInstance.fitView({ padding: 0.2, duration: 400 })` once (guards via `didInitialFitViewRef`).
>   - Persist viewport: `onMoveEnd` now calls `setUiViewport(viewport, { save: true })` to save user pan/zoom.
>   - Supporting changes: add `useEffect` and `didInitialFitViewRef` to manage one-time fit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f31eccf08a1de092e2e1ddb9b3adde0bd6b298a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Viewport now auto-fits the diagram on first load so all nodes are visible.
  * Viewport movements are now persisted after user pan/zoom, preserving the last view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->