### PR TITLE
feat: limit Data Store feature to internal plan users

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/data-stores/page.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/data-stores/page.tsx
@@ -1,11 +1,12 @@
 import { notFound } from "next/navigation";
-import { dataStoreFlag } from "@/flags";
+import { fetchCurrentTeam } from "@/services/teams";
+import { isInternalPlan } from "@/services/teams/utils";
 import { getDataStores } from "./actions";
 import { DataStoresPageClient } from "./page-client";
 
 export default async function DataStoresPage() {
-	const isDataStoreEnabled = await dataStoreFlag();
-	if (!isDataStoreEnabled) {
+	const team = await fetchCurrentTeam();
+	if (!isInternalPlan(team)) {
 		notFound();
 	}
 

--- a/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx
@@ -8,7 +8,7 @@ import type { IconName } from "lucide-react/dynamic";
 import { Accordion } from "radix-ui";
 import { fetchCurrentTeam } from "@/services/teams";
 import { isInternalPlan } from "@/services/teams/utils";
-import { dataStoreFlag, stageV2Flag } from "../../../../flags";
+import { stageV2Flag } from "../../../../flags";
 import { CreateAppButton } from "./create-app-button";
 import { SidebarLink } from "./sidebar-link";
 
@@ -184,15 +184,15 @@ function createBaseSidebarParts(
 }
 
 export async function Sidebar() {
-	const [isStageV2Enabled, isDataStoreEnabled, team] = await Promise.all([
+	const [isStageV2Enabled, team] = await Promise.all([
 		stageV2Flag(),
-		dataStoreFlag(),
 		fetchCurrentTeam(),
 	]);
 	const isApiPublishingEnabled = isInternalPlan(team);
+	const canAccessDataStore = isInternalPlan(team);
 	const baseSidebarParts = createBaseSidebarParts(
 		isApiPublishingEnabled,
-		isDataStoreEnabled,
+		canAccessDataStore,
 	);
 	const sidebarParts = [createStagePart(isStageV2Enabled), ...baseSidebarParts];
 

--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
@@ -5,7 +5,6 @@ import { db } from "@/db";
 import {
 	aiGatewayFlag,
 	aiGatewayUnsupportedModelsFlag,
-	dataStoreFlag,
 	generateContentNodeFlag,
 	googleUrlContextFlag,
 	layoutV3Flag,
@@ -65,7 +64,7 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 	const data = await giselle.getWorkspace(workspaceId);
 	const generateContentNode = await generateContentNodeFlag();
 	const privatePreviewTools = await privatePreviewToolsFlag();
-	const dataStore = await dataStoreFlag();
+	const dataStore = isInternalPlan(workspaceTeam);
 	const [teamGitHubRepositoryIndexes, officialGitHubRepositoryIndexes] =
 		await Promise.all([
 			getGitHubRepositoryIndexes(workspaceTeam.dbId),

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -213,23 +213,3 @@ export const privatePreviewToolsFlag = flag<boolean>({
 	],
 	defaultValue: false,
 });
-
-export const dataStoreFlag = flag<boolean>({
-	key: "data-store",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("DATA_STORE_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return false;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable Data Store and Data Query nodes",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-	defaultValue: false,
-});


### PR DESCRIPTION
### **User description**
## Summary
Replace the feature flag-based access control for Data Store with a plan-based check, restricting the feature exclusively to users with `team.plan = "internal"`.

## Changes
- Remove `dataStoreFlag` from `flags.ts`
- Update sidebar to use `isInternalPlan(team)` instead of the feature flag
- Update Data Store settings page to check plan instead of feature flag
- Update workspace data-loader to pass plan-based access to the toolbar

## Testing
- Verify that `internal` plan users can see Data Store in sidebar and toolbar
- Verify that other plans (free, pro, team, enterprise) cannot access Data Store
- Verify that direct URL access to `/settings/team/data-stores` returns 404 for non-internal plans

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes access control for the Data Store feature from a runtime flag to team plan checks, which could unintentionally hide or expose the feature if plan data is misclassified. Scope is limited to navigation, settings route guarding, and workspace loader feature flags.
> 
> **Overview**
> **Data Store access is now plan-gated.** The Data Store settings page and sidebar link are no longer controlled by `dataStoreFlag`; they are only available when `isInternalPlan(team)` is true, with non-internal users getting a `404` on direct access.
> 
> Workspace loading now sets the `featureFlags.dataStore` value based on `isInternalPlan(workspaceTeam)` (and drops the `dataStoreFlag` dependency). The `data-store` flag definition has been removed from `flags.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6480a00accb0e3e1483bce0d59486a4dbefeda7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated data store access control mechanism to verify team plan eligibility directly, replacing the previous feature flag-based approach for determining data store availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Enhancement


___

### **Description**
- Replace feature flag with plan-based access control for Data Store

- Restrict Data Store to internal plan users only

- Remove `dataStoreFlag` from flags configuration

- Update sidebar, settings page, and workspace loader


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dataStoreFlag removed"] --> B["isInternalPlan check"]
  B --> C["Sidebar visibility"]
  B --> D["Settings page access"]
  B --> E["Workspace data loader"]
  C --> F["Internal plan users only"]
  D --> F
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flags.ts</strong><dd><code>Remove dataStoreFlag definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/flags.ts

<ul><li>Removed <code>dataStoreFlag</code> function definition entirely<br> <li> Deleted flag configuration including key, decide logic, description, <br>and options<br> <li> Removed environment variable and edge config handling for data store <br>flag</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2701/files#diff-232c6973cad3eea9f920d96773cda2909886d4511fa433dab4d7000d858b7bce">+0/-20</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-loader.ts</strong><dd><code>Use plan check instead of feature flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts

<ul><li>Removed import of <code>dataStoreFlag</code><br> <li> Changed <code>dataStore</code> assignment from <code>await dataStoreFlag()</code> to <br><code>isInternalPlan(workspaceTeam)</code><br> <li> Now uses plan-based check instead of feature flag for workspace data <br>loading</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2701/files#diff-9f7a6561fcf469be8edd13cdb7931f806dfd8adc5f6becf1cb4d98511624df70">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Gate data stores page by team plan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/settings/team/data-stores/page.tsx

<ul><li>Replaced <code>dataStoreFlag</code> import with <code>fetchCurrentTeam</code> and <code>isInternalPlan</code><br> <li> Changed access control from feature flag check to <code>isInternalPlan(team)</code> <br>check<br> <li> Returns 404 for non-internal plan users accessing data stores settings</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2701/files#diff-ceb654477e8d05c88287dcb3d24f5274a8b78e3ede5af889741c4f9d1859219d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sidebar.tsx</strong><dd><code>Control sidebar Data Store link by plan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio.giselles.ai/app/(main)/ui/sidebar/sidebar.tsx

<ul><li>Removed <code>dataStoreFlag</code> import<br> <li> Removed <code>dataStoreFlag()</code> call from Promise.all<br> <li> Changed <code>isDataStoreEnabled</code> to <code>canAccessDataStore</code> using <br><code>isInternalPlan(team)</code><br> <li> Sidebar Data Store link now controlled by plan-based access</ul>


</details>


  </td>
  <td><a href="https://github.com/giselles-ai/giselle/pull/2701/files#diff-1b29a5b71ffeadb24999c5a893faa234976cd84967975907b7fba2bb44fc4395">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

