### PR TITLE
refactor(sdk): rename client.app to client.apps

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -6,7 +6,7 @@ This file is a **low-churn, batched snapshot** (“as of <date>”) of the repo�
 Recent, detailed intent logs live in `.continuity/` (per-branch ledgers). Periodically summarize `.continuity/*` into this file.
 
 ## Goal
-Add a public Runs SDK package (`@giselles-ai/sdk`) under `packages/` to call `POST /api/apps/{appId}/run` and expose `client.app.run()` (and a stubbed `runAndWait()`).
+Add a public Runs SDK package (`@giselles-ai/sdk`) under `packages/` to call `POST /api/apps/{appId}/run` and expose `client.apps.run()` (and a stubbed `runAndWait()`).
 
 ## Constraints/Assumptions
 - Adhere to `AGENTS.md` and `CLAUDE.md`.

--- a/docs/plan/sdk.md
+++ b/docs/plan/sdk.md
@@ -9,7 +9,7 @@ const client = new Giselle({
   apiKey: process.env.GISELLE_API_KEY,
 });
 
-const { taskId } = await client.app.run({
+const { taskId } = await client.apps.run({
   appId: "app-VC4zxzcdSrO0tGDY",
   input: { text: "your input here" },
 });
@@ -24,10 +24,10 @@ console.log(taskId);
 
 ### Done
 
-- [x] Add file input support to `client.app.runAndWait()` via **either** a `fileId` (from the upload API) **or** an inline base64 file payload (with a size limit).
+- [x] Add file input support to `client.apps.runAndWait()` via **either** a `fileId` (from the upload API) **or** an inline base64 file payload (with a size limit).
 - [x] Add file upload support to the SDK.
-- [x] Implement `client.app.run()` to call `POST /api/apps/{appId}/run` and return `{ taskId }`.
-- [x] Implement `client.app.runAndWait()` by polling `GET /api/apps/{appId}/tasks/{taskId}` until the task reaches a terminal status.
+- [x] Implement `client.apps.run()` to call `POST /api/apps/{appId}/run` and return `{ taskId }`.
+- [x] Implement `client.apps.runAndWait()` by polling `GET /api/apps/{appId}/tasks/{taskId}` until the task reaches a terminal status.
 - [x] On completion, fetch the final task result via `GET /api/apps/{appId}/tasks/{taskId}?includeGenerations=1` and return `{ steps, outputs }`.
 - [x] Align Runs/Tasks authentication for Team secret keys (use `Authorization: Bearer <apiKeyId>.<secret>`; no token prefix).
 - [x] Add SDK tests (mocked `fetch`) and document usage in `packages/sdk/README.md`.

--- a/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
@@ -427,7 +427,7 @@ const client = new Giselle({
   apiKey: process.env.GISELLE_API_KEY,
 });
 
-const { taskId } = await client.app.run({
+const { taskId } = await client.apps.run({
   appId: "${app.id}",
   input: { text: "your input here" },
 });

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -23,7 +23,7 @@ const client = new Giselle({
 });
 
 async function main() {
-	const { taskId } = await client.app.run({
+	const { taskId } = await client.apps.run({
 		appId: "app-xxxxx",
 		input: { text: "hello" },
 	});
@@ -82,7 +82,7 @@ main()
 - `fetch?: typeof fetch`
   - Optional. Useful for tests and nonstandard runtimes.
 
-### `client.app.run({ appId, input })`
+### `client.apps.run({ appId, input })`
 
 Calls:
 
@@ -90,7 +90,7 @@ Calls:
 - Body: `{ "text": string, "file"?: { "fileId": string } | { "base64": string, "name": string, "type": string } }`
 - Returns: `{ taskId: string }`
 
-### `client.app.runAndWait(...)`
+### `client.apps.runAndWait(...)`
 
 Calls `POST /api/apps/{appId}/run`, then polls the task status API until the task finishes.
 

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -30,7 +30,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		});
 
 		await expect(
-			client.app.run({ appId: "app-xxxxx", input: { text: "hello" } }),
+			client.apps.run({ appId: "app-xxxxx", input: { text: "hello" } }),
 		).resolves.toEqual({ taskId: "tsk_123" });
 	});
 
@@ -58,7 +58,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		});
 
 		await expect(
-			client.app.run({
+			client.apps.run({
 				appId: "app-xxxxx",
 				input: { text: "hello", file: { fileId: "fl_123" } },
 			}),
@@ -96,7 +96,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		});
 
 		await expect(
-			client.app.run({
+			client.apps.run({
 				appId: "app-xxxxx",
 				input: {
 					text: "hello",
@@ -124,7 +124,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		const overLimitBase64 = "A".repeat(len);
 
 		await expect(
-			client.app.run({
+			client.apps.run({
 				appId: "app-xxxxx",
 				input: {
 					text: "hello",
@@ -156,7 +156,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		});
 
 		await expect(
-			client.app.run({ appId: "app-xxxxx", input: { text: "hello" } }),
+			client.apps.run({ appId: "app-xxxxx", input: { text: "hello" } }),
 		).resolves.toEqual({ taskId: "tsk_123" });
 	});
 
@@ -167,7 +167,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		});
 
 		await expect(
-			client.app.run({ appId: "app-xxxxx", input: { text: "hello" } }),
+			client.apps.run({ appId: "app-xxxxx", input: { text: "hello" } }),
 		).rejects.toBeInstanceOf(ConfigurationError);
 	});
 
@@ -257,7 +257,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		});
 
 		await expect(
-			client.app.runAndWait({
+			client.apps.runAndWait({
 				appId: "app-xxxxx",
 				input: { text: "hello" },
 				pollIntervalMs: 0,
@@ -304,7 +304,7 @@ describe("Giselle SDK (public Runs API)", () => {
 		// We can't easily time-travel Date.now() without mocking timers, so we just assert the error type
 		// by making the fetch throw after a couple of polls.
 		await expect(
-			client.app.runAndWait({
+			client.apps.runAndWait({
 				appId: "app-xxxxx",
 				input: { text: "hello" },
 				pollIntervalMs: 0,

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -308,11 +308,9 @@ function parseTaskResponseJson(json: unknown): AppTaskResult {
 }
 
 export default class Giselle {
-	readonly app: {
+	readonly apps: {
 		run: (args: AppRunArgs) => Promise<AppRunResult>;
 		runAndWait: (args: AppRunAndWaitArgs) => Promise<AppTaskResult>;
-	};
-	readonly apps: {
 		list: () => Promise<AppListResult>;
 	};
 	readonly files: {
@@ -328,11 +326,9 @@ export default class Giselle {
 		this.#baseUrl = options.baseUrl ?? defaultBaseUrl;
 		this.#apiKey = options.apiKey;
 
-		this.app = {
+		this.apps = {
 			run: (args) => this.#runApp(args),
 			runAndWait: (args) => this.#runAppAndWait(args),
-		};
-		this.apps = {
 			list: () => this.#listApps(),
 		};
 		this.files = {


### PR DESCRIPTION
### **User description**
Align SDK API surface to use the plural `apps` namespace. Update docs, tests, and internal references to `client.apps.run()` and `runAndWait()`. Remove the deprecated singular `app` accessor for consistency.


___

### **PR Type**
Enhancement


___

### **Description**
- Rename `client.app` to `client.apps` for API consistency

- Consolidate `apps` namespace to include `run()`, `runAndWait()`, and `list()` methods

- Update all test cases, documentation, and internal references

- Remove deprecated singular `app` accessor


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["client.app<br/>singular accessor"] -->|"rename to"| B["client.apps<br/>unified namespace"]
  B --> C["run()"]
  B --> D["runAndWait()"]
  B --> E["list()"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sdk.ts</strong><dd><code>Consolidate app methods into apps namespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdk/src/sdk.ts

<ul><li>Rename <code>readonly app</code> property to <code>readonly apps</code><br> <li> Consolidate <code>apps</code> object to include <code>run()</code>, <code>runAndWait()</code>, and <code>list()</code> <br>methods<br> <li> Update constructor to initialize <code>apps</code> with all three methods<br> <li> Remove separate <code>app</code> object definition</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2650/files#diff-04689b788dad65b6ce4b43e7344d3b854b1a95ad2c8692c6ece28ccd7d9a96b4">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sdk.test.ts</strong><dd><code>Update test cases to use apps namespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdk/src/sdk.test.ts

<ul><li>Update all test calls from <code>client.app.run()</code> to <code>client.apps.run()</code><br> <li> Update all test calls from <code>client.app.runAndWait()</code> to <br><code>client.apps.runAndWait()</code><br> <li> Affects 8 test cases across multiple test suites</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2650/files#diff-442c9bdc0c17bf9e7e5875a764cca0c80a54c6a6192a6c912e0fd50f12d8130b">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update SDK documentation examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdk/README.md

<ul><li>Update code examples from <code>client.app.run()</code> to <code>client.apps.run()</code><br> <li> Update API documentation headers from <code>client.app.run()</code> to <br><code>client.apps.run()</code><br> <li> Update <code>client.app.runAndWait()</code> to <code>client.apps.runAndWait()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2650/files#diff-fb389a13c110d5b92cb85e2a1eb937b649ff8adc09a19626ab6cbc9218bb6d83">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sdk.md</strong><dd><code>Update plan documentation references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/plan/sdk.md

<ul><li>Update code example from <code>client.app.run()</code> to <code>client.apps.run()</code><br> <li> Update checklist items referencing <code>client.app.run()</code> and <br><code>client.app.runAndWait()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2650/files#diff-6e224ecac1f42fc454fe0953fb1aa2ebd20dcbdb47afb52f2cecd3eb24f90244">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CONTINUITY.md</strong><dd><code>Update continuity goal statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTINUITY.md

<ul><li>Update goal statement from <code>client.app.run()</code> to <code>client.apps.run()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2650/files#diff-e863740b70a19959b3b7747a1adb33c7e70db2c3f3040d82fdf4d5eae9c59afc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dialog.tsx</strong><dd><code>Update UI dialog code example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx

- Update code example from `client.app.run()` to `client.apps.run()`


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2650/files#diff-fbf40c162844b223b720f3187f4a9b123287807dad1fe97c8dcfe65f79a56f0a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns the SDK to a plural `apps` namespace.
> 
> - Replace `client.app.run()`/`runAndWait()` with `client.apps.run()`/`runAndWait()` and remove the singular accessor from `Giselle`.
> - Update `packages/sdk/README.md`, `docs/plan/sdk.md`, UI code sample in `dialog.tsx`, and all SDK tests to the new `client.apps.*` API.
> - No behavioral changes to endpoints or auth; calls still hit `POST /api/apps/{appId}/run` and related task/file routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8625af38a0f9f3e0eedd23e0980c1d10544a8e7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated the public SDK API from separate `app` and `apps` namespaces to a unified `apps` namespace. All app-related methods (run, runAndWait, list) are now accessed through the `apps` property.

* **Documentation**
  * Updated all documentation, examples, and code samples to reflect the unified `apps` API namespace.

* **Tests**
  * Updated test cases to match the refactored API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->