### PR TITLE
fix: use validated secretId and remove redundant cast for postgres tool

### DIFF
--- a/packages/node-registry/src/node-conversion.ts
+++ b/packages/node-registry/src/node-conversion.ts
@@ -303,8 +303,8 @@ export function convertContentGenerationToTextGeneration(
 					continue;
 				}
 				tools.postgres = {
-					secretId: tool.configuration.secretId,
-					tools: (tool.configuration.useTools as string[]) ?? [],
+					secretId: result.data,
+					tools: useTools,
 				};
 				break;
 			}


### PR DESCRIPTION
## Summary
Fixed a bug in the Postgres tool configuration where the unvalidated `secretId` was being used instead of the safely validated `result.data`.

## Related Issue
Fixes #2282

## Changes
* Replaced `tool.configuration.secretId` with the validated `result.data` when assigning `tools.postgres.secretId`
* Removed the redundant `as string[]` cast for `useTools`, as it is already validated as an array through the `Array.isArray()` check
* Aligns the postgres case with the existing pattern used in the github-api case

## Testing
- [x] TypeScript compilation passes without errors
- [x] Code follows the same validation pattern as the github-api case
- [x] Type narrowing correctly infers `useTools` type after validation

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling to ensure properly parsed and validated values are used in node conversion processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->