### PR TITLE
Rename context menu labels: Static → Source, Dynamic → Retrieval

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -433,6 +433,8 @@ export function Toolbar() {
 																createFileNode(FileCategory.parse("text")),
 															),
 														);
+													} else if (sourceType === "webPage") {
+														setSelectedTool(addNodeTool(createWebPageNode()));
 													}
 												}}
 											>
@@ -467,6 +469,14 @@ export function Toolbar() {
 												>
 													<TextFileIcon className="w-[20px] h-[20px]" />
 													<p className="text-[14px]">Text Upload</p>
+												</ToggleGroup.Item>
+												<ToggleGroup.Item
+													value="webPage"
+													data-tool
+													className="hover:bg-[rgba(222,233,242,0.10)]"
+												>
+													<WebPageFileIcon className="w-[20px] h-[20px]" />
+													<p className="text-[14px]">Webpage</p>
 												</ToggleGroup.Item>
 											</ToggleGroup.Root>
 											<ToggleGroup.Root
@@ -523,9 +533,6 @@ export function Toolbar() {
 														case "query":
 															setSelectedTool(addNodeTool(createQueryNode()));
 															break;
-														case "webPage":
-															setSelectedTool(addNodeTool(createWebPageNode()));
-															break;
 													}
 												}}
 											>
@@ -536,14 +543,6 @@ export function Toolbar() {
 												>
 													<DatabaseZapIcon className="w-[20px] h-[20px]" />
 													<p className="text-[14px]">Query</p>
-												</ToggleGroup.Item>
-												<ToggleGroup.Item
-													value="webPage"
-													data-tool
-													className="hover:bg-[rgba(222,233,242,0.10)]"
-												>
-													<WebPageFileIcon className="w-[20px] h-[20px]" />
-													<p className="text-[14px]">Webpage</p>
 												</ToggleGroup.Item>
 											</ToggleGroup.Root>
 										</div>


### PR DESCRIPTION
### **User description**
## Summary
- Rename context menu labels: Static → Source, Dynamic → Retrieval
- Move Webpage from Retrieval to Source section in context toolbar

## Changes

| main | This PR |
|--------|--------|
| <img width="271" height="427" alt="image" src="https://github.com/user-attachments/assets/234d81ab-1093-495d-b15c-7cd8180bb17b" /> | <img width="233" height="418" alt="image" src="https://github.com/user-attachments/assets/a580c820-27b6-438c-9efc-97708154fccb" /> | 

___

### **PR Type**
Enhancement


___

### **Description**
- Rename context menu labels for clarity

- "Static" changed to "Source"

- "Dynamic" changed to "Retrieval"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Context Menu Labels"] -- "rename" --> B["Static → Source"]
  A -- "rename" --> C["Dynamic → Retrieval"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolbar.tsx</strong><dd><code>Update context menu label terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx

<ul><li>Renamed "Static" label to "Source" in context menu section<br> <li> Renamed "Dynamic" label to "Retrieval" in context menu section<br> <li> Updated UI text labels for improved terminology clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2518/files#diff-66d2626182bb02f543d898ac63a53bfe09b5ee215056b7810b6235686968ddf7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames context menu sections to Source/Retrieval and relocates the Webpage option from Retrieval to Source (with corresponding handler updates).
> 
> - **UI (workflow designer toolbar `toolbar.tsx`)**:
>   - **Context popover**:
>     - Rename section labels: `Static` → `Source`, `Dynamic` → `Retrieval`.
>     - **Source**:
>       - Add `Webpage` option (`WebPageFileIcon`) and handle `webPage` in `onValueChange` via `createWebPageNode()`.
>     - **Retrieval**:
>       - Remove `Webpage` option; now only `query` is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30b2511b0ad1885ce2fc49668cbfca9aba143a1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated toolbar labels in the workflow designer: "Static" is now "Source" and "Dynamic" is now "Retrieval".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->