### PR TITLE
feat: add outputFormat discriminated union to task API response

### DIFF
--- a/.continuity/20260226-120000-feat__structured-output-api.md
+++ b/.continuity/20260226-120000-feat__structured-output-api.md
@@ -1,0 +1,75 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Add structured output support to the public task API (`GET /api/apps/:appId/tasks/:taskId`)
+- Use a discriminated union (`outputFormat: "passthrough" | "object"`) instead of optional fields
+- Keep backward compatibility for existing consumers (passthrough is the default)
+
+## Goal (incl. success criteria)
+
+- API returns `outputFormat` field in the task result
+- `passthrough`: includes `outputs` (existing behavior)
+- `object`: includes `object` field with transformed JSON (no `outputs` duplication)
+- `buildObject` logic lives in engine layer (mock for now in route)
+- SDK parses the new response shape
+
+## Constraints/Assumptions
+
+- Keep backward compatibility: tasks without `endNodeOutput` default to `{ format: "passthrough" }`
+- Follow discriminated union pattern (like Anthropic API) rather than optional fields
+- `buildObject` implementation is separate from this route change
+- Flat response structure (no nesting under `output` key) to preserve backward compatibility
+
+## Key decisions
+
+- Use discriminated union on `outputFormat` instead of optional field
+- When `format === "object"`, do NOT include `outputs` (avoid redundancy; raw data available in `steps`)
+- Investigated OpenAI, Anthropic, Vercel AI SDK patterns — none use optional fields for this
+- Field name `object` (not `structuredOutput`) to match `outputFormat: "object"` and Vercel AI SDK naming
+- Keep `outputFormat` (not `format`) for clarity and extensibility at the top level
+- Flat structure (not nested under `output`) to preserve backward compatibility with existing `task.outputs`
+- Exhaustive switch with `never` check on `endNodeOutput` (not `.format` due to Zod v4 built-type limitation)
+- Exported `EndOutputSchema` from `end.ts` (was file-local `Output`) for reuse in Task schema
+
+## State
+
+- All quality checks pass: format, build-sdk, check-types (31/31), tidy, test
+
+## Done
+
+- Analyzed API design patterns across OpenAI, Anthropic, Vercel AI SDK
+- Decided on discriminated union approach
+- Exported `EndOutputSchema` from `packages/protocol/src/node/operations/end.ts`
+- Added `endNodeOutput` field to Task schema (`packages/protocol/src/task/task.ts`) with `.default({ format: "passthrough" })`
+- Captured End Node `content.output` in `create-task.ts` and stored as `endNodeOutput` on Task
+- Implemented discriminated union `ApiTaskResult` type in route.ts
+- Implemented exhaustive switch on `endNodeOutput.format` in route.ts
+- Added `buildObject` mock function in route.ts
+- Fixed test fixtures (`patch-object.test.ts`, `task-execution-utils.test.ts`) to include `endNodeOutput`
+- All quality checks pass: `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, `pnpm test`
+
+## Now
+
+- API route implementation complete (with mock `buildObject`)
+
+## Next
+
+- Implement real `buildObject` in `packages/giselle/src/tasks/build-object.ts`
+- Add unit tests for `buildObject`
+- Update SDK (`packages/sdk/src/sdk.ts`) to parse the new `outputFormat` / `object` response fields
+- Update plan file to reflect completed items
+
+## Open questions (UNCONFIRMED if needed)
+
+- None currently
+
+## Working set (files/ids/commands)
+
+- `apps/studio.giselles.ai/app/api/apps/[appId]/tasks/[taskId]/route.ts` (modified)
+- `packages/protocol/src/task/task.ts` (modified)
+- `packages/protocol/src/node/operations/end.ts` (modified)
+- `packages/giselle/src/tasks/create-task.ts` (modified)
+- `packages/giselle/src/tasks/object/patch-object.test.ts` (modified)
+- `packages/giselle/src/tasks/shared/task-execution-utils.test.ts` (modified)
+- `packages/sdk/src/sdk.ts` (pending changes)

--- a/packages/giselle/src/tasks/create-task.ts
+++ b/packages/giselle/src/tasks/create-task.ts
@@ -91,6 +91,7 @@ export async function createTask(
 	);
 
 	let endNodeId: NodeId | undefined;
+	let endNodeOutput: Task["endNodeOutput"] = { format: "passthrough" };
 	for (const node of nodes) {
 		if (!isEndNode(node)) {
 			continue;
@@ -101,6 +102,7 @@ export async function createTask(
 			);
 		}
 		endNodeId = node.id;
+		endNodeOutput = node.content.output;
 	}
 	const nodeIdsConnectedToEnd = Array.from(
 		new Set(
@@ -300,6 +302,7 @@ export async function createTask(
 		status: "created",
 		name: starterNode ? defaultName(starterNode) : "group-nodes",
 		nodeIdsConnectedToEnd,
+		endNodeOutput,
 		steps: {
 			queued: generations.length,
 			inProgress: 0,

--- a/packages/giselle/src/tasks/object/patch-object.test.ts
+++ b/packages/giselle/src/tasks/object/patch-object.test.ts
@@ -32,6 +32,7 @@ describe("patchTask", () => {
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 			annotations: [],
+			endNodeOutput: { format: "passthrough" },
 			sequences: [
 				{
 					id: "sqn-001" as const,

--- a/packages/giselle/src/tasks/shared/task-execution-utils.test.ts
+++ b/packages/giselle/src/tasks/shared/task-execution-utils.test.ts
@@ -56,6 +56,7 @@ function createTestTask(overrides?: Partial<Task>): Task {
 		createdAt: 0,
 		updatedAt: 0,
 		annotations: [],
+		endNodeOutput: { format: "passthrough" },
 		sequences,
 		...overrides,
 	};

--- a/packages/protocol/src/node/operations/end.ts
+++ b/packages/protocol/src/node/operations/end.ts
@@ -12,7 +12,7 @@ const PropertyMapping = z.object({
 });
 export type PropertyMapping = z.infer<typeof PropertyMapping>;
 
-const Output = z.discriminatedUnion("format", [
+export const EndOutputSchema = z.discriminatedUnion("format", [
 	z.object({ format: z.literal("passthrough") }),
 	z.object({
 		format: z.literal("object"),
@@ -20,11 +20,11 @@ const Output = z.discriminatedUnion("format", [
 		mappings: z.array(PropertyMapping),
 	}),
 ]);
-export type EndOutput = z.infer<typeof Output>;
+export type EndOutput = z.infer<typeof EndOutputSchema>;
 
 export const EndContent = z.object({
 	type: z.literal("end"),
-	output: Output.default({ format: "passthrough" }),
+	output: EndOutputSchema.default({ format: "passthrough" }),
 });
 export type EndContent = z.infer<typeof EndContent>;
 

--- a/packages/protocol/src/task/task.ts
+++ b/packages/protocol/src/task/task.ts
@@ -4,6 +4,7 @@ import { AppId } from "../app";
 import { GenerationStatus } from "../generation";
 import { GenerationId } from "../generation/generation-id";
 import { NodeId } from "../node";
+import { EndOutputSchema } from "../node/operations/end";
 import { TriggerId } from "../trigger";
 import { WorkspaceId } from "../workspace";
 import { TaskId } from "./task-id";
@@ -99,6 +100,7 @@ export const Task = z.object({
 	annotations: z.array(ActAnnotationObject).default([]),
 	sequences: z.array(Sequence),
 	nodeIdsConnectedToEnd: z.array(NodeId.schema).optional(),
+	endNodeOutput: EndOutputSchema.default({ format: "passthrough" }),
 });
 export type Task = z.infer<typeof Task>;
 


### PR DESCRIPTION
## Summary
Add structured output support to the public task API (`GET /api/apps/:appId/tasks/:taskId`). The task result now uses a discriminated union on `outputFormat` to distinguish between passthrough (existing behavior) and object (structured output) responses. This is backward compatible -- existing consumers see the same `outputs` field with an additional `outputFormat` field they can ignore.

## Related Issue
N/A

## Changes
- Export `EndOutputSchema` from `packages/protocol/src/node/operations/end.ts` (previously file-local)
- Add `endNodeOutput` field to the Task schema with a passthrough default for backward compatibility
- Capture End Node `content.output` at task creation time in `create-task.ts`
- Implement `ApiTaskResult` discriminated union type in the task API route:
  - `outputFormat: "passthrough"` includes `outputs: ApiOutput[]`
  - `outputFormat: "object"` includes `object: Record<string, unknown>`
- Add exhaustive switch on `endNodeOutput.format` with `never` check
- Add mock `buildObject` function (real implementation to follow)
- Update test fixtures to include `endNodeOutput`

## Testing
- All quality checks pass: `pnpm format`, `pnpm build-sdk`, `pnpm check-types` (31/31), `pnpm tidy`, `pnpm test`

## Other Information
- This PR is for design review. Once the approach is approved, implementation will proceed in separate PRs (Task schema changes, then API route + `buildObject` implementation).
- `buildObject` is currently a mock returning `{}`. Real implementation will follow after approval.
- Design decisions documented in `.continuity/` ledger (investigated OpenAI, Anthropic, Vercel AI SDK patterns).