### PR TITLE
feat(protocol): add structured output schema and output format to generation content

### DIFF
--- a/.continuity/20260219-200700-feat__add-structured-output-schema.md
+++ b/.continuity/20260219-200700-feat__add-structured-output-schema.md
@@ -3,25 +3,30 @@
 ## Human intent (must not be overwritten)
 
 - Add structured output schema support to the protocol layer
-- Use discriminated union pattern to make illegal states (e.g., `outputFormat: "text"` with a `structuredOutputSchema`) unrepresentable
+- Use discriminated union pattern to make illegal states unrepresentable
 - Follow existing codebase patterns (nested discriminated union as field value, not flat intersection)
+- Align naming with AI SDK (`Output`, `format: "text" | "object"`)
 
 ## Goal (incl. success criteria)
 
-- `OutputConfiguration` discriminated union in `structured-output.ts` ensures `structuredOutputSchema` only exists when `outputFormat: "json"`
-- Field name `outputConfiguration` (not `outputFormat`) avoids `x.x` redundancy, matching existing patterns like `auth.type`, `state.status`
+- `Output` discriminated union in `structured-output.ts` ensures `schema` only exists when `format: "object"`
+- Field name `output` aligns with AI SDK's `output` option
+- Format values `"text"` / `"object"` match AI SDK conventions for intuitive downstream mapping
 - All consumers updated, format/build/types/tidy/tests pass
 
 ## Constraints/Assumptions
 
 - Follow existing discriminated union pattern: nested as field value, field name differs from discriminator key
-- Keep `OutputConfiguration` in `structured-output.ts` (root-level shared schema, consistent with `connection.ts` pattern)
+- Keep `Output` in `structured-output.ts` (root-level shared schema, consistent with `connection.ts` pattern)
+- Avoid naming conflict with existing `Output` type in `node/base.ts` (node output port)
 
 ## Key decisions
 
-- Renamed `OutputFormat` → `OutputConfiguration` (schema + type export)
-- Field name: `outputConfiguration` (avoids `outputFormat.outputFormat` redundancy)
-- Nested approach (not flat `z.intersection`/`extend`), consistent with all other discriminated unions in the codebase
+- Renamed `OutputConfiguration` → `Output`, `StructuredOutputSchema` → `Schema`
+- Field name: `output` (matches AI SDK)
+- Discriminator: `format` with values `"text"` | `"object"` (matches AI SDK `Output.text()` / `Output.object()`)
+- Schema field: `schema` (concise, matches AI SDK)
+- Barrel export: `export { Schema } from "./structured-output"` to avoid conflict with `Output` from `node/base.ts`
 
 ## State
 
@@ -29,11 +34,12 @@
 
 ## Done
 
-- Defined `OutputConfiguration` discriminated union in `structured-output.ts`
-- Updated `text-generation.ts` and `content-generation.ts` to use `outputConfiguration: OutputConfiguration`
-- Updated `node-conversion.ts` to pass `outputConfiguration` as a single object (no manual spread)
+- Defined `Output` discriminated union with `format: "text" | "object"` in `structured-output.ts`
+- Updated `text-generation.ts` and `content-generation.ts` to use `output: Output`
+- Updated `node-conversion.ts` to pass `output` field
 - Updated `node-factories.ts` create functions
 - Updated all test fixtures and assertions
+- Fixed barrel export in `index.ts` to avoid `Output` naming conflict
 - format, build-sdk, check-types, tidy, test all pass
 
 ## Now
@@ -53,6 +59,7 @@
 - `packages/protocol/src/structured-output.ts`
 - `packages/protocol/src/node/operations/text-generation.ts`
 - `packages/protocol/src/node/operations/content-generation.ts`
+- `packages/protocol/src/index.ts`
 - `packages/node-registry/src/node-conversion.ts`
 - `packages/node-registry/src/node-factories.ts`
 - `packages/node-registry/src/node-conversion.test.ts`

--- a/packages/node-registry/src/__fixtures__/node-conversion/nodes.ts
+++ b/packages/node-registry/src/__fixtures__/node-conversion/nodes.ts
@@ -32,7 +32,7 @@ export const openAI_1 = {
 		prompt:
 			'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"京都市右京区太秦、太映通り商店街に「アララ」という洋食店はありますか？Webを検索し"}]},{"type":"paragraph","content":[{"type":"text","text":"Yes/Noのみを出力してください。"}]}]}',
 		tools: { openaiWebSearch: { searchContextSize: "medium" } },
-		outputConfiguration: { outputFormat: "text" },
+		output: { format: "text" },
 	},
 };
 
