### PR TITLE
fix(workflow-designer-ui): remove array item property expansion in output source picker

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/output-source-picker.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/output-source-picker.tsx
@@ -113,17 +113,6 @@ function collectSubSchemaItems(
 				depth + 1,
 			);
 		}
-		if (subSchema.type === "array" && subSchema.items.type === "object") {
-			collectSubSchemaItems(
-				candidates,
-				subSchema.items.properties,
-				node,
-				outputId,
-				nodeName,
-				path,
-				depth + 1,
-			);
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The output source picker in the end node properties panel was recursing into the properties of array-typed schema items, exposing individual fields (e.g., `name`, `age` inside an `items` array) as selectable output sources. Since an array contains multiple elements, selecting a single property from its items is semantically invalid -- the picker cannot represent "which element's property" the user intends. This fix removes the expansion so that only the array field itself is selectable as a whole.

## Related Issue

close #2772
## Changes

- Removed the `if (subSchema.type === "array" && subSchema.items.type === "object")` branch in `collectSubSchemaItems` that recursively expanded array item properties as selectable candidates

## Testing

- Verify that array-type fields in structured output schemas appear as a single selectable item in the end node output source picker (not expanded into child properties)
- Verify that object-type fields still correctly expand their nested properties
- Verify no regressions in the end node properties panel

## Other Information

N/A



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that narrows the set of selectable structured-output fields; main risk is that users can no longer pick array-item subfields if they previously relied on that behavior.
> 
> **Overview**
> The output source picker no longer expands structured-output schemas into **array item** properties. Candidate generation in `collectSubSchemaItems` now only recurses into `object` subschemas, preventing array element fields from being shown as selectable sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a038f3c1a93ef45723fe95bc12117d020650b6dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->