### PR TITLE
fix: add authorization checks to tasks.ts

### DIFF
--- a/apps/studio.giselles.ai/lib/internal-api/tasks.ts
+++ b/apps/studio.giselles.ai/lib/internal-api/tasks.ts
@@ -3,27 +3,39 @@
 import type { CreateTaskInputs, StartTaskInputs } from "@giselles-ai/giselle";
 import type { TaskId, WorkspaceId } from "@giselles-ai/protocol";
 import { giselle } from "@/app/giselle";
+import { assertWorkspaceAccess } from "@/lib/assert-workspace-access";
 
 export async function createTask(input: CreateTaskInputs) {
+	const workspaceId = input.workspaceId ?? input.workspace?.id;
+	if (workspaceId === undefined) {
+		throw new Error("workspaceId or workspace is required");
+	}
+	await assertWorkspaceAccess(workspaceId);
 	return await giselle.createTask(input);
 }
 
 export async function startTask(input: StartTaskInputs) {
+	const task = await giselle.getTask({ taskId: input.taskId });
+	await assertWorkspaceAccess(task.workspaceId);
 	await giselle.startTask(input);
 }
 
 export async function getWorkspaceInprogressTask(input: {
 	workspaceId: WorkspaceId;
 }) {
+	await assertWorkspaceAccess(input.workspaceId);
 	const task = await giselle.getWorkspaceInprogressTask(input);
 	return { task };
 }
 
 export async function getTaskGenerationIndexes(input: { taskId: TaskId }) {
+	const task = await giselle.getTask({ taskId: input.taskId });
+	await assertWorkspaceAccess(task.workspaceId);
 	return await giselle.getTaskGenerationIndexes(input);
 }
 
 export async function getWorkspaceTasks(input: { workspaceId: WorkspaceId }) {
+	await assertWorkspaceAccess(input.workspaceId);
 	const tasks = await giselle.getWorkspaceTasks({
 		workspaceId: input.workspaceId,
 	});


### PR DESCRIPTION
## Summary
Add workspace access authorization checks to all task-related Server Actions in `tasks.ts`, ensuring users can only perform task operations on workspaces they are members of.

## Changes
- `createTask`: Extract `workspaceId` from `input.workspaceId` or `input.workspace.id` (matching SDK behavior) and verify access before creating a task
- `startTask`: Fetch the task by ID to obtain `workspaceId`, then verify access before starting
- `getWorkspaceInprogressTask`: Verify access to the workspace before querying in-progress tasks
- `getTaskGenerationIndexes`: Fetch the task by ID to obtain `workspaceId`, then verify access before returning generation indexes
- `getWorkspaceTasks`: Verify access to the workspace before listing tasks

## Testing
N/A

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization for server actions; incorrect `workspaceId` derivation or `getTask` behavior could unintentionally block legitimate task operations or add extra latency.
> 
> **Overview**
> Task-related server actions in `internal-api/tasks.ts` now enforce workspace authorization via `assertWorkspaceAccess` before creating, starting, or listing tasks.
> 
> For task-ID based calls (`startTask`, `getTaskGenerationIndexes`), the code now loads the task first to derive `workspaceId` and then checks access; `createTask` now derives `workspaceId` from either `input.workspaceId` or `input.workspace.id` and fails fast if missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 045311d92ba262e21da88a63eb71d9ad831d2463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace access validation across task operations to prevent unauthorized data access and improve security when creating, starting, and retrieving tasks within workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->