### PR TITLE
Add Playground Navigation and Refactor Try App Section with Conditional Link

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/index.tsx
@@ -308,7 +308,7 @@ function TryPlaygroundLink({ isDisabled }: { isDisabled: boolean }) {
 			href="/playground"
 			target="_blank"
 			rel="noopener noreferrer"
-			className="mt-[12px] w-full rounded-[12px] border border-blue-muted bg-blue-muted px-[16px] py-[12px] text-[14px] font-medium text-white transition-[filter] text-center hover:brightness-110"
+			className="block w-full rounded-[12px] border border-blue-muted bg-blue-muted px-[16px] py-[12px] text-[14px] font-medium text-white transition-[filter] text-center hover:brightness-110"
 		>
 			<TryPlaygroundContent />
 		</Link>
@@ -317,7 +317,7 @@ function TryPlaygroundLink({ isDisabled }: { isDisabled: boolean }) {
 
 function TryPlaygroundSection({ isDisabled }: { isDisabled: boolean }) {
 	return (
-		<div className="w-full flex flex-col">
+		<div className="mt-[12px]">
 			<TryPlaygroundLink isDisabled={isDisabled} />
 			{isDisabled && (
 				<p className="mt-[6px] text-[11px] text-text-muted/50">


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replace disabled button with conditional link component

- Extract Try App section into composable sub-components

- Update button text from "Try App in Stage" to "Try App in Playground"

- Add Next.js Link navigation to playground route


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Disabled Button"] -->|"Extract & Refactor"| B["TryPlaygroundLink Component"]
  B -->|"Conditional Render"| C["Disabled Div"]
  B -->|"Conditional Render"| D["Next.js Link"]
  E["TryPlaygroundContent"] -->|"Shared Content"| C
  E -->|"Shared Content"| D
  B -->|"Wrapped by"| F["TryPlaygroundSection"]
  F -->|"Replaces"| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Refactor Try App button to composable link components</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/index.tsx

<ul><li>Replaced disabled button with conditional <code>TryPlaygroundLink</code> component<br> <li> Extracted shared button content into <code>TryPlaygroundContent</code> component<br> <li> Created <code>TryPlaygroundSection</code> wrapper component managing disabled state<br> <li> Updated button text from "Try App in Stage" to "Try App in Playground"<br> <li> Added Next.js <code>Link</code> import for navigation to <code>/playground</code> route<br> <li> Improved styling with <code>clsx</code> for conditional class application</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2511/files#diff-bc6a6965ac4a02bc095ad86898adff1fabbde42e330f4ec89e7fb93a1d8cf6c5">+52/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the inline "Try App in Stage" action with a "Try App in Playground" section that links to the Playground when enabled and shows a non-clickable state when disabled.

* **Refactor**
  * Consolidated enabled/disabled UI and guidance into a single Playground-focused section and updated disabled messaging with contextual helper text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the End Node "Try App in Stage" button with a conditional Playground link and refactors the section into small reusable components.
> 
> - **UI: End Node Properties Panel (`index.tsx`)**
>   - Replace disabled action button with conditional `Link` to `/playground` (opens in new tab); show non-interactive styled div when disabled.
>   - Extract composable components: `TryPlaygroundSection`, `TryPlaygroundLink`, `TryPlaygroundContent`.
>   - Update copy to “Try App in Playground” and adjust helper text accordingly.
>   - Add `next/link` import for navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 235a2f248bb35fb0438f2a5f481eed9f75604d56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->