### PR TITLE
Proofreading: Modify Start/End node deletion warning

### DIFF
--- a/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-delete-nodes.ts
+++ b/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-delete-nodes.ts
@@ -121,9 +121,9 @@ export function useDeleteNodes() {
 
 			if (shouldPairDelete) {
 				const ok = await confirm({
-					title: "Delete Start and End?",
+					title: "Delete Start and End Nodes",
 					description:
-						"Start and End are a pair. Deleting either one will delete both. Do you want to continue?",
+						"The Start and End nodes are required to run your app in the playground. Are you sure you want to delete them?",
 					confirmLabel: "Delete",
 					cancelLabel: "Cancel",
 					destructive: true,


### PR DESCRIPTION
### **User description**
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
This PR updates the warning text when deleting the Start and End nodes.

## Related Issue
<!-- Mention the related issue number if applicable. -->

## Changes
<!-- List the main changes made in this PR. -->
- `Delete Start and End?`
  - Changed to better match other deletion prompts (Vector Stores/etc.)
- `Start and End are a pair. Deleting either one will delete both. Do you want to continue?`
  - Removed some unnecessary information and modified call to action. Also added a reminder that removing these nodes will disable playground testing.

## Testing
<!-- Briefly describe the testing steps or results. -->

## Other Information
<!-- Add any other relevant information for the reviewer. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Updated Start/End node deletion warning title for consistency

- Improved warning message to clarify playground testing impact

- Simplified language while maintaining critical information


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Warning Message"] -->|"Proofreading Update"| B["New Warning Message"]
  B -->|"Clearer Title"| C["Delete Start and End Nodes"]
  B -->|"Better Description"| D["Emphasizes Playground Impact"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-delete-nodes.ts</strong><dd><code>Refine Start/End node deletion confirmation dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-delete-nodes.ts

<ul><li>Changed confirmation dialog title from "Delete Start and End?" to <br>"Delete Start and End Nodes"<br> <li> Updated description to emphasize playground testing requirement <br>instead of pair deletion logic<br> <li> Simplified messaging while maintaining destructive action clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2539/files#diff-f5d9030a2affdab958d8b653bd7225e77353633f33499c1cca52244ba193a8f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confirmation message when deleting Start/End nodes to clarify that these nodes are essential for running the app.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->