### PR TITLE
Unsupported connection logic

### DIFF
--- a/packages/react/src/workspace/utils/is-supported-connection.test.ts
+++ b/packages/react/src/workspace/utils/is-supported-connection.test.ts
@@ -7,6 +7,8 @@ import {
 } from "@giselles-ai/language-model";
 import type {
 	ActionNode,
+	AppEntryNode,
+	EndNode,
 	FileNode,
 	GitHubNode,
 	ImageGenerationLanguageModelData,
@@ -138,6 +140,33 @@ describe("isSupportedConnection", () => {
 		},
 	});
 
+	const createAppEntryNode = (id: NodeId): AppEntryNode => ({
+		id,
+		type: "operation",
+		inputs: [],
+		outputs: [],
+		content: {
+			type: "appEntry",
+			status: "unconfigured",
+			draftApp: {
+				name: "test",
+				description: "test",
+				iconName: "test",
+				parameters: [],
+			},
+		},
+	});
+
+	const createEndNode = (id: NodeId): EndNode => ({
+		id,
+		type: "operation",
+		inputs: [],
+		outputs: [],
+		content: {
+			type: "end",
+		},
+	});
+
 	describe("Basic validation", () => {
 		test("should reject connection between the same node", () => {
 			const node = createTextGenerationNode("nd-test1");
@@ -161,6 +190,29 @@ describe("isSupportedConnection", () => {
 				"message",
 				"This node does not receive inputs",
 			);
+		});
+	});
+
+	describe("v2container restrictions", () => {
+		test("should reject connection between AppEntryNode and EndNode", () => {
+			const appEntryNode = createAppEntryNode(NodeId.generate());
+			const endNode = createEndNode(NodeId.generate());
+
+			const result1 = isSupportedConnection(appEntryNode, endNode);
+			expect(result1.canConnect).toBe(false);
+			if (!result1.canConnect) {
+				expect(result1.message).toBe(
+					"Connecting App Entry and End nodes is not allowed",
+				);
+			}
+
+			const result2 = isSupportedConnection(endNode, appEntryNode);
+			expect(result2.canConnect).toBe(false);
+			if (!result2.canConnect) {
+				expect(result2.message).toBe(
+					"Connecting App Entry and End nodes is not allowed",
+				);
+			}
 		});
 	});
 

--- a/packages/react/src/workspace/utils/is-supported-connection.ts
+++ b/packages/react/src/workspace/utils/is-supported-connection.ts
@@ -4,6 +4,8 @@ import {
 	languageModels,
 } from "@giselles-ai/language-model";
 import {
+	isAppEntryNode,
+	isEndNode,
 	isFileNode,
 	isImageGenerationNode,
 	isQueryNode,
@@ -33,6 +35,17 @@ export function isSupportedConnection(
 		return {
 			canConnect: false,
 			message: "This node does not receive inputs",
+		};
+	}
+
+	// v2container: AppEntryNode and EndNode cannot be connected directly.
+	if (
+		(isAppEntryNode(outputNode) && isEndNode(inputNode)) ||
+		(isEndNode(outputNode) && isAppEntryNode(inputNode))
+	) {
+		return {
+			canConnect: false,
+			message: "Connecting App Entry and End nodes is not allowed",
 		};
 	}
 


### PR DESCRIPTION
### **User description**
## Summary
Prevents direct connections between `AppEntryNode` and `EndNode` within the `v2container` workspace.

## Related Issue
<!-- None -->

## Changes
- Modified `isSupportedConnection` to explicitly reject connections between `AppEntryNode` and `EndNode` (in both directions).
- Added new unit tests to `is-supported-connection.test.ts` to verify this behavior.

## Testing
- New unit tests confirm `AppEntryNode` and `EndNode` cannot connect directly.
- All `pnpm` checks (`format`, `build-sdk`, `check-types`, `tidy`, `test`) passed successfully.

## Other Information
This change enforces a more structured flow within the `v2container`, preventing `AppEntryNode` from directly leading to `EndNode` and vice-versa.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a024883-f72b-4f2c-b30f-d3cc695052ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a024883-f72b-4f2c-b30f-d3cc695052ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Enhancement


___

### **Description**
- Prevents direct connections between `AppEntryNode` and `EndNode` nodes

- Enforces structured workflow flow in v2container workspace

- Added validation logic with bidirectional connection checks

- Includes comprehensive unit tests for new restrictions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AppEntry["AppEntryNode"]
  End["EndNode"]
  Validation["Connection Validation"]
  Result["Reject Connection"]
  AppEntry -- "attempt connection" --> Validation
  End -- "attempt connection" --> Validation
  Validation -- "bidirectional check" --> Result
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>is-supported-connection.ts</strong><dd><code>Add AppEntry-End node connection validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/workspace/utils/is-supported-connection.ts

<ul><li>Added imports for <code>isAppEntryNode</code> and <code>isEndNode</code> type guards<br> <li> Implemented validation logic to reject connections between <br><code>AppEntryNode</code> and <code>EndNode</code> in both directions<br> <li> Returns error message "Connecting App Entry and End nodes is not <br>allowed" when invalid connection is attempted</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2497/files#diff-ccdcba1c3d1280cc5c00141ae260c3e7334fe26d285bc67cbf49c9d0070695a0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>is-supported-connection.test.ts</strong><dd><code>Add tests for AppEntry-End node restrictions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/react/src/workspace/utils/is-supported-connection.test.ts

<ul><li>Added imports for <code>AppEntryNode</code> and <code>EndNode</code> types<br> <li> Created helper functions <code>createAppEntryNode</code> and <code>createEndNode</code> for test <br>setup<br> <li> Added new test suite "v2container restrictions" with bidirectional <br>connection tests<br> <li> Verifies that connections fail with appropriate error message in both <br>directions</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2497/files#diff-7a5a1d45042d14175a02781a8e1e48c477f864e5a40dd85552c21396015d4b6e">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation to prevent incompatible node connections in both directions.

* **Tests**
  * Added comprehensive test coverage for connection restriction scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->