### PR TITLE
feat: add subtle idle hints in Playground and Task detail

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
@@ -2,7 +2,10 @@
 
 import { Select } from "@giselle-internal/ui/select";
 import type { GenerationContextInput } from "@giselles-ai/protocol";
+import clsx from "clsx";
 import { ArrowUpIcon, Paperclip, X } from "lucide-react";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FileAttachments } from "../../playground/file-attachments";
 import type { StageApp } from "../../playground/types";
 import {
@@ -11,16 +14,30 @@ import {
 } from "../../stores/stage-app-selection-store";
 import { ACCEPTED_FILE_TYPES, useStageInput } from "./use-stage-input";
 
+const DEFAULT_IDLE_NUDGE_DELAY_MS = 8000;
+const PLAYGROUND_HAS_VISITED_KEY = "giselle:playground:hasVisited";
+const PLAYGROUND_HAS_SHOWN_IDLE_HINT_KEY =
+	"giselle:playground:hasShownIdleHint";
+const PLAYGROUND_HAS_RUN_ANY_APP_KEY = "giselle:playground:hasRunAnyApp";
+
 export function PlaygroundStageInput({
 	apps,
 	scope,
 	onSubmitAction,
 	isRunning,
+	interactionTick,
+	idleNudgeDelayMs = DEFAULT_IDLE_NUDGE_DELAY_MS,
+	renderIdleHint,
+	hasRunAnyApp,
 }: {
 	apps: StageApp[];
 	scope: StageAppSelectionScope;
 	onSubmitAction: (event: { inputs: GenerationContextInput[] }) => void;
 	isRunning: boolean;
+	interactionTick?: number;
+	idleNudgeDelayMs?: number;
+	renderIdleHint?: (props: { isVisible: boolean }) => ReactNode;
+	hasRunAnyApp?: boolean;
 }) {
 	const setSelectedAppId = useStageAppSelectionStore(
 		(state) => state.setSelectedAppId,
@@ -63,17 +80,161 @@ export function PlaygroundStageInput({
 
 	const firstAppOptionValue = appOptions[0]?.value;
 
+	// Idle nudge: after a short inactivity window, subtly animate the next action.
+	// This must be handled in an effect (timer) and should stop on any interaction.
+	const [lastInteractionAt, setLastInteractionAt] = useState(() => Date.now());
+	const [isIdleNudgeActive, setIsIdleNudgeActive] = useState(false);
+	const [isIdleHintVisible, setIsIdleHintVisible] = useState(false);
+	const [isFirstVisit, setIsFirstVisit] = useState(false);
+	const [hasShownIdleHintEver, setHasShownIdleHintEver] = useState(false);
+	const [hasRunAnyAppEver, setHasRunAnyAppEver] = useState(false);
+
+	useEffect(() => {
+		try {
+			const hasVisited = window.localStorage.getItem(
+				PLAYGROUND_HAS_VISITED_KEY,
+			);
+			setIsFirstVisit(!hasVisited);
+			window.localStorage.setItem(PLAYGROUND_HAS_VISITED_KEY, "1");
+
+			const shown = window.localStorage.getItem(
+				PLAYGROUND_HAS_SHOWN_IDLE_HINT_KEY,
+			);
+			setHasShownIdleHintEver(Boolean(shown));
+
+			const ran = window.localStorage.getItem(PLAYGROUND_HAS_RUN_ANY_APP_KEY);
+			setHasRunAnyAppEver(Boolean(ran));
+		} catch {
+			// localStorage might be unavailable (privacy mode). In that case, disable the hint.
+			setIsFirstVisit(false);
+			setHasShownIdleHintEver(true);
+			setHasRunAnyAppEver(true);
+		}
+	}, []);
+
+	const markInteraction = useCallback(() => {
+		setIsIdleNudgeActive(false);
+		setLastInteractionAt(Date.now());
+	}, []);
+
+	useEffect(() => {
+		if (interactionTick === undefined) return;
+		markInteraction();
+	}, [interactionTick, markInteraction]);
+
+	const shouldShowIdleNudge = useMemo(() => {
+		if (isRunning) return false;
+		if (hasInput) return false;
+		if (hasPendingUploads) return false;
+		return true;
+	}, [hasInput, hasPendingUploads, isRunning]);
+
+	const shouldAllowIdleHint = useMemo(() => {
+		if (!renderIdleHint) return false;
+		if (!isFirstVisit) return false;
+		if (hasShownIdleHintEver) return false;
+		if (hasRunAnyAppEver || Boolean(hasRunAnyApp)) return false;
+		return shouldShowIdleNudge;
+	}, [
+		hasRunAnyApp,
+		hasRunAnyAppEver,
+		hasShownIdleHintEver,
+		isFirstVisit,
+		renderIdleHint,
+		shouldShowIdleNudge,
+	]);
+
+	useEffect(() => {
+		if (!shouldShowIdleNudge) {
+			setIsIdleNudgeActive(false);
+			return;
+		}
+
+		const timeout = setTimeout(() => {
+			if (Date.now() - lastInteractionAt >= idleNudgeDelayMs) {
+				setIsIdleNudgeActive(true);
+			}
+		}, idleNudgeDelayMs);
+
+		return () => clearTimeout(timeout);
+	}, [idleNudgeDelayMs, lastInteractionAt, shouldShowIdleNudge]);
+
+	// Ensure fade-in always transitions by flipping visibility on the next frame.
+	// (0 -> 1 opacity transitions can "pop" if the browser doesn't paint the 0 state first.)
+	useEffect(() => {
+		if (!renderIdleHint) return;
+		if (!shouldAllowIdleHint || !isIdleNudgeActive) {
+			setIsIdleHintVisible(false);
+			return;
+		}
+		const raf = window.requestAnimationFrame(() => {
+			setIsIdleHintVisible(true);
+			try {
+				window.localStorage.setItem(PLAYGROUND_HAS_SHOWN_IDLE_HINT_KEY, "1");
+				setHasShownIdleHintEver(true);
+			} catch {
+				// ignore
+			}
+		});
+		return () => window.cancelAnimationFrame(raf);
+	}, [isIdleNudgeActive, renderIdleHint, shouldAllowIdleHint]);
+
+	const handleInputChangeWithInteraction = useCallback(
+		(...args: Parameters<typeof handleInputChange>) => {
+			markInteraction();
+			return handleInputChange(...args);
+		},
+		[handleInputChange, markInteraction],
+	);
+
+	const handleKeyDownWithInteraction = useCallback(
+		(...args: Parameters<typeof handleKeyDown>) => {
+			markInteraction();
+			return handleKeyDown(...args);
+		},
+		[handleKeyDown, markInteraction],
+	);
+
+	const handleAttachmentButtonClickWithInteraction = useCallback(() => {
+		markInteraction();
+		handleAttachmentButtonClick();
+	}, [handleAttachmentButtonClick, markInteraction]);
+
+	const handleSubmitWithInteraction = useCallback(() => {
+		markInteraction();
+		handleSubmit();
+	}, [handleSubmit, markInteraction]);
+
+	const handleDropWithInteraction = useCallback(
+		(...args: Parameters<typeof handleDrop>) => {
+			markInteraction();
+			return handleDrop(...args);
+		},
+		[handleDrop, markInteraction],
+	);
+
+	const handleRemoveFileWithInteraction = useCallback(
+		(...args: Parameters<typeof handleRemoveFile>) => {
+			markInteraction();
+			return handleRemoveFile(...args);
+		},
+		[handleRemoveFile, markInteraction],
+	);
+
 	return (
 		<div className="relative w-full max-w-[640px] min-w-[320px] mx-auto">
+			{renderIdleHint ? renderIdleHint({ isVisible: isIdleHintVisible }) : null}
 			<section
 				aria-label="Message input and dropzone"
-				className={`relative rounded-2xl bg-[rgba(131,157,195,0.14)] shadow-[inset_0_1px_4px_rgba(0,0,0,0.22)] pt-4 pb-3 sm:pt-5 sm:pb-4 px-4 transition-colors ${
-					isDragActive ? "ring-1 ring-blue-muted/50" : ""
-				}`}
+				className={clsx(
+					"relative rounded-2xl bg-[rgba(131,157,195,0.14)] shadow-[inset_0_1px_4px_rgba(0,0,0,0.22)] pt-4 pb-3 sm:pt-5 sm:pb-4 px-4 transition-colors",
+					isDragActive && "ring-1 ring-blue-muted/50",
+					isIdleNudgeActive && "ring-1 ring-blue-muted/30",
+				)}
 				onDragEnter={handleDragEnter}
 				onDragOver={handleDragOver}
 				onDragLeave={handleDragLeave}
-				onDrop={handleDrop}
+				onDrop={handleDropWithInteraction}
 			>
 				{isDragActive ? (
 					<div className="pointer-events-none absolute inset-0 rounded-2xl border border-dashed border-blue-muted/60 bg-blue-muted/10" />
@@ -82,10 +243,10 @@ export function PlaygroundStageInput({
 					<textarea
 						ref={textareaRef}
 						value={inputValue}
-						onChange={handleInputChange}
+						onChange={handleInputChangeWithInteraction}
 						onCompositionStart={handleCompositionStart}
 						onCompositionEnd={handleCompositionEnd}
-						onKeyDown={handleKeyDown}
+						onKeyDown={handleKeyDownWithInteraction}
 						placeholder={selectedApp?.description ?? ""}
 						rows={1}
 						disabled={isRunning}
@@ -96,7 +257,7 @@ export function PlaygroundStageInput({
 						<div className="flex items-center gap-2 flex-1 max-w-[260px]">
 							<button
 								type="button"
-								onClick={handleAttachmentButtonClick}
+								onClick={handleAttachmentButtonClickWithInteraction}
 								className="group flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-[5px] transition-colors hover:bg-white/5"
 								aria-label="Attach files"
 							>
@@ -108,6 +269,7 @@ export function PlaygroundStageInput({
 									placeholder="Select an app..."
 									value={selectedApp?.id ?? firstAppOptionValue}
 									onValueChange={(appId) => {
+										markInteraction();
 										setSelectedAppId(scope, appId);
 									}}
 									widthClassName="w-full"
@@ -119,11 +281,13 @@ export function PlaygroundStageInput({
 						<div className="flex items-center gap-2">
 							<button
 								type="button"
-								onClick={handleSubmit}
+								onClick={handleSubmitWithInteraction}
 								disabled={!canSubmit}
-								className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-[5px] bg-[color:var(--color-inverse)] disabled:cursor-not-allowed ${
-									hasInput && !hasPendingUploads ? "opacity-100" : "opacity-40"
-								}`}
+								className={clsx(
+									"flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-[5px] bg-[color:var(--color-inverse)] disabled:cursor-not-allowed",
+									hasInput && !hasPendingUploads ? "opacity-100" : "opacity-40",
+									isIdleNudgeActive && "motion-safe:animate-pulse",
+								)}
 							>
 								<ArrowUpIcon className="h-3 w-3 text-[color:var(--color-background)]" />
 							</button>
@@ -132,7 +296,7 @@ export function PlaygroundStageInput({
 
 					<FileAttachments
 						files={attachedFiles}
-						onRemoveFile={handleRemoveFile}
+						onRemoveFile={handleRemoveFileWithInteraction}
 						workspaceId={selectedApp?.workspaceId}
 						basePath={basePath}
 						localPreviews={localPreviews}
@@ -177,7 +341,12 @@ export function PlaygroundStageInput({
 					/>
 				</div>
 			</section>
-			<div className="mt-1 flex flex-wrap items-center justify-end gap-3 pr-0 text-[11px] text-blue-muted/60">
+			<div
+				className={clsx(
+					"mt-1 flex flex-wrap items-center justify-end gap-3 pr-0 text-[11px] text-blue-muted/60",
+					isIdleNudgeActive && "motion-safe:animate-pulse",
+				)}
+			>
 				<div className="flex items-center gap-[6px]">
 					<div className="flex h-[18px] w-[18px] items-center justify-center rounded-[6px] border border-blue-muted/40 bg-blue-muted/10">
 						<span className="text-[10px] leading-none tracking-[0.08em]">

--- a/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/page.client.tsx
@@ -13,6 +13,7 @@ import type { ReactNode } from "react";
 import {
 	use,
 	useCallback,
+	useEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -32,6 +33,27 @@ type AppListCardBadgeType =
 	| "other-team"
 	| "official"
 	| "ambassador";
+
+function IdleHintArrow({ className }: { className?: string }) {
+	return (
+		<svg
+			className={className}
+			width="77"
+			height="127"
+			viewBox="0 0 77 127"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M76.1042 19.8128C76.0142 15.4228 75.7242 10.9328 74.4342 6.70278C73.7942 4.59278 72.8942 2.57278 71.7242 0.70278C70.7042 -0.92722 68.1042 0.57278 69.1342 2.21278C73.5042 9.19278 73.1742 17.9128 73.1542 25.8428C73.1342 33.6228 72.5742 41.6928 67.9042 48.2128C63.9642 53.7128 57.9742 58.1928 51.6442 60.5628C51.0242 60.7928 50.3942 61.0028 49.7542 61.1928C49.8142 57.2328 49.7342 53.2428 49.4442 49.3128C49.1642 45.6428 48.5842 41.8528 46.7942 38.5828C45.0842 35.4528 42.1142 33.0028 38.5442 32.4028C34.9242 31.7928 31.1242 32.7628 28.2042 34.9828C21.7242 39.9128 21.4842 49.7528 25.9542 56.1028C30.3042 62.2828 38.3942 65.9428 45.9142 65.0528C46.1542 65.0228 46.3942 64.9828 46.6342 64.9528C46.2242 71.9128 44.7642 78.6428 40.9842 84.7228C38.7142 88.3728 35.9542 91.6728 33.1942 94.9628C30.7642 97.8628 28.3042 100.743 25.7142 103.503C20.6042 108.933 14.8342 114.093 7.86415 116.963C7.57415 117.083 7.27415 117.193 6.97415 117.303C9.59415 113.043 12.6742 109.073 16.1742 105.463C17.5142 104.073 15.4042 101.953 14.0542 103.343C9.63415 107.903 5.83415 113.033 2.76415 118.573C2.74415 118.573 2.71415 118.583 2.69415 118.593C1.69415 118.823 1.45415 119.763 1.73415 120.513C1.18415 121.583 0.644152 122.673 0.154152 123.773C-0.445848 125.093 0.804152 126.593 2.20415 125.823C8.80415 122.223 16.5242 120.763 23.9842 121.823C24.7942 121.933 25.5842 121.623 25.8342 120.773C26.0342 120.073 25.5842 119.043 24.7842 118.923C17.9442 117.953 11.0342 118.783 4.69415 121.343C4.72415 121.273 4.76415 121.213 4.79415 121.143C12.3642 119.053 18.8742 114.413 24.4842 109.013C27.5042 106.103 30.3042 102.973 33.0342 99.7828C35.9942 96.3228 38.9742 92.8528 41.6242 89.1528C44.3242 85.3728 46.5242 81.2828 47.8242 76.8128C49.0042 72.7628 49.5042 68.5328 49.6942 64.3228C55.7542 62.7428 61.3642 59.2428 65.8642 55.0128C68.5042 52.5328 70.8942 49.6428 72.5342 46.4028C74.5542 42.4128 75.4542 37.9828 75.8642 33.5628C76.2842 29.0028 76.2142 24.3828 76.1142 19.8128H76.1042ZM42.3742 62.1628C38.9942 61.9428 35.5942 60.5928 32.8042 58.7028C26.8942 54.7128 23.6042 46.4728 27.6042 39.9828C31.0242 34.4428 39.6042 33.3728 43.4942 38.9628C45.4042 41.7028 46.0542 45.1628 46.3542 48.4228C46.7142 52.3228 46.7542 56.2828 46.7542 60.1928C46.7542 60.7628 46.7542 61.3428 46.7342 61.9128C45.2942 62.1528 43.8342 62.2628 42.3642 62.1628H42.3742Z"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+}
+
+const PLAYGROUND_HAS_RUN_ANY_APP_KEY = "giselle:playground:hasRunAnyApp";
 
 const APP_LIST_BADGE_CONFIG: Record<
 	AppListCardBadgeType,
@@ -209,6 +231,8 @@ export function Page({
 	const [isRunning, startTransition] = useTransition();
 	const [appSearchQuery, setAppSearchQuery] = useState("");
 	const [isSearchActive, setIsSearchActive] = useState(false);
+	const [interactionTick, setInteractionTick] = useState(0);
+	const [hasRunAnyApp, setHasRunAnyApp] = useState(false);
 	const appSearchInputRef = useRef<HTMLInputElement | null>(null);
 	const { showOverlay, hideOverlay } = useTaskOverlayStore(
 		useShallow((state) => ({
@@ -237,9 +261,30 @@ export function Page({
 		selectableApps,
 	);
 
+	const markInteraction = useCallback(() => {
+		setInteractionTick((prev) => prev + 1);
+	}, []);
+
+	useEffect(() => {
+		try {
+			setHasRunAnyApp(
+				Boolean(window.localStorage.getItem(PLAYGROUND_HAS_RUN_ANY_APP_KEY)),
+			);
+		} catch {
+			setHasRunAnyApp(true);
+		}
+	}, []);
+
 	const handleRunSubmit = useCallback(
 		(event: { inputs: GenerationContextInput[] }) => {
 			if (!selectedApp) return;
+			markInteraction();
+			try {
+				window.localStorage.setItem(PLAYGROUND_HAS_RUN_ANY_APP_KEY, "1");
+				setHasRunAnyApp(true);
+			} catch {
+				setHasRunAnyApp(true);
+			}
 			const parametersInput = event.inputs.find(
 				(input): input is ParametersInput => input.type === "parameters",
 			);
@@ -270,7 +315,14 @@ export function Page({
 				}
 			});
 		},
-		[selectedApp, createAndStartTaskAction, router, showOverlay, hideOverlay],
+		[
+			selectedApp,
+			createAndStartTaskAction,
+			router,
+			showOverlay,
+			hideOverlay,
+			markInteraction,
+		],
 	);
 
 	return (
@@ -279,10 +331,15 @@ export function Page({
 				{/* Main content: apps area */}
 				<div className="flex-1 min-w-0 flex flex-col px-4 sm:px-[24px] pt-[24px]">
 					{/* Top section: app info + chat input */}
-					<div className="space-y-4 pb-8">
-						<div className="relative flex w-full max-w-[960px] min-w-[320px] mx-auto flex-col overflow-hidden">
+					<div
+						className="relative space-y-4 pb-8"
+						onPointerDownCapture={markInteraction}
+						onKeyDownCapture={markInteraction}
+						onFocusCapture={markInteraction}
+					>
+						<div className="relative flex w-full max-w-[960px] min-w-[320px] mx-auto flex-col overflow-visible">
 							<div className="w-full flex justify-center items-center pt-1 pb-1 sm:pt-2 sm:pb-2">
-								<div className="flex flex-col items-center relative">
+								<div className="flex flex-col items-center relative w-full">
 									<p className="font-thin text-[36px] font-sans text-blue-muted/70 text-center">
 										What's the task?
 										<span className="block sm:inline">
@@ -301,6 +358,21 @@ export function Page({
 							scope="playground"
 							onSubmitAction={handleRunSubmit}
 							isRunning={isRunning}
+							interactionTick={interactionTick}
+							hasRunAnyApp={hasRunAnyApp}
+							renderIdleHint={({ isVisible }) => (
+								<div
+									className={`pointer-events-none absolute right-[-100px] top-[-12px] z-20 flex flex-col items-start text-left text-[#B8E8F4] origin-top-right rotate-[20deg] translate-y-[6px] transition-opacity duration-300 ease-out ${
+										isVisible ? "opacity-100" : "opacity-0"
+									}`}
+									aria-hidden="true"
+								>
+									<span className="text-[12px] font-mono tracking-[0.02em]">
+										Run a sample app.
+									</span>
+									<IdleHintArrow className="mt-2 h-[44px] w-[44px] text-[#B8E8F4]" />
+								</div>
+							)}
 						/>
 					</div>
 

--- a/apps/studio.giselles.ai/components/task/edit-in-studio-link-with-hint.tsx
+++ b/apps/studio.giselles.ai/components/task/edit-in-studio-link-with-hint.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { StatusBadge } from "@giselle-internal/ui/status-badge";
+import type { WorkspaceId } from "@giselles-ai/protocol";
+import clsx from "clsx";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+const IDLE_HINT_DELAY_MS = 8000;
+const TASK_EDIT_IN_STUDIO_HINT_SHOWN_KEY =
+	"giselle:tasks:editInStudioHintShown";
+
+function IdleHintArrow({ className }: { className?: string }) {
+	return (
+		<svg
+			className={className}
+			width="77"
+			height="127"
+			viewBox="0 0 77 127"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M76.1042 19.8128C76.0142 15.4228 75.7242 10.9328 74.4342 6.70278C73.7942 4.59278 72.8942 2.57278 71.7242 0.70278C70.7042 -0.92722 68.1042 0.57278 69.1342 2.21278C73.5042 9.19278 73.1742 17.9128 73.1542 25.8428C73.1342 33.6228 72.5742 41.6928 67.9042 48.2128C63.9642 53.7128 57.9742 58.1928 51.6442 60.5628C51.0242 60.7928 50.3942 61.0028 49.7542 61.1928C49.8142 57.2328 49.7342 53.2428 49.4442 49.3128C49.1642 45.6428 48.5842 41.8528 46.7942 38.5828C45.0842 35.4528 42.1142 33.0028 38.5442 32.4028C34.9242 31.7928 31.1242 32.7628 28.2042 34.9828C21.7242 39.9128 21.4842 49.7528 25.9542 56.1028C30.3042 62.2828 38.3942 65.9428 45.9142 65.0528C46.1542 65.0228 46.3942 64.9828 46.6342 64.9528C46.2242 71.9128 44.7642 78.6428 40.9842 84.7228C38.7142 88.3728 35.9542 91.6728 33.1942 94.9628C30.7642 97.8628 28.3042 100.743 25.7142 103.503C20.6042 108.933 14.8342 114.093 7.86415 116.963C7.57415 117.083 7.27415 117.193 6.97415 117.303C9.59415 113.043 12.6742 109.073 16.1742 105.463C17.5142 104.073 15.4042 101.953 14.0542 103.343C9.63415 107.903 5.83415 113.033 2.76415 118.573C2.74415 118.573 2.71415 118.583 2.69415 118.593C1.69415 118.823 1.45415 119.763 1.73415 120.513C1.18415 121.583 0.644152 122.673 0.154152 123.773C-0.445848 125.093 0.804152 126.593 2.20415 125.823C8.80415 122.223 16.5242 120.763 23.9842 121.823C24.7942 121.933 25.5842 121.623 25.8342 120.773C26.0342 120.073 25.5842 119.043 24.7842 118.923C17.9442 117.953 11.0342 118.783 4.69415 121.343C4.72415 121.273 4.76415 121.213 4.79415 121.143C12.3642 119.053 18.8742 114.413 24.4842 109.013C27.5042 106.103 30.3042 102.973 33.0342 99.7828C35.9942 96.3228 38.9742 92.8528 41.6242 89.1528C44.3242 85.3728 46.5242 81.2828 47.8242 76.8128C49.0042 72.7628 49.5042 68.5328 49.6942 64.3228C55.7542 62.7428 61.3642 59.2428 65.8642 55.0128C68.5042 52.5328 70.8942 49.6428 72.5342 46.4028C74.5542 42.4128 75.4542 37.9828 75.8642 33.5628C76.2842 29.0028 76.2142 24.3828 76.1142 19.8128H76.1042ZM42.3742 62.1628C38.9942 61.9428 35.5942 60.5928 32.8042 58.7028C26.8942 54.7128 23.6042 46.4728 27.6042 39.9828C31.0242 34.4428 39.6042 33.3728 43.4942 38.9628C45.4042 41.7028 46.0542 45.1628 46.3542 48.4228C46.7142 52.3228 46.7542 56.2828 46.7542 60.1928C46.7542 60.7628 46.7542 61.3428 46.7342 61.9128C45.2942 62.1528 43.8342 62.2628 42.3642 62.1628H42.3742Z"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+}
+
+export function EditInStudioLinkWithHint({
+	workspaceId,
+	leftIcon,
+	label = "Edit in Studio",
+	hintText,
+}: {
+	workspaceId: WorkspaceId;
+	leftIcon: ReactNode;
+	label?: string;
+	hintText?: string;
+}) {
+	const [lastInteractionAt, setLastInteractionAt] = useState(() => Date.now());
+	const [hasShownOnce, setHasShownOnce] = useState(false);
+	const [shouldBeVisible, setShouldBeVisible] = useState(false);
+	const [isVisible, setIsVisible] = useState(false);
+	const [hasShownEver, setHasShownEver] = useState(false);
+
+	useEffect(() => {
+		try {
+			setHasShownEver(
+				Boolean(
+					window.localStorage.getItem(TASK_EDIT_IN_STUDIO_HINT_SHOWN_KEY),
+				),
+			);
+		} catch {
+			// localStorage might be unavailable (privacy mode). In that case, disable the hint.
+			setHasShownEver(true);
+		}
+	}, []);
+
+	const markInteraction = useCallback(() => {
+		setShouldBeVisible(false);
+		setLastInteractionAt(Date.now());
+	}, []);
+
+	useEffect(() => {
+		if (hasShownOnce || hasShownEver) return;
+		const timeout = window.setTimeout(() => {
+			if (Date.now() - lastInteractionAt < IDLE_HINT_DELAY_MS) return;
+			setHasShownOnce(true);
+			try {
+				window.localStorage.setItem(TASK_EDIT_IN_STUDIO_HINT_SHOWN_KEY, "1");
+				setHasShownEver(true);
+			} catch {
+				// ignore
+			}
+			setShouldBeVisible(true);
+		}, IDLE_HINT_DELAY_MS);
+
+		return () => window.clearTimeout(timeout);
+	}, [hasShownEver, hasShownOnce, lastInteractionAt]);
+
+	// Stabilize fade-in (avoid "pop" on show).
+	useEffect(() => {
+		if (!shouldBeVisible) {
+			setIsVisible(false);
+			return;
+		}
+		const raf = window.requestAnimationFrame(() => setIsVisible(true));
+		return () => window.cancelAnimationFrame(raf);
+	}, [shouldBeVisible]);
+
+	useEffect(() => {
+		// Any interaction on the page should dismiss the hint immediately.
+		window.addEventListener("keydown", markInteraction, { capture: true });
+		window.addEventListener("focusin", markInteraction, { capture: true });
+		return () => {
+			window.removeEventListener("keydown", markInteraction, { capture: true });
+			window.removeEventListener("focusin", markInteraction, { capture: true });
+		};
+	}, [markInteraction]);
+
+	return (
+		<div className="relative inline-block">
+			<Link
+				href={`/workspaces/${workspaceId}`}
+				className="inline-block"
+				target="_blank"
+				rel="noreferrer"
+				onClick={markInteraction}
+			>
+				<div className="group [&>div]:rounded-lg [&>div>div]:rounded-md [&>div>div]:text-[hsl(192,73%,84%)] [&>div>div]:border-[hsl(192,73%,84%)] [&>div>div]:transition-colors [&>div>div]:cursor-pointer hover:[&>div>div]:bg-[hsl(192,73%,84%)] hover:[&>div>div]:text-[hsl(192,73%,20%)]">
+					<StatusBadge status="warning" variant="default" leftIcon={leftIcon}>
+						{label}
+					</StatusBadge>
+				</div>
+			</Link>
+
+			{/* Hint element (text TBD) */}
+			<div
+				className={clsx(
+					"pointer-events-none absolute right-[-18px] top-[-14px] z-10 flex flex-col items-start text-left text-[#B8E8F4] origin-top-right rotate-[-20deg] translate-x-[105px] translate-y-[-15px] transition-opacity duration-300 ease-out",
+					isVisible ? "opacity-100" : "opacity-0",
+				)}
+				aria-hidden="true"
+			>
+				<IdleHintArrow
+					className={clsx(
+						"h-[44px] w-[44px] rotate-180 -scale-x-100",
+						hintText ? "mb-2" : "",
+					)}
+				/>
+				{hintText ? (
+					<span className="text-[12px] font-mono tracking-[0.02em]">
+						{hintText}
+					</span>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/apps/studio.giselles.ai/components/task/task-header.tsx
+++ b/apps/studio.giselles.ai/components/task/task-header.tsx
@@ -7,7 +7,7 @@ import type {
 	WorkspaceId,
 } from "@giselles-ai/protocol";
 import { Check, FilePenLineIcon } from "lucide-react";
-import Link from "next/link";
+import { EditInStudioLinkWithHint } from "./edit-in-studio-link-with-hint";
 
 function formatFileSize(bytes?: number) {
 	const safeBytes = Number.isFinite(bytes) ? (bytes as number) : 0;
@@ -107,24 +107,13 @@ export function TaskHeader({
 					{/* Title */}
 					<div className="flex items-center gap-3 mb-1">
 						<h3 className="text-[20px] font-normal text-inverse">{title}</h3>
-						<Link
-							href={`/workspaces/${workspaceId}`}
-							className="inline-block"
-							target="_blank"
-							rel="noreferrer"
-						>
-							<div className="group [&>div]:rounded-lg [&>div>div]:rounded-md [&>div>div]:text-[hsl(192,73%,84%)] [&>div>div]:border-[hsl(192,73%,84%)] [&>div>div]:transition-colors [&>div>div]:cursor-pointer hover:[&>div>div]:bg-[hsl(192,73%,84%)] hover:[&>div>div]:text-[hsl(192,73%,20%)]">
-								<StatusBadge
-									status="warning"
-									variant="default"
-									leftIcon={
-										<FilePenLineIcon className="stroke-[hsl(192,73%,84%)] stroke-[1.5] transition-colors group-hover:stroke-[hsl(192,73%,20%)]" />
-									}
-								>
-									Edit in Studio
-								</StatusBadge>
-							</div>
-						</Link>
+						<EditInStudioLinkWithHint
+							workspaceId={workspaceId}
+							leftIcon={
+								<FilePenLineIcon className="stroke-[hsl(192,73%,84%)] stroke-[1.5] transition-colors group-hover:stroke-[hsl(192,73%,20%)]" />
+							}
+							hintText="Explore how this app works."
+						/>
 					</div>
 					{/* App summary heading + text (2-column layout to reduce height) */}
 					{description.length > 0 && (


### PR DESCRIPTION
## Summary
This PR adds subtle, non-blocking idle hints to help users discover next actions.

## Changes
- **/playground**: Add an idle hint (text + arrow) that appears in sync with the “to send” nudge.
  - <img width="1210" height="774" alt="スクリーンショット 2025-12-22 15 25 11" src="https://github.com/user-attachments/assets/a5c6bc5e-8b81-4620-8502-019762520655" />
  - Uses a 1-frame rAF flip to avoid a “pop” on fade-in.
  - Persists state so it only shows on first visit and never reappears after a run.
- **/tasks/[taskId]**: Add an idle hint near **Edit in Studio**.
  - <img width="973" height="214" alt="スクリーンショット 2025-12-22 16 24 33" src="https://github.com/user-attachments/assets/11d79e91-fd27-4342-9831-b686fbafbab7" />
  - Copy: "Explore how this app works."
  - Persisted so it only ever shows once.
  - Does not dismiss on pointerdown (so taking screenshots doesn’t hide it).


## Hint conditions
### /playground
**Show when**
- First visit only (`localStorage: giselle:playground:hasVisited` is missing)
- User has NOT run any app yet (`localStorage: giselle:playground:hasRunAnyApp` is missing)
- Hint has NOT been shown before (`localStorage: giselle:playground:hasShownIdleHint` is missing)
- No user interaction for 8 seconds (not running, no input, no pending uploads)

**Hide when**
- Any interaction (typing/keys, selecting app, run) immediately hides it
- Once shown, it won’t re-show in the same session
- After any run, it will never show again (persisted)

### /tasks/[taskId]
**Show when**
- No user interaction for 8 seconds
- Hint has NOT been shown before (`localStorage: giselle:tasks:editInStudioHintShown` is missing)

**Hide when**
- keydown / focusin / clicking "Edit in Studio" hides it

## Files
- `apps/studio.giselles.ai/app/(main)/playground/page.client.tsx`
- `apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx`
- `apps/studio.giselles.ai/components/task/task-header.tsx`
- `apps/studio.giselles.ai/components/task/edit-in-studio-link-with-hint.tsx`


___

### **PR Type**
Enhancement


___

### **Description**
- Add idle hint system to Playground showing "Run a sample app" after 8 seconds of inactivity

- Add idle hint to Task detail page showing "Explore how this app works" near Edit in Studio button

- Implement localStorage persistence to show hints only once per user

- Add visual feedback with animated arrow SVG and subtle pulse animation on idle state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User["User visits page"]
  Idle["8 seconds idle<br/>no interaction"]
  Check{"localStorage<br/>hint shown?"}
  Show["Show hint with<br/>arrow animation"]
  Interact["User interaction<br/>keydown/click"]
  Hide["Hide hint"]
  Persist["Mark hint as<br/>shown in storage"]
  
  User --> Idle
  Idle --> Check
  Check -->|No| Show
  Check -->|Yes| Hide
  Show --> Persist
  Show --> Interact
  Interact --> Hide
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playground-stage-input.tsx</strong><dd><code>Implement idle hint system with interaction tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx

<ul><li>Add idle nudge state management with localStorage keys for tracking <br>first visit, hint display, and app runs<br> <li> Implement interaction tracking via callbacks that reset idle timer on <br>user actions (typing, file upload, app selection, submit)<br> <li> Add conditional rendering of idle hint with rAF-based fade-in to <br>prevent visual "pop"<br> <li> Apply visual pulse animation to submit button and file info section <br>when idle nudge is active<br> <li> Wrap all event handlers to trigger interaction tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2532/files#diff-3adf1662d37dc3d71b30dbe9c4a77393a59741e0e28a42faf2298e3734b46bad">+182/-13</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.client.tsx</strong><dd><code>Add idle hint UI and interaction propagation to Playground</code></dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/playground/page.client.tsx

<ul><li>Add <code>IdleHintArrow</code> SVG component for visual idle hint indicator<br> <li> Add interaction tick state and <code>hasRunAnyApp</code> tracking to parent <br>component<br> <li> Pass interaction tick and idle hint renderer to <code>PlaygroundStageInput</code> <br>component<br> <li> Add global event listeners for pointer, keyboard, and focus <br>interactions<br> <li> Render idle hint with custom text "Run a sample app." and arrow <br>positioned near input area</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2532/files#diff-bee7c505d563c48e3d29a449cdcec06f7018b455056f0594073521829583703f">+76/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edit-in-studio-link-with-hint.tsx</strong><dd><code>Create Edit in Studio link with idle hint wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/components/task/edit-in-studio-link-with-hint.tsx

<ul><li>Create new component wrapping "Edit in Studio" link with idle hint <br>functionality<br> <li> Implement 8-second idle timer with localStorage persistence for hint <br>display<br> <li> Add <code>IdleHintArrow</code> SVG component with rotation and mirroring for <br>right-to-left direction<br> <li> Use rAF-based fade-in animation to prevent visual pop on hint <br>appearance<br> <li> Attach global keydown and focusin listeners to dismiss hint on any <br>interaction</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2532/files#diff-b3fc4dd68faeca69bd288d9ce1a1cf3f7df3ed8da51497bbde7eb31ff5c3d3ea">+143/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-header.tsx</strong><dd><code>Integrate idle hint component into Task header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/components/task/task-header.tsx

<ul><li>Replace inline "Edit in Studio" link with new <code>EditInStudioLinkWithHint</code> <br>component<br> <li> Pass workspace ID, icon, and hint text "Explore how this app works." <br>to new component<br> <li> Remove previous Link and StatusBadge markup in favor of extracted <br>component</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2532/files#diff-a326696aaee378e21dbe21c9793da6c284ba02c7a8e4ead0cd17f86b992fe74c">+8/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idle-hint nudges that appear after inactivity to guide user interactions in the playground and workspace editing areas.
  * Idle hints are shown once per user and remembered via local storage.
  * Added visual feedback animations when idle to prompt engagement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->