### PR TITLE
fix(giselle): Prevent connection string exposure in execute-data-query

### DIFF
--- a/packages/giselle/src/operations/execute-data-query.ts
+++ b/packages/giselle/src/operations/execute-data-query.ts
@@ -20,7 +20,7 @@ import {
 	isJsonContent,
 	jsonContentToPlainText,
 } from "@giselles-ai/text-editor-utils";
-import { Client, type QueryResult } from "pg";
+import { Pool, type QueryResult } from "pg";
 import { getDataStore } from "../data-stores/get-data-store";
 import { DataQueryError } from "../error";
 import type { AppEntryResolver, GenerationMetadata } from "../generations";
@@ -90,22 +90,28 @@ export function executeDataQuery(args: {
 				});
 				const connectionString = await args.context.vault.decrypt(secret.value);
 
-				const client = new Client({
-					connectionString,
-					connectionTimeoutMillis: 10000,
-					query_timeout: 60000,
-				});
-
 				let result: QueryResult;
+				let pool: Pool | undefined;
 				try {
-					await client.connect();
-					result = await client.query(parameterizedQuery, values);
+					pool = new Pool({
+						connectionString,
+						connectionTimeoutMillis: 10000,
+						query_timeout: 65000,
+						statement_timeout: 60000,
+					});
+					result = await pool.query(parameterizedQuery, values);
 				} catch (error) {
 					throw new DataQueryError(
 						error instanceof Error ? error.message : String(error),
 					);
 				} finally {
-					await client.end();
+					try {
+						await pool?.end();
+					} catch {
+						args.context.logger.warn(
+							`Failed to close pool for data store: ${dataStoreId}`,
+						);
+					}
 				}
 
 				const outputId = operationNode.outputs.find(


### PR DESCRIPTION
### **User description**
### Summary
This PR fixes a security concern where PostgreSQL connection strings could potentially be exposed in error messages when the client constructor fails. By moving the Pool construction inside the try block, any constructor-level errors are now properly caught and wrapped in `DataQueryError`.

### Related Issue
fixes https://github.com/giselles-ai/giselle/issues/2670

### Changes
- Move `pg.Pool` construction inside the try block to catch constructor-level errors
- Replace `pg.Client` with `pg.Pool` for improved connection management
- Add `statement_timeout` (60s) for server-side query termination
- Wrap pool cleanup in try-catch to prevent unhandled errors during resource cleanup

### Testing
Manual verification of data query execution with external PostgreSQL data stores.

### Other Information
Previously, if the Pool/Client constructor threw an error (e.g., due to malformed connection string parsing), the error message could include parts of the connection string, potentially exposing credentials. This change ensures all errors are caught and wrapped in `DataQueryError` to prevent credential leakage.

___

### **PR Type**
Bug fix


___

### **Description**
- Move Client instantiation inside try block to prevent credential exposure

- Use optional chaining for safe client cleanup in finally block

- Adjust timeout values for better control and consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client instantiation<br/>outside try block"] -->|"Move inside<br/>try block"| B["Client instantiation<br/>inside try block"]
  C["client.end()<br/>in finally"] -->|"Add optional<br/>chaining"| D["client?.end()<br/>in finally"]
  E["query_timeout: 60s"] -->|"Add statement_timeout<br/>and adjust"| F["query_timeout: 65s<br/>statement_timeout: 60s"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execute-data-query.ts</strong><dd><code>Secure client instantiation and improve timeout handling</code>&nbsp; </dd></summary>
<hr>

packages/giselle/src/operations/execute-data-query.ts

<ul><li>Moved <code>Client</code> instantiation from outside to inside the try block to <br>prevent connection string exposure in error messages<br> <li> Added optional chaining operator (<code>?.</code>) for <code>client.end()</code> call in finally <br>block to safely handle undefined client<br> <li> Adjusted timeout configuration by increasing <code>query_timeout</code> from 60s to <br>65s and adding <code>statement_timeout</code> of 60s<br> <li> Declared <code>client</code> variable as optional (<code>Client | undefined</code>) before try <br>block</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2685/files#diff-954e6c1997123a6e0e44bf8df68d96ea202ebc1c4500abc2004622b41278344b">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Postgres connection/timeout handling in `executeDataQuery`, which can impact query reliability and resource cleanup. Changes are localized but affect production DB connectivity and error surfacing.
> 
> **Overview**
> `executeDataQuery` now uses a `pg` `Pool` created inside the `try` block (instead of a `Client`) so constructor failures don’t risk including the decrypted connection string in thrown errors.
> 
> It also tightens DB execution timeouts by adding `statement_timeout` and bumping `query_timeout`, and makes cleanup more defensive by safely closing the pool and logging a warning if pool shutdown fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05c812b8ee21b84e69e6e611f91fb3ee0a79a866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for database query operations to prevent connection-related failures.

* **Chores**
  * Optimized query execution timeout configurations for improved stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->