### PR TITLE
Login redirect conditional change

### DIFF
--- a/apps/studio.giselles.ai/app/(auth)/join/success/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/success/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
+import { stageFlag } from "@/flags";
 import { AuthButton } from "../../components/auth-button";
 
-export default function Page() {
+export default async function Page() {
+	const isStageEnabled = await stageFlag();
+	const redirectTo = isStageEnabled ? "/playground" : "/workspaces";
+
 	return (
 		<div className="min-h-screen flex items-center justify-center p-4">
 			<div className="flex items-center justify-center py-12">
@@ -17,7 +21,7 @@ export default function Page() {
 						</p>
 						<div className="mt-2">
 							<AuthButton asChild className="px-8 py-2 text-lg">
-								<Link href="/workspaces">Go to team</Link>
+								<Link href={redirectTo}>Go to team</Link>
 							</AuthButton>
 						</div>
 					</div>

--- a/apps/studio.giselles.ai/app/(auth)/login/login.ts
+++ b/apps/studio.giselles.ai/app/(auth)/login/login.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { isValidReturnUrl } from "@/app/(auth)/lib";
+import { stageFlag } from "@/flags";
 import { type AuthError, createAuthError, createClient } from "@/lib/supabase";
 
 export async function login(
@@ -31,10 +32,13 @@ export async function login(
 		return createAuthError(error);
 	}
 
+	const isStageEnabled = await stageFlag();
+	const fallbackUrl = isStageEnabled ? "/playground" : "/workspaces";
+
 	// Validate returnUrl to prevent open redirect attacks
 	const validReturnUrl = isValidReturnUrl(returnUrlEntry)
 		? returnUrlEntry
-		: "/workspaces";
+		: fallbackUrl;
 	redirect(validReturnUrl);
 	return null;
 }


### PR DESCRIPTION
### **User description**
## Summary
Updates the default post-authentication redirect destination to `/playground` instead of `/workspaces` when the `stageFlag` feature flag is enabled.

## Related Issue
N/A

## Changes
- **`apps/studio.giselles.ai/app/(auth)/login/login.ts`**: Modified the default redirect fallback URL to `/playground` if `stageFlag()` is true, otherwise `/workspaces`.
- **`apps/studio.giselles.ai/app/(auth)/join/success/page.tsx`**: Updated the "Go to team" button's link to dynamically point to `/playground` or `/workspaces` based on `stageFlag()`.

## Testing
- Ran `pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, and `pnpm test` successfully.

## Other Information
This change ensures consistency in redirect behavior across login and new account creation flows when the `stageFlag` is active.

---
<a href="https://cursor.com/background-agent?bcId=bc-d96e40d2-e7a6-4258-b374-04e58427d5d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d96e40d2-e7a6-4258-b374-04e58427d5d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Enhancement


___

### **Description**
- Implement conditional redirect to `/playground` based on `stageFlag` feature flag

- Update login flow to use dynamic fallback URL instead of hardcoded `/workspaces`

- Make join success page async to support feature flag evaluation

- Ensure consistent redirect behavior across authentication flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Authentication"] --> B["Check stageFlag"]
  B -->|Enabled| C["/playground"]
  B -->|Disabled| D["/workspaces"]
  C --> E["Redirect User"]
  D --> E
  E --> F["Login/Join Success"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>login.ts</strong><dd><code>Add stage flag-based redirect logic to login</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(auth)/login/login.ts

<ul><li>Import <code>stageFlag</code> from feature flags module<br> <li> Evaluate <code>stageFlag()</code> after successful authentication<br> <li> Set <code>fallbackUrl</code> to <code>/playground</code> when stage flag enabled, otherwise <br><code>/workspaces</code><br> <li> Replace hardcoded <code>/workspaces</code> fallback with dynamic <code>fallbackUrl</code> <br>variable</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2529/files#diff-ad01a43bd06ccd096d01eb6e27d7f74d12d35716c2d31e3f548037fa89903ade">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Make join success page async with dynamic redirect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(auth)/join/success/page.tsx

<ul><li>Import <code>stageFlag</code> from feature flags module<br> <li> Convert page component to async function to support feature flag <br>evaluation<br> <li> Evaluate <code>stageFlag()</code> and set <code>redirectTo</code> variable conditionally<br> <li> Update "Go to team" button link to use dynamic <code>redirectTo</code> instead of <br>hardcoded <code>/workspaces</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2529/files#diff-d5d23ec8ee94219aba3cdd91ec2ad0cdb8bc550dec395ee8c787402bc46fbc95">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated post-authentication routing to dynamically direct users to the appropriate destination based on available platform features, improving the experience for both login and signup flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->