### PR TITLE
Replace apiPublishing flag with internal team plan gating

### DIFF
--- a/.continuity/20260113-125213-detached-head.md
+++ b/.continuity/20260113-125213-detached-head.md
@@ -1,0 +1,62 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+<!--
+Write 1–5 bullets capturing the human goal and motivation.
+This section is intentionally stable: do not overwrite it when updating the ledger.
+-->
+
+- Replace Studio’s `apiPublishingFlag` gating with team plan gating (`internal` only) so API keys UI is not controlled by a deploy-time flag.
+
+## Goal (incl. success criteria)
+
+- All `apps/studio.giselles.ai` branches on `apiPublishingFlag` are replaced with `team.plan === "internal"`.
+- `apiPublishingFlag` and `apiPublishing` feature-flag plumbing are removed (no dangling references; build/types remain clean).
+
+## Constraints/Assumptions
+
+- Non-internal plans should behave as before: hide the sidebar link and return `notFound()` (404).
+- Keep changes minimal and obvious (no new abstractions beyond a small helper).
+
+## Key decisions
+
+- Introduced `isInternalPlan(team)` in `services/teams/utils.ts` and reused it across server components for clarity and consistency.
+
+## State
+
+- Before: access was controlled by Edge Config / env (`apiPublishingFlag`).
+- After: access is controlled by persisted team plan in DB (`teams.plan`).
+
+## Done
+
+- Added `isInternalPlan(team)` helper.
+- Updated `/settings/team/api-keys` and `/manage/api-keys` to gate by internal plan (404 otherwise).
+- Updated sidebar to show the “API keys” link only for internal plan.
+- Removed `apiPublishingFlag` from `apps/studio.giselles.ai/flags.ts`.
+- Removed `apiPublishing` field from `packages/react` feature-flag context/provider wiring.
+- Removed `apiPublishing` from Studio workspace loader `featureFlags`.
+
+## Now
+
+- Ready to commit.
+
+## Next
+
+- Optional: update `CONTINUITY.md` batched snapshot to reflect that `apiPublishingFlag` is removed and the gate is plan-based.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `apps/studio.giselles.ai/services/teams/utils.ts`
+- `apps/studio.giselles.ai/app/(main)/settings/team/api-keys/page.tsx`
+- `apps/studio.giselles.ai/app/(main)/manage/api-keys/page.tsx`
+- `apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx`
+- `apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts`
+- `apps/studio.giselles.ai/flags.ts`
+- `packages/react/src/feature-flags/context.ts`
+- `packages/react/src/workspace/provider.tsx`
+

--- a/apps/studio.giselles.ai/app/(main)/manage/api-keys/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/manage/api-keys/page.tsx
@@ -1,9 +1,10 @@
 import { notFound, redirect } from "next/navigation";
