### PR TITLE
Rename Query node default name to "Vector Query"

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -535,7 +535,7 @@ export function Toolbar() {
 													className="hover:bg-[rgba(222,233,242,0.10)]"
 												>
 													<DatabaseZapIcon className="w-[20px] h-[20px]" />
-													<p className="text-[14px]">Query</p>
+													<p className="text-[14px]">Vector Query</p>
 												</ToggleGroup.Item>
 												<ToggleGroup.Item
 													value="webPage"

--- a/packages/node-registry/src/node-default-name.ts
+++ b/packages/node-registry/src/node-default-name.ts
@@ -82,7 +82,7 @@ export function defaultName(node: NodeLike) {
 					if (!isQueryNode(node)) {
 						throw new Error(`Expected query node, got ${node.type}`);
 					}
-					return node.name ?? "Query";
+					return node.name ?? "Vector Query";
 				case "end":
 					if (!isEndNode(node)) {
 						throw new Error(`Expected end node, got ${node.type}`);


### PR DESCRIPTION
### **User description**
## Summary
Update the default display name from "Query" to "Vector Query" to better reflect the node's purpose of performing vector store searches.

## Changes
| main | This PR |
|--------|--------|
| <img width="264" height="421" alt="image" src="https://github.com/user-attachments/assets/6ea188d3-dc28-4118-ad50-01454c51f772" /> | <img width="238" height="413" alt="image" src="https://github.com/user-attachments/assets/f720286c-12e9-4a84-95cf-314354d64b85" /> | 
| <img width="416" height="99" alt="image" src="https://github.com/user-attachments/assets/b2d0d883-e667-4c62-920a-9711de36c3fa" /> | <img width="442" height="99" alt="image" src="https://github.com/user-attachments/assets/aa5134f5-e81d-49f0-afae-c026d725b841" /> |

___

### **PR Type**
Enhancement


___

### **Description**
- Rename Query node default name to "Vector Query"

- Update toolbar label to match new node naming

- Better reflect node's vector store search purpose


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query Node"] -- "rename default name" --> B["Vector Query Node"]
  C["Toolbar UI"] -- "update label" --> D["Vector Query Label"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-default-name.ts</strong><dd><code>Update query node default name constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-registry/src/node-default-name.ts

<ul><li>Changed default name for query nodes from "Query" to "Vector Query"<br> <li> Updated the fallback name returned by <code>defaultName()</code> function for query <br>node type</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2519/files#diff-70e8319c76ee6bdfff462b7250f469e33cb0d7b9ea7cd12c4cc976511535bfe1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>toolbar.tsx</strong><dd><code>Update toolbar query button label text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx

<ul><li>Updated toolbar button label from "Query" to "Vector Query"<br> <li> Maintains consistency with renamed node default name</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2519/files#diff-66d2626182bb02f543d898ac63a53bfe09b5ee215056b7810b6235686968ddf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames the query node default name and toolbar label to "Vector Query".
> 
> - **UI (workflow-designer-ui)**:
>   - Update `ToggleGroup.Item` label for `query` in `internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx` from `Query` to `Vector Query`.
> - **Node Registry**:
>   - Change default name for `query` nodes in `packages/node-registry/src/node-default-name.ts` from `Query` to `Vector Query`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60b7b1b0ac9982461541a21ade863b9729114b9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed the "Query" option to "Vector Query" throughout the workflow designer interface for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->