### PR TITLE
fix: Use LocalDateTime component for task startedAt display

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/tasks/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/tasks/page.tsx
@@ -8,6 +8,7 @@ import { giselle } from "@/app/giselle";
 import { db } from "@/db";
 import { fetchCurrentTeam } from "@/services/teams/fetch-current-team";
 import { Card } from "../settings/components/card";
+import { LocalDateTime } from "../settings/team/components/local-date-time";
 
 interface UITaskListAppOrigin {
 	type: "app";
@@ -38,10 +39,6 @@ type TaskListPageProps = {
 
 function clampInt(value: number, { min, max }: { min: number; max: number }) {
 	return Math.min(max, Math.max(min, value));
-}
-
-function formatTimestamp(ms: number) {
-	return new Date(ms).toISOString().slice(0, 19).replace("T", " ");
 }
 
 function getStatusBadge(taskStatus: Task["status"]) {
@@ -267,7 +264,7 @@ export default async function TaskListPage({
 											{task.id}
 										</Link>
 										<span className="text-[13px] text-text/60 truncate">
-											{formatTimestamp(task.startedAt)}
+											<LocalDateTime date={new Date(task.startedAt)} />
 											<span className="md:hidden"> · {originLabel}</span>
 										</span>
 									</div>


### PR DESCRIPTION
### **User description**
### Summary
Replace the custom `formatTimestamp` function with the existing `LocalDateTime` component to display task start times in the user's local timezone with a more readable format.

### Related Issue
N/A

### Changes
- Removed the inline `formatTimestamp` function that displayed timestamps in UTC ISO format
- Imported and used the `LocalDateTime` component from the settings team components
- Task start times now display in the user's local timezone with a human-readable format (e.g., "December 24, 2025 at 10:30 JST")

### Testing
Verify that task start times on the `/tasks` page display correctly in the user's local timezone.

<img width="1044" height="392" alt="image" src="https://github.com/user-attachments/assets/aa935e3f-8238-486b-8938-eec24ec388a7" />


### Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Replace custom `formatTimestamp` with `LocalDateTime` component

- Display task start times in user's local timezone

- Remove unused UTC ISO formatting function

- Improve timestamp readability with human-friendly format


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["formatTimestamp function<br/>UTC ISO format"] -->|"Remove"| B["LocalDateTime component<br/>Local timezone display"]
  C["task.startedAt<br/>milliseconds"] -->|"Pass as Date"| B
  B -->|"Display"| D["Human-readable format<br/>e.g. December 24, 2025 at 10:30 JST"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Replace formatTimestamp with LocalDateTime component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/tasks/page.tsx

<ul><li>Imported <code>LocalDateTime</code> component from settings team components<br> <li> Removed the <code>formatTimestamp</code> helper function that converted timestamps <br>to UTC ISO format<br> <li> Updated task start time display to use <code>LocalDateTime</code> component with <br>proper Date object conversion<br> <li> Task timestamps now render in user's local timezone with readable <br>format</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2559/files#diff-bb13bc05006f11a22b83666a78b72697a9b0ed5725a5e30cdbf2671b68281364">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Uses the shared date-time component for clearer, locale-aware timestamps on the tasks page.
> 
> - Remove inline `formatTimestamp` and import/use `LocalDateTime` in `apps/studio.giselles.ai/app/(main)/tasks/page.tsx`
> - `startedAt` now displays in the user's local timezone instead of a raw ISO UTC string
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5448fb8af2af28d6a4eff53adeaaaa9778a617f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated timestamp rendering in the tasks page for improved code maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->