### PR TITLE
fix: add authorization checks to generation API

### DIFF
--- a/apps/studio.giselles.ai/lib/internal-api/generations.ts
+++ b/apps/studio.giselles.ai/lib/internal-api/generations.ts
@@ -44,7 +44,9 @@ function isNoSuchKeyError(error: unknown) {
 }
 
 export async function setGeneration(input: { generation: Generation }) {
-	let existingGeneration: Awaited<ReturnType<typeof giselle.getGeneration>> | undefined;
+	let existingGeneration:
+		| Awaited<ReturnType<typeof giselle.getGeneration>>
+		| undefined;
 	try {
 		existingGeneration = await giselle.getGeneration(input.generation.id);
 	} catch (error) {
@@ -80,7 +82,9 @@ export async function generateImage(input: { generation: QueuedGeneration }) {
 export async function startContentGeneration(input: {
 	generation: Generation;
 }) {
-	let storedGeneration: Awaited<ReturnType<typeof giselle.getGeneration>> | undefined;
+	let storedGeneration:
+		| Awaited<ReturnType<typeof giselle.getGeneration>>
+		| undefined;
 	try {
 		storedGeneration = await giselle.getGeneration(input.generation.id);
 	} catch (error) {


### PR DESCRIPTION
## Summary
- Add `assertWorkspaceAccess` checks to all generation internal API functions


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization and data-access boundaries for generation operations; mistakes could cause regressions (blocked valid access) or continued leakage if edge cases aren’t covered.
> 
> **Overview**
> Enforces **workspace-scoped authorization** throughout `internal-api/generations.ts` by adding `assertWorkspaceAccess` checks before reading, listing, cancelling, generating, starting, or streaming generation data.
> 
> Tightens write paths: `setGeneration` and `startContentGeneration` now distinguish create vs update via `NoSuchKey`, authorize against the existing generation’s workspace when present, and prevent callers from changing `context.origin` on update; `getNodeGenerations` additionally filters results to the requested workspace because storage paths aren’t workspace-scoped, and `generateImage` now loads the stored generation and validates it is queued before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 992e477562548f713eb1d3d265b6cc6eac1012da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Strengthened access control validation for generation read and write operations across the system.
  * Enhanced error handling and state validation to ensure generation requests are properly managed.
  * Improved workflow for generation creation and updates with better status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->