### PR TITLE
fix: restore exhaustive type-check in execute-action

### DIFF
--- a/packages/giselle/src/operations/execute-action.ts
+++ b/packages/giselle/src/operations/execute-action.ts
@@ -66,11 +66,8 @@ export function executeAction(args: {
 					});
 					break;
 				default: {
-					// TODO: Uncomment after implementing all action providers
-					// const _exhaustiveCheck: never = command.provider;
-					// throw new Error(`Unhandled provider: ${_exhaustiveCheck}`);
-					const unknownProvider = (command as { provider: string }).provider;
-					throw new Error(`Unhandled provider: ${unknownProvider}`);
+					const _exhaustiveCheck: never = command.provider;
+					throw new Error(`Unhandled provider: ${_exhaustiveCheck}`);
 				}
 			}
 			await finishGeneration({


### PR DESCRIPTION
## What

Restores the exhaustive type-check (`never` guard) in the `default` case of the provider switch in `execute-action.ts`.

## Why

The commented-out `never` check was replaced with a relaxed runtime cast (`command as { provider: string }`), which loses compile-time safety. Since `github` is currently the only provider in the `ActionData` discriminated union, the `default` case is correctly unreachable, and the `never` type-check compiles cleanly.

With this change, if a new provider is added to the union without a corresponding `case`, TypeScript will produce a compile-time error — catching the oversight before it reaches production.

Closes #1106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type validation and error handling pattern for improved code robustness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->