@@ -70,7 +70,7 @@ export const openAIWithGitHubTool = {
 				auth: { type: "secret", secretId: "scrt-TESTTESTTESTTEST" },
 			},
 		},
-		outputConfiguration: { outputFormat: "text" },
+		output: { format: "text" },
 	},
 };
 
@@ -102,7 +102,7 @@ export const openAIWithoutTools = {
 		},
 		prompt:
 			'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hello"}]}]}',
-		outputConfiguration: { outputFormat: "text" },
+		output: { format: "text" },
 	},
 };
 
@@ -134,7 +134,7 @@ export const openAIWithEmptyTools = {
 		prompt:
 			'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Please tell me React.js"}]}]}',
 		tools: {},
-		outputConfiguration: { outputFormat: "text" },
+		output: { format: "text" },
 	},
 };
 
@@ -163,7 +163,7 @@ export const anthropicClaudeSonnet = {
 		},
 		prompt:
 			'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"前提条件"},{"type":"text","text":"："},{"type":"text","marks":[{"type":"bold"}],"text":"Nは100〜250の整数"},{"type":"text","text":"。"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"(a) "},{"type":"text","marks":[{"type":"bold"}],"text":"9の倍数"},{"type":"text","text":"。"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"(b) "},{"type":"text","marks":[{"type":"bold"}],"text":"5の倍数"},{"type":"text","text":"。"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"(c) "},{"type":"text","marks":[{"type":"bold"}],"text":"7進表記で回文（3桁）"},{"type":"text","text":"、すなわち "},{"type":"text","marks":[{"type":"bold"}],"text":"N = 50a + 7b"},{"type":"text","text":"（a∈{2,3,4}, b∈{0..6}）。"}]}]}]},{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"問"},{"type":"text","text":"：Nを求めよ。"}]},{"type":"paragraph"},{"type":"paragraph","content":[{"type":"text","text":"You must outputs number only"}]}]}',
-		outputConfiguration: { outputFormat: "text" },
+		output: { format: "text" },
 	},
 };
 
@@ -192,7 +192,7 @@ export const anthropicClaudeOpus45 = {
 		},
 		prompt:
 			'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Solve x^2 + 4x + 4 = 0."}]}]}',
-		outputConfiguration: { outputFormat: "text" },
+		output: { format: "text" },
 	},
 };
 
@@ -227,6 +227,6 @@ export const googleGemini = {
 		},
 		prompt:
 			'{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"京都市右京区太秦、太映通り商店街に「アララ」という洋食店はありますか？Webを検索し"}]},{"type":"paragraph","content":[{"type":"text","text":"Yes/Noのみを出力してください。"}]}]}',
-		outputConfiguration: { outputFormat: "text" },
+		output: { format: "text" },
 	},
 };

--- a/packages/node-registry/src/node-conversion.test.ts
+++ b/packages/node-registry/src/node-conversion.test.ts
@@ -43,7 +43,7 @@ function createOpenAITextNode(
 				},
 			},
 			prompt: "test",
-			outputConfiguration: { outputFormat: "text" },
+			output: { format: "text" },
 		},
 	};
 }
@@ -357,9 +357,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 			expect(convertedBack.content.tools?.openaiWebSearch).toBeDefined();
 		});
 
@@ -377,9 +375,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 			expect(convertedBack.content.tools?.github).toBeDefined();
 			expect(convertedBack.content.tools?.github?.auth.type).toBe("secret");
 			// @ts-expect-error - Test file: fixture may have type mismatch
@@ -406,9 +402,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 			expect(convertedBack.content.tools).toBeUndefined();
 		});
 
