### PR TITLE
fix: exclude data store nodes from @ mention candidates

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/data-query-properties-panel/sources/use-connected-sources.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/data-query-properties-panel/sources/use-connected-sources.ts
@@ -122,7 +122,8 @@ export function useConnectedSources(node: DataQueryNode) {
 								node: outputNode as DataStoreNode,
 								connection,
 							});
-							break;
+							// Data Store nodes should not appear as @ mention candidates
+							continue;
 						case "text":
 							connectedVariableSources.push({
 								output,


### PR DESCRIPTION
## Summary
Fix a bug where Data Store nodes incorrectly appeared as @ mention candidates in the Data Query properties panel. After being added to `connectedDataStoreSources`, the loop should `continue` to skip adding them to the mention list, rather than `break` which falls through to the mention candidate logic.

## Changes
- Changed `break` to `continue` in the `dataStore` case within `useConnectedSources` so that Data Store nodes are not added to the @ mention candidates after being processed as connected data store sources.

## Testing
- Open a workspace with a Data Query node connected to a Data Store node.
- Open the Data Query properties panel and verify that the Data Store node no longer appears in the @ mention candidate list.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized control-flow change in the properties panel source aggregation; minimal blast radius and no security/data persistence impact.
> 
> **Overview**
> Fixes a bug in `useConnectedSources` where connected `dataStore` variable outputs could still be processed as @-mention candidates.
> 
> After adding a Data Store output to `connectedDataStoreSources` (and skipping the `schema` accessor), the loop now `continue`s instead of `break`ing, preventing the Data Store connection from being added to the generic `uiConnections`/mention-candidate list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcf8dd339330701045e7b24cd99eb8b522bd71e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the handling of Data Store node connections in the data query properties interface. Data Store nodes are now properly excluded from appearing as mention candidates when selecting connected data sources.
  * Updated the source aggregation process to prevent Data Store entries from being included in candidate results, ensuring a cleaner source selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->