### PR TITLE
Fix task overlay overlapping with other pages on navigation

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/ui/task-overlay.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/task-overlay.tsx
@@ -1,19 +1,34 @@
 "use client";
 
 import { AnimatePresence, motion } from "motion/react";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
 import { useShallow } from "zustand/shallow";
 import { TaskHeader } from "@/components/task/task-header";
 import { TaskLayout } from "@/components/task/task-layout";
 import { useTaskOverlayStore } from "../stores/task-overlay-store";
 
 export function TaskOverlay() {
-	const { isVisible, overlayApp, overlayInput } = useTaskOverlayStore(
-		useShallow((state) => ({
-			isVisible: state.isVisible,
-			overlayApp: state.overlayApp,
-			overlayInput: state.overlayInput,
-		})),
-	);
+	const { isVisible, overlayApp, overlayInput, hideOverlay } =
+		useTaskOverlayStore(
+			useShallow((state) => ({
+				isVisible: state.isVisible,
+				overlayApp: state.overlayApp,
+				overlayInput: state.overlayInput,
+				hideOverlay: state.hideOverlay,
+			})),
+		);
+
+	const pathname = usePathname();
+	const prevPathnameRef = useRef(pathname);
+
+	// Auto-hide overlay when navigating to a different page
+	useEffect(() => {
+		if (prevPathnameRef.current !== pathname && isVisible) {
+			hideOverlay();
+		}
+		prevPathnameRef.current = pathname;
+	}, [pathname, isVisible, hideOverlay]);
 
 	return (
 		<AnimatePresence>


### PR DESCRIPTION
### **User description**
## Summary
- Auto-hide TaskOverlay when navigating to other pages during task execution
- Task continues running in the background after navigation

## Changes

### Problem
When running an App in Playground and navigating to Workspaces (or other pages) via the sidebar, the Task screen and destination page overlapped.

### Solution
Added pathname change detection in `TaskOverlay` component. When the user navigates away, the overlay automatically hides while the task continues executing server-side.


## Testing
- [ ] Run an App in Playground
- [ ] While "Creating task..." is shown, click "Workspaces" in sidebar
- [ ] Verify the overlay disappears and Workspaces page displays correctly
- [ ] Verify the task completes successfully (check /tasks page)


___

### **PR Type**
Bug fix


___

### **Description**
- Auto-hide TaskOverlay when navigating away from current page

- Task continues executing in background after navigation

- Prevents overlay from overlapping destination page content


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User navigates to different page"] -- "pathname changes" --> B["useEffect detects change"]
  B -- "isVisible is true" --> C["hideOverlay called"]
  C -- "overlay hidden" --> D["Destination page displays"]
  C -- "task continues" --> E["Background execution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-overlay.tsx</strong><dd><code>Add pathname change detection to auto-hide overlay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/ui/task-overlay.tsx

<ul><li>Added <code>usePathname</code> hook to track current route<br> <li> Added <code>useRef</code> to store previous pathname for comparison<br> <li> Implemented <code>useEffect</code> hook to detect pathname changes<br> <li> Auto-hide overlay when user navigates away while task is visible<br> <li> Added <code>hideOverlay</code> action to store selector</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2573/files#diff-06cf514fd52f4f212189a1a14ac4f7cd599552d1cbcfa996efaf84f62c6e71eb">+22/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents the task overlay from persisting when navigating to other pages.
> 
> - Detects route changes in `TaskOverlay` using `usePathname` and a `useEffect`; when the pathname changes and the overlay is visible, calls `hideOverlay`
> - Extends store selector to include `hideOverlay`; keeps existing overlay layout and animations intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cd7138076c245d7fa771597cc859039868ac197. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task overlay now automatically closes when navigating to a different route, improving the navigation experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->