### PR TITLE
Update recommended models order and selection for Free/Pro tiers

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx
@@ -155,34 +155,38 @@ export function Toolbar() {
 	// Recommended models for each provider - adjust based on user tier
 	const isFreeUser = userTier === Tier.enum.free;
 	const openaiModels = getAvailableModels(
-		isFreeUser ? ["gpt-5-nano"] : ["gpt-5"],
+		isFreeUser ? ["gpt-5-nano"] : ["gpt-5.2"],
 		"openai",
 		llmProviders,
 		availableLanguageModels,
 	);
 	const anthropicModels = getAvailableModels(
-		isFreeUser
-			? ["claude-haiku-4.5"]
-			: ["claude-sonnet-4.5", "claude-opus-4.5"],
+		isFreeUser ? ["claude-haiku-4.5"] : ["claude-opus-4.5"],
 		"anthropic",
 		llmProviders,
 		availableLanguageModels,
 	);
 	const googleModels = getAvailableModels(
-		isFreeUser
-			? ["gemini-2.5-flash-lite"]
-			: ["gemini-2.5-pro-exp-03-25", "gemini-1.5-pro-latest", "gemini-1.0-pro"],
+		isFreeUser ? ["gemini-2.5-flash-lite"] : ["gemini-3-flash"],
 		"google",
 		llmProviders,
 		availableLanguageModels,
 	);
 
 	// Combine all recommended models
-	const recommendedModels = [
-		...openaiModels.slice(0, 1),
-		...googleModels.slice(0, 1),
-		...anthropicModels.slice(0, 1),
-	];
+	// Free tier: OpenAI, Google, Anthropic
+	// Pro tier: Google, OpenAI, Anthropic
+	const recommendedModels = isFreeUser
+		? [
+				...openaiModels.slice(0, 1),
+				...googleModels.slice(0, 1),
+				...anthropicModels.slice(0, 1),
+			]
+		: [
+				...googleModels.slice(0, 1),
+				...openaiModels.slice(0, 1),
+				...anthropicModels.slice(0, 1),
+			];
 
 	// Hover management is handled by useHoverState hook
 


### PR DESCRIPTION
### **User description**
## Summary
- Reorder Free tier recommended models: OpenAI → Google → Anthropic
- Update Pro tier models to latest versions (gpt-5.2, gemini-3-flash, claude-opus-4.5)
- Reorder Pro tier recommended models: Google → OpenAI → Anthropic


## Related Issue
None.

## Changes
### Free tier
| Order | Model |
|-------|-------|
| 1 | openai/gpt-5-nano |
| 2 | google/gemini-2.5-flash-lite |
| 3 | anthropic/claude-haiku-4.5 |

### Pro tier
| Order | Model |
|-------|-------|
| 1 | google/gemini-3-flash |
| 2 | openai/gpt-5.2 |
| 3 | anthropic/claude-opus-4.5 |

## Testing
- [ ] Verify Free tier users see models in correct order
- [ ] Verify Pro tier users see updated models in correct order


___

### **PR Type**
Enhancement


___

### **Description**
- Reorder recommended models by tier: Free (OpenAI → Google → Anthropic), Pro (Google → OpenAI → Anthropic)

- Update Pro tier models to latest versions: gpt-5.2, gemini-3-flash, claude-opus-4.5

- Simplify Pro tier Anthropic selection to single claude-opus-4.5 model

- Simplify Pro tier Google selection to single gemini-3-flash model


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Tier Detection"] --> B{Is Free User?}
  B -->|Yes| C["Free Tier Order:<br/>OpenAI → Google → Anthropic"]
  B -->|No| D["Pro Tier Order:<br/>Google → OpenAI → Anthropic"]
  C --> E["Recommended Models<br/>Display"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolbar.tsx</strong><dd><code>Reorder and update tier-specific recommended models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/tool/toolbar/toolbar.tsx

<ul><li>Updated Pro tier OpenAI model from gpt-5 to gpt-5.2<br> <li> Simplified Pro tier Anthropic models to single claude-opus-4.5 option<br> <li> Simplified Pro tier Google models to single gemini-3-flash option<br> <li> Reordered Free tier models: OpenAI → Google → Anthropic<br> <li> Reordered Pro tier models: Google → OpenAI → Anthropic</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2542/files#diff-66d2626182bb02f543d898ac63a53bfe09b5ee215056b7810b6235686968ddf7">+16/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented subscription tier-aware AI model selection in the workflow designer, enabling different model options and recommendations for free and pro subscribers.
  * Reordered AI provider recommendations based on subscription tier to optimize model suggestions for each user segment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->