### PR TITLE
refactor: simplify file preview to use local blob URLs only

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/playground-stage-input.tsx
@@ -47,7 +47,6 @@ export function PlaygroundStageInput({
 		handleFileInputChange,
 		handleAttachmentButtonClick,
 		handleRemoveFile,
-		handleImageLoad,
 		handleDismissFileRestrictionError,
 		handleSubmit,
 		selectedApp,
@@ -140,10 +139,7 @@ export function PlaygroundStageInput({
 					<FileAttachments
 						files={attachedFiles}
 						onRemoveFile={handleRemoveFile}
-						workspaceId={selectedApp?.workspaceId}
-						basePath="/api/giselle"
 						localPreviews={localPreviews}
-						onImageLoad={handleImageLoad}
 					/>
 
 					{fileRestrictionError ? (

--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/task-compact-stage-input.tsx
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/task-compact-stage-input.tsx
@@ -44,7 +44,6 @@ export function TaskCompactStageInput({
 		handleFileInputChange,
 		handleAttachmentButtonClick,
 		handleRemoveFile,
-		handleImageLoad,
 		handleDismissFileRestrictionError,
 		handleSubmit,
 		selectedApp,
@@ -134,10 +133,7 @@ export function TaskCompactStageInput({
 					<FileAttachments
 						files={attachedFiles}
 						onRemoveFile={handleRemoveFile}
-						workspaceId={selectedApp?.workspaceId}
-						basePath="/api/giselle"
 						localPreviews={localPreviews}
-						onImageLoad={handleImageLoad}
 					/>
 
 					{fileRestrictionError ? (

--- a/apps/studio.giselles.ai/app/(main)/components/stage-input/use-stage-input.ts
+++ b/apps/studio.giselles.ai/app/(main)/components/stage-input/use-stage-input.ts
@@ -437,19 +437,6 @@ export function useStageInput({
 		});
 	}, []);
 
-	const handleImageLoad = useCallback((fileId: string) => {
-		setLocalPreviews((prev) => {
-			const previewUrl = prev.get(fileId);
-			if (previewUrl) {
-				URL.revokeObjectURL(previewUrl);
-				const next = new Map(prev);
-				next.delete(fileId);
-				return next;
-			}
-			return prev;
-		});
-	}, []);
-
 	const handleDismissFileRestrictionError = useCallback(() => {
 		setFileRestrictionError(null);
 	}, []);
@@ -568,7 +555,6 @@ export function useStageInput({
 			handleFileInputChange,
 			handleAttachmentButtonClick,
 			handleRemoveFile,
-			handleImageLoad,
 			handleDismissFileRestrictionError,
 			handleSubmit: submitInputs,
 		}),
@@ -595,7 +581,6 @@ export function useStageInput({
 			handleFileInputChange,
 			handleAttachmentButtonClick,
 			handleRemoveFile,
-			handleImageLoad,
 			handleDismissFileRestrictionError,
 			submitInputs,
 		],

--- a/apps/studio.giselles.ai/app/(main)/playground/file-attachments.tsx
+++ b/apps/studio.giselles.ai/app/(main)/playground/file-attachments.tsx
@@ -4,61 +4,15 @@ import {
 	TextFileIcon,
 	XlsxFileIcon,
 } from "@giselle-internal/workflow-designer-ui";
-import type {
-	FileData,
-	UploadedFileData,
-	WorkspaceId,
-} from "@giselles-ai/protocol";
+import type { FileData } from "@giselles-ai/protocol";
 import { AlertCircle, Check, Loader2, Paperclip, X } from "lucide-react";
 import Image from "next/image";
 import type React from "react";
-import { useEffect, useState } from "react";
 
 interface FileAttachmentsProps {
 	files: FileData[];
 	onRemoveFile: (fileId: string) => void;
-	workspaceId?: WorkspaceId;
-	basePath?: string;
 	localPreviews?: Map<string, string>;
-	onImageLoad?: (fileId: string) => void;
-}
-
-function ImageThumbnail(props: {
-	remoteSrc: string;
-	localFallbackSrc?: string;
-	alt: string;
-	onRemoteLoaded?: () => void;
-}) {
-	const { remoteSrc, localFallbackSrc, alt, onRemoteLoaded } = props;
-	const [src, setSrc] = useState(remoteSrc);
-
-	useEffect(() => {
-		setSrc(remoteSrc);
-	}, [remoteSrc]);
-
-	return (
-		<Image
-			src={src}
-			alt={alt}
-			fill
-			sizes="60px"
-			// We may render blob/object URLs (local previews) here.
-			unoptimized
-			className="object-cover"
-			onError={() => {
-				if (localFallbackSrc && src !== localFallbackSrc) {
-					setSrc(localFallbackSrc);
-				}
-			}}
-			onLoad={() => {
-				// Notify the parent only when the remote image successfully loads.
-				// The parent uses this to safely clean up the local preview URL.
-				if (src === remoteSrc) {
-					onRemoteLoaded?.();
-				}
-			}}
-		/>
-	);
 }
 
 function formatFileSize(bytes: number) {
@@ -75,7 +29,7 @@ function formatFileSize(bytes: number) {
 	return `${value.toFixed(decimals)} ${units[exponent]}`;
 }
 
-function isUploadedFile(file: FileData): file is UploadedFileData {
+function isUploadedFile(file: FileData): boolean {
 	return file.status === "uploaded";
 }
 
@@ -148,30 +102,15 @@ function getFileTypeLabel(file: FileData): string | null {
 	return labelMap[ext] || null;
 }
 
-function getFileUrl(
-	file: UploadedFileData,
-	workspaceId: WorkspaceId,
-	basePath: string,
-): string {
-	// Generate file path for stage type
-	const path = `workspaces/${workspaceId}/files/${file.id}/${file.id}`;
-	const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
-	return `${basePath}/${normalizedPath}`;
-}
-
 export function FileAttachments({
 	files,
 	onRemoveFile,
-	workspaceId,
-	basePath,
 	localPreviews,
-	onImageLoad,
 }: FileAttachmentsProps) {
 	if (files.length === 0) {
 		return null;
 	}
 
-	const resolvedBasePath = basePath ?? "";
 	const readyCount = files.filter(isUploadedFile).length;
 	const thumbnailFiles = files.filter(
 		(file) => isImageFile(file) || getFileTypeBadge(file) !== null,
@@ -197,33 +136,21 @@ export function FileAttachments({
 
 						// Image file rendering
 						if (isImage) {
-							const isUploaded = isUploadedFile(file);
 							const localPreview = localPreviews?.get(file.id);
-							let imageUrl: string | null = null;
-
-							if (isUploaded && workspaceId && resolvedBasePath.length > 0) {
-								imageUrl = getFileUrl(file, workspaceId, resolvedBasePath);
-							} else if (localPreview) {
-								imageUrl = localPreview;
-							}
 
 							return (
 								<div
 									key={file.id}
 									className="relative group shrink-0 rounded-lg overflow-hidden bg-white/5 border border-white/5 w-[60px] h-[60px]"
 								>
-									{imageUrl ? (
-										<ImageThumbnail
-											remoteSrc={imageUrl}
-											localFallbackSrc={isUploaded ? localPreview : undefined}
+									{localPreview ? (
+										<Image
+											src={localPreview}
 											alt={file.name}
-											onRemoteLoaded={() => {
-												// Notify parent that server image loaded successfully
-												// Parent will clean up local preview URL
-												if (isUploaded && onImageLoad) {
-													onImageLoad(file.id);
-												}
-											}}
+											fill
+											sizes="60px"
+											unoptimized
+											className="object-cover"
 										/>
 									) : (
 										<div className="w-full h-full flex items-center justify-center text-blue-muted/50">


### PR DESCRIPTION
## Summary

Simplifies the file attachment preview system by removing server-side image URL resolution. File thumbnails now render using only local blob URLs created when files are selected.

### What changed
- Removed `ImageThumbnail` component and server URL fetching logic
- Removed `workspaceId`, `basePath`, and `onImageLoad` props from `FileAttachments`
- Removed `handleImageLoad` callback from `useStageInput` hook

### Benefits
- **Simpler**: ~100 fewer lines of code
- **Faster**: No server requests for preview thumbnails
- **Easier to maintain**: Single source of truth (local blob URLs)

### Trade-off
Image previews are now transient - they will show a placeholder icon after page refresh since blob URLs don't persist across navigation. The uploaded files themselves are still stored on the server; only the visual preview is affected.

Resolves #2656

---

## Test Plan
- [x] Attach an image file and verify the preview thumbnail displays
- [x] Attach multiple files (images + documents) and verify all previews render correctly
- [x] Remove an attached file and verify the preview is removed
- [x] Refresh the page with attached files and confirm placeholder icons appear (expected behavior)
