### PR TITLE
fix: unify unnamed workspace label to "Untitled"

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/lib/stage-apps.ts
+++ b/apps/studio.giselles.ai/app/(main)/lib/stage-apps.ts
@@ -192,12 +192,12 @@ async function getAppsBySampleFlag(
 
 		apps.push({
 			id: data.giselleApp.id,
-			name: data.workspace.name ?? "No name app",
+			name: data.workspace.name ?? "Untitled",
 			description: data.giselleApp.description,
 			entryNodeId: data.giselleApp.entryNodeId,
 			parameters: data.giselleApp.parameters,
 			workspaceId: data.workspace.id,
-			workspaceName: data.workspace.name ?? "Untitled workspace",
+			workspaceName: data.workspace.name ?? "Untitled",
 			isMine: data.dbWorkspace.creatorDbId === userDbId,
 			vectorStoreRepositories: data.githubRepositories,
 			vectorStoreFiles: data.documentFiles,

--- a/apps/studio.giselles.ai/app/(main)/tasks/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/tasks/page.tsx
@@ -138,7 +138,7 @@ export default async function TaskListPage({
 				inputSummary: null,
 				origin: {
 					type: "app",
-					appName: dbTask.app.workspace.name ?? "Untitled App",
+					appName: dbTask.app.workspace.name ?? "Untitled",
 				},
 			} satisfies UITaskListRow;
 		}),

--- a/apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx
+++ b/apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx
@@ -33,7 +33,7 @@ export function AgentCard({ agent }: AgentCardProps) {
 
 	return (
 		<section
-			aria-label={agent.name || "Untitled workspace"}
+			aria-label={agent.name || "Untitled"}
 			className={clsx(
 				"relative flex h-[252px] w-full flex-none flex-col rounded-[12px]",
 				"bg-[linear-gradient(135deg,color-mix(in_srgb,var(--color-blue-muted)_10%,var(--color-background))_0%,color-mix(in_srgb,var(--color-blue-muted)_6%,var(--color-stage-background))_55%,color-mix(in_srgb,var(--color-blue-muted)_4%,var(--color-background))_100%)]",


### PR DESCRIPTION
### **User description**
## Summary
Unify unnamed workspace label to "Untitled".

## Changes
Previously, workspaces without a name displayed inconsistently:
- /playground: "No name app"
- /tasks: "Untitled App"
- /workspaces: "Untitled workspace"

Unified all fallback labels to "Untitled" for consistency.


___

### **PR Type**
Bug fix


___

### **Description**
- Unify unnamed workspace fallback labels to "Untitled"

- Replace inconsistent labels across three files

- Standardize display text for unnamed workspaces


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Inconsistent fallback labels<br/>No name app / Untitled App / Untitled workspace"] -- "Standardize to" --> B["Unified Untitled label<br/>across all files"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stage-apps.ts</strong><dd><code>Unify stage apps fallback labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/lib/stage-apps.ts

<ul><li>Changed <code>name</code> fallback from "No name app" to "Untitled"<br> <li> Changed <code>workspaceName</code> fallback from "Untitled workspace" to "Untitled"<br> <li> Ensures consistent unnamed workspace display in app listings</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2577/files#diff-ed63dfa1ddfd8f932f1f27d0ad13654bf1b12058d2029d55ddef82b68a7e1a34">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Unify task list app name fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/tasks/page.tsx

<ul><li>Changed <code>appName</code> fallback from "Untitled App" to "Untitled"<br> <li> Standardizes task origin display for unnamed workspaces</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2577/files#diff-bb13bc05006f11a22b83666a78b72697a9b0ed5725a5e30cdbf2671b68281364">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent-card.tsx</strong><dd><code>Unify agent card aria-label fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/workspaces/components/agent-card.tsx

<ul><li>Changed <code>aria-label</code> fallback from "Untitled workspace" to "Untitled"<br> <li> Improves accessibility label consistency for unnamed agents</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2577/files#diff-82f10eeae9dd84bb7a03b100b9d17482d5744819ab7cb4073847832ecd63379a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies display of unnamed apps/workspaces to "Untitled" for consistency across UI surfaces.
> 
> - `stage-apps.ts`: Set `name` and `workspaceName` fallbacks to `"Untitled"`
> - `tasks/page.tsx`: Use `"Untitled"` as fallback for `origin.appName`
> - `workspaces/components/agent-card.tsx`: Use `"Untitled"` for `aria-label` and control labels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 215936bcd94db2d7f2ef817677168b1441bb1954. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized default display names for unnamed apps, tasks, and agents to "Untitled" across the application for improved consistency.
  * Updated accessibility labels for unnamed items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->