### PR TITLE
Ui text standardization

### DIFF
--- a/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-delete-nodes.ts
+++ b/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-delete-nodes.ts
@@ -121,9 +121,9 @@ export function useDeleteNodes() {
 
 			if (shouldPairDelete) {
 				const ok = await confirm({
-					title: "Delete App Entry and End?",
+					title: "Delete Start and End?",
 					description:
-						"App Entry and End are a pair. Deleting either one will delete both. Do you want to continue?",
+						"Start and End are a pair. Deleting either one will delete both. Do you want to continue?",
 					confirmLabel: "Delete",
 					cancelLabel: "Cancel",
 					destructive: true,

--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/run-button.tsx
@@ -287,7 +287,7 @@ function MultipleRunsDropdown({
 			if (appEntryRunItems.length > 0) {
 				groups.push({
 					groupId: "appEntry",
-					groupLabel: "App Entry Nodes",
+					groupLabel: "Start Nodes",
 					items: appEntryRunItems,
 				});
 			}


### PR DESCRIPTION
## Summary
UI表示の統一のため、`internal-packages` 内の `App Entry` という表現を `Start` に変更しました。

## Related Issue
N/A

## Changes
- ノード削除確認ダイアログのタイトルと説明文で `App Entry` を `Start` に変更。
- Runメニューのグループラベル `App Entry Nodes` を `Start Nodes` に変更。
- `App Request` および `Stage Request` はUI表示箇所が見つからなかったため、変更していません。

## Testing
`pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, `pnpm test` を実行し、すべて成功しました。

## Other Information
ファイル名、定義名、関数名など、UIに表示されない文字列は変更していません。

---
<a href="https://cursor.com/background-agent?bcId=bc-1e528d40-a5b6-4eeb-b353-ac48aff7de89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e528d40-a5b6-4eeb-b353-ac48aff7de89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

