### PR TITLE
fix: don’t treat SVG uploads as vision images

### DIFF
--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -567,11 +567,19 @@ export async function useGenerationExecutor<T>(args: {
 							case "image/jpeg":
 							case "image/png":
 							case "image/gif":
-							case "image/svg+xml":
+							case "image/webp":
 								return {
 									type: "image",
 									image: blob,
 								} as ImagePart;
+
+							case "image/svg+xml":
+								args.context.logger.warn(
+									{ id: fileParameter.id, type: fileParameter.type, name: fileParameter.name },
+									"SVG is not supported for vision input. Please upload PNG/JPEG/GIF/WebP instead.",
+								);
+								return undefined;
+								
 							case "application/pdf":
 								return {
 									type: "file",


### PR DESCRIPTION
## Summary
Prevent `image/svg+xml` files from being treated as vision `ImagePart` input.

Instead of sending SVG files to LLM providers (which do not support SVG), this change logs a warning and skips the file.

## Why
LLM vision providers (OpenAI, Anthropic, Google) do not support SVG image input and return:
`Unsupported MIME type: image/svg+xml`.

This prevents SVG files from being passed as ImagePart objects.

## Testing
pnpm -C packages/giselle test

All tests in the giselle package pass.

Closes #2714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebP image format support for vision input processing.

* **Bug Fixes**
  * SVG images are now properly rejected during vision input processing with a warning message, preventing improper handling of unsupported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->