### PR TITLE
Proofreading: End Node panel

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/index.tsx
@@ -321,7 +321,8 @@ function TryPlaygroundSection({ isDisabled }: { isDisabled: boolean }) {
 			<TryPlaygroundLink isDisabled={isDisabled} />
 			{isDisabled && (
 				<p className="mt-[6px] text-[11px] text-text-muted/50">
-					Make sure there's a connection from Start to End to try this app in the playground.
+					Make sure there's a connection from Start to End to try this app in
+					the playground.
 				</p>
 			)}
 		</div>


### PR DESCRIPTION
### **User description**
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
Fix up various text on the End Node panel.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->

## Testing
<!-- Briefly describe the testing steps or results. -->
- Create a new app
- Add a Start/End Node, then click on the End Node to open the panel

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Documentation


___

### **Description**
- Standardize button text to title case ("Add Output")

- Simplify and clarify End Node panel labels and helper text

- Improve user-facing messaging for output configuration

- Refine playground connection requirement description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["End Node Panel UI"] -- "Update button text" --> B["Title case standardization"]
  A -- "Simplify labels" --> C["Clearer output descriptions"]
  A -- "Improve helper text" --> D["Better user guidance"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Proofreading and text clarity improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/index.tsx

<ul><li>Changed button text from "Add output" to "Add Output" for title case <br>consistency<br> <li> Simplified "Output(s) of the app" label to "Outputs"<br> <li> Rewrote helper text from "What is displayed here will be shown as the <br>result of the App" to "These outputs will determine the results of <br>your app"<br> <li> Updated empty state message from "No outputs are connected to this End <br>node yet" to "This node doesn't have any outputs yet"<br> <li> Shortened secondary helper text from "Add a node to use as an App <br>output first" to "Add a node as an output first"<br> <li> Refined playground connection requirement message for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2526/files#diff-bc6a6965ac4a02bc095ad86898adff1fabbde42e330f4ec89e7fb93a1d8cf6c5">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated UI labels, button text, section header, and helper/instructional copy in the End Node properties panel for clearer, more concise guidance (e.g., button capitalization, "Outputs" section label, and streamlined playground/connect instructions).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->