### PR TITLE
chore(flags): remove stageFlag and make Stage always enabled

### DIFF
--- a/.continuity/20260113-125213-detached-head.md
+++ b/.continuity/20260113-125213-detached-head.md
@@ -36,6 +36,7 @@ This section is intentionally stable: do not overwrite it when updating the ledg
 - Removed `apiPublishingFlag` from `apps/studio.giselles.ai/flags.ts`.
 - Removed `apiPublishing` field from `packages/react` feature-flag context/provider wiring.
 - Removed `apiPublishing` from Studio workspace loader `featureFlags`.
+- Removed `stageFlag` (always enabled) and simplified all call sites to treat Stage as always enabled.
 
 ## Now
 
@@ -59,4 +60,8 @@ This section is intentionally stable: do not overwrite it when updating the ledg
 - `apps/studio.giselles.ai/flags.ts`
 - `packages/react/src/feature-flags/context.ts`
 - `packages/react/src/workspace/provider.tsx`
+- `apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx`
+- `apps/studio.giselles.ai/app/(auth)/login/login.ts`
+- `apps/studio.giselles.ai/app/(auth)/join/success/page.tsx`
+- `apps/studio.giselles.ai/app/api/stage/acts/route.ts`
 

--- a/apps/studio.giselles.ai/app/(auth)/join/success/page.tsx
+++ b/apps/studio.giselles.ai/app/(auth)/join/success/page.tsx
@@ -1,10 +1,8 @@
 import Link from "next/link";
-import { stageFlag } from "@/flags";
 import { AuthButton } from "../../components/auth-button";
 
