### PR TITLE
feat(task): persist end node output format on task creation

### DIFF
--- a/packages/giselle/src/tasks/create-task.ts
+++ b/packages/giselle/src/tasks/create-task.ts
@@ -3,6 +3,7 @@ import {
 	type AppId,
 	ConnectionId,
 	type CreatedGeneration,
+	type EndOutput,
 	GenerationContextInput,
 	GenerationId,
 	GenerationOrigin,
@@ -91,6 +92,7 @@ export async function createTask(
 	);
 
 	let endNodeId: NodeId | undefined;
+	let endNodeOutput: EndOutput | undefined;
 	for (const node of nodes) {
 		if (!isEndNode(node)) {
 			continue;
@@ -101,6 +103,7 @@ export async function createTask(
 			);
 		}
 		endNodeId = node.id;
+		endNodeOutput = node.content.output;
 	}
 	const nodeIdsConnectedToEnd = Array.from(
 		new Set(
@@ -300,6 +303,7 @@ export async function createTask(
 		status: "created",
 		name: starterNode ? defaultName(starterNode) : "group-nodes",
 		nodeIdsConnectedToEnd,
+		endNodeOutput: endNodeOutput ?? { format: "passthrough" },
 		steps: {
 			queued: generations.length,
 			inProgress: 0,

--- a/packages/giselle/src/tasks/object/patch-object.test.ts
+++ b/packages/giselle/src/tasks/object/patch-object.test.ts
@@ -32,6 +32,7 @@ describe("patchTask", () => {
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 			annotations: [],
+			endNodeOutput: { format: "passthrough" },
 			sequences: [
 				{
 					id: "sqn-001" as const,

--- a/packages/giselle/src/tasks/shared/task-execution-utils.test.ts
+++ b/packages/giselle/src/tasks/shared/task-execution-utils.test.ts
@@ -42,6 +42,7 @@ function createTestTask(overrides?: Partial<Task>): Task {
 		starter: { type: "run-button" },
 		name: "Test Task",
 		status: "inProgress",
+		endNodeOutput: { format: "passthrough" },
 		steps: {
 			queued: totalSteps,
 			inProgress: 0,

--- a/packages/protocol/src/node/operations/end.ts
+++ b/packages/protocol/src/node/operations/end.ts
@@ -12,7 +12,7 @@ const PropertyMapping = z.object({
 });
 export type PropertyMapping = z.infer<typeof PropertyMapping>;
 
-const Output = z.discriminatedUnion("format", [
+export const EndOutputSchema = z.discriminatedUnion("format", [
 	z.object({ format: z.literal("passthrough") }),
 	z.object({
 		format: z.literal("object"),
@@ -20,11 +20,11 @@ const Output = z.discriminatedUnion("format", [
 		mappings: z.array(PropertyMapping),
 	}),
 ]);
-export type EndOutput = z.infer<typeof Output>;
+export type EndOutput = z.infer<typeof EndOutputSchema>;
 
 export const EndContent = z.object({
 	type: z.literal("end"),
-	output: Output.default({ format: "passthrough" }),
+	output: EndOutputSchema.default({ format: "passthrough" }),
 });
 export type EndContent = z.infer<typeof EndContent>;
 

--- a/packages/protocol/src/task/task.ts
+++ b/packages/protocol/src/task/task.ts
@@ -4,6 +4,7 @@ import { AppId } from "../app";
 import { GenerationStatus } from "../generation";
 import { GenerationId } from "../generation/generation-id";
 import { NodeId } from "../node";
+import { EndOutputSchema } from "../node/operations/end";
 import { TriggerId } from "../trigger";
 import { WorkspaceId } from "../workspace";
 import { TaskId } from "./task-id";
@@ -99,6 +100,7 @@ export const Task = z.object({
 	annotations: z.array(ActAnnotationObject).default([]),
 	sequences: z.array(Sequence),
 	nodeIdsConnectedToEnd: z.array(NodeId.schema).optional(),
+	endNodeOutput: EndOutputSchema.default({ format: "passthrough" }),
 });
 export type Task = z.infer<typeof Task>;
 


### PR DESCRIPTION
## Summary
Store end-node output configuration (passthrough/object) on the Task so API consumers can reference it after execution.


## Changes
- `packages/protocol/src/node/operations/end.ts`: export `EndOutputSchema` and use it for `EndContent.output`.
- `packages/protocol/src/task/task.ts`: add required `endNodeOutput` field to `Task` schema with default `{ format: "passthrough" }`.
- `packages/giselle/src/tasks/create-task.ts`: capture and persist `endNodeOutput` when end nodes are present.
- `packages/giselle/src/tasks/object/patch-object.test.ts`: add `endNodeOutput` to test task fixture.
- `packages/giselle/src/tasks/shared/task-execution-utils.test.ts`: add `endNodeOutput` to test task fixture.

## Testing
- N/A

## Other Information
N/A
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive schema change: `Task` now persists `endNodeOutput` with a safe default, but downstream consumers expecting the old task shape may need to tolerate the new field.
> 
> **Overview**
> Tasks now **persist the end node output format** at creation time via a new `Task.endNodeOutput` field (defaulting to `{ format: "passthrough" }` when no end node is present).
> 
> The protocol exports `EndOutputSchema` from `end.ts` and reuses it in the `Task` schema, and task-related test fixtures are updated to include the new field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 323d9171cd4a73ba3e6a0a55a5a7a8b940fd0234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->