### PR TITLE
fix: add authorization checks to apps.ts

### DIFF
--- a/apps/studio.giselles.ai/lib/internal-api/apps.ts
+++ b/apps/studio.giselles.ai/lib/internal-api/apps.ts
@@ -2,18 +2,44 @@
 
 import type { AppId } from "@giselles-ai/protocol";
 import { giselle } from "@/app/giselle";
+import { assertWorkspaceAccess } from "@/lib/assert-workspace-access";
 
 export async function getApp(input: { appId: AppId }) {
 	const app = await giselle.getApp(input);
+	await assertWorkspaceAccess(app.workspaceId);
 	return { app };
 }
 
+function isNoSuchKeyError(error: unknown) {
+	return error instanceof Error && error.name === "NoSuchKey";
+}
+
 export async function saveApp(input: Parameters<typeof giselle.saveApp>[0]) {
-	await giselle.saveApp(input);
+	let existingApp: Awaited<ReturnType<typeof giselle.getApp>> | undefined;
+	try {
+		existingApp = await giselle.getApp({ appId: input.app.id });
+	} catch (error) {
+		if (!isNoSuchKeyError(error)) {
+			throw error;
+		}
+		// App doesn't exist, verify access to the target workspace for new app creation
+		await assertWorkspaceAccess(input.app.workspaceId);
+		await giselle.saveApp(input);
+	}
+
+	if (existingApp) {
+		// Update existing app, verify access to the existing workspace
+		await assertWorkspaceAccess(existingApp.workspaceId);
+		await giselle.saveApp({
+			app: { ...input.app, workspaceId: existingApp.workspaceId },
+		});
+	}
 }
 
 export async function deleteApp(
 	input: Parameters<typeof giselle.deleteApp>[0],
 ) {
+	const app = await giselle.getApp(input);
+	await assertWorkspaceAccess(app.workspaceId);
 	await giselle.deleteApp(input);
 }


### PR DESCRIPTION
## Summary
Add workspace access verification to all app-related Server Actions (`getApp`, `saveApp`, `deleteApp`) to ensure users can only access apps in workspaces they are members of.

## Changes
- `getApp`: Verify workspace access after fetching the app
- `saveApp`: Handle both new app creation and updates
  - For new apps: verify access to the target workspace
  - For existing apps: verify access to the existing workspace and prevent workspaceId spoofing
- `deleteApp`: Verify workspace access before deletion
- Add `isNoSuchKeyError` helper for distinguishing new vs existing apps

## Testing
- `pnpm format`, `pnpm check-types`, `pnpm tidy`, `pnpm test` all pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization logic on all app mutations/reads; mistakes could block legitimate access or inadvertently allow cross-workspace operations if edge cases (e.g., error classification) are mishandled.
> 
> **Overview**
> Adds workspace-level authorization to the app Server Actions in `internal-api/apps.ts`.
> 
> `getApp` and `deleteApp` now fetch the app first and call `assertWorkspaceAccess(app.workspaceId)` before returning/deleting. `saveApp` now distinguishes create vs update by attempting `giselle.getApp`, checks access to the target workspace on create, and on update checks access to the existing app’s workspace while overriding `workspaceId` to prevent spoofing; introduces an `isNoSuchKeyError` helper for the create path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1863117d42a6941dfdc220d64da98990ff4cb070. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->