### PR TITLE
Add will_cancel_at column to subscription histories

### DIFF
--- a/apps/studio.giselles.ai/db/migrate/0073_striped_proudstar.sql
+++ b/apps/studio.giselles.ai/db/migrate/0073_striped_proudstar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "stripe_pricing_plan_subscription_histories" ADD COLUMN "will_cancel_at" timestamp;

--- a/apps/studio.giselles.ai/db/migrate/meta/0073_snapshot.json
+++ b/apps/studio.giselles.ai/db/migrate/meta/0073_snapshot.json
@@ -1,0 +1,3446 @@
+{
+  "id": "889b8ca0-7b07-46d6-8790-2529a8284a29",
+  "prevId": "8f0d05b8-37f8-4614-bb21-0dae0e670dcd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.acts": {
+      "name": "acts",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "director_db_id": {
+          "name": "director_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_workspace_id": {
+          "name": "sdk_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_flow_trigger_id": {
+          "name": "sdk_flow_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdk_act_id": {
+          "name": "sdk_act_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "acts_team_db_id_index": {
+          "name": "acts_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acts_sdk_workspace_id_index": {
+          "name": "acts_sdk_workspace_id_index",
+          "columns": [
+            {
+              "expression": "sdk_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acts_sdk_flow_trigger_id_index": {
+          "name": "acts_sdk_flow_trigger_id_index",
+          "columns": [
+            {
+              "expression": "sdk_flow_trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "acts_sdk_act_id_index": {
+          "name": "acts_sdk_act_id_index",
+          "columns": [
+            {
+              "expression": "sdk_act_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "acts_team_db_id_teams_db_id_fk": {
+          "name": "acts_team_db_id_teams_db_id_fk",
+          "tableFrom": "acts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "acts_director_db_id_users_db_id_fk": {
+          "name": "acts_director_db_id_users_db_id_fk",
+          "tableFrom": "acts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "director_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_activities": {
+      "name": "agent_activities",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_report_db_id": {
+          "name": "usage_report_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_activities_agent_db_id_index": {
+          "name": "agent_activities_agent_db_id_index",
+          "columns": [
+            {
+              "expression": "agent_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activities_ended_at_index": {
+          "name": "agent_activities_ended_at_index",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_activities_agent_db_id_agents_db_id_fk": {
+          "name": "agent_activities_agent_db_id_agents_db_id_fk",
+          "tableFrom": "agent_activities",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk": {
+          "name": "agent_activities_usage_report_db_id_agent_time_usage_reports_db_id_fk",
+          "tableFrom": "agent_activities",
+          "tableTo": "agent_time_usage_reports",
+          "columnsFrom": [
+            "usage_report_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_time_restrictions": {
+      "name": "agent_time_restrictions",
+      "schema": "",
+      "columns": {
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_time_restrictions_team_db_id_index": {
+          "name": "agent_time_restrictions_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_time_restrictions_team_db_id_teams_db_id_fk": {
+          "name": "agent_time_restrictions_team_db_id_teams_db_id_fk",
+          "tableFrom": "agent_time_restrictions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_time_usage_reports": {
+      "name": "agent_time_usage_reports",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accumulated_duration_ms": {
+          "name": "accumulated_duration_ms",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minutes_increment": {
+          "name": "minutes_increment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_event_id": {
+          "name": "stripe_meter_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_time_usage_reports_team_db_id_index": {
+          "name": "agent_time_usage_reports_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_time_usage_reports_created_at_index": {
+          "name": "agent_time_usage_reports_created_at_index",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_time_usage_reports_stripe_meter_event_id_index": {
+          "name": "agent_time_usage_reports_stripe_meter_event_id_index",
+          "columns": [
+            {
+              "expression": "stripe_meter_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_time_usage_reports_team_db_id_teams_db_id_fk": {
+          "name": "agent_time_usage_reports_team_db_id_teams_db_id_fk",
+          "tableFrom": "agent_time_usage_reports",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_url": {
+          "name": "graph_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_db_id": {
+          "name": "creator_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"sample\":false}'::jsonb"
+        }
+      },
+      "indexes": {
+        "agents_team_db_id_index": {
+          "name": "agents_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_team_db_id_teams_db_id_fk": {
+          "name": "agents_team_db_id_teams_db_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_creator_db_id_users_db_id_fk": {
+          "name": "agents_creator_db_id_users_db_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_id_unique": {
+          "name": "agents_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_entry_node_id": {
+          "name": "app_entry_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_node_id": {
+          "name": "end_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_db_id": {
+          "name": "workspace_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "apps_team_db_id_index": {
+          "name": "apps_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apps_team_db_id_teams_db_id_fk": {
+          "name": "apps_team_db_id_teams_db_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "apps_workspace_db_id_workspaces_db_id_fk": {
+          "name": "apps_workspace_db_id_workspaces_db_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "apps_id_unique": {
+          "name": "apps_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "apps_workspace_db_id_app_entry_node_id_unique": {
+          "name": "apps_workspace_db_id_app_entry_node_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_db_id",
+            "app_entry_node_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_embedding_profiles": {
+      "name": "document_embedding_profiles",
+      "schema": "",
+      "columns": {
+        "document_vector_store_db_id": {
+          "name": "document_vector_store_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "doc_vs_emb_profiles_store_fk": {
+          "name": "doc_vs_emb_profiles_store_fk",
+          "tableFrom": "document_embedding_profiles",
+          "tableTo": "document_vector_stores",
+          "columnsFrom": [
+            "document_vector_store_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "doc_vs_emb_profiles_pk": {
+          "name": "doc_vs_emb_profiles_pk",
+          "columns": [
+            "document_vector_store_db_id",
+            "embedding_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_embeddings": {
+      "name": "document_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_vector_store_db_id": {
+          "name": "document_vector_store_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_vector_store_source_db_id": {
+          "name": "document_vector_store_source_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_key": {
+          "name": "document_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_embs_embedding_1536_idx": {
+          "name": "doc_embs_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::vector(1536)) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"document_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "doc_embs_embedding_3072_idx": {
+          "name": "doc_embs_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::halfvec(3072)) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"document_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "doc_embs_store_idx": {
+          "name": "doc_embs_store_idx",
+          "columns": [
+            {
+              "expression": "document_vector_store_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_embeddings_document_vector_store_db_id_document_vector_stores_db_id_fk": {
+          "name": "document_embeddings_document_vector_store_db_id_document_vector_stores_db_id_fk",
+          "tableFrom": "document_embeddings",
+          "tableTo": "document_vector_stores",
+          "columnsFrom": [
+            "document_vector_store_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_embeddings_document_vector_store_source_db_id_document_vector_store_sources_db_id_fk": {
+          "name": "document_embeddings_document_vector_store_source_db_id_document_vector_store_sources_db_id_fk",
+          "tableFrom": "document_embeddings",
+          "tableTo": "document_vector_store_sources",
+          "columnsFrom": [
+            "document_vector_store_source_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doc_embs_src_prof_doc_chunk_unique": {
+          "name": "doc_embs_src_prof_doc_chunk_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_vector_store_source_db_id",
+            "embedding_profile_id",
+            "document_key",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_vector_store_sources": {
+      "name": "document_vector_store_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_vector_store_db_id": {
+          "name": "document_vector_store_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_bucket": {
+          "name": "storage_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_checksum": {
+          "name": "file_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "upload_error_code": {
+          "name": "upload_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_status": {
+          "name": "ingest_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "ingest_error_code": {
+          "name": "ingest_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "doc_vs_src_upload_status_idx": {
+          "name": "doc_vs_src_upload_status_idx",
+          "columns": [
+            {
+              "expression": "upload_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_vs_src_ingest_status_idx": {
+          "name": "doc_vs_src_ingest_status_idx",
+          "columns": [
+            {
+              "expression": "ingest_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_vector_store_sources_document_vector_store_db_id_document_vector_stores_db_id_fk": {
+          "name": "document_vector_store_sources_document_vector_store_db_id_document_vector_stores_db_id_fk",
+          "tableFrom": "document_vector_store_sources",
+          "tableTo": "document_vector_stores",
+          "columnsFrom": [
+            "document_vector_store_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doc_vs_src_id_unique": {
+          "name": "doc_vs_src_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "doc_vs_src_storage_unique": {
+          "name": "doc_vs_src_storage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_vector_store_db_id",
+            "storage_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_vector_stores": {
+      "name": "document_vector_stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_vs_team_db_id_idx": {
+          "name": "doc_vs_team_db_id_idx",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_vector_stores_team_db_id_teams_db_id_fk": {
+          "name": "document_vector_stores_team_db_id_teams_db_id_fk",
+          "tableFrom": "document_vector_stores",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "doc_vs_id_unique": {
+          "name": "doc_vs_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flow_triggers": {
+      "name": "flow_triggers",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staged": {
+          "name": "staged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_trigger_id": {
+          "name": "flow_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flow_triggers_flow_trigger_id_index": {
+          "name": "flow_triggers_flow_trigger_id_index",
+          "columns": [
+            {
+              "expression": "flow_trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flow_triggers_team_db_id_index": {
+          "name": "flow_triggers_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flow_triggers_staged_index": {
+          "name": "flow_triggers_staged_index",
+          "columns": [
+            {
+              "expression": "staged",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flow_triggers_team_db_id_teams_db_id_fk": {
+          "name": "flow_triggers_team_db_id_teams_db_id_fk",
+          "tableFrom": "flow_triggers",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_integration_settings": {
+      "name": "github_integration_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_db_id": {
+          "name": "agent_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_sign": {
+          "name": "call_sign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_node_mappings": {
+          "name": "event_node_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_integration_settings_agent_db_id_agents_db_id_fk": {
+          "name": "github_integration_settings_agent_db_id_agents_db_id_fk",
+          "tableFrom": "github_integration_settings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_integration_settings_id_unique": {
+          "name": "github_integration_settings_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_content_status": {
+      "name": "github_repository_content_status",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gh_content_status_query_idx": {
+          "name": "gh_content_status_query_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_content_status_repo_idx_fk": {
+          "name": "gh_content_status_repo_idx_fk",
+          "tableFrom": "github_repository_content_status",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_content_status_unique": {
+          "name": "gh_content_status_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "content_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_embedding_profiles": {
+      "name": "github_repository_embedding_profiles",
+      "schema": "",
+      "columns": {
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_repo_emb_profiles_repo_idx_fk": {
+          "name": "gh_repo_emb_profiles_repo_idx_fk",
+          "tableFrom": "github_repository_embedding_profiles",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_repo_emb_profiles_pk": {
+          "name": "gh_repo_emb_profiles_pk",
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_embeddings": {
+      "name": "github_repository_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_sha": {
+          "name": "file_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_embeddings_embedding_1536_idx": {
+          "name": "github_repository_embeddings_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::vector(1536) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "github_repository_embeddings_embedding_3072_idx": {
+          "name": "github_repository_embeddings_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::halfvec(3072) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_embeddings_repository_index_db_id_github_repository_index_db_id_fk": {
+          "name": "github_repository_embeddings_repository_index_db_id_github_repository_index_db_id_fk",
+          "tableFrom": "github_repository_embeddings",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_repo_emb_unique": {
+          "name": "gh_repo_emb_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "path",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_index": {
+      "name": "github_repository_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_ingested_commit_sha": {
+          "name": "last_ingested_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_repository_index_team_db_id_index": {
+          "name": "github_repository_index_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_index_status_index": {
+          "name": "github_repository_index_status_index",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_index_team_db_id_teams_db_id_fk": {
+          "name": "github_repository_index_team_db_id_teams_db_id_fk",
+          "tableFrom": "github_repository_index",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_repository_index_id_unique": {
+          "name": "github_repository_index_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "github_repository_index_owner_repo_team_db_id_unique": {
+          "name": "github_repository_index_owner_repo_team_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner",
+            "repo",
+            "team_db_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_issue_embeddings": {
+      "name": "github_repository_issue_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_state": {
+          "name": "issue_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_state_reason": {
+          "name": "issue_state_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_updated_at": {
+          "name": "issue_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_closed_at": {
+          "name": "issue_closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_key": {
+          "name": "document_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_created_at": {
+          "name": "content_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_edited_at": {
+          "name": "content_edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_version": {
+          "name": "metadata_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gh_issue_embeddings_embedding_1536_idx": {
+          "name": "gh_issue_embeddings_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::vector(1536)) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_issue_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_issue_embeddings_embedding_3072_idx": {
+          "name": "gh_issue_embeddings_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "(\"embedding\"::halfvec(3072)) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_issue_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_issue_emb_repo_doc_idx": {
+          "name": "gh_issue_emb_repo_doc_idx",
+          "columns": [
+            {
+              "expression": "repository_index_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_issue_embeddings_repo_idx_fk": {
+          "name": "gh_issue_embeddings_repo_idx_fk",
+          "tableFrom": "github_repository_issue_embeddings",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_issue_emb_unique": {
+          "name": "gh_issue_emb_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "issue_number",
+            "content_type",
+            "content_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_pull_request_embeddings": {
+      "name": "github_repository_pull_request_embeddings",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_index_db_id": {
+          "name": "repository_index_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_profile_id": {
+          "name": "embedding_profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_key": {
+          "name": "document_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_content": {
+          "name": "chunk_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gh_pr_embeddings_embedding_1536_idx": {
+          "name": "gh_pr_embeddings_embedding_1536_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::vector(1536) vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_pull_request_embeddings\".\"embedding_dimensions\" = 1536",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_pr_embeddings_embedding_3072_idx": {
+          "name": "gh_pr_embeddings_embedding_3072_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\"::halfvec(3072) halfvec_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_repository_pull_request_embeddings\".\"embedding_dimensions\" = 3072",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "gh_pr_emb_repo_doc_idx": {
+          "name": "gh_pr_emb_repo_doc_idx",
+          "columns": [
+            {
+              "expression": "repository_index_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_embeddings_repo_idx_fk": {
+          "name": "gh_pr_embeddings_repo_idx_fk",
+          "tableFrom": "github_repository_pull_request_embeddings",
+          "tableTo": "github_repository_index",
+          "columnsFrom": [
+            "repository_index_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gh_pr_emb_unique": {
+          "name": "gh_pr_emb_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_index_db_id",
+            "embedding_profile_id",
+            "pr_number",
+            "content_type",
+            "content_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_db_id": {
+          "name": "inviter_user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitations_team_db_id_revoked_at_index": {
+          "name": "invitations_team_db_id_revoked_at_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_team_db_id_teams_db_id_fk": {
+          "name": "invitations_team_db_id_teams_db_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_user_db_id_users_db_id_fk": {
+          "name": "invitations_inviter_user_db_id_users_db_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_credentials_user_id_users_db_id_fk": {
+          "name": "oauth_credentials_user_id_users_db_id_fk",
+          "tableFrom": "oauth_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_credentials_user_id_provider_provider_account_id_unique": {
+          "name": "oauth_credentials_user_id_provider_provider_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_billing_cadence_histories": {
+      "name": "stripe_billing_cadence_histories",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_profile_id": {
+          "name": "billing_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_type": {
+          "name": "payer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_type": {
+          "name": "billing_cycle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_interval_count": {
+          "name": "billing_cycle_interval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_day_of_month": {
+          "name": "billing_cycle_day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_month_of_year": {
+          "name": "billing_cycle_month_of_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_time_hour": {
+          "name": "billing_cycle_time_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_time_minute": {
+          "name": "billing_cycle_time_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle_time_second": {
+          "name": "billing_cycle_time_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_settings_id": {
+          "name": "bill_settings_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lookup_key": {
+          "name": "lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_cadence_hist_id_idx": {
+          "name": "stripe_cadence_hist_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_cadence_hist_team_db_id_idx": {
+          "name": "stripe_cadence_hist_team_db_id_idx",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_cadence_hist_customer_id_idx": {
+          "name": "stripe_cadence_hist_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_billing_cadence_histories_team_db_id_teams_db_id_fk": {
+          "name": "stripe_billing_cadence_histories_team_db_id_teams_db_id_fk",
+          "tableFrom": "stripe_billing_cadence_histories",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_pricing_plan_subscription_histories": {
+      "name": "stripe_pricing_plan_subscription_histories",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cadence_db_id": {
+          "name": "billing_cadence_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cadence_id": {
+          "name": "billing_cadence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_plan_id": {
+          "name": "pricing_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_plan_version_id": {
+          "name": "pricing_plan_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servicing_status": {
+          "name": "servicing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_status": {
+          "name": "collection_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "will_cancel_at": {
+          "name": "will_cancel_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_current_at": {
+          "name": "collection_current_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_past_due_at": {
+          "name": "collection_past_due_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_paused_at": {
+          "name": "collection_paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_unpaid_at": {
+          "name": "collection_unpaid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_awaiting_customer_action_at": {
+          "name": "collection_awaiting_customer_action_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_pps_hist_id_idx": {
+          "name": "stripe_pps_hist_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_pps_hist_team_db_id_idx": {
+          "name": "stripe_pps_hist_team_db_id_idx",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_pps_hist_billing_cadence_db_id_idx": {
+          "name": "stripe_pps_hist_billing_cadence_db_id_idx",
+          "columns": [
+            {
+              "expression": "billing_cadence_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_pricing_plan_subscription_histories_team_db_id_teams_db_id_fk": {
+          "name": "stripe_pricing_plan_subscription_histories_team_db_id_teams_db_id_fk",
+          "tableFrom": "stripe_pricing_plan_subscription_histories",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stripe_pricing_plan_subscription_histories_billing_cadence_db_id_stripe_billing_cadence_histories_db_id_fk": {
+          "name": "stripe_pricing_plan_subscription_histories_billing_cadence_db_id_stripe_billing_cadence_histories_db_id_fk",
+          "tableFrom": "stripe_pricing_plan_subscription_histories",
+          "tableTo": "stripe_billing_cadence_histories",
+          "columnsFrom": [
+            "billing_cadence_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supabase_user_mappings": {
+      "name": "supabase_user_mappings",
+      "schema": "",
+      "columns": {
+        "user_db_id": {
+          "name": "user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_user_id": {
+          "name": "supabase_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supabase_user_mappings_user_db_id_users_db_id_fk": {
+          "name": "supabase_user_mappings_user_db_id_users_db_id_fk",
+          "tableFrom": "supabase_user_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supabase_user_mappings_user_db_id_unique": {
+          "name": "supabase_user_mappings_user_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_db_id"
+          ]
+        },
+        "supabase_user_mappings_supabase_user_id_unique": {
+          "name": "supabase_user_mappings_supabase_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "supabase_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_db_id": {
+          "name": "app_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_team_db_id_index": {
+          "name": "tasks_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_team_db_id_teams_db_id_fk": {
+          "name": "tasks_team_db_id_teams_db_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_app_db_id_apps_db_id_fk": {
+          "name": "tasks_app_db_id_apps_db_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasks_id_unique": {
+          "name": "tasks_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_db_id": {
+          "name": "user_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_memberships_user_db_id_users_db_id_fk": {
+          "name": "team_memberships_user_db_id_users_db_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_memberships_team_db_id_teams_db_id_fk": {
+          "name": "team_memberships_team_db_id_teams_db_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_memberships_user_db_id_team_db_id_unique": {
+          "name": "team_memberships_user_db_id_team_db_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_db_id",
+            "team_db_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "active_subscription_id": {
+          "name": "active_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_customer_id": {
+          "name": "active_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_id_unique": {
+          "name": "teams_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_seat_usage_reports": {
+      "name": "user_seat_usage_reports",
+      "schema": "",
+      "columns": {
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_db_id_list": {
+          "name": "user_db_id_list",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_event_id": {
+          "name": "stripe_meter_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_seat_usage_reports_team_db_id_index": {
+          "name": "user_seat_usage_reports_team_db_id_index",
+          "columns": [
+            {
+              "expression": "team_db_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_seat_usage_reports_created_at_index": {
+          "name": "user_seat_usage_reports_created_at_index",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_seat_usage_reports_stripe_meter_event_id_index": {
+          "name": "user_seat_usage_reports_stripe_meter_event_id_index",
+          "columns": [
+            {
+              "expression": "stripe_meter_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_seat_usage_reports_team_db_id_teams_db_id_fk": {
+          "name": "user_seat_usage_reports_team_db_id_teams_db_id_fk",
+          "tableFrom": "user_seat_usage_reports",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "db_id": {
+          "name": "db_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_db_id": {
+          "name": "team_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "creator_db_id": {
+          "name": "creator_db_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"sample\":false}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_team_db_id_teams_db_id_fk": {
+          "name": "workspaces_team_db_id_teams_db_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_creator_db_id_users_db_id_fk": {
+          "name": "workspaces_creator_db_id_users_db_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_db_id"
+          ],
+          "columnsTo": [
+            "db_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspaces_id_unique": {
+          "name": "workspaces_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/studio.giselles.ai/db/migrate/meta/_journal.json
+++ b/apps/studio.giselles.ai/db/migrate/meta/_journal.json
@@ -1,517 +1,524 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1727672114041,
-			"tag": "0000_aberrant_stardust",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1727751238434,
-			"tag": "0001_glorious_mathemanic",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1727759326160,
-			"tag": "0002_mighty_zarek",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1729227804577,
-			"tag": "0003_messy_fabian_cortez",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1729759218608,
-			"tag": "0004_handy_kylun",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1730368916214,
-			"tag": "0005_smart_vapor",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1731571831614,
-			"tag": "0006_demonic_morlocks",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1731653065873,
-			"tag": "0007_breezy_bromley",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1731653081961,
-			"tag": "0008_cloudy_squadron_supreme",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1732504730844,
-			"tag": "0009_fuzzy_santa_claus",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1732514526781,
-			"tag": "0010_classy_jackpot",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1732852967369,
-			"tag": "0011_thin_ink",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1733113434236,
-			"tag": "0012_military_talisman",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1733117334658,
-			"tag": "0013_nosy_whiplash",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1733382854673,
-			"tag": "0014_lucky_sabretooth",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1733719570344,
-			"tag": "0015_parched_talon",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1733811412858,
-			"tag": "0016_short_madelyne_pryor",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1734079652838,
-			"tag": "0017_lying_dexter_bennett",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1734418310592,
-			"tag": "0018_greedy_starhawk",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1734493751390,
-			"tag": "0019_oval_zaran",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1734927301188,
-			"tag": "0020_marvelous_obadiah_stane",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1734928974767,
-			"tag": "0021_watery_microchip",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1735186892591,
-			"tag": "0022_conscious_maelstrom",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1735191139280,
-			"tag": "0023_colossal_nuke",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1736210588971,
-			"tag": "0024_lush_night_nurse",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1737000272132,
-			"tag": "0025_flimsy_ravenous",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1737012769271,
-			"tag": "0026_military_spirit",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1741074174409,
-			"tag": "0027_funny_infant_terrible",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1741075599419,
-			"tag": "0028_ambiguous_eternity",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1742868382390,
-			"tag": "0029_lame_senator_kelly",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1744680181946,
-			"tag": "0030_neat_legion",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1745211444575,
-			"tag": "0031_gorgeous_tomorrow_man",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1747026321465,
-			"tag": "0032_careless_wrecker",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1747029097419,
-			"tag": "0033_eminent_white_tiger",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1750920392746,
-			"tag": "0034_steady_roulette",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1751350483095,
-			"tag": "0035_big_the_hunter",
-			"breakpoints": true
-		},
-		{
-			"idx": 36,
-			"version": "7",
-			"when": 1752216310233,
-			"tag": "0036_workable_hiroim",
-			"breakpoints": true
-		},
-		{
-			"idx": 37,
-			"version": "7",
-			"when": 1752221767858,
-			"tag": "0037_safe_korvac",
-			"breakpoints": true
-		},
-		{
-			"idx": 38,
-			"version": "7",
-			"when": 1752801923078,
-			"tag": "0038_lyrical_black_cat",
-			"breakpoints": true
-		},
-		{
-			"idx": 39,
-			"version": "7",
-			"when": 1752993516031,
-			"tag": "0039_wooden_tyrannus",
-			"breakpoints": true
-		},
-		{
-			"idx": 40,
-			"version": "7",
-			"when": 1753157006204,
-			"tag": "0040_dusty_jasper_sitwell",
-			"breakpoints": true
-		},
-		{
-			"idx": 41,
-			"version": "7",
-			"when": 1753157963455,
-			"tag": "0041_friendly_jack_flag",
-			"breakpoints": true
-		},
-		{
-			"idx": 42,
-			"version": "7",
-			"when": 1753251958235,
-			"tag": "0042_material_colonel_america",
-			"breakpoints": true
-		},
-		{
-			"idx": 43,
-			"version": "7",
-			"when": 1754533323164,
-			"tag": "0043_tiresome_boom_boom",
-			"breakpoints": true
-		},
-		{
-			"idx": 44,
-			"version": "7",
-			"when": 1754981716516,
-			"tag": "0044_curious_lord_hawal",
-			"breakpoints": true
-		},
-		{
-			"idx": 45,
-			"version": "7",
-			"when": 1755063337287,
-			"tag": "0045_brown_spitfire",
-			"breakpoints": true
-		},
-		{
-			"idx": 46,
-			"version": "7",
-			"when": 1755567043931,
-			"tag": "0046_lush_shriek",
-			"breakpoints": true
-		},
-		{
-			"idx": 47,
-			"version": "7",
-			"when": 1755584435518,
-			"tag": "0047_hot_chamber",
-			"breakpoints": true
-		},
-		{
-			"idx": 48,
-			"version": "7",
-			"when": 1758091630511,
-			"tag": "0048_useful_the_phantom",
-			"breakpoints": true
-		},
-		{
-			"idx": 49,
-			"version": "7",
-			"when": 1758718182512,
-			"tag": "0049_confused_thor_girl",
-			"breakpoints": true
-		},
-		{
-			"idx": 50,
-			"version": "7",
-			"when": 1759219670441,
-			"tag": "0050_wise_cyclops",
-			"breakpoints": true
-		},
-		{
-			"idx": 51,
-			"version": "7",
-			"when": 1759471300254,
-			"tag": "0051_glossy_nocturne",
-			"breakpoints": true
-		},
-		{
-			"idx": 52,
-			"version": "7",
-			"when": 1760921212407,
-			"tag": "0052_safe_bloodstrike",
-			"breakpoints": true
-		},
-		{
-			"idx": 53,
-			"version": "7",
-			"when": 1760921778568,
-			"tag": "0053_move-data-from-agents-to-workspaces",
-			"breakpoints": true
-		},
-		{
-			"idx": 54,
-			"version": "7",
-			"when": 1760930907155,
-			"tag": "0054_majestic_justin_hammer",
-			"breakpoints": true
-		},
-		{
-			"idx": 55,
-			"version": "7",
-			"when": 1760930966370,
-			"tag": "0055_move-data-from-agents-to-workspaces",
-			"breakpoints": true
-		},
-		{
-			"idx": 56,
-			"version": "7",
-			"when": 1761274607282,
-			"tag": "0056_wild_sue_storm",
-			"breakpoints": true
-		},
-		{
-			"idx": 57,
-			"version": "7",
-			"when": 1761663556284,
-			"tag": "0057_third_wonder_man",
-			"breakpoints": true
-		},
-		{
-			"idx": 58,
-			"version": "7",
-			"when": 1762260433419,
-			"tag": "0058_shallow_frog_thor",
-			"breakpoints": true
-		},
-		{
-			"idx": 59,
-			"version": "7",
-			"when": 1762310898966,
-			"tag": "0059_skinny_saracen",
-			"breakpoints": true
-		},
-		{
-			"idx": 60,
-			"version": "7",
-			"when": 1762323932695,
-			"tag": "0060_freezing_ultron",
-			"breakpoints": true
-		},
-		{
-			"idx": 61,
-			"version": "7",
-			"when": 1762411864922,
-			"tag": "0061_violet_mastermind",
-			"breakpoints": true
-		},
-		{
-			"idx": 62,
-			"version": "7",
-			"when": 1762516937963,
-			"tag": "0062_migrate-team-plan",
-			"breakpoints": true
-		},
-		{
-			"idx": 63,
-			"version": "7",
-			"when": 1762837754029,
-			"tag": "0063_slim_mindworm",
-			"breakpoints": true
-		},
-		{
-			"idx": 64,
-			"version": "7",
-			"when": 1763366738292,
-			"tag": "0064_fluffy_drax",
-			"breakpoints": true
-		},
-		{
-			"idx": 65,
-			"version": "7",
-			"when": 1763469697487,
-			"tag": "0065_far_kree",
-			"breakpoints": true
-		},
-		{
-			"idx": 66,
-			"version": "7",
-			"when": 1763522209496,
-			"tag": "0066_cuddly_wither",
-			"breakpoints": true
-		},
-		{
-			"idx": 67,
-			"version": "7",
-			"when": 1763705586852,
-			"tag": "0067_peaceful_the_executioner",
-			"breakpoints": true
-		},
-		{
-			"idx": 68,
-			"version": "7",
-			"when": 1764222491592,
-			"tag": "0068_warm_vector",
-			"breakpoints": true
-		},
-		{
-			"idx": 69,
-			"version": "7",
-			"when": 1764256980624,
-			"tag": "0069_shocking_shooting_star",
-			"breakpoints": true
-		},
-		{
-			"idx": 70,
-			"version": "7",
-			"when": 1764318117118,
-			"tag": "0070_even_living_lightning",
-			"breakpoints": true
-		},
-		{
-			"idx": 71,
-			"version": "7",
-			"when": 1765275369057,
-			"tag": "0071_lush_william_stryker",
-			"breakpoints": true
-		},
-		{
-			"idx": 72,
-			"version": "7",
-			"when": 1765802781116,
-			"tag": "0072_add-end-node-id-to-apps",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1727672114041,
+      "tag": "0000_aberrant_stardust",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1727751238434,
+      "tag": "0001_glorious_mathemanic",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1727759326160,
+      "tag": "0002_mighty_zarek",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1729227804577,
+      "tag": "0003_messy_fabian_cortez",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1729759218608,
+      "tag": "0004_handy_kylun",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1730368916214,
+      "tag": "0005_smart_vapor",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1731571831614,
+      "tag": "0006_demonic_morlocks",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1731653065873,
+      "tag": "0007_breezy_bromley",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1731653081961,
+      "tag": "0008_cloudy_squadron_supreme",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1732504730844,
+      "tag": "0009_fuzzy_santa_claus",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1732514526781,
+      "tag": "0010_classy_jackpot",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1732852967369,
+      "tag": "0011_thin_ink",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1733113434236,
+      "tag": "0012_military_talisman",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1733117334658,
+      "tag": "0013_nosy_whiplash",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1733382854673,
+      "tag": "0014_lucky_sabretooth",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1733719570344,
+      "tag": "0015_parched_talon",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1733811412858,
+      "tag": "0016_short_madelyne_pryor",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1734079652838,
+      "tag": "0017_lying_dexter_bennett",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1734418310592,
+      "tag": "0018_greedy_starhawk",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1734493751390,
+      "tag": "0019_oval_zaran",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1734927301188,
+      "tag": "0020_marvelous_obadiah_stane",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1734928974767,
+      "tag": "0021_watery_microchip",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1735186892591,
+      "tag": "0022_conscious_maelstrom",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1735191139280,
+      "tag": "0023_colossal_nuke",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1736210588971,
+      "tag": "0024_lush_night_nurse",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1737000272132,
+      "tag": "0025_flimsy_ravenous",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1737012769271,
+      "tag": "0026_military_spirit",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1741074174409,
+      "tag": "0027_funny_infant_terrible",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1741075599419,
+      "tag": "0028_ambiguous_eternity",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1742868382390,
+      "tag": "0029_lame_senator_kelly",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1744680181946,
+      "tag": "0030_neat_legion",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1745211444575,
+      "tag": "0031_gorgeous_tomorrow_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1747026321465,
+      "tag": "0032_careless_wrecker",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1747029097419,
+      "tag": "0033_eminent_white_tiger",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1750920392746,
+      "tag": "0034_steady_roulette",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1751350483095,
+      "tag": "0035_big_the_hunter",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1752216310233,
+      "tag": "0036_workable_hiroim",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1752221767858,
+      "tag": "0037_safe_korvac",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1752801923078,
+      "tag": "0038_lyrical_black_cat",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1752993516031,
+      "tag": "0039_wooden_tyrannus",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1753157006204,
+      "tag": "0040_dusty_jasper_sitwell",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1753157963455,
+      "tag": "0041_friendly_jack_flag",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1753251958235,
+      "tag": "0042_material_colonel_america",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1754533323164,
+      "tag": "0043_tiresome_boom_boom",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1754981716516,
+      "tag": "0044_curious_lord_hawal",
+      "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1755063337287,
+      "tag": "0045_brown_spitfire",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1755567043931,
+      "tag": "0046_lush_shriek",
+      "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1755584435518,
+      "tag": "0047_hot_chamber",
+      "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1758091630511,
+      "tag": "0048_useful_the_phantom",
+      "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1758718182512,
+      "tag": "0049_confused_thor_girl",
+      "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1759219670441,
+      "tag": "0050_wise_cyclops",
+      "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1759471300254,
+      "tag": "0051_glossy_nocturne",
+      "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1760921212407,
+      "tag": "0052_safe_bloodstrike",
+      "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1760921778568,
+      "tag": "0053_move-data-from-agents-to-workspaces",
+      "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1760930907155,
+      "tag": "0054_majestic_justin_hammer",
+      "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1760930966370,
+      "tag": "0055_move-data-from-agents-to-workspaces",
+      "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1761274607282,
+      "tag": "0056_wild_sue_storm",
+      "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1761663556284,
+      "tag": "0057_third_wonder_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1762260433419,
+      "tag": "0058_shallow_frog_thor",
+      "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1762310898966,
+      "tag": "0059_skinny_saracen",
+      "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1762323932695,
+      "tag": "0060_freezing_ultron",
+      "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1762411864922,
+      "tag": "0061_violet_mastermind",
+      "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1762516937963,
+      "tag": "0062_migrate-team-plan",
+      "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1762837754029,
+      "tag": "0063_slim_mindworm",
+      "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1763366738292,
+      "tag": "0064_fluffy_drax",
+      "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1763469697487,
+      "tag": "0065_far_kree",
+      "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1763522209496,
+      "tag": "0066_cuddly_wither",
+      "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1763705586852,
+      "tag": "0067_peaceful_the_executioner",
+      "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1764222491592,
+      "tag": "0068_warm_vector",
+      "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1764256980624,
+      "tag": "0069_shocking_shooting_star",
+      "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1764318117118,
+      "tag": "0070_even_living_lightning",
+      "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1765275369057,
+      "tag": "0071_lush_william_stryker",
+      "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1765802781116,
+      "tag": "0072_add-end-node-id-to-apps",
+      "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1766018346438,
+      "tag": "0073_striped_proudstar",
+      "breakpoints": true
+    }
+  ]
 }

--- a/apps/studio.giselles.ai/db/schema.ts
+++ b/apps/studio.giselles.ai/db/schema.ts
@@ -150,6 +150,7 @@ export const stripePricingPlanSubscriptionHistories = pgTable(
 		activatedAt: timestamp("activated_at"),
 		canceledAt: timestamp("canceled_at"),
 		pausedAt: timestamp("paused_at"),
+		willCancelAt: timestamp("will_cancel_at"), // https://docs.stripe.com/api/v2/pricing-plan-subscriptions/update?api-version=2025-12-15.preview#v2_update_pricing_plan_subscriptions-response-servicing_status_transitions-will_cancel_at
 
 		// Collection status transitions
 		collectionCurrentAt: timestamp("collection_current_at"),


### PR DESCRIPTION
### **User description**
## Summary
Add will_cancel_at column to subscription histories
Track when a Stripe subscription is scheduled for cancellation.

## Other Information
https://docs.stripe.com/api/v2/pricing-plan-subscriptions/update?api-version=2025-12-15.preview#v2_update_pricing_plan_subscriptions-response-servicing_status_transitions-will_cancel_at


___

### **PR Type**
Enhancement


___

### **Description**
- Added `willCancelAt` timestamp column to the `stripePricingPlanSubscriptionHistories` table to track when a Stripe subscription is scheduled for cancellation

- Created database migration (0073_striped_proudstar.sql) to add the nullable `will_cancel_at` column to the `stripe_pricing_plan_subscription_histories` table

- Updated schema definition in TypeScript to include the new column mapping

- Generated migration snapshot and updated migration journal with the new migration entry

- Reformatted migration journal JSON for consistency (tab to 2-space indentation)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stripe API<br/>will_cancel_at field"] -- "track cancellation<br/>scheduling" --> B["Database Column<br/>will_cancel_at"]
  B -- "schema mapping" --> C["TypeScript Type<br/>willCancelAt"]
  D["Migration 0073<br/>striped_proudstar"] -- "creates column" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.ts</strong><dd><code>Add willCancelAt timestamp column to subscription histories</code></dd></summary>
<hr>

apps/studio.giselles.ai/db/schema.ts

<ul><li>Added <code>willCancelAt</code> timestamp column to the <br><code>stripePricingPlanSubscriptionHistories</code> table<br> <li> Column maps to database field <code>will_cancel_at</code><br> <li> Includes reference link to Stripe API documentation for the servicing <br>status transitions</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2495/files#diff-dde376759ce503306024865f21ff81ba647ff3c38db203c2aafe88e8d4cc3b8c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0073_striped_proudstar.sql</strong><dd><code>Database migration for will_cancel_at column addition</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/db/migrate/0073_striped_proudstar.sql

<ul><li>Created new migration file to add <code>will_cancel_at</code> timestamp column<br> <li> Alters the <code>stripe_pricing_plan_subscription_histories</code> table<br> <li> Column is nullable by default</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2495/files#diff-45648c2fb6543fcad03774e92a8d8533558f06fdaf54aa64c7a1d269656e71ee">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0073_snapshot.json</strong><dd><code>Migration snapshot with updated subscription histories schema</code></dd></summary>
<hr>

apps/studio.giselles.ai/db/migrate/meta/0073_snapshot.json

<ul><li>Generated migration snapshot file with complete database schema state<br> <li> Documents the new <code>will_cancel_at</code> column in <br><code>stripe_pricing_plan_subscription_histories</code> table<br> <li> Includes full schema metadata for all tables, indexes, and foreign <br>keys</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2495/files#diff-1f8e49ad03d384d69a86efcac5a72d15ce4a69e246c4ad900e65c76c0cf50b58">+3446/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_journal.json</strong><dd><code>Add new migration entry and reformat JSON indentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/db/migrate/meta/_journal.json

<ul><li>Reformatted JSON file from tab indentation to 2-space indentation for <br>consistency<br> <li> Added new migration entry <code>0073_striped_proudstar</code> with timestamp <br><code>1766018346438</code><br> <li> Updated file to reflect the latest database migration in the journal</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2495/files#diff-b774219e34219c43212d2ca3bdaedf130b8b234365320d96920b057f645c178f">+523/-516</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `will_cancel_at` timestamp to `stripe_pricing_plan_subscription_histories` and updates ORM schema and migration metadata.
> 
> - **Database**:
>   - Add `will_cancel_at` timestamp column to `stripe_pricing_plan_subscription_histories`.
>   - Update ORM in `db/schema.ts` to include `willCancelAt` field.
>   - Add migration `0073_striped_proudstar.sql` with corresponding `meta` snapshot and `_journal` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d631ed25d843e33830765835014b4c8427f229f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated subscription database schema to track scheduled cancellation dates, enabling improved subscription lifecycle management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->