### PR TITLE
Openai text generation memoization

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
@@ -16,40 +16,6 @@ import {
 	TopPSlider,
 } from "./shared-model-controls";
 
-type ReasoningEffortConfig = {
-	options: readonly string[];
-	defaultValue: string;
-};
-
-/**
- * Returns the available reasoning effort options and default value for the given model.
- *
- * GPT-5.2 defaults:
- * - Reasoning depth: "none" (for lower latency)
- * - Output verbosity: "medium"
- *
- * @see https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility
- */
-function getReasoningEffortConfig(modelId: string): ReasoningEffortConfig {
-	// GPT-5.2 and GPT-5.1 variants support none/low/medium/high/xhigh
-	// GPT-5.2 defaults to "none" for lower latency
-	if (
-		modelId === "gpt-5.2" ||
-		modelId === "gpt-5.1-thinking" ||
-		modelId === "gpt-5.1-codex"
-	) {
-		return {
-			options: ["none", "low", "medium", "high", "xhigh"] as const,
-			defaultValue: "none",
-		};
-	}
-	// Older models (gpt-5, gpt-5-mini, gpt-5-nano) support minimal/low/medium/high
-	return {
-		options: ["minimal", "low", "medium", "high"] as const,
-		defaultValue: "medium",
-	};
-}
-
 export function OpenAIModelPanel({
 	openaiLanguageModel,
 	onModelChange,
@@ -64,6 +30,25 @@ export function OpenAIModelPanel({
 	onWebSearchChange: (enabled: boolean) => void;
 }) {
 	useUsageLimits();
+
+	const reasoningEffortOptions = useMemo(() => {
+		/**
+		 * GPT-5.2 defaults:
+		 * - Reasoning depth: "none" (for lower latency)
+		 * - Output verbosity: "medium"
+		 *
+		 * @see https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility
+		 */
+		const options =
+			openaiLanguageModel.id === "gpt-5.2" ||
+			openaiLanguageModel.id === "gpt-5.1-thinking" ||
+			openaiLanguageModel.id === "gpt-5.1-codex"
+				? (["none", "low", "medium", "high", "xhigh"] as const)
+				: (["minimal", "low", "medium", "high"] as const);
+
+		return options.map((value) => ({ value, label: value }));
+	}, [openaiLanguageModel.id]);
+
 	const languageModel = useMemo(
 		() => openaiLanguageModels.find((lm) => lm.id === openaiLanguageModel.id),
 		[openaiLanguageModel.id],
@@ -102,12 +87,7 @@ export function OpenAIModelPanel({
 									}),
 								);
 							}}
-							options={getReasoningEffortConfig(
-								openaiLanguageModel.id,
-							).options.map((v) => ({
-								value: v,
-								label: v,
-							}))}
+							options={reasoningEffortOptions}
 						/>
 					</SettingRow>
 


### PR DESCRIPTION
## Summary
Replaced the `getReasoningEffortConfig` function with a `useMemo` hook to prevent unnecessary re-calculation of reasoning effort options on every render, improving performance.

## Related Issue
N/A

## Changes
- Removed the `getReasoningEffortConfig` utility function.
- Introduced `reasoningEffortOptions` as a `useMemo` hook within `OpenAIModelPanel`, dependent on `openaiLanguageModel.id`.
- Updated the `Select` component for reasoning effort to use the memoized `reasoningEffortOptions`.
- Adjusted the placement of the `useMemo` hook to comply with React Hooks rules.

## Testing
Verified by running `pnpm format`, `build-sdk`, `check-types`, `tidy`, and `test`.

## Other Information
This change optimizes the rendering performance by memoizing the reasoning effort options, ensuring they are only re-calculated when the model ID changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e45e05c-f160-4aad-837d-cd0bd1eb3c7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e45e05c-f160-4aad-837d-cd0bd1eb3c7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

