### PR TITLE
fix: add duplicate URL detection in useAddWebPages

### DIFF
--- a/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-add-web-pages.ts
+++ b/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-add-web-pages.ts
@@ -59,10 +59,10 @@ export function useAddWebPages() {
 				}
 
 				const existingUrls = new Set(
-					node.content.webpages.map((w) => w.url),
+					node.content.webpages.map((w) => normalizeHttpsUrl(w.url) ?? w.url),
 				);
 				if (batchSeen.has(url) || existingUrls.has(url)) {
-					args.onError?.(`Duplicate URL: ${url}`);
+					args.onError?.(`duplicate URL: ${url}`);
 					continue;
 				}
 				batchSeen.add(url);

--- a/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-add-web-pages.ts
+++ b/internal-packages/workflow-designer-ui/src/app-designer/store/usecases/use-add-web-pages.ts
@@ -48,6 +48,8 @@ export function useAddWebPages() {
 				normalizedUrls.push(normalized);
 			}
 
+			const batchSeen = new Set<string>();
+
 			for (const url of normalizedUrls) {
 				const node = store.getState().nodes.find((n) => n.id === args.nodeId) as
 					| WebPageNode
@@ -55,6 +57,15 @@ export function useAddWebPages() {
 				if (!node || node.content.type !== "webPage") {
 					return;
 				}
+
+				const existingUrls = new Set(
+					node.content.webpages.map((w) => w.url),
+				);
+				if (batchSeen.has(url) || existingUrls.has(url)) {
+					args.onError?.(`Duplicate URL: ${url}`);
+					continue;
+				}
+				batchSeen.add(url);
 
 				const newWebPage: WebPage = {
 					id: WebPageId.generate(),


### PR DESCRIPTION
## Summary
- Adds duplicate URL detection to the `useAddWebPages` hook, preventing the same URL from being added multiple times
- Uses a `batchSeen` Set to catch duplicates within the current batch, and checks against existing `node.content.webpages` URLs
- Follows the same dedup pattern already established in `useUploadFile`

Closes #2490

## Test plan
- [ ] Add a web page URL to a node, then try adding the same URL again — should show "Duplicate URL" error and skip
- [ ] Paste multiple identical URLs at once — only the first should be added
- [ ] Adding distinct URLs should still work normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate handling when adding web pages: URLs added in the same operation or already present are now detected and skipped, preventing redundant submissions and avoiding unnecessary network requests. Duplicate attempts trigger immediate error feedback to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->