### PR TITLE
fix: prevent orphaned secrets when deleting data store

### DIFF
--- a/.continuity/20260127-160000-fix__delete-data-store-orphan-prevention.md
+++ b/.continuity/20260127-160000-fix__delete-data-store-orphan-prevention.md
@@ -1,0 +1,64 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Fix deleteDataStore to prevent orphaned resources when deletion fails
+- Prioritize deleting secret first (encrypted credentials) to avoid orphaning sensitive data
+- Accept that DataStore (metadata only) may be orphaned as a trade-off
+- Make getDataStore and deleteDataStore idempotent for retry support
+
+## Goal (incl. success criteria)
+
+- When deleteDataStore is called, delete in order: secret → dataStore → DB
+- If deletion fails partway, user can retry and complete the deletion
+- Secret (credentials) should never be orphaned; DataStore (metadata) orphan is acceptable
+
+## Constraints/Assumptions
+
+- S3-compatible storage (Supabase) has no transactions
+- Cannot atomically delete multiple objects
+- deleteSecret already handles non-existent case gracefully (returns without error)
+- Failure probability of deleteDataStore after deleteSecret succeeds is very low (~0.001%)
+
+## Key decisions
+
+- Delete order: secret → dataStore → DB (security-first approach)
+- Changed getDataStore to return undefined instead of throwing when not found
+- Changed deleteDataStore to return undefined instead of throwing when not found
+- Added null checks in execution contexts (execute-data-query.ts, use-generation-executor.ts)
+- Accept temporary broken state where dataStore exists but secret is deleted (user can retry)
+
+## State
+
+- Implementation complete
+- All verification passed: format, build-sdk, check-types, test, tidy
+
+## Done
+
+- Modified `packages/giselle/src/data-stores/get-data-store.ts`: return undefined when not found
+- Modified `packages/giselle/src/data-stores/delete-data-store.ts`: return undefined when not found
+- Modified `packages/giselle/src/operations/execute-data-query.ts`: added null check with error
+- Modified `packages/giselle/src/generations/internal/use-generation-executor.ts`: added null check with error
+- Modified `apps/studio.giselles.ai/app/(main)/settings/team/data-stores/actions.ts`: reordered deletion to secret → dataStore → DB
+- Modified `packages/http/src/router.ts`: added 404 response for getDataStore and deleteDataStore when not found
+
+## Now
+
+- N/A (complete)
+
+## Next
+
+- N/A (complete)
+
+## Open questions (UNCONFIRMED if needed)
+
+- None
+
+## Working set (files/ids/commands)
+
+- `packages/giselle/src/data-stores/get-data-store.ts` (modified)
+- `packages/giselle/src/data-stores/delete-data-store.ts` (modified)
+- `packages/giselle/src/operations/execute-data-query.ts` (modified)
+- `packages/giselle/src/generations/internal/use-generation-executor.ts` (modified)
+- `apps/studio.giselles.ai/app/(main)/settings/team/data-stores/actions.ts` (modified)
+- `packages/http/src/router.ts` (modified)

