### PR TITLE
fix: add authorization checks to file operations

### DIFF
--- a/apps/studio.giselles.ai/lib/internal-api/files.ts
+++ b/apps/studio.giselles.ai/lib/internal-api/files.ts
@@ -2,6 +2,7 @@
 
 import { FileId, WorkspaceId } from "@giselles-ai/protocol";
 import { giselle } from "@/app/giselle";
+import { assertWorkspaceAccess } from "@/lib/assert-workspace-access";
 
 /**
  * Hard limit to upload file since Vercel Serverless Functions have a 4.5MB body size limit.
@@ -49,6 +50,7 @@ export async function uploadFile(formData: FormData) {
 	const workspaceId = WorkspaceId.parse(workspaceIdRaw);
 	const fileId = FileId.parse(fileIdRaw);
 
+	await assertWorkspaceAccess(workspaceId);
 	await giselle.uploadFile(file, workspaceId, fileId, fileNameRaw);
 }
 
@@ -56,6 +58,7 @@ export async function removeFile(input: {
 	workspaceId: WorkspaceId;
 	fileId: FileId;
 }) {
+	await assertWorkspaceAccess(input.workspaceId);
 	await giselle.removeFile(input.workspaceId, input.fileId);
 }
 
@@ -64,6 +67,7 @@ export async function copyFile(input: {
 	sourceFileId: FileId;
 	destinationFileId: FileId;
 }) {
+	await assertWorkspaceAccess(input.workspaceId);
 	await giselle.copyFile(
 		input.workspaceId,
 		input.sourceFileId,
@@ -75,6 +79,7 @@ export async function getFileText(input: {
 	workspaceId: WorkspaceId;
 	fileId: FileId;
 }) {
+	await assertWorkspaceAccess(input.workspaceId);
 	return {
 		text: await giselle.getFileText({
 			workspaceId: input.workspaceId,
@@ -86,6 +91,7 @@ export async function getFileText(input: {
 export async function addWebPage(
 	input: Parameters<typeof giselle.addWebPage>[0],
 ) {
+	await assertWorkspaceAccess(input.workspaceId);
 	return await giselle.addWebPage(input);
 }
 


### PR DESCRIPTION
## Summary
Add `assertWorkspaceAccess` authorization checks to all file-related server actions in `files.ts` to ensure users can only operate on files within workspaces they have access to.

## Related Issue
N/A

## Changes
- Add `assertWorkspaceAccess` to `uploadFile` - validates workspace access before uploading
- Add `assertWorkspaceAccess` to `removeFile` - validates workspace access before deleting
- Add `assertWorkspaceAccess` to `copyFile` - validates workspace access before copying
- Add `assertWorkspaceAccess` to `getFileText` - validates workspace access before reading
- Add `assertWorkspaceAccess` to `addWebPage` - validates workspace access before adding web page

## Testing
- Linter checks pass with no errors

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization checks on file operations; misconfiguration or edge cases could block legitimate workspace members from uploading/reading/removing files.
> 
> **Overview**
> **Adds workspace authorization gates to internal file server actions.** All file-related actions in `lib/internal-api/files.ts` (`uploadFile`, `removeFile`, `copyFile`, `getFileText`, `addWebPage`) now call `assertWorkspaceAccess(workspaceId)` before invoking the underlying `giselle` operation, preventing cross-workspace file access.
> 
> This is a behavior change that will cause previously-allowed calls to fail with an authorization error when the current user is not a member of the target workspace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a52d10e594e3d060ed7210d9b4914f7a0495bd32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->