### PR TITLE
refactor: simplify stage input to use local-only blob previews

### DIFF
--- a/.continuity/20260114-101202-HEAD.md
+++ b/.continuity/20260114-101202-HEAD.md
@@ -59,6 +59,7 @@ This section is intentionally stable: do not overwrite it when updating the ledg
 - Updated SDK apps.list tests and README to reflect the name return.
 - Removed Studio `/api/giselle` catch-all route and cleaned up Studio leftovers (basePath constant, robots disallow, proxy matcher exception).
 - Updated Studio playground file attachment previews to use an optional `basePath` prop (no `/api/giselle` dependency).
+- Simplified Stage input file previews to local-only blob URLs; removed `basePath`/`workspaceId`/`onImageLoad` plumbing from `FileAttachments` and stage input components.
 
 ## Now
 
@@ -93,6 +94,9 @@ This section is intentionally stable: do not overwrite it when updating the ledg
 - `apps/studio.giselles.ai/app/robots.ts`
 - `apps/studio.giselles.ai/proxy.ts`
 - `apps/studio.giselles.ai/app/(main)/playground/file-attachments.tsx`
+- `apps/studio.giselles.ai/app/(main)/components/stage-input/use-stage-input.ts`
+- `apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx`
+- `apps/studio.giselles.ai/app/(main)/components/stage-input/task-compact-stage-input.tsx`
 - `docs/plan/api-giselle-deprecation.md`
 - Tests: `pnpm -F @giselles-ai/sdk test`, `pnpm -F studio.giselles.ai test`
 

