### PR TITLE
Fix task page scroll for long input

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/task-client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/tasks/[taskId]/ui/task-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { TaskHeader } from "@/components/task/task-header";
+import { TaskHeader, TaskInputPreview } from "@/components/task/task-header";
 import { FinalStepOutput } from "./final-step-output";
 import { StepsSection } from "./steps-section";
 import type { UITask } from "./task-data";
@@ -120,8 +120,10 @@ export function TaskClient({
 				description={data.description}
 				workspaceId={data.workspaceId}
 				input={data.input}
+				showInputPreview={false}
 			/>
 			<div className="flex-1 overflow-y-auto overflow-x-hidden pb-8">
+				<TaskInputPreview input={data.input} />
 				<StepsSection {...data.stepsSection} />
 				<FinalStepOutput finalStep={data.finalStep} />
 			</div>

--- a/apps/studio.giselles.ai/components/task/task-header.tsx
+++ b/apps/studio.giselles.ai/components/task/task-header.tsx
@@ -247,6 +247,7 @@ interface TaskHeaderProps {
 	description: string;
 	workspaceId: WorkspaceId;
 	input: GenerationContextInput | null;
+	showInputPreview?: boolean;
 }
 
 export function TaskHeader({
@@ -255,6 +256,7 @@ export function TaskHeader({
 	description,
 	workspaceId,
 	input,
+	showInputPreview = true,
 }: TaskHeaderProps) {
 	return (
 		<div className="w-full pb-3  bg-[color:var(--color-background)]">
@@ -314,22 +316,31 @@ export function TaskHeader({
 					)}
 				</div>
 
-				{/* Task input preview */}
-				<div className="mt-3">
-					<div className="rounded-[10px] border border-blue-muted/40 bg-blue-muted/7 px-3 py-2 text-[13px] text-text/80">
-						{input == null ? (
-							<p>No task input</p>
-						) : input.type === "parameters" ? (
-							input.items.map((item) => (
-								<TaskInputItem key={item.name} item={item} />
-							))
-						) : input.type === "github-webhook-event" ? (
-							<TaskInputGitHubWebhookEvent webhookEvent={input.webhookEvent} />
-						) : (
-							<p>No task input</p>
-						)}
-					</div>
-				</div>
+				{showInputPreview ? <TaskInputPreview input={input} /> : null}
+			</div>
+		</div>
+	);
+}
+
+export function TaskInputPreview({
+	input,
+}: {
+	input: GenerationContextInput | null;
+}) {
+	return (
+		<div className="mt-3">
+			<div className="rounded-[10px] border border-blue-muted/40 bg-blue-muted/7 px-3 py-2 text-[13px] text-text/80">
+				{input == null ? (
+					<p>No task input</p>
+				) : input.type === "parameters" ? (
+					input.items.map((item) => (
+						<TaskInputItem key={item.name} item={item} />
+					))
+				) : input.type === "github-webhook-event" ? (
+					<TaskInputGitHubWebhookEvent webhookEvent={input.webhookEvent} />
+				) : (
+					<p>No task input</p>
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
 **What**
  - Collapse long string task input preview (2-line preview with chevron toggle)
  - Move task input preview into the scrollable content area on /tasks/:id

https://github.com/user-attachments/assets/c82a5add-a6d2-455c-bda2-2905bba4ae53

- **Why**
  - Long inputs from /playground could make the /tasks/:id page effectively non-scrollable because the header grew too tall.

- **Notes**
  - Commits: 7473bfb57, 20429bd9b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes task page scroll by shrinking the header and collapsing long inputs.
> 
> - Extracts `TaskInputPreview` from `TaskHeader` and adds `showInputPreview` prop to toggle header rendering
> - Moves input preview into the scrollable content area in `task-client.tsx` (header sets `showInputPreview={false}`)
> - Collapses long/multi-line string parameter values with an expandable `<details>` UI using a chevron indicator
> - Minor UI tweaks/imports (`ChevronDown`) without changing task polling or core logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e63d5e560a8c10365cded457c71b69807f3445df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long and multi-line string fields now show as expandable sections with a chevron for easier reading.
  * Task input preview reorganized and surfaced as a distinct preview area alongside existing sections.
  * Added a control to show or hide the input preview so consumers can disable the preview when desired.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->