### PR TITLE
fix(workflow-designer-ui): align text generation node output format layout with end node

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/advanced-options.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel-v2/advanced-options.tsx
@@ -29,8 +29,8 @@ export function AdvancedOptions({ node }: { node: ContentGenerationNode }) {
 			{isAdvancedOpen && (
 				<div className="mt-[12px] space-y-[12px]">
 					{structuredOutput && (
-						<div>
-							<SettingDetail className="mb-[6px]">Output format</SettingDetail>
+						<div className="flex items-start justify-between gap-[12px]">
+							<SettingDetail>Output Format</SettingDetail>
 							<OutputFormatPanel
 								output={node.content.output}
 								onOutputChange={(output) =>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/advanced-options.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/advanced-options.tsx
@@ -29,8 +29,8 @@ export function AdvancedOptions({ node }: { node: TextGenerationNode }) {
 			{isAdvancedOpen && (
 				<div className="mt-[12px] space-y-[12px]">
 					{structuredOutput && (
-						<div>
-							<SettingDetail className="mb-[6px]">Output format</SettingDetail>
+						<div className="flex items-start justify-between gap-[12px]">
+							<SettingDetail>Output Format</SettingDetail>
 							<OutputFormatPanel
 								output={node.content.output}
 								onOutputChange={(output) =>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/output-format-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/output-format-panel.tsx
@@ -31,7 +31,7 @@ export function OutputFormatPanel({
 	const isSchemaConfigured = Object.keys(schemaObject.properties).length > 0;
 
 	return (
-		<>
+		<div className="flex flex-col items-end gap-[16px]">
 			<Select
 				options={outputFormatOptions}
 				placeholder="Select format"
@@ -44,9 +44,10 @@ export function OutputFormatPanel({
 						onOutputChange({ format: "text" });
 					}
 				}}
+				widthClassName="w-[100px]"
 			/>
 			{hasOutputSchema && (
-				<div className="mt-[8px] flex justify-end">
+				<div>
 					<StructuredOutputDialog
 						schema={schemaObject}
 						onUpdate={(schema) => onOutputChange({ format: "object", schema })}
@@ -68,6 +69,6 @@ export function OutputFormatPanel({
 					/>
 				</div>
 			)}
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
## Summary
Fixes the layout of the "Output Format" section in the text generation node properties panel to be consistent with the end node's output format layout. The label and select are now displayed side-by-side instead of stacked.

## Related Issue
close #2787

## Changes
- Updated the output format container in both `text-generation-node-properties-panel` and `text-generation-node-properties-panel-v2` `advanced-options.tsx` to use a horizontal flexbox layout (`flex items-start justify-between gap-[12px]`) and removed the bottom margin from `SettingDetail`
- Refactored `OutputFormatPanel` to use a vertical flex container with right-aligned items instead of a fragment, and added a fixed width (`w-[100px]`) to the `Select` component
- Capitalized "Output Format" label for consistency

## Testing
Visually verify that the output format section in the text generation node properties panel matches the layout of the end node properties panel.

## Other Information
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweaks to the text generation node properties panel; no changes to data flow or feature gating beyond minor markup/class adjustments.
> 
> **Overview**
> Aligns the *Text Generation* node **Output Format** section with the End node by switching the label+control to a side-by-side flex layout (in both `text-generation-node-properties-panel` and `-v2`) and standardizing the label text to `Output Format`.
> 
> Refactors `OutputFormatPanel` to use a right-aligned vertical flex container and fixes the format `Select` width (`w-[100px]`) so the select and schema button align consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d838c931904368ca9797c29ec64ddad545be1e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Output Format field layout and visual alignment in the properties panel
  * Standardized label text capitalization to "Output Format"
  * Refined spacing and alignment for better UI consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->