-export default async function Page() {
-	const isStageEnabled = await stageFlag();
-	const redirectTo = isStageEnabled ? "/playground" : "/workspaces";
+export default function Page() {
+	const redirectTo = "/playground";
 
 	return (
 		<div className="min-h-screen flex items-center justify-center p-4">

--- a/apps/studio.giselles.ai/app/(auth)/login/login.ts
+++ b/apps/studio.giselles.ai/app/(auth)/login/login.ts
@@ -2,7 +2,6 @@
 
 import { redirect } from "next/navigation";
 import { isValidReturnUrl } from "@/app/(auth)/lib";
-import { stageFlag } from "@/flags";
 import { type AuthError, createAuthError, createClient } from "@/lib/supabase";
 
 export async function login(
@@ -32,8 +31,7 @@ export async function login(
 		return createAuthError(error);
 	}
 
-	const isStageEnabled = await stageFlag();
-	const fallbackUrl = isStageEnabled ? "/playground" : "/workspaces";
+	const fallbackUrl = "/playground";
 
 	// Validate returnUrl to prevent open redirect attacks
 	const validReturnUrl = isValidReturnUrl(returnUrlEntry)

--- a/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
@@ -8,7 +8,7 @@ import type { IconName } from "lucide-react/dynamic";
 import { Accordion } from "radix-ui";
 import { fetchCurrentTeam } from "@/services/teams";
 import { isInternalPlan } from "@/services/teams/utils";
-import { stageFlag, stageV2Flag } from "../../../../flags";
+import { stageV2Flag } from "../../../../flags";
 import { CreateAppButton } from "./create-app-button";
 import { SidebarLink } from "./sidebar-link";
 
@@ -172,16 +172,13 @@ function createBaseSidebarParts(
 }
 
 export async function Sidebar() {
-	const [isStageEnabled, isStageV2Enabled, team] = await Promise.all([
-		stageFlag(),
+	const [isStageV2Enabled, team] = await Promise.all([
 		stageV2Flag(),
 		fetchCurrentTeam(),
 	]);
 	const isApiPublishingEnabled = isInternalPlan(team);
 	const baseSidebarParts = createBaseSidebarParts(isApiPublishingEnabled);
-	const sidebarParts = isStageEnabled
-		? [createStagePart(isStageV2Enabled), ...baseSidebarParts]
-		: baseSidebarParts;
+	const sidebarParts = [createStagePart(isStageV2Enabled), ...baseSidebarParts];
 
 	return (
 		<div className="w-[240px]">

--- a/apps/studio.giselles.ai/app/api/stage/acts/route.ts
+++ b/apps/studio.giselles.ai/app/api/stage/acts/route.ts
@@ -1,16 +1,9 @@
-import { notFound } from "next/navigation";
 // import { fetchEnrichedActs } from "@/app/stage/(top)/services";
 import { fetchEnrichedActs } from "@/app/(main)/stage/(depreacted)/services";
-import { stageFlag } from "@/flags";
 import { fetchCurrentUser } from "@/services/accounts";
 import { fetchUserTeams } from "@/services/teams";
 
 export async function GET() {
-	const enableStage = await stageFlag();
-	if (!enableStage) {
-		return notFound();
-	}
-
 	const teams = await fetchUserTeams();
 	const user = await fetchCurrentUser();
 	const acts = await fetchEnrichedActs(teams, user);

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
@@ -10,7 +10,6 @@ import {
 	googleUrlContextFlag,
 	layoutV3Flag,
 	privatePreviewToolsFlag,
-	stageFlag,
 	webSearchActionFlag,
 } from "@/flags";
 import { logger } from "@/lib/logger";
@@ -58,7 +57,7 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 	const usageLimits = await getUsageLimitsForTeam(workspaceTeam);
 	const webSearchAction = await webSearchActionFlag();
 	const layoutV3 = await layoutV3Flag();
-	const stage = await stageFlag();
+	const stage = true;
 	const aiGateway = await aiGatewayFlag();
 	const aiGatewayUnsupportedModels = await aiGatewayUnsupportedModelsFlag();
 	const googleUrlContext = await googleUrlContextFlag();

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -78,25 +78,6 @@ export const experimental_storageFlag = flag<boolean>({
 	],
 });
 
-export const stageFlag = flag<boolean>({
-	key: "stage",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("STAGE_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return true;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable stage",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-});
-
 export const stageV2Flag = flag<boolean>({
 	key: "stage-v2",
 	async decide() {


### PR DESCRIPTION
### **User description**
Stage has been the default execution surface for some time, and the legacy
stageFlag was effectively always-on. This change removes the flag entirely
and simplifies all call sites to assume Stage is enabled.

- Delete stageFlag from flags.ts and feature-flag wiring
- Remove conditional routing (/playground vs /workspaces) and always route to Stage
- Always include Stage in sidebar composition
- Remove Stage-gating from Stage API routes and workspace loaders


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `stageFlag` feature flag entirely from codebase

- Simplify all call sites to assume Stage is always enabled

- Remove conditional routing logic between /playground and /workspaces

- Always include Stage in sidebar composition without gating


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stageFlag Feature Flag"] -->|Removed| B["flags.ts"]
  C["Conditional Routing Logic"] -->|Simplified| D["login.ts & join/success/page.tsx"]
  E["Stage API Gating"] -->|Removed| F["stage/acts/route.ts"]
  G["Sidebar Stage Composition"] -->|Always Enabled| H["sidebar.tsx"]
  I["Workspace Data Loader"] -->|stage = true| J["data-loader.ts"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Delete stageFlag feature flag definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Removed entire <code>stageFlag</code> function definition and its configuration<br> <li> Removed flag key, decision logic, description, and UI options<br> <li> Kept other feature flags like <code>stageV2Flag</code> intact</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2634/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+0/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>login.ts</strong><dd><code>Simplify login redirect to always use /playground</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(auth)/login/login.ts

<ul><li>Removed import of <code>stageFlag</code><br> <li> Removed conditional logic checking if Stage is enabled<br> <li> Hardcoded fallback URL to <code>/playground</code> instead of conditional <br><code>/playground</code> or <code>/workspaces</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2634/files#diff-ad01a43bd06ccd096d01eb6e27d7f74d12d35716c2d31e3f548037fa89903ade">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Simplify join success redirect logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(auth)/join/success/page.tsx

<ul><li>Removed import of <code>stageFlag</code><br> <li> Removed async function wrapper and <code>stageFlag()</code> call<br> <li> Hardcoded redirect URL to <code>/playground</code> instead of conditional routing</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2634/files#diff-d5d23ec8ee94219aba3cdd91ec2ad0cdb8bc550dec395ee8c787402bc46fbc95">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Remove Stage API gating logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/api/stage/acts/route.ts

<ul><li>Removed import of <code>stageFlag</code> and <code>notFound</code> from next/navigation<br> <li> Removed conditional check that returned <code>notFound()</code> when Stage was <br>disabled<br> <li> Simplified GET handler to always execute Stage acts logic</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2634/files#diff-082f8ca79d7df7bc936f32652e4342108fa34226d6ec2697e8d156e19a0cdc33">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data-loader.ts</strong><dd><code>Hardcode stage as always enabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts

<ul><li>Removed import of <code>stageFlag</code> from flags<br> <li> Changed <code>stage</code> variable from <code>await stageFlag()</code> to hardcoded <code>true</code><br> <li> Simplified data loader to always treat Stage as enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2634/files#diff-9f7a6561fcf469be8edd13cdb7931f806dfd8adc5f6becf1cb4d98511624df70">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sidebar.tsx</strong><dd><code>Always include Stage in sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx

<ul><li>Removed import of <code>stageFlag</code><br> <li> Removed <code>stageFlag()</code> call from Promise.all<br> <li> Removed conditional logic that gated Stage part inclusion in sidebar<br> <li> Always include Stage part in sidebar composition</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2634/files#diff-1b29a5b71ffeadb24999c5a893faa234976cd84967975907b7fba2bb44fc4395">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20260113-125213-detached-head.md</strong><dd><code>Update continuity ledger with changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.continuity/20260113-125213-detached-head.md

<ul><li>Added entry documenting removal of <code>stageFlag</code> and simplification of all <br>call sites<br> <li> Updated list of modified files to include sidebar, login, <br>join/success, and stage/acts/route</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2634/files#diff-039bf87665839b26042cab5bda68678de5659cd6acdac6ee46a3f5eccfd20656">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * The Stage feature is now permanently enabled as a core feature rather than being conditionally gated, ensuring consistent availability for all users.

* **Updates**
  * Authentication redirects and navigation flows have been streamlined with deterministic behavior.
  * The sidebar now consistently displays the Stage section in all user sessions, providing uniform access to stage-related functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->