### PR TITLE
fix: adjust tasks page document link style to match workspaces page

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/tasks/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/tasks/page.tsx
@@ -1,7 +1,8 @@
+import { DocsLink } from "@giselle-internal/ui/docs-link";
 import { PageHeading } from "@giselle-internal/ui/page-heading";
 import { StatusBadge } from "@giselle-internal/ui/status-badge";
 import type { Task, TaskId as TaskIdType } from "@giselles-ai/protocol";
-import { ClipboardList, ExternalLinkIcon } from "lucide-react";
+import { ClipboardList } from "lucide-react";
 import Link from "next/link";
 import { createSearchParamsCache, parseAsInteger } from "nuqs/server";
 import { giselle } from "@/app/giselle";
@@ -154,15 +155,13 @@ export default async function TaskListPage({
 				</div>
 
 				<div className="flex items-center gap-4">
-					<a
+					<DocsLink
 						href="https://docs.giselles.ai/en/guides/tasks"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="inline-flex items-center gap-1 text-[13px] text-text/60 hover:text-inverse transition-colors"
 					>
-						<span>About Tasks</span>
-						<ExternalLinkIcon className="size-4" />
-					</a>
+						About Tasks
+					</DocsLink>
 					<p className="text-sm text-text/60">Showing {tasks.length} task(s)</p>
 					{prevOffset != null ? (
 						<Link


### PR DESCRIPTION
### **User description**
Adjusts the document link style on the /tasks page to match the style used on the /workspaces page by using the DocsLink component.

|Before|After|
|---|---|
|<img width="974" height="94" alt="スクリーンショット 2025-12-24 15 34 39" src="https://github.com/user-attachments/assets/03b66a70-a1de-47ce-b783-b69030d3c4b3" />|<img width="969" height="91" alt="スクリーンショット 2025-12-24 15 34 44" src="https://github.com/user-attachments/assets/b18e9f5f-adfb-4440-8dec-26a9bb279f5e" />|


___

### **PR Type**
Enhancement


___

### **Description**
- Replace custom anchor tag with DocsLink component

- Remove ExternalLinkIcon import from lucide-react

- Standardize document link styling across pages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom anchor tag<br/>with ExternalLinkIcon"] -- "Replace with<br/>DocsLink component" --> B["Standardized<br/>document link"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Replace custom anchor with DocsLink component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/tasks/page.tsx

<ul><li>Import DocsLink component from @giselle-internal/ui/docs-link<br> <li> Remove ExternalLinkIcon import from lucide-react<br> <li> Replace custom anchor tag with DocsLink component for documentation <br>link<br> <li> Remove inline styling and icon rendering, delegating to DocsLink <br>component</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2560/files#diff-bb13bc05006f11a22b83666a78b72697a9b0ed5725a5e30cdbf2671b68281364">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes the docs link on the tasks page.
> 
> - Replace the custom external anchor with `DocsLink` in `tasks/page.tsx` to match shared styling; keeps "About Tasks" text and docs URL
> - Remove unused `ExternalLinkIcon` import/usage; retain `ClipboardList`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2307fce8d9d06cd668c61a594dac2644d79170. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->