@@ -426,9 +420,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 		});
 
 		it("should preserve data through round-trip conversion with Anthropic Claude Opus 4.5", () => {
@@ -445,9 +437,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 		});
 
 		it("should preserve data through round-trip conversion with Google Gemini", () => {
@@ -464,9 +454,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 		});
 
 		it("should preserve data through round-trip conversion with Google Gemini 3 Pro Preview", () => {
@@ -485,9 +473,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 		});
 
 		it("should preserve data through round-trip conversion for GPT-5.1 models", () => {
@@ -505,9 +491,7 @@ describe("node-conversion", () => {
 			);
 			expect(convertedBack.content.llm?.id).toBe(originalNode.content.llm.id);
 			expect(convertedBack.content.prompt).toBe(originalNode.content.prompt);
-			expect(convertedBack.content.outputConfiguration).toEqual(
-				originalNode.content.outputConfiguration,
-			);
+			expect(convertedBack.content.output).toEqual(originalNode.content.output);
 			expect(convertedBack.content.llm?.id).toBe("gpt-5.1-thinking");
 		});
 	});

--- a/packages/node-registry/src/node-conversion.ts
+++ b/packages/node-registry/src/node-conversion.ts
@@ -200,7 +200,7 @@ export function convertTextGenerationToContentGeneration(
 			languageModel,
 			tools,
 			prompt: textGenerationContent.prompt ?? "",
-			outputConfiguration: textGenerationContent.outputConfiguration,
+			output: textGenerationContent.output,
 		},
 	};
 }
@@ -341,7 +341,7 @@ export function convertContentGenerationToTextGeneration(
 			llm,
 			prompt: contentGenerationContent.prompt,
 			tools: toolsToInclude,
-			outputConfiguration: contentGenerationContent.outputConfiguration,
+			output: contentGenerationContent.output,
 		},
 	};
 }

--- a/packages/node-registry/src/node-factories.ts
+++ b/packages/node-registry/src/node-factories.ts
@@ -194,7 +194,7 @@ const textGenerationFactoryImpl = {
 			content: {
 				type: "textGeneration",
 				llm,
-				outputConfiguration: { outputFormat: "text" },
+				output: { format: "text" },
 			},
 			inputs: [],
 			outputs,
@@ -832,7 +832,7 @@ const contentGenerationFactoryImpl = {
 					configuration: languageModel.defaultConfiguration,
 				},
 				tools: [],
-				outputConfiguration: { outputFormat: "text" },
+				output: { format: "text" },
 			},
 			inputs: [],
 			outputs,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -6,7 +6,7 @@ export * from "./generation";
 export * from "./integrations";
 export * from "./node";
 export * from "./secret";
-export * from "./structured-output";
+export { Schema } from "./structured-output";
 export * from "./task";
 export * from "./trigger";
 export * from "./workspace";

--- a/packages/protocol/src/node/operations/content-generation.ts
+++ b/packages/protocol/src/node/operations/content-generation.ts
@@ -7,7 +7,7 @@ import {
 	type LanguageModelToolName,
 } from "@giselles-ai/language-model-registry";
 import * as z from "zod/v4";
-import { OutputConfiguration } from "../../structured-output";
+import { Output } from "../../structured-output";
 
 export const ContentGenerationContent = z.object({
 	type: z.literal("contentGeneration"),
@@ -26,7 +26,7 @@ export const ContentGenerationContent = z.object({
 		}),
 	),
 	prompt: z.string(),
-	outputConfiguration: OutputConfiguration.default({ outputFormat: "text" }),
+	output: Output.default({ format: "text" }),
 });
 
 export type ContentGenerationContent = z.infer<typeof ContentGenerationContent>;

--- a/packages/protocol/src/node/operations/text-generation.ts
+++ b/packages/protocol/src/node/operations/text-generation.ts
@@ -6,7 +6,7 @@ import {
 } from "@giselles-ai/language-model";
 import * as z from "zod/v4";
 import { SecretId } from "../../secret";
-import { OutputConfiguration } from "../../structured-output";
+import { Output } from "../../structured-output";
 
 export const AnthropicLanguageModelData = AnthropicLanguageModel.pick({
 	provider: true,
@@ -122,7 +122,7 @@ export const TextGenerationContent = z.object({
 	llm: TextGenerationLanguageModelData,
 	prompt: z.string().optional(),
 	tools: z.optional(ToolSet),
-	outputConfiguration: OutputConfiguration.default({ outputFormat: "text" }),
+	output: Output.default({ format: "text" }),
 });
 export type TextGenerationContent = z.infer<typeof TextGenerationContent>;
 

--- a/packages/protocol/src/structured-output.ts
+++ b/packages/protocol/src/structured-output.ts
@@ -55,20 +55,20 @@ const StructuredOutputProperty: z.ZodType<StructuredOutputPropertyType> =
 		}),
 	]);
 