--- a/packages/giselle/src/data-stores/delete-data-store.ts
+++ b/packages/giselle/src/data-stores/delete-data-store.ts
@@ -8,12 +8,12 @@ export async function deleteDataStore({
 }: {
 	context: GiselleContext;
 	dataStoreId: DataStoreId;
-}): Promise<DataStore> {
+}): Promise<DataStore | undefined> {
 	const path = dataStorePath(dataStoreId);
 
 	const exists = await context.storage.exists(path);
 	if (!exists) {
-		throw new Error(`DataStore not found: ${dataStoreId}`);
+		return;
 	}
 
 	const dataStore = await context.storage.getJson({

--- a/packages/giselle/src/data-stores/get-data-store.ts
+++ b/packages/giselle/src/data-stores/get-data-store.ts
@@ -8,12 +8,12 @@ export async function getDataStore({
 }: {
 	context: GiselleContext;
 	dataStoreId: DataStoreId;
-}): Promise<DataStore> {
+}): Promise<DataStore | undefined> {
 	const path = dataStorePath(dataStoreId);
 
 	const exists = await context.storage.exists(path);
 	if (!exists) {
-		throw new Error(`DataStore not found: ${dataStoreId}`);
+		return;
 	}
 
 	const dataStore = await context.storage.getJson({

--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -376,6 +376,9 @@ export async function useGenerationExecutor<T>(args: {
 				context: args.context,
 				dataStoreId,
 			});
+			if (!dataStore) {
+				throw new Error(`DataStore not found: ${dataStoreId}`);
+			}
 
 			const config = parseConfiguration(
 				dataStore.provider,

--- a/packages/giselle/src/operations/execute-data-query.ts
+++ b/packages/giselle/src/operations/execute-data-query.ts
@@ -78,6 +78,9 @@ export function executeDataQuery(args: {
 					context: args.context,
 					dataStoreId,
 				});
+				if (!dataStore) {
+					throw new Error(`DataStore not found: ${dataStoreId}`);
+				}
 				const config = parseConfiguration(
 					dataStore.provider,
 					dataStore.configuration,

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -502,6 +502,12 @@ export const jsonRoutes = {
 			}),
 			handler: async ({ input }) => {
 				const dataStore = await giselle.getDataStore(input);
+				if (!dataStore) {
+					return JsonResponse.json(
+						{ error: `DataStore not found: ${input.dataStoreId}` },
+						{ status: 404 },
+					);
+				}
 				return JsonResponse.json({ dataStore });
 			},
 		}),
@@ -523,6 +529,10 @@ export const jsonRoutes = {
 			}),
 			handler: async ({ input }) => {
 				const dataStore = await giselle.deleteDataStore(input);
+				if (!dataStore) {
+					// For idempotent DELETE, treat not found as success
+					return new Response(null, { status: 204 });
+				}
 				return JsonResponse.json({ dataStore });
 			},
 		}),


### PR DESCRIPTION
### **User description**
## Summary

- Changed deletion order to: secret → dataStore → DB record to prevent orphaning encrypted credentials
- Made `getDataStore` and `deleteDataStore` idempotent by returning `undefined` instead of throwing when resource not found
- Added undefined checks in callers that require the resource to exist

## Problem

Previously, the DB record was deleted first, which could leave secrets orphaned in giselle storage if subsequent deletions failed. Since S3-compatible storage has no transactions, we cannot atomically delete multiple objects.

## Solution

Delete in order: secret (credentials) → dataStore (metadata) → DB record

- **Secret first**: Contains encrypted connection credentials - we don't want it orphaned
- **DataStore second**: May be orphaned if deletion fails, but acceptable since it only contains metadata
- **DB record last**: Enables retry if giselle storage deletion fails

## Changes

### Deletion order (`actions.ts`)
- Before: DB record → giselle storage (parallel, errors ignored)
- After: secret → dataStore → DB record (sequential, errors propagate)

### Idempotency (`get-data-store.ts`, `delete-data-store.ts`)
- Return `undefined` instead of throwing when resource not found
- Enables retry scenarios where giselle storage is already cleaned up

### Caller updates
- `execute-data-query.ts`, `use-generation-executor.ts`: Added undefined check with error throw
- `router.ts`: Added 404 response for missing resources

## Test plan

- [x] Data store can be deleted successfully
- [x] If deletion fails partway, retry completes successfully



___

### **PR Type**
Bug fix


___

### **Description**
- Reorder deletion sequence to prevent orphaned secrets: secret → dataStore → DB

- Make getDataStore and deleteDataStore idempotent by returning undefined

- Add undefined checks in callers that require the resource to exist

- Return 404 responses in HTTP API for missing data stores


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Delete Secret<br/>encrypted credentials"] --> B["Delete DataStore<br/>metadata reference"]
  B --> C["Delete DB Record<br/>final cleanup"]
  D["getDataStore/deleteDataStore<br/>return undefined if not found"] --> E["Callers check undefined<br/>throw or return 404"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Reorder deletion sequence to prevent orphaned secrets</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/data-stores/actions.ts

<ul><li>Changed deletion order from parallel (DB first) to sequential (secret <br>→ dataStore → DB)<br> <li> Removed try-catch that silently ignored giselle storage deletion <br>errors<br> <li> Added detailed comments explaining deletion order rationale<br> <li> Errors now propagate instead of being logged and ignored</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2682/files#diff-1689dad5bd9c146909287e97ea952d8feb81e17cd3a54c1a5f38245f8b045664">+17/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get-data-store.ts</strong><dd><code>Make getDataStore idempotent with undefined return</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/data-stores/get-data-store.ts

<ul><li>Changed return type from <code>DataStore</code> to <code>DataStore | undefined</code><br> <li> Return <code>undefined</code> instead of throwing when resource not found<br> <li> Enables idempotent behavior for retry scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2682/files#diff-6d8292a745bbd34a434ff07a5a3d474e1481576a60e707b46915854d1c067145">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>delete-data-store.ts</strong><dd><code>Make deleteDataStore idempotent with undefined return</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/data-stores/delete-data-store.ts

<ul><li>Changed return type from <code>DataStore</code> to <code>DataStore | undefined</code><br> <li> Return <code>undefined</code> instead of throwing when resource not found<br> <li> Supports retry scenarios where giselle storage already cleaned up</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2682/files#diff-b9d6c71cb7be4e27aa96969bb2c85980104a08d516a2215c5a0c461bc3c14b5b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execute-data-query.ts</strong><dd><code>Add undefined check for data store retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/operations/execute-data-query.ts

<ul><li>Added undefined check after getDataStore call<br> <li> Throw error if dataStore not found instead of proceeding with <br>undefined<br> <li> Ensures execution fails gracefully when resource missing</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2682/files#diff-954e6c1997123a6e0e44bf8df68d96ea202ebc1c4500abc2004622b41278344b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>use-generation-executor.ts</strong><dd><code>Add undefined check for data store retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/giselle/src/generations/internal/use-generation-executor.ts

<ul><li>Added undefined check after getDataStore call<br> <li> Throw error if dataStore not found instead of proceeding with <br>undefined<br> <li> Prevents schema retrieval with missing data store</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2682/files#diff-782c88a70f1ce2b1da39915f22a822acc95af5301d3f7b4da93bf245293ca3ca">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.ts</strong><dd><code>Add 404 responses for missing data stores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/http/src/router.ts

<ul><li>Added undefined check in getDataStore handler<br> <li> Added undefined check in deleteDataStore handler<br> <li> Return 404 JSON response when data store not found<br> <li> Provides proper HTTP status codes for missing resources</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2682/files#diff-e3b2e215b6b4369f8114454277f8460c118ff05461dbfb0306561f4831067616">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20260127-160000-fix__delete-data-store-orphan-prevention.md</strong><dd><code>Add continuity ledger for deletion fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.continuity/20260127-160000-fix__delete-data-store-orphan-prevention.md

<ul><li>Added continuity ledger documenting human intent and design decisions<br> <li> Explains deletion order rationale and trade-offs<br> <li> Lists all modified files and verification status<br> <li> Documents constraints and key decisions for future reference</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2682/files#diff-fac34367609472d06ec194ca5da2829f514d3c60bafa2d647bbfe51a2d926a5e">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retrieval/deletion of missing data stores no longer throws; GET returns 404 and DELETE is idempotent (no-content) when absent.
  * Added defensive null checks in execution flows to fail fast and avoid downstream errors.

* **Improvements**
  * Reordered deletion steps to remove secrets and remote resources before deleting local records for more reliable cleanup.
  * Public API now consistently signals missing data-store conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures secure, retry-friendly deletion and consistent not-found handling across APIs and callers.
> 
> - Reorders deletion to `secret → dataStore → DB` in `actions.ts`; stop ignoring errors so failures surface and can be retried
> - Makes `getDataStore`/`deleteDataStore` return `undefined` when missing; DELETE becomes idempotent with `204` and GET returns `404` in `router.ts`
> - Adds `undefined` checks with explicit errors in `execute-data-query.ts` and `use-generation-executor.ts`
> - Adds continuity ledger documenting intent and decisions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdbe60e9b9520aacdc2f3530dc04725dba8771cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->