### PR TITLE
Playground: autofocus prompt input on navigation

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
@@ -3,6 +3,7 @@
 import { Select } from "@giselle-internal/ui/select";
 import type { GenerationContextInput } from "@giselles-ai/protocol";
 import { ArrowUpIcon, Paperclip, X } from "lucide-react";
+import { useEffect } from "react";
 import { FileAttachments } from "../../playground/file-attachments";
 import type { StageApp } from "../../playground/types";
 import {
@@ -16,11 +17,13 @@ export function PlaygroundStageInput({
 	scope,
 	onSubmitAction,
 	isRunning,
+	shouldAutoFocus = false,
 }: {
 	apps: StageApp[];
 	scope: StageAppSelectionScope;
 	onSubmitAction: (event: { inputs: GenerationContextInput[] }) => void;
 	isRunning: boolean;
+	shouldAutoFocus?: boolean;
 }) {
 	const setSelectedAppId = useStageAppSelectionStore(
 		(state) => state.setSelectedAppId,
@@ -62,6 +65,17 @@ export function PlaygroundStageInput({
 	});
 
 	const firstAppOptionValue = appOptions[0]?.value;
+
+	// We intentionally focus the prompt input on /playground entry.
+	// This can't be done during render; it requires an effect after mount.
+	useEffect(() => {
+		if (!shouldAutoFocus || isRunning) return;
+		const textarea = textareaRef.current;
+		if (!textarea) return;
+		textarea.focus();
+		const end = textarea.value.length;
+		textarea.setSelectionRange(end, end);
+	}, [isRunning, shouldAutoFocus, textareaRef]);
 
 	return (
 		<div className="relative w-full max-w-[640px] min-w-[320px] mx-auto">

--- a/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
@@ -301,6 +301,7 @@ export function Page({
 							scope="playground"
 							onSubmitAction={handleRunSubmit}
 							isRunning={isRunning}
+							shouldAutoFocus
 						/>
 					</div>
 


### PR DESCRIPTION
<img width="697" height="264" alt="スクリーンショット 2025-12-22 14 10 47" src="https://github.com/user-attachments/assets/5dc7c0c4-758e-44fa-ae94-f5486985f4cc" />

### What changed
- When navigating to /playground, automatically focus the prompt textarea so users can start typing immediately.
- Implemented via ref + useEffect (avoids the autoFocus attribute to satisfy a11y lint).

### Files changed
- apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
- apps/studio.giselles.ai/app/(main)/playground/page.client.tsx


___

### **PR Type**
Enhancement


___

### **Description**
- Add autofocus functionality to playground prompt textarea

- Implement focus via useEffect hook after component mount

- Position cursor at end of textarea value on focus

- Pass shouldAutoFocus prop from page to stage input component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["page.client.tsx"] -- "passes shouldAutoFocus prop" --> B["PlaygroundStageInput"]
  B -- "useEffect hook" --> C["Focus textarea & set cursor position"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playground-stage-input.tsx</strong><dd><code>Add autofocus logic to prompt textarea</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx

<ul><li>Add <code>useEffect</code> import from React<br> <li> Add <code>shouldAutoFocus</code> optional prop with default value false<br> <li> Implement useEffect hook to focus textarea and position cursor at end<br> <li> Include guard conditions to prevent focus when running or prop is <br>false</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2531/files#diff-3adf1662d37dc3d71b30dbe9c4a77393a59741e0e28a42faf2298e3734b46bad">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.client.tsx</strong><dd><code>Enable autofocus on playground stage input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/playground/page.client.tsx

- Pass `shouldAutoFocus` prop to PlaygroundStageInput component


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2531/files#diff-bee7c505d563c48e3d29a449cdcec06f7018b455056f0594073521829583703f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional auto-focus capability to the playground input field. The text area can now automatically receive focus with the cursor positioned at the end upon render.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->