### PR TITLE
feat(api): Implement public App Run API endpoint

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -84,12 +84,24 @@ Add API publishing settings UI to App Entry Node Properties Panel, protected by 
  - Updated Studio Giselle initialization to configure `apiSecretScrypt` via env (and removed pepper usage).
  - Updated Playground Giselle initialization to configure `apiSecretScrypt` via env (and removed pepper usage).
 
+- Added a new `GenerationOrigin` type: `api` (public API executions).
+- Added a Studio API Route to run an App via API key: `POST /api/apps/{appId}/run` with body `{ text: string }` and `Authorization: Bearer gsk_{apiKeyId}.{secret}`.
+- Updated origin-type switches/callbacks to handle `api` (task creation, generation execution, trigger resolution, file paths, Studio tracing + Trigger.dev processes).
+- Updated `@giselles-ai/giselle` exports to expose API publishing helpers needed by the Studio route.
+- Updated App Entry properties panel to show the API URL (copyable) above the Secret Key section so users can discover `appId` easily.
+
 ## Now
 - Spec work progressed: endpoint format, App persistence approach, and API key design (hash-only + show-once) are recorded as TEMPORARY agreements in this ledger.
 - Current behavior: key records live in Giselle Storage (hash-only). `createApiSecret` attempts best-effort single-active by revoking the previous key if present, but verification is record-based and does not enforce “current `app.apiPublishing.apiKeyId` only”.
 - Security follow-up: Code scanning flagged `hmac-sha256` for API secret hashing; plan is to remove HMAC and standardize on `scrypt` with configurable parameters.
 
+- Public App Run API is implemented and callable locally; the next missing piece for richer inputs is a public File Upload API so Runs can accept files (e.g. `{ text, file: FileId }`).
+
 ## Next
+
+- Add documentation / examples for the public run API (`curl` usage) in an appropriate Studio doc page.
+- Add a public API to fetch task status/results for API-triggered runs (e.g. `GET /api/tasks/{taskId}` or a dedicated Runs API that returns outputs/steps).
+- Define and implement a public upload API to support file parameters in public runs.
 
 ## Open questions (UNCONFIRMED if needed)
 - What minimal metadata/fingerprint do we need for Api secret records (e.g., createdAt, revokedAt, lastUsedAt, label, fingerprint)?

--- a/apps/studio.giselles.ai/app/api/apps/[appId]/run/route.ts
+++ b/apps/studio.giselles.ai/app/api/apps/[appId]/run/route.ts
@@ -1,0 +1,106 @@
+import { verifyApiSecretForApp } from "@giselles-ai/giselle";
+import {
+	AppId,
+	type AppParameter,
+	type GenerationContextInput,
+	type ParameterItem,
+} from "@giselles-ai/protocol";
+import type { NextRequest } from "next/server";
+import * as z from "zod/v4";
+import { giselle } from "@/app/giselle";
+
+const requestSchema = z.object({
+	text: z.string(),
+});
+
+function buildInputsFromText(args: {
+	appParameters: AppParameter[];
+	text: string;
+}): GenerationContextInput[] {
+	const multilineTextParam = args.appParameters.find(
+		(p) => p.type === "multiline-text",
+	);
+	const singleLineTextParam = args.appParameters.find((p) => p.type === "text");
+	const targetParam = multilineTextParam ?? singleLineTextParam;
+
+	if (!targetParam) {
+		throw new Error("App has no text parameter");
+	}
+
+	const items: ParameterItem[] = [
+		{
+			name: targetParam.id,
+			type: "string",
+			value: args.text,
+		},
+	];
+
+	return [
+		{
+			type: "parameters",
+			items,
+		},
+	];
+}
+
+export async function POST(
+	request: NextRequest,
+	{ params }: { params: Promise<{ appId: string }> },
+) {
+	const rawAppId = (await params).appId;
+	const appIdParse = AppId.safeParse(rawAppId);
+	if (!appIdParse.success) {
+		return new Response("Invalid appId", { status: 400 });
+	}
+	const appId = appIdParse.data;
+
+	const verifyResult = await verifyApiSecretForApp({
+		context: giselle.getContext(),
+		appId,
+		authorizationHeader: request.headers.get("authorization"),
+	});
+	if (!verifyResult.ok) {
+		return new Response("Unauthorized", { status: 401 });
+	}
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return new Response("Invalid JSON body", { status: 400 });
+	}
+
+	const parsed = requestSchema.safeParse(body);
+	if (!parsed.success) {
+		return new Response("Invalid request body", { status: 400 });
+	}
+
+	const app = await giselle.getApp({ appId }).catch(() => null);
+	if (!app) {
+		return new Response("App not found", { status: 404 });
+	}
+
+	let inputs: GenerationContextInput[];
+	try {
+		inputs = buildInputsFromText({
+			appParameters: app.parameters,
+			text: parsed.data.text,
+		});
+	} catch {
+		return new Response("App has no text parameter", { status: 400 });
+	}
+
+	const { task } = await giselle.createTask({
+		workspaceId: app.workspaceId,
+		nodeId: app.entryNodeId,
+		inputs,
+		generationOriginType: "api",
+	});
+
+	await giselle.startTask({
+		taskId: task.id,
+		generationOriginType: "api",
+	});
+
+	return Response.json({ taskId: task.id });
+}

