### PR TITLE
Add isEndNode check to task creation filter

### DIFF
--- a/packages/giselle/src/tasks/create-task.ts
+++ b/packages/giselle/src/tasks/create-task.ts
@@ -6,6 +6,7 @@ import {
 	GenerationId,
 	GenerationOrigin,
 	isAppEntryNode,
+	isEndNode,
 	isOperationNode,
 	isTriggerNode,
 	Node,
@@ -116,10 +117,16 @@ export async function createTask(
 		const steps: Step[] = [];
 		for (const nodeId of level) {
 			const node = nodes.find((node) => node.id === nodeId);
+			// Exclusion conditions: Skip nodes that are:
+			// - undefined (not found)
+			// - not operation nodes
+			// - app entry nodes (starting points)
+			// - end nodes (termination points)
 			if (
 				node === undefined ||
 				!isOperationNode(node) ||
-				isAppEntryNode(node)
+				isAppEntryNode(node) ||
+				isEndNode(node)
 			) {
 				continue;
 			}


### PR DESCRIPTION
### **User description**
End nodes should be skipped during task step creation, similar to app entry nodes.


___

### **PR Type**
Bug fix


___

### **Description**
- Skip end nodes during task step creation

- Prevents invalid task steps from termination nodes

- Aligns end node handling with app entry nodes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Task Creation Filter"] --> B["Check Node Conditions"]
  B --> C["Skip undefined nodes"]
  B --> D["Skip non-operation nodes"]
  B --> E["Skip app entry nodes"]
  B --> F["Skip end nodes"]
  F --> G["Create valid task steps"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-task.ts</strong><dd><code>Add end node exclusion to task filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/tasks/create-task.ts

<ul><li>Added <code>isEndNode</code> import from node registry<br> <li> Updated task creation filter to exclude end nodes<br> <li> Enhanced filter logic with clarifying comments<br> <li> End nodes now treated consistently with app entry nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2480/files#diff-ac25d189ced1a64a276a1684ffa043da6e9d2adf7c9ad529b298ee1cc6d08bf3">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task creation processing to properly handle end nodes as termination points, preventing them from being incorrectly processed as generation steps in workflow execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->