--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
@@ -47,7 +47,6 @@ export function PlaygroundStageInput({
 		handleFileInputChange,
 		handleAttachmentButtonClick,
 		handleRemoveFile,
-		handleImageLoad,
 		handleDismissFileRestrictionError,
 		handleSubmit,
 		selectedApp,
@@ -140,9 +139,7 @@ export function PlaygroundStageInput({
 					<FileAttachments
 						files={attachedFiles}
 						onRemoveFile={handleRemoveFile}
-						workspaceId={selectedApp?.workspaceId}
 						localPreviews={localPreviews}
-						onImageLoad={handleImageLoad}
 					/>
 
 					{fileRestrictionError ? (

--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/task-compact-stage-input.tsx
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/task-compact-stage-input.tsx
@@ -44,7 +44,6 @@ export function TaskCompactStageInput({
 		handleFileInputChange,
 		handleAttachmentButtonClick,
 		handleRemoveFile,
-		handleImageLoad,
 		handleDismissFileRestrictionError,
 		handleSubmit,
 		selectedApp,
@@ -134,9 +133,7 @@ export function TaskCompactStageInput({
 					<FileAttachments
 						files={attachedFiles}
 						onRemoveFile={handleRemoveFile}
-						workspaceId={selectedApp?.workspaceId}
 						localPreviews={localPreviews}
-						onImageLoad={handleImageLoad}
 					/>
 
 					{fileRestrictionError ? (

--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/use-stage-input.ts
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/use-stage-input.ts
@@ -437,19 +437,6 @@ export function useStageInput({
 		});
 	}, []);
 
-	const handleImageLoad = useCallback((fileId: string) => {
-		setLocalPreviews((prev) => {
-			const previewUrl = prev.get(fileId);
-			if (previewUrl) {
-				URL.revokeObjectURL(previewUrl);
-				const next = new Map(prev);
-				next.delete(fileId);
-				return next;
-			}
-			return prev;
-		});
-	}, []);
-
 	const handleDismissFileRestrictionError = useCallback(() => {
 		setFileRestrictionError(null);
 	}, []);
@@ -568,7 +555,6 @@ export function useStageInput({
 			handleFileInputChange,
 			handleAttachmentButtonClick,
 			handleRemoveFile,
-			handleImageLoad,
 			handleDismissFileRestrictionError,
 			handleSubmit: submitInputs,
 		}),
@@ -595,7 +581,6 @@ export function useStageInput({
 			handleFileInputChange,
 			handleAttachmentButtonClick,
 			handleRemoveFile,
-			handleImageLoad,
 			handleDismissFileRestrictionError,
 			submitInputs,
 		],

--- a/apps/studio.giselles.ai/app/(main)/playground/file-attachments.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/file-attachments.tsx
@@ -4,61 +4,15 @@ import {
 	TextFileIcon,
 	XlsxFileIcon,
 } from "@giselle-internal/workflow-designer-ui";
-import type {
-	FileData,
-	UploadedFileData,
-	WorkspaceId,
-} from "@giselles-ai/protocol";
+import type { FileData, UploadedFileData } from "@giselles-ai/protocol";
 import { AlertCircle, Check, Loader2, Paperclip, X } from "lucide-react";
 import Image from "next/image";
 import type React from "react";
-import { useEffect, useState } from "react";
 
 interface FileAttachmentsProps {
 	files: FileData[];
 	onRemoveFile: (fileId: string) => void;
-	workspaceId?: WorkspaceId;
-	basePath?: string;
 	localPreviews?: Map<string, string>;
-	onImageLoad?: (fileId: string) => void;
-}
-
-function ImageThumbnail(props: {
-	remoteSrc: string;
-	localFallbackSrc?: string;
-	alt: string;
-	onRemoteLoaded?: () => void;
-}) {
-	const { remoteSrc, localFallbackSrc, alt, onRemoteLoaded } = props;
-	const [src, setSrc] = useState(remoteSrc);
-
-	useEffect(() => {
-		setSrc(remoteSrc);
-	}, [remoteSrc]);
-
-	return (
-		<Image
-			src={src}
-			alt={alt}
-			fill
-			sizes="60px"
-			// We may render blob/object URLs (local previews) here.
-			unoptimized
-			className="object-cover"
-			onError={() => {
-				if (localFallbackSrc && src !== localFallbackSrc) {
-					setSrc(localFallbackSrc);
-				}
-			}}
-			onLoad={() => {
-				// Notify the parent only when the remote image successfully loads.
-				// The parent uses this to safely clean up the local preview URL.
-				if (src === remoteSrc) {
-					onRemoteLoaded?.();
-				}
-			}}
-		/>
-	);
 }
 
 function formatFileSize(bytes: number) {
@@ -148,30 +102,15 @@ function getFileTypeLabel(file: FileData): string | null {
 	return labelMap[ext] || null;
 }
 
-function getFileUrl(
-	file: UploadedFileData,
-	workspaceId: WorkspaceId,
-	basePath: string,
-): string {
-	// Generate file path for stage type
-	const path = `workspaces/${workspaceId}/files/${file.id}/${file.id}`;
-	const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
-	return `${basePath}/${normalizedPath}`;
-}
-
 export function FileAttachments({
 	files,
 	onRemoveFile,
-	workspaceId,
-	basePath,
 	localPreviews,
-	onImageLoad,
 }: FileAttachmentsProps) {
 	if (files.length === 0) {
 		return null;
 	}
 
-	const resolvedBasePath = basePath ?? "";
 	const readyCount = files.filter(isUploadedFile).length;
 	const thumbnailFiles = files.filter(
 		(file) => isImageFile(file) || getFileTypeBadge(file) !== null,
@@ -197,33 +136,21 @@ export function FileAttachments({
 
 						// Image file rendering
 						if (isImage) {
-							const isUploaded = isUploadedFile(file);
 							const localPreview = localPreviews?.get(file.id);
-							let imageUrl: string | null = null;
-
-							if (isUploaded && workspaceId && resolvedBasePath.length > 0) {
-								imageUrl = getFileUrl(file, workspaceId, resolvedBasePath);
-							} else if (localPreview) {
-								imageUrl = localPreview;
-							}
 
 							return (
 								<div
 									key={file.id}
 									className="relative group shrink-0 rounded-lg overflow-hidden bg-white/5 border border-white/5 w-[60px] h-[60px]"
 								>
-									{imageUrl ? (
-										<ImageThumbnail
-											remoteSrc={imageUrl}
-											localFallbackSrc={isUploaded ? localPreview : undefined}
+									{localPreview ? (
+										<Image
+											src={localPreview}
 											alt={file.name}
-											onRemoteLoaded={() => {
-												// Notify parent that server image loaded successfully
-												// Parent will clean up local preview URL
-												if (isUploaded && onImageLoad) {
-													onImageLoad(file.id);
-												}
-											}}
+											fill
+											sizes="60px"
+											unoptimized
+											className="object-cover"
 										/>
 									) : (
 										<div className="w-full h-full flex items-center justify-center text-blue-muted/50">


### PR DESCRIPTION
### **User description**
Dropped all server-side image plumbing—workspaceId, basePath, and onImageLoad callbacks—so file thumbnails now render solely from local blob URLs.

resolves #2656


___

### **PR Type**
Enhancement, Refactoring


___

### **Description**
- Removed server-side image plumbing from file attachment components

- Eliminated `workspaceId`, `basePath`, and `onImageLoad` callback dependencies

- Simplified image rendering to use only local blob URL previews

- Deleted `ImageThumbnail` component and `getFileUrl` helper function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stage Input Components"] -->|removed| B["workspaceId/basePath props"]
  A -->|removed| C["onImageLoad callback"]
  D["FileAttachments Component"] -->|simplified to| E["Local blob previews only"]
  F["ImageThumbnail Component"] -->|deleted| G["Direct Image component"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-stage-input.ts</strong><dd><code>Remove handleImageLoad callback from hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/components/stage-input/use-stage-input.ts

<ul><li>Removed <code>handleImageLoad</code> callback function that revoked blob URLs<br> <li> Removed <code>handleImageLoad</code> from returned hook object in two locations<br> <li> Simplified state management by eliminating server-side image load <br>tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2660/files#diff-968ee46c4a0e7f134e6543faa92a7ee26eaa1af07434f255da7f010215e20024">+0/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>playground-stage-input.tsx</strong><dd><code>Remove server-side props from playground input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx

<ul><li>Removed <code>handleImageLoad</code> from destructured hook return<br> <li> Removed <code>workspaceId</code> and <code>onImageLoad</code> props passed to <code>FileAttachments</code><br> <li> Simplified component to rely only on local preview URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2660/files#diff-3adf1662d37dc3d71b30dbe9c4a77393a59741e0e28a42faf2298e3734b46bad">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-compact-stage-input.tsx</strong><dd><code>Remove server-side props from compact input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/components/stage-input/task-compact-stage-input.tsx

<ul><li>Removed <code>handleImageLoad</code> from destructured hook return<br> <li> Removed <code>workspaceId</code> and <code>onImageLoad</code> props passed to <code>FileAttachments</code><br> <li> Aligned with playground component simplification</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2660/files#diff-c146089ba8fc9f99eb118758c97f275d6ef712aa9d34727a54e9a802b7c754c0">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>file-attachments.tsx</strong><dd><code>Simplify FileAttachments to local-only previews</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/playground/file-attachments.tsx

<ul><li>Removed <code>WorkspaceId</code> type import and <code>workspaceId</code>, <code>basePath</code>, <code>onImageLoad</code> <br>props<br> <li> Deleted <code>ImageThumbnail</code> component that handled remote/local fallback <br>logic<br> <li> Deleted <code>getFileUrl</code> helper function for server-side image URL <br>generation<br> <li> Simplified image rendering to use only <code>localPreviews</code> with direct <code>Image</code> <br>component<br> <li> Removed <code>useState</code> and <code>useEffect</code> hooks no longer needed</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2660/files#diff-9bea074c0c024cd2be90b18c823bae1f9b510b13e53197e36715f87f8c201cdf">+8/-81</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20260114-101202-HEAD.md</strong><dd><code>Update continuity ledger with refactoring details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.continuity/20260114-101202-HEAD.md

<ul><li>Added entry documenting simplified Stage input file previews<br> <li> Listed three modified stage input component files in changelog<br> <li> Updated continuity ledger to track refactoring changes</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2660/files#diff-e2efaeadb17328e013c79226e01b1e140984a4cedcb903e4cdd97c89262e4afe">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new stage input components for enhanced file upload capabilities in the playground and task interfaces.

* **Improvements**
  * Simplified file preview handling to use local blob URLs, eliminating unnecessary remote file fetch operations for faster preview rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->