### PR TITLE
fix: Use timing-safe comparison for signed cookie verification

### DIFF
--- a/apps/studio.giselles.ai/lib/signed-cookie.test.ts
+++ b/apps/studio.giselles.ai/lib/signed-cookie.test.ts
@@ -70,4 +70,12 @@ describe("signed-cookie", () => {
 		const result = await getCookie("odd-hex");
 		expect(result).toBeNull();
 	});
+
+	test("should handle value containing separator", async () => {
+		const testData = { url: "https://example.com" };
+		await setCookie("dot-value", testData);
+
+		const result = await getCookie("dot-value");
+		expect(result).toEqual(testData);
+	});
 });

--- a/apps/studio.giselles.ai/lib/signed-cookie.ts
+++ b/apps/studio.giselles.ai/lib/signed-cookie.ts
@@ -17,8 +17,12 @@ function verify(signed: string): string | null {
 	const SECRET = process.env.COOKIE_SECRET;
 	invariant(SECRET, "COOKIE_SECRET is not set");
 
-	const [value, signature] = signed.split(SEPARATOR);
-	if (!value || !signature || signature.length !== SIGNATURE_LENGTH) {
+	const separatorIndex = signed.lastIndexOf(SEPARATOR);
+	if (separatorIndex <= 0) return null;
+
+	const value = signed.slice(0, separatorIndex);
+	const signature = signed.slice(separatorIndex + 1);
+	if (signature.length !== SIGNATURE_LENGTH) {
 		return null;
 	}
 	const expectedSignature = createHmac("sha256", SECRET)


### PR DESCRIPTION
### **User description**
### Summary
Replace standard string comparison with `crypto.timingSafeEqual()` in the signed cookie signature verification to prevent potential timing attacks.

### Related Issue
N/A

### Changes
- Import `timingSafeEqual` from `node:crypto`
- Convert signature strings to Buffers using hex encoding
- Add length check before comparison (required by `timingSafeEqual`)
- Replace `===` comparison with `timingSafeEqual()` for constant-time comparison

### Testing
Existing tests in `signed-cookie.test.ts` pass, verifying that the functional behavior remains unchanged.

### Other Information
Standard string comparison (`===`) can leak timing information because it returns early on the first mismatched character. `timingSafeEqual` always compares all bytes regardless of matches, preventing attackers from guessing valid signatures by measuring response times.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace standard string comparison with timing-safe comparison

- Import `timingSafeEqual` from `node:crypto` module

- Add length check before signature comparison

- Prevent timing-based attacks on signed cookie verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Standard === comparison"] -->|"vulnerable to timing attacks"| B["Timing leak risk"]
  C["timingSafeEqual comparison"] -->|"constant-time comparison"| D["Secure verification"]
  E["Length check"] -->|"prevents errors"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signed-cookie.ts</strong><dd><code>Implement timing-safe signature comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/lib/signed-cookie.ts

<ul><li>Import <code>timingSafeEqual</code> from <code>node:crypto</code> for constant-time comparison<br> <li> Convert signature strings to Buffers with hex encoding<br> <li> Add length validation before comparison to prevent runtime errors<br> <li> Replace <code>===</code> operator with <code>timingSafeEqual()</code> for secure verification</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2475/files#diff-3976acd05e9948c22261c2180018169b0187222cb98b1b096ee9f834a1b090ee">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened cookie security by switching to a timing-safe signature comparison to reduce risk of timing attacks.
  * Added strict validation for missing or malformed cookie signatures to prevent errors while preserving existing session compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use constant-time signature verification and add strict parsing/validation for signed cookies, with tests for malformed signatures and edge cases.
> 
> - **Signed Cookie Verification (`apps/studio.giselles.ai/lib/signed-cookie.ts`)**:
>   - Use `timingSafeEqual` for constant-time signature comparison.
>   - Parse using `lastIndexOf` to preserve values containing `.`.
>   - Enforce signature length (`64` hex chars) and validate hex buffers before compare.
>   - Return `null` on missing separator or invalid/odd-length hex.
> - **Tests (`apps/studio.giselles.ai/lib/signed-cookie.test.ts`)**:
>   - Add cases for no separator, non-hex signature, odd-length hex, and values containing a dot.
>   - Ensure tampered or malformed cookies return `null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0165169916968e240185f67d08aac5a3f007bf8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->