### PR TITLE
Rename "Event" grouping to "Integration" in toolbar

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/hooks/use-keyboard-shortcuts.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/hooks/use-keyboard-shortcuts.ts
@@ -101,7 +101,7 @@ export function useKeyboardShortcuts(
 		() => addNodeTool(createAppEntryNode()),
 		!isStageFlowAlreadyPlaced,
 	);
-	useToolAction("e", selectIntegrationTool);
+	useToolAction("i", selectIntegrationTool);
 	useToolAction("c", selectContextTool);
 	useToolAction("m", selectLanguageModelTool, !generateContentNode);
 	useToolAction("m", selectLanguageModelV2Tool, generateContentNode);

--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -277,7 +277,7 @@ export function Toolbar() {
 						data-tool
 						className="relative order-4"
 					>
-						<Tooltip text={<TooltipAndHotkey text="Event" hotkey="e" />}>
+						<Tooltip text={<TooltipAndHotkey text="Integration" hotkey="i" />}>
 							<CableIcon data-icon />
 						</Tooltip>
 						{selectedTool?.action === "selectIntegration" && (


### PR DESCRIPTION
### **User description**
## Summary
Change the grouping name for GitHub Trigger/Action nodes from "Event" to "Integration" as it better represents external service connections. Also update the keyboard shortcut from "e" to "i".

## Changes
| main | This PR |
|--------|--------|
| <img width="227" height="202" alt="image" src="https://github.com/user-attachments/assets/45851f45-73e9-4ce6-b031-113e9efee39c" /> | <img width="255" height="218" alt="image" src="https://github.com/user-attachments/assets/cc1bf498-7fe7-4193-ad8f-a77302b4d347" /> | 


___

### **PR Type**
Enhancement


___

### **Description**
- Rename "Event" grouping to "Integration" in toolbar

- Update keyboard shortcut from "e" to "i"

- Better represents external service connections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event grouping<br/>with shortcut e"] -- "rename and<br/>update shortcut" --> B["Integration grouping<br/>with shortcut i"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-keyboard-shortcuts.ts</strong><dd><code>Update integration tool keyboard shortcut</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/hooks/use-keyboard-shortcuts.ts

<ul><li>Updated keyboard shortcut for <code>selectIntegrationTool</code> from "e" to "i"</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2520/files#diff-bdc94c9cef917edf79902c1476db43900d19b665ecdcd5f07798153ab9f78633">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>toolbar.tsx</strong><dd><code>Update integration tool tooltip and hotkey</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx

<ul><li>Changed tooltip text from "Event" to "Integration"<br> <li> Updated associated hotkey display from "e" to "i"</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2520/files#diff-66d2626182bb02f543d898ac63a53bfe09b5ee215056b7810b6235686968ddf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames the toolbar group to Integration with hotkey "i" and moves Webpage into Static Context sources.
> 
> - **UI Toolbar**:
>   - Integration tool: tooltip label updated to "Integration" with hotkey `i` in `internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx`.
>   - Context panel: add Static "Webpage" source (`createWebPageNode`) and remove "Webpage" from Dynamic list.
> - **Keyboard Shortcuts**:
>   - Update `selectIntegrationTool` shortcut from `e` to `i` in `internal-packages/workflow-designer-ui/src/editor/hooks/use-keyboard-shortcuts.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeae726481db275f1198c6b2069e9365c0c2d1cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Web Page upload option in the Static triggers, which creates a Web Page node when selected.
  * Introduced corresponding UI elements for the new Web Page option.

* **Bug Fixes**
  * Updated the Integration tool label and hotkey from "Event (e)" to "Integration (i)" for clarity and consistency.
  * Removed the Web Page option from the Dynamic/Query section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->