### PR TITLE
fix: Show Giselle Team as creator for sample app

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx
+++ b/apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx
@@ -209,7 +209,7 @@ export function AgentCard({ agent }: AgentCardProps) {
 							<span className="font-geist text-[12px] text-text/70">
 								by{" "}
 								{agent.metadata.sample
-									? "Giselle"
+									? "Giselle Team"
 									: agent.creator?.displayName || "Unknown"}
 							</span>
 							<div className="flex items-center gap-3">

--- a/apps/studio.giselles.ai/app/(main)/workspaces/components/searchable-agent-list.tsx
+++ b/apps/studio.giselles.ai/app/(main)/workspaces/components/searchable-agent-list.tsx
@@ -122,7 +122,7 @@ export function SearchableAgentList({
 								subtitle={`Edited ${agent.updatedAt.toLocaleDateString()}`}
 								creator={
 									agent.metadata.sample
-										? "Giselle"
+										? "Giselle Team"
 										: agent.creator?.displayName || null
 								}
 								githubRepositories={agent.githubRepositories}


### PR DESCRIPTION
### **User description**
### Summary
Updates the workspaces list to display "Giselle Team" as the creator name for sample apps instead of showing "Unknown" or null. This fix applies to both grid view and list view for consistent behavior.

### Related Issue
N/A

### Changes
- Modified `agent-card.tsx` (grid view) to check `agent.metadata.sample` flag and display "Giselle Team" for sample apps
- Modified `searchable-agent-list.tsx` (list view) to apply the same logic for consistency across view modes

### Testing
1. Navigate to the workspaces page
2. Verify sample apps show "by Giselle Team" in grid view
3. Switch to list view and verify sample apps also show "Giselle Team" as the builder

<img width="2302" height="1370" alt="image" src="https://github.com/user-attachments/assets/abf5afac-628e-441c-ad7b-86de7bf6b66b" />

<img width="2286" height="1034" alt="image" src="https://github.com/user-attachments/assets/825108e1-98c5-4bd4-baa6-cf133d18ea51" />




### Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Display "Giselle" as creator for sample agents

- Fallback to existing creator logic for non-sample agents

- Fixes "Unknown" creator display on workspaces page


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Agent Card Component"] -- "Check metadata.sample flag" --> B{Is Sample Agent?}
  B -- "Yes" --> C["Display Giselle"]
  B -- "No" --> D["Display creator.displayName or Unknown"]
  C --> E["Render Footer"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent-card.tsx</strong><dd><code>Add sample agent creator display logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx

<ul><li>Modified creator display logic in AgentCard footer<br> <li> Added conditional check for <code>agent.metadata.sample</code> flag<br> <li> Shows "Giselle" for sample agents, falls back to existing logic <br>otherwise</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2571/files#diff-82f10eeae9dd84bb7a03b100b9d17482d5744819ab7cb4073847832ecd63379a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures consistent creator display for sample agents in workspaces.
> 
> - Updates `agent-card.tsx` (grid) to show `"Giselle Team"` when `agent.metadata.sample` is true; otherwise use `agent.creator?.displayName || "Unknown"`
> - Updates `searchable-agent-list.tsx` (list) to pass `creator` as `"Giselle Team"` for sample agents; otherwise use existing creator logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9d656406db1c5f9d85063f1bd4319f458a2ab42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sample agents now display the author label "by Giselle Team" in card footers and list/grid views; non-sample agents continue to show their creator's name or "Unknown" when unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->