### PR TITLE
Refactor final step output UI and remove unused component

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/experimental/final-step-output.tsx
+++ b/apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/experimental/final-step-output.tsx
@@ -15,24 +15,6 @@ export function FinalStepOutput({
 	const defaultTabValue = outputs.at(0)?.generation.id;
 	const singleOutput = outputCount === 1 ? outputs[0] : undefined;
 
-	const OutputGenerationPanel = ({
-		generation,
-	}: {
-		generation: (typeof outputs)[number]["generation"];
-	}) => {
-		return (
-			<>
-				<div className="flex items-center justify-between mb-2 w-full">
-					<div className="flex-1" />
-					<OutputActions generation={generation} />
-				</div>
-				<div className="[&_.markdown-renderer]:text-[13px] [&_*[class*='text-[14px]']]:text-[13px] [&_*]:text-text-muted/70 [&_*[class*='text-inverse']]:!text-text-muted/70">
-					<GenerationView generation={generation} />
-				</div>
-			</>
-		);
-	};
-
 	return (
 		<div className="mt-8">
 			<div className="flex items-center justify-between text-text-muted text-[13px] font-semibold mb-2 w-full">
@@ -51,17 +33,25 @@ export function FinalStepOutput({
 					</span>
 				</p>
 			) : singleOutput ? (
-				<div className="overflow-hidden rounded-xl bg-blue-muted/5 px-4 py-3">
-					<OutputGenerationPanel generation={singleOutput.generation} />
+				<div className="overflow-hidden rounded-t-xl rounded-b-none bg-blue-muted/5 px-4 py-3">
+					<div className="flex items-center justify-between mb-2 w-full gap-3">
+						<h3 className="text-[14px] font-medium text-inverse truncate">
+							{singleOutput.title}
+						</h3>
+						<OutputActions generation={singleOutput.generation} />
+					</div>
+					<div className="[&_.markdown-renderer]:text-[13px] [&_*[class*='text-[14px]']]:text-[13px] [&_*]:text-text-muted/70 [&_*[class*='text-inverse']]:!text-text-muted/70">
+						<GenerationView generation={singleOutput.generation} />
+					</div>
 				</div>
 			) : (
 				<Tabs.Root defaultValue={defaultTabValue}>
-					<Tabs.List className="inline-flex items-center gap-1 rounded-xl bg-blue-muted/5 p-1">
+					<Tabs.List className="inline-flex items-center gap-0 rounded-t-xl rounded-b-none max-w-full overflow-x-auto pl-4">
 						{outputs.map((output) => (
 							<Tabs.Trigger
 								key={output.generation.id}
 								value={output.generation.id}
-								className="rounded-lg px-2.5 py-1.5 text-[13px] font-medium text-text-muted/70 transition-colors hover:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(192,73%,84%)]/30 data-[state=active]:bg-blue-muted/10 data-[state=active]:text-text-muted"
+								className="rounded-t-lg rounded-b-none px-2.5 py-1.5 text-[13px] font-medium transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(192,73%,84%)]/30 text-text-muted/70 hover:text-text-muted data-[state=active]:bg-blue-muted/10 data-[state=active]:text-text-muted"
 							>
 								{output.title}
 							</Tabs.Trigger>
@@ -72,9 +62,17 @@ export function FinalStepOutput({
 						<Tabs.Content
 							key={output.generation.id}
 							value={output.generation.id}
-							className="mt-3 overflow-hidden rounded-xl bg-blue-muted/5 px-4 py-3"
+							className="overflow-hidden rounded-xl bg-blue-muted/10 px-4 py-3"
 						>
-							<OutputGenerationPanel generation={output.generation} />
+							<div className="flex items-center justify-between mb-2 w-full gap-3">
+								<h3 className="text-[14px] font-medium text-inverse truncate">
+									{output.title}
+								</h3>
+								<OutputActions generation={output.generation} />
+							</div>
+							<div className="[&_.markdown-renderer]:text-[13px] [&_*[class*='text-[14px]']]:text-[13px] [&_*]:text-text-muted/70 [&_*[class*='text-inverse']]:!text-text-muted/70">
+								<GenerationView generation={output.generation} />
+							</div>
 						</Tabs.Content>
 					))}
 				</Tabs.Root>


### PR DESCRIPTION
### **User description**
Inline the `OutputGenerationPanel` component and update styling to use rounded top corners only. Add title display in single and tabbed output views.


___

### **PR Type**
Enhancement


___

### **Description**
- Inline `OutputGenerationPanel` component into single and tabbed views

- Add title display for outputs in both view modes

- Update border radius to rounded top corners only

- Refine tab styling with improved spacing and overflow handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OutputGenerationPanel<br/>component"] -->|"inline into"| B["Single output<br/>view"]
  A -->|"inline into"| C["Tabbed output<br/>view"]
  B -->|"add"| D["Title display<br/>& styling"]
  C -->|"add"| D
  E["Border radius<br/>updates"] -->|"apply to"| B
  E -->|"apply to"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>final-step-output.tsx</strong><dd><code>Inline output panel and add title display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/experimental/final-step-output.tsx

<ul><li>Removed <code>OutputGenerationPanel</code> component definition and inlined its <br>content into both single and tabbed output views<br> <li> Added title display (<code>h3</code> element) for outputs in single output view <br>with truncation support<br> <li> Added title display for outputs in tabbed content view with matching <br>styling<br> <li> Updated border radius from <code>rounded-xl</code> to <code>rounded-t-xl rounded-b-none</code> <br>for single output and tab list<br> <li> Refined tab trigger styling with <code>rounded-t-lg rounded-b-none</code>, <br><code>whitespace-nowrap</code>, and improved color transitions<br> <li> Updated tab content background from <code>bg-blue-muted/5</code> to <br><code>bg-blue-muted/10</code> and removed top margin<br> <li> Modified tab list layout with <code>gap-0</code>, <code>max-w-full</code>, <code>overflow-x-auto</code>, and <br><code>pl-4</code> for better spacing and scrolling</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2522/files#diff-086118daa83a2f12c2af646fd73dbbc27e5dda66e31d761c909f04ef42c947c4">+22/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned output display layout for improved clarity and visual hierarchy.
  * Updated styling for tabbed outputs with enhanced spacing and scrolling behavior.
  * Refined visual appearance of headers, typography, and color contrast for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->