### PR TITLE
fix: prevent orphaned resources when creating data store

### DIFF
--- a/.continuity/20260128-100000-fix__create-data-store-orphan-prevention.md
+++ b/.continuity/20260128-100000-fix__create-data-store-orphan-prevention.md
@@ -1,0 +1,55 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Fix createDataStore to prevent orphaned secrets and data stores when creation fails
+- Extract Giselle operations into a helper function with internal rollback
+- Add rollback for DB insert failure in main function
+
+## Goal (incl. success criteria)
+
+- When createDataStore is called, if any step fails, previously created resources are cleaned up
+- Secret is never orphaned; DataStore orphan is acceptable only if rollback itself fails
+
+## Constraints/Assumptions
+
+- S3-compatible storage (Supabase) has no transactions
+- Cannot atomically create multiple objects
+- deleteSecret and deleteDataStore already handle non-existent case gracefully
+
+## Key decisions
+
+- Created helper function `createGiselleDataStoreWithSecret` that:
+  - Creates secret first
+  - Creates data store with reference to secret
+  - If createDataStore fails, deletes secret before re-throwing
+- Updated `createDataStore` to:
+  - Fetch team first (sequentially) to avoid orphaned resources if fetchCurrentTeam fails
+  - Use the helper function
+  - If db.insert fails, delete both secret and data store before re-throwing
+
+## State
+
+- Implementation complete
+- All verification passed: format, build-sdk, check-types, test, tidy
+
+## Done
+
+- Added `createGiselleDataStoreWithSecret` helper function with internal rollback
+- Updated `createDataStore` to use helper and add DB failure rollback
+
+## Now
+
+- N/A (complete)
+
+## Next
+
+- N/A (complete)
+
+## Open questions (UNCONFIRMED if needed)
+
+- None
+
+## Working set (files/ids/commands)
+
+- `apps/studio.giselles.ai/app/(main)/settings/team/data-stores/actions.ts` (modified)

--- a/apps/studio.giselles.ai/app/(main)/settings/team/data-stores/actions.ts
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/data-stores/actions.ts
@@ -86,12 +86,14 @@ export async function createDataStore(
 			});
 		} catch (dbError) {
 			// Rollback: delete secret and data store if DB insert failed
-			await giselle.deleteSecret({ secretId }).catch((e) => {
-				console.error("Failed to rollback secret:", e);
-			});
-			await giselle.deleteDataStore({ dataStoreId }).catch((e) => {
-				console.error("Failed to rollback data store:", e);
-			});
+			await Promise.all([
+				giselle.deleteSecret({ secretId }).catch((e) => {
+					console.error("Failed to rollback secret:", e);
+				}),
+				giselle.deleteDataStore({ dataStoreId }).catch((e) => {
+					console.error("Failed to rollback data store:", e);
+				}),
+			]);
 			throw dbError;
 		}
 


### PR DESCRIPTION
### **User description**
### Summary
This PR adds rollback support for data store creation to prevent orphaned secrets when the creation process fails partway through.

### Related Issue
N/A

### Changes
- Added `createGiselleDataStoreWithSecret` helper function that creates secret and data store with automatic rollback if `createDataStore` fails
- Added rollback logic to delete both secret and data store if DB insert fails during creation
- Refactored `createDataStore` action to use the new helper function

### Testing
- Verified with `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm test`, and `pnpm tidy`

### Other Information
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Adds rollback support for data store creation to prevent orphaned resources

- Extracts Giselle operations into `createGiselleDataStoreWithSecret` helper function

- Deletes secret if data store creation fails

- Deletes both secret and data store if database insertion fails

- Moves `fetchCurrentTeam` call before Giselle operations to prevent orphans


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["createDataStore action"] --> B["fetchCurrentTeam"]
  B --> C["createGiselleDataStoreWithSecret"]
  C --> D["addSecret"]
  D --> E["createDataStore"]
  E -->|success| F["db.insert"]
  E -->|failure| G["deleteSecret rollback"]
  F -->|success| H["revalidatePath"]
  F -->|failure| I["deleteSecret + deleteDataStore rollback"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.ts</strong><dd><code>Add rollback support for data store creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/data-stores/actions.ts

<ul><li>Added <code>createGiselleDataStoreWithSecret</code> helper function with rollback <br>logic for secret creation<br> <li> Refactored <code>createDataStore</code> to use the new helper and add database <br>insertion rollback<br> <li> Moved <code>fetchCurrentTeam</code> call before Giselle operations to prevent <br>orphans if it fails<br> <li> Added try-catch blocks with cleanup logic for both Giselle and <br>database operations</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2683/files#diff-1689dad5bd9c146909287e97ea952d8feb81e17cd3a54c1a5f38245f8b045664">+53/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Safer, sequential data-store creation flow with centralized rollback handling to avoid partial/failed creations.
* **Bug Fixes**
  * Prevents orphaned resources by ensuring created secrets and data stores are cleaned up on failures.
  * Adds consistent rollback behavior for create, update, and delete paths to improve reliability of team settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents orphaned resources when creating data stores by adding transactional-style rollback around Giselle operations and DB insertion.
> 
> - Introduces `createGiselleDataStoreWithSecret` to create a secret then data store, deleting the secret if `createDataStore` fails
> - Refactors `createDataStore` to fetch team first and, on DB insert failure, delete both the newly created secret and data store
> - Keeps existing paths and revalidation behavior unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 823bcab836dfff52207d7c692a2f655a38defdd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->