### PR TITLE
Fix task overlay lingering on route change

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/ui/task-overlay.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/task-overlay.tsx
@@ -1,19 +1,35 @@
 "use client";
 
 import { AnimatePresence, motion } from "motion/react";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
 import { useShallow } from "zustand/shallow";
 import { TaskHeader } from "@/components/task/task-header";
 import { TaskLayout } from "@/components/task/task-layout";
 import { useTaskOverlayStore } from "../stores/task-overlay-store";
 
 export function TaskOverlay() {
-	const { isVisible, overlayApp, overlayInput } = useTaskOverlayStore(
-		useShallow((state) => ({
-			isVisible: state.isVisible,
-			overlayApp: state.overlayApp,
-			overlayInput: state.overlayInput,
-		})),
-	);
+	const { isVisible, overlayApp, overlayInput, hideOverlay } =
+		useTaskOverlayStore(
+			useShallow((state) => ({
+				isVisible: state.isVisible,
+				overlayApp: state.overlayApp,
+				overlayInput: state.overlayInput,
+				hideOverlay: state.hideOverlay,
+			})),
+		);
+	const pathname = usePathname();
+	const previousPathnameRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (
+			previousPathnameRef.current !== null &&
+			previousPathnameRef.current !== pathname
+		) {
+			hideOverlay();
+		}
+		previousPathnameRef.current = pathname;
+	}, [pathname, hideOverlay]);
 
 	return (
 		<AnimatePresence>


### PR DESCRIPTION
### **User description**
## Summary
Close the task overlay when the route changes to prevent UI overlap


___

### **PR Type**
Bug fix


___

### **Description**
- Close task overlay when route changes to prevent UI overlap

- Add pathname tracking with useEffect hook

- Retrieve hideOverlay method from task overlay store

- Compare previous and current pathname to trigger overlay closure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Route Change Detected"] -- "pathname updated" --> B["useEffect triggered"]
  B -- "compare previous pathname" --> C["Pathname changed?"]
  C -- "yes" --> D["Call hideOverlay"]
  D --> E["Task Overlay Closed"]
  C -- "no" --> F["No action"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-overlay.tsx</strong><dd><code>Add pathname tracking to close overlay on navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/ui/task-overlay.tsx

<ul><li>Import <code>usePathname</code> hook from next/navigation for route tracking<br> <li> Import <code>useEffect</code> and <code>useRef</code> hooks for pathname comparison logic<br> <li> Add <code>hideOverlay</code> method to store selector<br> <li> Implement useEffect hook that detects pathname changes and closes <br>overlay<br> <li> Store previous pathname in ref to compare against current pathname</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2572/files#diff-06cf514fd52f4f212189a1a14ac4f7cd599552d1cbcfa996efaf84f62c6e71eb">+23/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->