### PR TITLE
test(api): add test for missing app record in Tasks API (#2614)

### DIFF
--- a/apps/studio.giselles.ai/app/api/apps/[appId]/tasks/[taskId]/route.test.ts
+++ b/apps/studio.giselles.ai/app/api/apps/[appId]/tasks/[taskId]/route.test.ts
@@ -49,6 +49,31 @@ describe("GET /api/apps/[appId]/tasks/[taskId]", () => {
 		}) as unknown as Parameters<typeof GET>[0];
 	}
 
+	it("returns 401 when app record is not found", async () => {
+		const appId = AppId.generate();
+		const taskId = TaskId.generate();
+
+		// @ts-expect-error - mocked shape
+		db.select.mockReturnValue({
+			from: () => ({
+				where: () => ({
+					limit: async () => [],
+				}),
+			}),
+		});
+
+		const request = makeNextRequest("https://example.com", {
+			headers: { authorization: "Bearer gsk-test.secret" },
+		});
+
+		const response = await GET(request, {
+			params: Promise.resolve({ appId, taskId }),
+		});
+
+		expect(response.status).toBe(401);
+		expect(verifyApiSecretForTeam).not.toHaveBeenCalled();
+	});
+
 	it("returns 401 when team API key verification fails", async () => {
 		const appId = AppId.generate();
 		const taskId = TaskId.generate();


### PR DESCRIPTION
### **User description**
Adds test for missing app record case. The route returns 401 when `appRecord` is undefined (line 68-72), but there was no test for this.

**Test verifies:**
- Returns 401 when app record is missing
- `verifyApiSecretForTeam` is not called (prevents app existence leakage)

This is a distinct code path from API key verification failure.

Fixes #2614

## Summary
Adds missing test case for when the app record is not found in the database for the Tasks API endpoint (`GET /api/apps/{appId}/tasks/{taskId}`). The route returns 401 when `appRecord` is undefined (route.ts lines 68-72), but there was no test verifying this behavior. This test ensures the endpoint doesn't leak app existence by returning 401 immediately without attempting authentication.

## Changes
- Added test case `"returns 401 when app record is not found"` in `app/api/apps/[appId]/tasks/[taskId]/route.test.ts`
- Test mocks database query to return empty array (simulating `appRecord` being `undefined`)
- Test verifies:
  - Endpoint returns 401 status when app record is missing
  - `verifyApiSecretForTeam` is **not** called (prevents app existence leakage)
- This test is distinct from the existing "returns 401 when team API key verification fails" test

## Testing
- New test passes and correctly verifies 401 response when app record is missing
- Test confirms `verifyApiSecretForTeam` is not invoked, ensuring no app existence leakage
- All existing tests continue to pass
- Test follows the same pattern as similar tests in `files/upload/route.test.ts`

## Other Information
This test ensures the endpoint doesn't leak app existence by attempting authentication with a non-existent app. The 401 response should be returned immediately without calling API key verification, maintaining consistent behavior with the Run API endpoint (as noted in route.ts line 69-70 comment: "Keep behavior consistent with the run endpoint: unauthenticated requests should not reveal whether an appId exists").


___

### **PR Type**
Tests


___

### **Description**
- Adds test for missing app record in Tasks API endpoint

- Verifies 401 response when app record not found

- Ensures `verifyApiSecretForTeam` not called to prevent app existence leakage

- Maintains consistent behavior with Run API endpoint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Case Added"] --> B["Mock DB Query Returns Empty"]
  B --> C["GET Request with Auth Header"]
  C --> D["Verify 401 Response"]
  D --> E["Verify verifyApiSecretForTeam Not Called"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.test.ts</strong><dd><code>Add missing app record test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/api/apps/[appId]/tasks/[taskId]/route.test.ts

<ul><li>Added new test case <code>"returns 401 when app record is not found"</code><br> <li> Mocks database query to return empty array simulating missing <br><code>appRecord</code><br> <li> Verifies endpoint returns 401 status code<br> <li> Confirms <code>verifyApiSecretForTeam</code> is not invoked to prevent app <br>existence leakage</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2674/files#diff-b66a294cfad53837ec1944c30718e9935bc2ee78a282e2115b3d4900153b49b7">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for handling missing app records in authorization flows, ensuring proper error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->