### PR TITLE
fix: use continue instead of return in handleEdgesChange

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/v2/components/v2-container.tsx
@@ -403,7 +403,7 @@ function V2NodeCanvas() {
 						);
 						if (removeConnection === undefined) {
 							console.warn(`Connection with id ${change.id} not found`);
-							return;
+							continue;
 						}
 						disconnectNodes(
 							removeConnection.outputNode.id,


### PR DESCRIPTION
## Summary
- Fixes a bug where `return` in `handleEdgesChange` exits the entire callback when a connection lookup fails during a "remove" operation, silently skipping all subsequent edge changes in the batch
- Replaced `return` with `continue` so only the failed lookup is skipped and remaining changes are processed

Closes #2491

## Test plan
- [x] Delete multiple edges at once in the workflow editor
- [x] Verify all selected edges are removed, even if one connection ID is stale/missing
- [x] Confirm warning is still logged for missing connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection removal handling in the workflow designer to continue processing batch operations even when a connection is not found, preventing premature termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->