--- a/apps/studio.giselles.ai/proxy.ts
+++ b/apps/studio.giselles.ai/proxy.ts
@@ -22,6 +22,6 @@ export const proxy = supabaseMiddleware(async (user, request) => {
 
 export const config = {
 	matcher: [
-		"/((?!_next/static|_next/image|.well-known|webhooks|legal|login|signup|join|pricing|password_reset|subscription|auth|api/giselle/github-webhook|api/vector-stores/cron|robots\\.txt|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+		"/((?!_next/static|_next/image|.well-known|webhooks|legal|login|signup|join|pricing|password_reset|subscription|auth|api/giselle/github-webhook|api/vector-stores/cron|api/apps|robots\\.txt|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
 	],
 };

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/app-entry-node-properties-panel/app-entry-configured-view.tsx
@@ -46,6 +46,11 @@ export function AppEntryConfiguredView({
 	const client = useGiselle();
 	const { apiPublishing } = useFeatureFlag();
 
+	const apiUrl =
+		typeof window === "undefined"
+			? `/api/apps/${app.id}/run`
+			: `${window.location.origin}/api/apps/${app.id}/run`;
+
 	const [appDescription, setAppDescription] = useState(app.description);
 	const [isSavingDescription, setIsSavingDescription] = useState(false);
 	const [apiSecretRecord, setApiSecretRecord] =
@@ -173,6 +178,25 @@ export function AppEntryConfiguredView({
 			{apiPublishing && (
 				<div className="flex flex-col gap-[16px] pt-[8px] border-t border-border">
 					<div className="flex flex-col gap-[12px]">
+						<div className="flex flex-col gap-[4px]">
+							<label htmlFor="api-url" className="text-[12px] text-text-muted">
+								API URL
+							</label>
+							<div className="flex items-center gap-[8px]">
+								<Input
+									id="api-url"
+									type="text"
+									value={apiUrl}
+									readOnly
+									className="flex-1 font-mono text-[12px]"
+								/>
+								<ClipboardButton
+									text={apiUrl}
+									tooltip="Copy API URL"
+									sizeClassName="h-[20px] w-[20px]"
+								/>
+							</div>
+						</div>
 						<div className="flex flex-col gap-[4px]">
 							<label htmlFor="api-key" className="text-[12px] text-text-muted">
 								Secret Key

--- a/packages/giselle/src/files/utils.ts
+++ b/packages/giselle/src/files/utils.ts
@@ -5,6 +5,7 @@ export function filePath(params: { fileId: FileId } & GenerationOrigin) {
 		case "studio":
 			return `workspaces/${params.workspaceId}/files/${params.fileId}/${params.fileId}`;
 
+		case "api":
 		case "stage":
 		case "github-app":
 			return `workspaces/${params.workspaceId}/files/${params.fileId}/${params.fileId}`;

--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -131,6 +131,7 @@ export async function useGenerationExecutor<T>(args: {
 	let workspaceId: WorkspaceId;
 	switch (args.generation.context.origin.type) {
 		case "stage":
+		case "api":
 		case "github-app":
 			workspaceId = args.generation.context.origin.workspaceId;
 			break;

--- a/packages/giselle/src/index.ts
+++ b/packages/giselle/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./api-publishing";
 export * from "./giselle";
 export * from "./types";

--- a/packages/giselle/src/tasks/create-task.ts
+++ b/packages/giselle/src/tasks/create-task.ts
@@ -274,6 +274,7 @@ export async function createTask(
 			};
 			break;
 		}
+		case "api":
 		case "stage":
 			if (!isAppEntryNode(starterNode)) {
 				throw new Error("starterNode must be an start node");

--- a/packages/giselle/src/triggers/resolve-trigger.ts
+++ b/packages/giselle/src/triggers/resolve-trigger.ts
@@ -98,6 +98,30 @@ export async function resolveTrigger(args: {
 
 					break;
 				}
+				case "api": {
+					const parameterInput = generationContext.inputs?.find(
+						(input) => input.type === "parameters",
+					);
+					if (parameterInput === undefined) {
+						throw new Error("Missing Parameters Input");
+					}
+
+					for (const output of operationNode.outputs) {
+						const inputItem = parameterInput.items.find(
+							(item) => item.name === output.accessor,
+						);
+						if (inputItem === undefined) {
+							continue;
+						}
+						outputs.push({
+							outputId: output.id,
+							type: "generated-text",
+							content: `${inputItem.value}`,
+						});
+					}
+
+					break;
+				}
 				default: {
 					const _exhaustiveCheck: never = args.generation.context.origin;
 					throw new Error(`Unhandled origin type: ${_exhaustiveCheck}`);

--- a/packages/protocol/src/generation/context.ts
+++ b/packages/protocol/src/generation/context.ts
@@ -29,10 +29,18 @@ export type GenerationOriginGitHubApp = z.infer<
 	typeof GenerationOriginGitHubApp
 >;
 
+export const GenerationOriginApi = z.object({
+	taskId: TaskId.schema,
+	workspaceId: WorkspaceId.schema,
+	type: z.literal("api"),
+});
+export type GenerationOriginApi = z.infer<typeof GenerationOriginApi>;
+
 export const GenerationOrigin = z.discriminatedUnion("type", [
 	GenerationOriginStudio,
 	GenerationOriginStage,
 	GenerationOriginGitHubApp,
+	GenerationOriginApi,
 ]);
 export type GenerationOrigin = z.infer<typeof GenerationOrigin>;
 


### PR DESCRIPTION
## Summary
Implemented a public API endpoint to run Giselle Apps programmatically. Added a new `api` generation origin type and integrated it across task creation, generation execution, trigger resolution, file handling, and tracing systems. Also added UI to display the API URL in the App Entry properties panel.

## Changes
- Added `POST /api/apps/{appId}/run` endpoint accepting `{ text: string }` with Bearer token auth (`gsk_{apiKeyId}.{secret}`)
- Introduced `GenerationOriginApi` type and updated all origin-type switches to handle the `api` type
- Implemented text parameter binding for API-triggered runs via `resolveTrigger` handler
- Added API URL display with copy button in the App Entry properties panel for easy appId discovery

## Testing
Verified locally through development testing; endpoint successfully creates and starts tasks for Apps with text parameters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a public App Run API and propagates a new execution origin to support API-triggered runs.
> 
> - New Next.js route `POST /api/apps/{appId}/run` (zod-validated `{ text }`, verifies `Authorization: Bearer gsk_{apiKeyId}.{secret}`) that creates and starts a task, returning `{ taskId }`
> - Protocol: adds `GenerationOriginApi` and includes it in `GenerationOrigin`
> - Core handling updated for `api`: `create-task`, `use-generation-executor`, `resolve-trigger` (parameter binding), and `files/utils`
> - Studio/processing: tracing and Trigger.dev job wiring updated to treat `api` similarly to `github-app`
> - Exposes API publishing helpers via `@giselles-ai/giselle` exports; proxy matcher allows `/api/apps` routes
> - UI: App Entry properties panel shows a copyable API URL above the Secret Key section
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef3cc52ecd11d344d43db112091dd8f8f11f7fc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->