### PR TITLE
Remove unused output parameters section from app entry configured view

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@giselle-internal/ui/button";
 import { useToasts } from "@giselle-internal/ui/toast";
 import type { App, AppEntryNode } from "@giselles-ai/protocol";
-import { AppParameterId } from "@giselles-ai/protocol";
 import { useGiselle } from "@giselles-ai/react";
 import { LoaderIcon } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
@@ -9,7 +8,6 @@ import type { KeyedMutator } from "swr";
 import { SettingDetail, SettingLabel } from "../ui/setting-label";
 
 export function AppEntryConfiguredView({
-	node,
 	app,
 	mutateApp,
 }: {
@@ -93,48 +91,6 @@ export function AppEntryConfiguredView({
 					</Button>
 				</form>
 			</div>
-
-			{node.outputs.length > 0 && (
-				<div className="space-y-[4px]">
-					<SettingLabel className="py-[1.5px]">Output Parameters</SettingLabel>
-					<div className="px-[4px] py-0 w-full bg-transparent text-[14px] mt-[8px]">
-						<ul className="w-full flex flex-col gap-[12px]">
-							{node.outputs.map((output) => {
-								const parameterIdResult = AppParameterId.schema.safeParse(
-									output.accessor,
-								);
-								const parameter = parameterIdResult.success
-									? app.parameters.find((p) => p.id === parameterIdResult.data)
-									: undefined;
-
-								return (
-									<li key={output.id}>
-										<div className="flex flex-col gap-[4px]">
-											<div className="flex items-center gap-[8px]">
-												<span className="text-[14px] font-medium">
-													{output.label}
-												</span>
-												{parameter?.required && (
-													<span className="text-[12px] text-muted-foreground">
-														(Required)
-													</span>
-												)}
-											</div>
-											{parameter && (
-												<div className="flex items-center gap-[8px] pl-[4px]">
-													<span className="text-[12px] text-muted-foreground">
-														Type: {parameter.type}
-													</span>
-												</div>
-											)}
-										</div>
-									</li>
-								);
-							})}
-						</ul>
-					</div>
-				</div>
-			)}
 		</div>
 	);
 }


### PR DESCRIPTION
### **User description**
The output parameters display section was not being used and relied on the `node` prop which is no longer needed by this component.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove unused output parameters display section

- Eliminate unnecessary `node` prop dependency

- Simplify component by removing unused imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AppEntryConfiguredView Component"] -->|Remove| B["Output Parameters Section"]
  A -->|Remove| C["node Prop"]
  A -->|Remove| D["AppParameterId Import"]
  A -->|Keep| E["Input Parameters Form"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app-entry-configured-view.tsx</strong><dd><code>Remove unused output parameters and node prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx

<ul><li>Removed <code>node</code> prop from component interface<br> <li> Deleted entire output parameters display section (42 lines)<br> <li> Removed unused <code>AppParameterId</code> import<br> <li> Retained input parameters form functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2503/files#diff-dc9401c79d3938de9e1da98aef235616c7a56fc9ab3d45b658e605e6140a79ab">+0/-44</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the unused Output Parameters UI and its dependency on the node prop from AppEntryConfiguredView.
> 
> - **UI**:
>   - **`app-entry-configured-view.tsx`**:
>     - Remove the "Output Parameters" section that rendered from `node.outputs`.
>     - Stop using the `node` prop; component now operates using only `app` and `mutateApp`.
>     - Delete `AppParameterId` import tied to the removed section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe1b396fcaea3ead3180bffaea0deb53ee017950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the app entry node properties panel by removing the outputs section from the component interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->