### PR TITLE
Add GPT-5.2 Codex model support

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx
@@ -20,6 +20,7 @@ import {
  * Returns the available reasoning effort options for the given OpenAI model.
  *
  * GPT-5.2 and GPT-5.1-thinking support: none/low/medium/high/xhigh
+ * GPT-5.2-codex supports: low/medium/high/xhigh
  * GPT-5.1-codex supports: low/medium/high
  * Older models (gpt-5, gpt-5-mini, gpt-5-nano) support: minimal/low/medium/high
  *
@@ -29,6 +30,9 @@ function getReasoningEffortOptions(modelId: string): readonly string[] {
 	if (modelId === "gpt-5.2" || modelId === "gpt-5.1-thinking") {
 		return ["none", "low", "medium", "high", "xhigh"] as const;
 	}
+	if (modelId === "gpt-5.2-codex") {
+		return ["low", "medium", "high", "xhigh"] as const;
+	}
 	if (modelId === "gpt-5.1-codex") {
 		return ["low", "medium", "high"] as const;
 	}
@@ -37,10 +41,10 @@ function getReasoningEffortOptions(modelId: string): readonly string[] {
 
 /**
  * Returns the available textVerbosity options for the given OpenAI model.
- * GPT-5.1-codex only supports verbosity: medium.
+ * Codex models only support verbosity: medium.
  */
 function getTextVerbosityOptions(modelId: string): readonly string[] {
-	if (modelId === "gpt-5.1-codex") {
+	if (modelId === "gpt-5.1-codex" || modelId === "gpt-5.2-codex") {
 		return ["medium"] as const;
 	}
 	return ["low", "medium", "high"] as const;

--- a/packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts
+++ b/packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts
@@ -19,7 +19,8 @@ export function transformGiselleLanguageModelToAiSdkLanguageModelCallOptions(
 		case "openai/gpt-5-nano":
 		case "openai/gpt-5.1-codex":
 		case "openai/gpt-5.1-thinking":
-		case "openai/gpt-5.2": {
+		case "openai/gpt-5.2":
+		case "openai/gpt-5.2-codex": {
 			const config = parseConfiguration(
 				languageModel,
 				content.languageModel.configuration,

--- a/packages/language-model-registry/src/openai.ts
+++ b/packages/language-model-registry/src/openai.ts
@@ -116,6 +116,36 @@ export const openai = {
 		},
 		url: "https://platform.openai.com/docs/models/gpt-5.1-codex",
 	}),
+	"openai/gpt-5.2-codex": defineLanguageModel({
+		provider: openaiProvider,
+		id: "openai/gpt-5.2-codex",
+		name: "GPT-5.2 Codex",
+		description:
+			"GPT-5.2-Codex is specifically designed for use in Codex and agentic coding tasks in Codex-like environments.",
+		contextWindow: 400_000,
+		maxOutputTokens: 128_000,
+		knowledgeCutoff: new Date(2025, 7, 31).getTime(),
+		pricing: {
+			input: definePricing(1.75),
+			output: definePricing(14.0),
+		},
+		requiredTier: "pro",
+		configurationOptions: {
+			reasoningEffort: {
+				description: reasoningEffortDescription,
+				schema: z.enum(["low", "medium", "high", "xhigh"]),
+			},
+			textVerbosity: {
+				description: textVerbosityDescription,
+				schema: z.enum(["medium"]),
+			},
+		},
+		defaultConfiguration: {
+			reasoningEffort: "medium",
+			textVerbosity: "medium",
+		},
+		url: "https://platform.openai.com/docs/models/gpt-5.2-codex",
+	}),
 
 	"openai/gpt-5": defineLanguageModel({
 		provider: openaiProvider,

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -25,6 +25,21 @@ export const openAiTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
+	"gpt-5.2-codex": {
+		prices: [
+			{
+				validFrom: "2026-01-15T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 1.75,
+					},
+					output: {
+						costPerMegaToken: 14.0,
+					},
+				},
+			},
+		],
+	},
 	"gpt-5.1-thinking": {
 		prices: [
 			{

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -48,6 +48,7 @@ const gpt51CodexConfigurations: OpenAILanguageModelConfigurations = {
 export const OpenAILanguageModelId = z
 	.enum([
 		"gpt-5.2",
+		"gpt-5.2-codex",
 		"gpt-5.1-thinking",
 		"gpt-5.1-codex",
 		"gpt-5",
@@ -59,6 +60,10 @@ export const OpenAILanguageModelId = z
 			return "gpt-5-nano";
 		}
 		const v = ctx.value;
+
+		if (/^gpt-5\.2-codex(?:-.+)?$/.test(v)) {
+			return "gpt-5.2-codex";
+		}
 
 		if (/^gpt-5\.2(?:-.+)?$/.test(v)) {
 			return "gpt-5.2";
@@ -151,6 +156,18 @@ const gpt51codex: OpenAILanguageModel = {
 	configurations: gpt51CodexConfigurations,
 };
 
+const gpt52codex: OpenAILanguageModel = {
+	provider: "openai",
+	id: "gpt-5.2-codex",
+	capabilities:
+		Capability.ImageFileInput |
+		Capability.TextGeneration |
+		Capability.OptionalSearchGrounding |
+		Capability.Reasoning,
+	tier: Tier.enum.pro,
+	configurations: gpt51CodexConfigurations,
+};
+
 const gpt5: OpenAILanguageModel = {
 	provider: "openai",
 	id: "gpt-5",
@@ -188,6 +205,7 @@ const gpt5nano: OpenAILanguageModel = {
 
 export const models = [
 	gpt52,
+	gpt52codex,
 	gpt51Thinking,
 	gpt51codex,
 	gpt5,

--- a/packages/node-registry/src/node-conversion.ts
+++ b/packages/node-registry/src/node-conversion.ts
@@ -49,6 +49,8 @@ function convertTextGenerationLanguageModelIdToContentGenerationLanguageModelId(
 			return "google/gemini-2.5-pro";
 		case "gpt-5.2":
 			return "openai/gpt-5.2";
+		case "gpt-5.2-codex":
+			return "openai/gpt-5.2-codex";
 		case "gpt-5.1-thinking":
 			return "openai/gpt-5.1-thinking";
 		case "gpt-5":
@@ -95,6 +97,8 @@ function convertContentGenerationLanguageModelIdToTextGenerationLanguageModelId(
 			return "gemini-2.5-pro";
 		case "openai/gpt-5.2":
 			return "gpt-5.2";
+		case "openai/gpt-5.2-codex":
+			return "gpt-5.2-codex";
 		case "openai/gpt-5.1-thinking":
 			return "gpt-5.1-thinking";
 		case "openai/gpt-5":


### PR DESCRIPTION
### **User description**
This PR introduces first-class support for **GPT-5.2 Codex** across the platform.

### Summary

* Extends UI model configuration to reflect Codex-specific capabilities.
* Registers the model with pricing, defaults, and constraints.
* Ensures end-to-end compatibility through SDK transforms and node conversion.

### Details

* **UI**: Updates reasoning effort and verbosity options for Codex.
* **Language Model**: Adds model definition, enum normalization, and capabilities.
* **Registry**: Registers metadata, pricing, defaults, and documentation URL.
* **Costs**: Adds pricing effective from 2026-01-15.
* **Conversion**: Maps between internal and provider model IDs.

### Notes

* Codex models restrict `textVerbosity` to `medium`.
* Reasoning effort options differ from non-Codex GPT-5.2.

No breaking changes expected.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds GPT-5.2-Codex model with full platform support

- Registers model pricing, capabilities, and configuration constraints

- Updates UI to reflect Codex-specific reasoning and verbosity options

- Implements model ID conversion between internal and provider formats


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GPT-5.2-Codex Model"] --> B["Registry Definition"]
  A --> C["Pricing Configuration"]
  A --> D["UI Controls"]
  A --> E["Model Conversion"]
  B --> F["Capabilities & Constraints"]
  D --> G["Reasoning Effort Options"]
  D --> H["Text Verbosity Options"]
  E --> I["Node Conversion Mapping"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Register GPT-5.2-Codex model definition and configuration</code></dd></summary>
<hr>

packages/language-model-registry/src/openai.ts

<ul><li>Defines GPT-5.2-Codex model with 400k context window and 128k max <br>output tokens<br> <li> Sets pricing at $1.75 input and $14.0 output per million tokens<br> <li> Restricts textVerbosity to "medium" only for Codex variant<br> <li> Supports reasoning effort levels: low, medium, high, xhigh<br> <li> Requires pro tier access</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2643/files#diff-e6017504117029db5da4178595c2dea30f4436d59fa5e293cf2c4d43998db98d">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openai.ts</strong><dd><code>Define GPT-5.2-Codex model with capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/openai.ts

<ul><li>Adds gpt-5.2-codex to OpenAI model ID enum with normalization regex<br> <li> Creates gpt52codex model definition with pro tier and Codex <br>capabilities<br> <li> Includes image input, text generation, search grounding, and reasoning<br> <li> Registers model in exported models array</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2643/files#diff-1891a7f0ef98437d982f18296668e40c171f03da7e4b82d2dff4b3a2b3f791d8">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transform-giselle-to-ai-sdk.ts</strong><dd><code>Include GPT-5.2-Codex in SDK transformation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts

<ul><li>Adds gpt-5.2-codex case to SDK transformation switch statement<br> <li> Ensures Codex variant uses same configuration parsing as gpt-5.2</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2643/files#diff-0a09de5e2c8b926e5c6fe97190e30c07afcc824bdad76066f6d54272a544c12f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-conversion.ts</strong><dd><code>Add GPT-5.2-Codex node ID conversion mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/node-registry/src/node-conversion.ts

<ul><li>Maps gpt-5.2-codex between text generation and content generation <br>formats<br> <li> Adds bidirectional conversion: gpt-5.2-codex ↔ openai/gpt-5.2-codex</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2643/files#diff-d3a73003e50f7bd7c2d3edbd874ea5522dc9d8bcfcfc21a6f62126e3b7b0125f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openai.tsx</strong><dd><code>Configure UI controls for GPT-5.2-Codex parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/openai.tsx

<ul><li>Adds gpt-5.2-codex to reasoning effort options: low, medium, high, <br>xhigh<br> <li> Updates text verbosity logic to restrict Codex models to "medium" only<br> <li> Updates documentation comments to reflect Codex model constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2643/files#diff-dc80a63a37f4eac39c7a2fbe8976912929b8ad377394512e91117e5ec636cfdc">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-prices.ts</strong><dd><code>Add GPT-5.2-Codex pricing configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/language-model/src/costs/model-prices.ts

<ul><li>Adds pricing entry for gpt-5.2-codex model<br> <li> Sets effective date from 2026-01-15<br> <li> Defines input cost at 1.75 and output cost at 14.0 per million tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2643/files#diff-edfd8b7be916cc898f2e958d766b426a7c44aafe94081857b525993ddf4f4374">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added OpenAI gpt-5.2-codex model variant to available language models for text generation workflows.
* Model supports configurable reasoning effort levels (low, medium, high, xhigh) and medium verbosity settings.
* Requires pro tier access with pricing of $1.75 per million input tokens and $14.00 per million output tokens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->