### PR TITLE
refactor(workflow-designer-ui): remove clear button from output source picker

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/output-source-picker.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/output-source-picker.tsx
@@ -7,7 +7,7 @@ import type {
 	SubSchema,
 } from "@giselles-ai/protocol";
 import { isImageGenerationNode, isOperationNode } from "@giselles-ai/protocol";
-import { Search, X } from "lucide-react";
+import { Search } from "lucide-react";
 import { Popover as PopoverPrimitive } from "radix-ui";
 import { useMemo, useState } from "react";
 import { typeConfig } from "../structured-output/field-type-config";
@@ -197,14 +197,12 @@ interface OutputSourcePickerProps {
 	nodes: NodeLike[];
 	value: PropertyMapping["source"] | undefined;
 	onSelect: (ref: PropertyMapping["source"], fieldType: FieldType) => void;
-	onClear: () => void;
 }
 
 export function OutputSourcePicker({
 	nodes,
 	value,
 	onSelect,
-	onClear,
 }: OutputSourcePickerProps) {
 	const [open, setOpen] = useState(false);
 	const [query, setQuery] = useState("");
@@ -230,31 +228,19 @@ export function OutputSourcePicker({
 	}, [value, flatCandidates]);
 
 	const trigger = selectedCandidate ? (
-		<div className="flex-1 min-w-0 flex items-center gap-[4px]">
-			<button
-				type="button"
-				className="flex items-center gap-[8px] rounded-[6px] border border-border-muted bg-transparent px-[8px] py-[4px] min-w-0 flex-1 cursor-pointer hover:bg-white/5 transition-colors"
+		<button
+			type="button"
+			className="flex items-center gap-[8px] rounded-[6px] border border-border-muted bg-transparent px-[8px] py-[4px] min-w-0 w-full cursor-pointer hover:bg-white/5 transition-colors"
+		>
+			<span
+				className={`shrink-0 ${typeConfig[selectedCandidate.fieldType].colorClass}`}
 			>
-				<span
-					className={`shrink-0 ${typeConfig[selectedCandidate.fieldType].colorClass}`}
-				>
-					{typeConfig[selectedCandidate.fieldType].icon}
-				</span>
-				<span className="text-[12px] text-text truncate">
-					{selectedCandidate.label}
-				</span>
-			</button>
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					onClear();
-				}}
-				className="shrink-0 p-[2px] text-white/30 hover:text-white/60 transition-colors cursor-pointer"
-			>
-				<X className="size-[12px]" />
-			</button>
-		</div>
+				{typeConfig[selectedCandidate.fieldType].icon}
+			</span>
+			<span className="text-[12px] text-text truncate">
+				{selectedCandidate.label}
+			</span>
+		</button>
 	) : (
 		<button
 			type="button"

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/structured-output-dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/end-node-properties-panel/structured-output-dialog.tsx
@@ -373,14 +373,6 @@ export function StructuredOutputDialog({
 		[nodes],
 	);
 
-	const handleSourceClear = useCallback((fieldId: string) => {
-		setFieldSourceMapping((prev) => {
-			const next = new Map(prev);
-			next.delete(fieldId);
-			return next;
-		});
-	}, []);
-
 	const isTypeLocked = useCallback(
 		(fieldId: string) => fieldSourceMapping.has(fieldId),
 		[fieldSourceMapping],
@@ -394,10 +386,9 @@ export function StructuredOutputDialog({
 				onSelect={(ref, fieldType) =>
 					handleSourceSelect(field.id, ref, fieldType)
 				}
-				onClear={() => handleSourceClear(field.id)}
 			/>
 		),
-		[nodes, fieldSourceMapping, handleSourceSelect, handleSourceClear],
+		[nodes, fieldSourceMapping, handleSourceSelect],
 	);
 
 	return (


### PR DESCRIPTION
## Summary

Remove the clear (X) button from `OutputSourcePicker` in the structured output dialog. Users can change a selected source by picking a different one, making the explicit clear action unnecessary.

## Related Issue

Closes #2792

## Changes

- Remove `onClear` prop and clear button (X icon) from `OutputSourcePicker`
- Remove `handleSourceClear` callback from `StructuredOutputDialog`
- Simplify the selected source trigger UI by removing the wrapper `div`
- Remove unused `X` import from `lucide-react`

## Testing

- Open the structured output dialog on an end node
- Select a source for a field — verify it displays correctly
- Select a different source — verify it replaces the previous selection
- Confirm no X button is shown next to the selected source

## Other Information

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that removes the ability to explicitly clear a selected output source; main risk is minor UX/regression if users relied on unsetting mappings without choosing a replacement.
> 
> **Overview**
> Simplifies `OutputSourcePicker` by removing the `onClear` prop and the adjacent X-button UI, leaving the selected source display as a single full-width trigger button.
> 
> Updates `StructuredOutputDialog` to drop the source-clearing callback and stop wiring any clear handler into the picker, so mappings can only be changed by selecting a different source.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55338f3be250aabf2e95ef399eb76515e8f87b34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Simplified the output source picker interface with a consolidated button design showing the selected source and icon.
  * Removed the clear action for source selections in the picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->