### PR TITLE
fix(task): keep Edit in Studio button visible with long titles

### DIFF
--- a/apps/studio.giselles.ai/components/task/task-header.tsx
+++ b/apps/studio.giselles.ai/components/task/task-header.tsx
@@ -105,11 +105,13 @@ export function TaskHeader({
 						)}
 					</div>
 					{/* Title */}
-					<div className="flex items-center gap-3 mb-1">
-						<h3 className="text-[20px] font-normal text-inverse">{title}</h3>
+					<div className="flex items-start justify-between gap-3 mb-1 w-full">
+						<h3 className="text-[20px] font-normal text-inverse min-w-0 break-words whitespace-normal">
+							{title}
+						</h3>
 						<Link
 							href={`/workspaces/${workspaceId}`}
-							className="inline-block"
+							className="inline-block shrink-0 whitespace-nowrap"
 							target="_blank"
 							rel="noreferrer"
 						>


### PR DESCRIPTION

<img width="660" height="143" alt="スクリーンショット 2025-12-22 18 06 03" src="https://github.com/user-attachments/assets/60586733-f823-4b87-aceb-87e4408587af" />
<img width="650" height="208" alt="スクリーンショット 2025-12-22 18 06 26" src="https://github.com/user-attachments/assets/1c8d9dbd-c4fa-4af7-be9a-e9f06cec7409" />

## Summary
Adjust the Task detail header layout so long task titles don't shrink or push the "Edit in Studio" button out of view.

## Changes
- Place the title and "Edit in Studio" action at opposite ends of the header row.
- Keep the action width stable (no shrinking), while allowing the title to wrap onto multiple lines (no truncation).

## Files
- `apps/studio.giselles.ai/components/task/task-header.tsx`


___

### **PR Type**
Bug fix


___

### **Description**
- Adjust header layout to prevent long titles from hiding "Edit in Studio" button

- Title now wraps across multiple lines instead of truncating

- "Edit in Studio" button maintains fixed width and stays visible

- Use flexbox with `justify-between` to position title and action at opposite ends


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Task Header Layout"] --> B["Title Section"]
  A --> C["Edit in Studio Button"]
  B --> D["min-w-0 break-words<br/>whitespace-normal"]
  C --> E["shrink-0 whitespace-nowrap"]
  D --> F["Wraps on multiple lines"]
  E --> G["Stays visible and fixed width"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-header.tsx</strong><dd><code>Fix header layout for long task titles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/components/task/task-header.tsx

<ul><li>Changed header container from <code>flex items-center</code> to <code>flex items-start </code><br><code>justify-between gap-3 mb-1 w-full</code> to position title and button at <br>opposite ends<br> <li> Added <code>min-w-0 break-words whitespace-normal</code> to title to allow text <br>wrapping instead of truncation<br> <li> Added <code>shrink-0 whitespace-nowrap</code> to "Edit in Studio" link to prevent <br>button shrinking and maintain fixed width</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2534/files#diff-a326696aaee378e21dbe21c9793da6c284ba02c7a8e4ead0cd17f86b992fe74c">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update task header layout so long titles wrap while the "Edit in Studio" action remains visible and fixed-width.
> 
> - **UI**
>   - **Task header (`apps/studio.giselles.ai/components/task/task-header.tsx`)**:
>     - Switch header row to `flex` with `justify-between`; title gets `min-w-0`, `break-words`, `whitespace-normal` to wrap.
>     - Action link gets `shrink-0` and `whitespace-nowrap` to prevent shrinking/wrapping, keeping "Edit in Studio" visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 472fa1cf32d742b07d215ef904f16db3e90cc4f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved task header layout to better accommodate and properly support automatic text wrapping for long titles, preventing content overflow and enhancing readability.
  * Enhanced workspace link styling to prevent unintended shrinking behavior and maintain consistent single-line display across varying content lengths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->