-import { apiPublishingFlag } from "../../../../flags";
+import { fetchCurrentTeam } from "@/services/teams";
+import { isInternalPlan } from "@/services/teams/utils";
 
 export default async function ApiKeysPage() {
-	const isApiPublishingEnabled = await apiPublishingFlag();
-	if (!isApiPublishingEnabled) {
+	const team = await fetchCurrentTeam();
+	if (!isInternalPlan(team)) {
 		notFound();
 	}
 	redirect("/settings/team/api-keys");

--- a/apps/studio.giselles.ai/app/(main)/settings/team/api-keys/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/api-keys/page.tsx
@@ -1,16 +1,15 @@
 import { notFound } from "next/navigation";
 import { listApiSecretRecordsForTeam } from "@/lib/api-keys";
 import { fetchCurrentTeam } from "@/services/teams";
-import { apiPublishingFlag } from "../../../../../flags";
+import { isInternalPlan } from "@/services/teams/utils";
 import { ApiKeysPageClient } from "./page-client";
 
 export default async function ApiKeysPage() {
-	const isApiPublishingEnabled = await apiPublishingFlag();
-	if (!isApiPublishingEnabled) {
+	const team = await fetchCurrentTeam();
+	if (!isInternalPlan(team)) {
 		notFound();
 	}
 
-	const team = await fetchCurrentTeam();
 	const apiKeys = await listApiSecretRecordsForTeam(team.dbId);
 
 	return <ApiKeysPageClient apiKeys={apiKeys} />;

--- a/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
@@ -6,7 +6,9 @@ import {
 } from "lucide-react";
 import type { IconName } from "lucide-react/dynamic";
 import { Accordion } from "radix-ui";
-import { apiPublishingFlag, stageFlag, stageV2Flag } from "../../../../flags";
+import { fetchCurrentTeam } from "@/services/teams";
+import { isInternalPlan } from "@/services/teams/utils";
+import { stageFlag, stageV2Flag } from "../../../../flags";
 import { CreateAppButton } from "./create-app-button";
 import { SidebarLink } from "./sidebar-link";
 
@@ -170,8 +172,12 @@ function createBaseSidebarParts(
 }
 
 export async function Sidebar() {
-	const [isStageEnabled, isStageV2Enabled, isApiPublishingEnabled] =
-		await Promise.all([stageFlag(), stageV2Flag(), apiPublishingFlag()]);
+	const [isStageEnabled, isStageV2Enabled, team] = await Promise.all([
+		stageFlag(),
+		stageV2Flag(),
+		fetchCurrentTeam(),
+	]);
+	const isApiPublishingEnabled = isInternalPlan(team);
 	const baseSidebarParts = createBaseSidebarParts(isApiPublishingEnabled);
 	const sidebarParts = isStageEnabled
 		? [createStagePart(isStageV2Enabled), ...baseSidebarParts]

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
@@ -5,7 +5,6 @@ import { db } from "@/db";
 import {
 	aiGatewayFlag,
 	aiGatewayUnsupportedModelsFlag,
-	apiPublishingFlag,
 	dataStoreFlag,
 	generateContentNodeFlag,
 	googleUrlContextFlag,
@@ -64,7 +63,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 	const data = await giselle.getWorkspace(workspaceId);
 	const generateContentNode = await generateContentNodeFlag();
 	const privatePreviewTools = await privatePreviewToolsFlag();
-	const apiPublishing = await apiPublishingFlag();
 	const dataStore = await dataStoreFlag();
 	const [teamGitHubRepositoryIndexes, officialGitHubRepositoryIndexes] =
 		await Promise.all([
@@ -130,7 +128,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 			googleUrlContext,
 			generateContentNode,
 			privatePreviewTools,
-			apiPublishing,
 			dataStore,
 		},
 		llmProviders,

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -233,26 +233,6 @@ export const privatePreviewToolsFlag = flag<boolean>({
 	defaultValue: false,
 });
 
-export const apiPublishingFlag = flag<boolean>({
-	key: "api-publishing",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("API_PUBLISHING_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return false;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable API publishing settings in App Entry Node",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-	defaultValue: false,
-});
-
 export const dataStoreFlag = flag<boolean>({
 	key: "data-store",
 	async decide() {

--- a/apps/studio.giselles.ai/services/teams/utils.ts
+++ b/apps/studio.giselles.ai/services/teams/utils.ts
@@ -10,6 +10,10 @@ export function isProPlan(team: Pick<CurrentTeam, "plan">) {
 	);
 }
 
+export function isInternalPlan(team: Pick<CurrentTeam, "plan">) {
+	return team.plan === "internal";
+}
+
 const PLAN_LABELS: Record<string, string> = {
 	free: "Free plan",
 	pro: "Pro plan",

--- a/packages/react/src/feature-flags/context.ts
+++ b/packages/react/src/feature-flags/context.ts
@@ -9,7 +9,6 @@ export interface FeatureFlagContextValue {
 	googleUrlContext: boolean;
 	generateContentNode: boolean;
 	privatePreviewTools: boolean;
-	apiPublishing: boolean;
 	dataStore: boolean;
 }
 export const FeatureFlagContext = createContext<

--- a/packages/react/src/workspace/provider.tsx
+++ b/packages/react/src/workspace/provider.tsx
@@ -50,7 +50,6 @@ export function WorkspaceProvider({
 				googleUrlContext: featureFlag?.googleUrlContext ?? false,
 				generateContentNode: featureFlag?.generateContentNode ?? false,
 				privatePreviewTools: featureFlag?.privatePreviewTools ?? false,
-				apiPublishing: featureFlag?.apiPublishing ?? false,
 				dataStore: featureFlag?.dataStore ?? false,
 			}}
 		>


### PR DESCRIPTION
- Gate API keys pages and sidebar link by team.plan === "internal"
- Introduce isInternalPlan(team) helper for consistent checks
- Remove apiPublishingFlag and all related feature-flag wiring
- Drop apiPublishing from workspace loader and React feature flag context