### PR TITLE
Show output count in final step output header

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/experimental/final-step-output.tsx
+++ b/apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/experimental/final-step-output.tsx
@@ -36,7 +36,11 @@ export function FinalStepOutput({
 	return (
 		<div className="mt-8">
 			<div className="flex items-center justify-between text-text-muted text-[13px] font-semibold mb-2 w-full">
-				<span className="block">Output from last completed step</span>
+				<span className="block">
+					{outputCount > 1
+						? `Outputs from last completed step (${outputCount})`
+						: "Output from last completed step"}
+				</span>
 			</div>
 			{finalStep.finishedStepItemsCount === 0 ? (
 				<p className="text-[13px] text-text-muted/70 italic">


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Display output count in final step output header when multiple outputs exist

- Conditionally show pluralized text based on output count

- Improves clarity for users viewing step results


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Output Header Text"] -->|outputCount > 1| B["Show count in parentheses"]
  A -->|outputCount = 1| C["Show singular form"]
  B --> D["Outputs from last completed step (N)"]
  C --> E["Output from last completed step"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>final-step-output.tsx</strong><dd><code>Add conditional output count display to header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/experimental/final-step-output.tsx

<ul><li>Modified output header text to conditionally display output count<br> <li> Added ternary operator to show pluralized "Outputs" with count when <br>outputCount > 1<br> <li> Maintains singular "Output" text when outputCount equals 1<br> <li> Enhances user experience by providing visibility into number of <br>outputs</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2525/files#diff-086118daa83a2f12c2af646fd73dbbc27e5dda66e31d761c909f04ef42c947c4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed output label to correctly pluralize in the final step results display based on the number of outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->