### PR TITLE
feat: add documentation link to Data Stores settings page

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/settings/team/data-stores/page.client.tsx
+++ b/apps/studio.giselles.ai/app/(main)/settings/team/data-stores/page.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { DocsLink } from "@giselle-internal/ui/docs-link";
 import { EmptyState } from "@giselle-internal/ui/empty-state";
 import { PageHeading } from "@giselle-internal/ui/page-heading";
 import { Pencil, Plus, Trash } from "lucide-react";
@@ -68,17 +69,26 @@ export function DataStoresPageClient({
 				<PageHeading as="h1" glow>
 					Data Stores
 				</PageHeading>
-				<GlassButton
-					type="button"
-					onClick={handleCreateClick}
-					disabled={isCreateDisabled}
-					title={createDisabledReason}
-				>
-					<span className="grid place-items-center rounded-full size-4 bg-primary-200 opacity-50">
-						<Plus className="size-3 text-link-muted" />
-					</span>
-					New Data Store
-				</GlassButton>
+				<div className="flex items-center gap-3">
+					<DocsLink
+						href="https://docs.giselles.ai/en/guides/settings/team/data-stores"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						About Data Stores
+					</DocsLink>
+					<GlassButton
+						type="button"
+						onClick={handleCreateClick}
+						disabled={isCreateDisabled}
+						title={createDisabledReason}
+					>
+						<span className="grid place-items-center rounded-full size-4 bg-primary-200 opacity-50">
+							<Plus className="size-3 text-link-muted" />
+						</span>
+						New Data Store
+					</GlassButton>
+				</div>
 			</div>
 
 			<Card className="rounded-[8px] bg-transparent p-6 border-0">


### PR DESCRIPTION
## Summary
Add an "About Data Stores" documentation link to the Data Stores settings page header, consistent with other settings tabs (Team Settings, Members, Integrations, Usage, Vector Stores).

## Changes
- Added `DocsLink` component to the Data Stores page header, linking to https://docs.giselles.ai/en/guides/settings/team/data-stores
- Wrapped the docs link and "New Data Store" button in a flex container, matching the Members page pattern

## Testing
- Verify the "About Data Stores" link appears to the left of the "New Data Store" button on `/settings/team/data-stores`
- Verify the link opens the docs page in a new tab

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change (new external docs link and minor layout tweak) with no impact to data access or business logic.
> 
> **Overview**
> Adds an **“About Data Stores”** documentation link to the `/settings/team/data-stores` page header, opening the relevant docs in a new tab.
> 
> Refactors the header layout to group the new `DocsLink` and existing **New Data Store** button in a shared flex container for consistent spacing/alignment with other settings pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8fa7289907887fa0eddac54b84b350dc401d6ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation link for Data Stores in the settings area, making it easier for users to access information about data store functionality while managing their team's data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->