### PR TITLE
fix: Limit gpt-5.1-codex verbosity and reasoning options

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/model-defaults.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/model-defaults.ts
@@ -10,17 +10,14 @@ type Provider = "openai" | "anthropic" | "google";
 /**
  * Returns the default reasoningEffort for the given OpenAI model.
  *
- * GPT-5.2 and GPT-5.1 variants default to "none" for lower latency.
+ * GPT-5.2 and GPT-5.1-thinking default to "none" for lower latency.
+ * GPT-5.1-codex only supports low/medium/high, so it defaults to "medium".
  * Older models (gpt-5, gpt-5-mini, gpt-5-nano) default to "medium".
  *
  * @see https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility
  */
 function getDefaultReasoningEffort(modelId: string): string {
-	if (
-		modelId === "gpt-5.2" ||
-		modelId === "gpt-5.1-thinking" ||
-		modelId === "gpt-5.1-codex"
-	) {
+	if (modelId === "gpt-5.2" || modelId === "gpt-5.1-thinking") {
 		return "none";
 	}
 	return "medium";

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
@@ -19,20 +19,31 @@ import {
 /**
  * Returns the available reasoning effort options for the given OpenAI model.
  *
- * GPT-5.2 and GPT-5.1 variants support: none/low/medium/high/xhigh
+ * GPT-5.2 and GPT-5.1-thinking support: none/low/medium/high/xhigh
+ * GPT-5.1-codex supports: low/medium/high
  * Older models (gpt-5, gpt-5-mini, gpt-5-nano) support: minimal/low/medium/high
  *
  * @see https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility
  */
 function getReasoningEffortOptions(modelId: string): readonly string[] {
-	if (
-		modelId === "gpt-5.2" ||
-		modelId === "gpt-5.1-thinking" ||
-		modelId === "gpt-5.1-codex"
-	) {
+	if (modelId === "gpt-5.2" || modelId === "gpt-5.1-thinking") {
 		return ["none", "low", "medium", "high", "xhigh"] as const;
 	}
+	if (modelId === "gpt-5.1-codex") {
+		return ["low", "medium", "high"] as const;
+	}
 	return ["minimal", "low", "medium", "high"] as const;
+}
+
+/**
+ * Returns the available textVerbosity options for the given OpenAI model.
+ * GPT-5.1-codex only supports verbosity: medium.
+ */
+function getTextVerbosityOptions(modelId: string): readonly string[] {
+	if (modelId === "gpt-5.1-codex") {
+		return ["medium"] as const;
+	}
+	return ["low", "medium", "high"] as const;
 }
 
 export function OpenAIModelPanel({
@@ -118,10 +129,12 @@ export function OpenAIModelPanel({
 									}),
 								);
 							}}
-							options={["low", "medium", "high"].map((v) => ({
-								value: v,
-								label: v,
-							}))}
+							options={getTextVerbosityOptions(openaiLanguageModel.id).map(
+								(v) => ({
+									value: v,
+									label: v,
+								}),
+							)}
 						/>
 					</SettingRow>
 				</div>

--- a/packages/language-model-registry/src/openai.ts
+++ b/packages/language-model-registry/src/openai.ts
@@ -103,15 +103,15 @@ export const openai = {
 		configurationOptions: {
 			reasoningEffort: {
 				description: reasoningEffortDescription,
-				schema: z.enum(["none", "low", "medium", "high", "xhigh"]),
+				schema: z.enum(["low", "medium", "high"]),
 			},
 			textVerbosity: {
 				description: textVerbosityDescription,
-				schema: z.enum(["low", "medium", "high"]),
+				schema: z.enum(["medium"]),
 			},
 		},
 		defaultConfiguration: {
-			reasoningEffort: "none",
+			reasoningEffort: "medium",
 			textVerbosity: "medium",
 		},
 		url: "https://platform.openai.com/docs/models/gpt-5.1-codex",

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -28,12 +28,21 @@ const defaultConfigurations: OpenAILanguageModelConfigurations = {
 };
 
 /**
- * GPT-5.2 and GPT-5.1 variants default to "none" for lower latency.
+ * GPT-5.2 and GPT-5.1-thinking default to "none" for lower latency.
  * @see https://platform.openai.com/docs/guides/latest-model#gpt-5-2-parameter-compatibility
  */
-const gpt52And51Configurations: OpenAILanguageModelConfigurations = {
+const gpt52And51ThinkingConfigurations: OpenAILanguageModelConfigurations = {
 	...defaultConfigurations,
 	reasoningEffort: "none",
+};
+
+/**
+ * GPT-5.1-codex only supports reasoningEffort: low/medium/high and textVerbosity: medium.
+ */
+const gpt51CodexConfigurations: OpenAILanguageModelConfigurations = {
+	...defaultConfigurations,
+	reasoningEffort: "medium",
+	textVerbosity: "medium",
 };
 
 export const OpenAILanguageModelId = z
@@ -115,7 +124,7 @@ const gpt52: OpenAILanguageModel = {
 		Capability.OptionalSearchGrounding |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
-	configurations: gpt52And51Configurations,
+	configurations: gpt52And51ThinkingConfigurations,
 };
 
 const gpt51Thinking: OpenAILanguageModel = {
@@ -127,7 +136,7 @@ const gpt51Thinking: OpenAILanguageModel = {
 		Capability.OptionalSearchGrounding |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
-	configurations: gpt52And51Configurations,
+	configurations: gpt52And51ThinkingConfigurations,
 };
 
 const gpt51codex: OpenAILanguageModel = {
@@ -139,7 +148,7 @@ const gpt51codex: OpenAILanguageModel = {
 		Capability.OptionalSearchGrounding |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
-	configurations: gpt52And51Configurations,
+	configurations: gpt51CodexConfigurations,
 };
 
 const gpt5: OpenAILanguageModel = {


### PR DESCRIPTION
### **User description**
### Summary
This PR fixes the configuration options for the GPT-5.1-codex model, which has different constraints compared to GPT-5.2 and GPT-5.1-thinking models. GPT-5.1-codex only supports `low/medium/high` for reasoningEffort (no `none` or `xhigh`) and only `medium` for textVerbosity.

### Related Issue
N/A

### Changes
- Updated `getDefaultReasoningEffort()` to return `"medium"` for GPT-5.1-codex (instead of `"none"`)
- Updated `getReasoningEffortOptions()` to return `["low", "medium", "high"]` for GPT-5.1-codex
- Added `getTextVerbosityOptions()` function to return model-specific verbosity options
- Updated language model registry schema for GPT-5.1-codex to reflect the correct allowed values
- Created separate `gpt51CodexConfigurations` object with appropriate defaults
- Renamed `gpt52And51Configurations` to `gpt52And51ThinkingConfigurations` for clarity

### Testing
Manual testing required to verify:
1. GPT-5.1-codex model shows only low/medium/high reasoning effort options in the UI
2. GPT-5.1-codex model shows only medium textVerbosity option in the UI
3. Default reasoning effort for GPT-5.1-codex is "medium"

### Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Restrict GPT-5.1-codex to low/medium/high reasoning effort options

- Set GPT-5.1-codex default reasoning effort to "medium"

- Limit GPT-5.1-codex textVerbosity to "medium" only

- Separate GPT-5.1-codex configurations from GPT-5.2/5.1-thinking models


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GPT-5.1-codex Model"] -->|"Restrict reasoning effort"| B["low/medium/high options"]
  A -->|"Set default reasoning"| C["medium"]
  A -->|"Limit verbosity"| D["medium only"]
  A -->|"Use dedicated config"| E["gpt51CodexConfigurations"]
  F["GPT-5.2/5.1-thinking"] -->|"Keep existing options"| G["none/low/medium/high/xhigh"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-defaults.ts</strong><dd><code>Adjust GPT-5.1-codex default reasoning effort</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/model-defaults.ts

<ul><li>Updated <code>getDefaultReasoningEffort()</code> to return "medium" for <br>GPT-5.1-codex instead of "none"<br> <li> Separated GPT-5.1-codex handling from GPT-5.2 and GPT-5.1-thinking <br>models<br> <li> Updated documentation comments to reflect model-specific constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2516/files#diff-abf53293c426bd9168c076223d4fcf76b9f91fef6d57f33c7d94ad017147404d">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Update GPT-5.1-codex registry schema constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model-registry/src/openai.ts

<ul><li>Changed <code>reasoningEffort</code> schema from ["none", "low", "medium", "high", <br>"xhigh"] to ["low", "medium", "high"]<br> <li> Changed <code>textVerbosity</code> schema from ["low", "medium", "high"] to <br>["medium"]<br> <li> Updated default <code>reasoningEffort</code> from "none" to "medium" for <br>GPT-5.1-codex</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2516/files#diff-e6017504117029db5da4178595c2dea30f4436d59fa5e293cf2c4d43998db98d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Separate GPT-5.1-codex configuration object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/openai.ts

<ul><li>Renamed <code>gpt52And51Configurations</code> to <code>gpt52And51ThinkingConfigurations</code> <br>for clarity<br> <li> Created new <code>gpt51CodexConfigurations</code> object with "medium" as default <br>reasoning effort<br> <li> Updated <code>gpt52</code> and <code>gpt51Thinking</code> models to use <br><code>gpt52And51ThinkingConfigurations</code><br> <li> Updated <code>gpt51codex</code> model to use <code>gpt51CodexConfigurations</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2516/files#diff-1891a7f0ef98437d982f18296668e40c171f03da7e4b82d2dff4b3a2b3f791d8">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.tsx</strong><dd><code>Add model-specific UI option filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx

<ul><li>Updated <code>getReasoningEffortOptions()</code> to return ["low", "medium", <br>"high"] specifically for GPT-5.1-codex<br> <li> Added new <code>getTextVerbosityOptions()</code> function to return model-specific <br>verbosity options<br> <li> Updated textVerbosity dropdown to use <code>getTextVerbosityOptions()</code> <br>instead of hardcoded values<br> <li> Updated documentation comments to reflect GPT-5.1-codex constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2516/files#diff-dc80a63a37f4eac39c7a2fbe8976912929b8ad377394512e91117e5ec636cfdc">+23/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts `gpt-5.1-codex` to low/medium/high reasoning and medium verbosity, updating defaults, UI options, configs, and registry schemas.
> 
> - **UI (workflow-designer)**:
>   - Update `getReasoningEffortOptions()` to return `["low","medium","high"]` for `gpt-5.1-codex` and keep extended options for `gpt-5.2`/`gpt-5.1-thinking`.
>   - Add `getTextVerbosityOptions()` and wire into `Select` to limit `gpt-5.1-codex` verbosity to `"medium"`.
>   - Adjust `getDefaultReasoningEffort()` to exclude `gpt-5.1-codex` from `"none"` default; now defaults to `"medium"`.
> - **Language Model Registry**:
>   - Constrain `openai/gpt-5.1-codex` schemas to `reasoningEffort: ["low","medium","high"]` and `textVerbosity: ["medium"]`; set default `reasoningEffort: "medium"`.
> - **Language Model Definitions**:
>   - Introduce `gpt51CodexConfigurations` with `reasoningEffort: "medium"`, `textVerbosity: "medium"`.
>   - Rename `gpt52And51Configurations` to `gpt52And51ThinkingConfigurations` and apply to `gpt-5.2` and `gpt-5.1-thinking`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52e58f51deec2d7c51574c981166e6830ca5097f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Adjusted model-specific parameter options for GPT-5.1-codex, GPT-5.2, and GPT-5.1-thinking models
  * Updated default reasoning effort settings; GPT-5.1-codex now defaults to "medium" instead of "none"
  * Modified available text verbosity options per model; GPT-5.1-codex now supports "medium" only

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