-export const StructuredOutputSchema = z.object({
+export const Schema = z.object({
 	title: z.string(),
 	type: z.literal("object"),
 	properties: z.record(z.string(), StructuredOutputProperty),
 	additionalProperties: z.literal(false),
 	required: z.array(z.string()),
 });
-export type StructuredOutputSchema = z.infer<typeof StructuredOutputSchema>;
+export type Schema = z.infer<typeof Schema>;
 
-export const OutputConfiguration = z.discriminatedUnion("outputFormat", [
-	z.object({ outputFormat: z.literal("text") }),
+export const Output = z.discriminatedUnion("format", [
+	z.object({ format: z.literal("text") }),
 	z.object({
-		outputFormat: z.literal("json"),
-		structuredOutputSchema: StructuredOutputSchema,
+		format: z.literal("object"),
+		schema: Schema,
 	}),
 ]);
-export type OutputConfiguration = z.infer<typeof OutputConfiguration>;
+export type Output = z.infer<typeof Output>;

--- a/packages/react/src/workspace/utils/is-supported-connection.test.ts
+++ b/packages/react/src/workspace/utils/is-supported-connection.test.ts
@@ -42,7 +42,7 @@ describe("isSupportedConnection", () => {
 			content: {
 				type: "textGeneration",
 				llm,
-				outputConfiguration: { outputFormat: "text" },
+				output: { format: "text" },
 			},
 		}) satisfies TextGenerationNode;
 	const createImageGenerationNode = (
@@ -220,7 +220,7 @@ describe("isSupportedConnection", () => {
 				configuration: {},
 			},
 			tools: [],
-			outputConfiguration: { outputFormat: "text" },
+			output: { format: "text" },
 		},
 	});
 


### PR DESCRIPTION
## Summary
Add `StructuredOutputSchema` Zod schema to the protocol package and integrate `outputFormat` / `structuredOutputSchema` fields into both `TextGenerationContent` and `ContentGenerationContent`. This enables nodes to specify JSON structured output with a user-defined schema, laying the groundwork for AI-driven JSON schema generation.

## Related Issue
N/A

## Changes
- Add `packages/protocol/src/structured-output.ts` with recursive JSON Schema-like Zod types (`StringProperty`, `NumberProperty`, `BooleanProperty`, `object`, `array`) and export `StructuredOutputSchema`
- Add `outputFormat` (`"text" | "json"`, default `"text"`) and optional `structuredOutputSchema` fields to `TextGenerationContent` and `ContentGenerationContent`
- Export `structured-output` from the protocol package index (placed at `src/` root since it is shared across generation output and node content)
- Propagate `outputFormat` and `structuredOutputSchema` through `convertTextGenerationToContentGeneration` / `convertContentGenerationToTextGeneration`
- Set default `outputFormat: "text"` in node factories for both text generation and content generation nodes
- Update test fixtures and test helpers with the new required `outputFormat` field

## Testing
- `pnpm format` -- pass
- `pnpm build-sdk` -- pass
- `pnpm check-types` -- pass (31/31 packages)
- `pnpm tidy` -- pass
- `pnpm test` -- pass (all tests green)

## Other Information
`StructuredOutputSchema` is placed at `packages/protocol/src/structured-output.ts` (not under `node/`) because it will also be used for AI-driven JSON schema generation beyond node content definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a structured output schema and exposed it for generation workflows.
  * Generation nodes now include an explicit output designation (e.g., text or object with schema).

* **Tests**
  * Updated fixtures and tests to include and verify the new output field is preserved across conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches protocol-level schemas and node conversion/factory logic, so mismatches could break persisted node data or SDK consumers expecting the old shape; changes are straightforward and mostly additive with defaults.
> 
> **Overview**
> Adds `packages/protocol/src/structured-output.ts` defining a Zod `Schema` (recursive JSON-schema-like) and an `Output` discriminated union (`format: "text" | "object"`, with `schema` only for `object`).
> 
> Updates `TextGenerationContent` and `ContentGenerationContent` to include a new `output` field defaulting to `{ format: "text" }`, threads this field through text/content generation node conversions and default node factories, and updates fixtures/tests to assert round-trip preservation. Exports only `Schema` from the protocol barrel to avoid a naming conflict with the existing node port `Output` type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99fe43e7761e042d2cab385027e1b3086542eff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->