### PR TITLE
docs: add INTERNAL_USER_EMAIL_DOMAIN to setup documentation

### DIFF
--- a/apps/studio.giselles.ai/.env.example
+++ b/apps/studio.giselles.ai/.env.example
@@ -74,6 +74,12 @@ SMTP_PASS=
 SEND_EMAIL_DEBUG=1
 
 
+# Internal User Configuration
+# Email domain for internal users (e.g., example.com)
+# When set, users with matching email domain are treated as internal users.
+# Note: Only exact domain matches are considered (subdomains are not matched).
+INTERNAL_USER_EMAIL_DOMAIN=
+
 # ---
 # for development only
 # ---

--- a/apps/studio.giselles.ai/README.md
+++ b/apps/studio.giselles.ai/README.md
@@ -30,3 +30,16 @@ https://studio.giselles.ai/
     ```sh
     pnpm turbo dev
     ```
+
+## Optional environment variables
+
+### Internal User Configuration
+
+- **`INTERNAL_USER_EMAIL_DOMAIN`**: Email domain for internal users
+  - When set, users whose email domain exactly matches are treated as internal users
+  - Internal users receive `internal` team type instead of creating free teams
+  - Only exact domain matches are considered (subdomains do not match)
+  - Example: If set to `example.com`:
+    - `user@example.com` → internal user
+    - `user@sub.example.com` → external user (no match)
+  - If not set, all users are treated as external users


### PR DESCRIPTION
## Summary
- Add `INTERNAL_USER_EMAIL_DOMAIN` environment variable documentation to setup guides
- This documents the feature introduced in #2349

## Changes
- `.env.example`: Added `INTERNAL_USER_EMAIL_DOMAIN` with explanatory comments
- `README.md`: Added "Optional environment variables" section with detailed usage

## Test plan
- [x] Verify documentation is clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding an example env var and README guidance; no runtime logic or security-sensitive code is modified.
> 
> **Overview**
> Adds documentation for the optional `INTERNAL_USER_EMAIL_DOMAIN` environment variable.
> 
> Updates `.env.example` with commented guidance and extends the Studio `README.md` with an *Optional environment variables* section explaining exact-domain matching behavior and its effect on treating users as internal vs external.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d0b4045a43cc1f7f5dcb20228673020d68ec8c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `INTERNAL_USER_EMAIL_DOMAIN` optional environment variable to configure which users are classified as internal based on email domain matching.
  * Updated README with configuration details and usage guidelines for the new environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->