### PR TITLE
feat: add Novita provider integration

### DIFF
--- a/apps/studio.giselles.ai/.env.example
+++ b/apps/studio.giselles.ai/.env.example
@@ -29,6 +29,10 @@ LANGFUSE_SECRET_KEY=
 # @see https://platform.openai.com/docs/quickstart
 OPENAI_API_KEY=
 
+# Novita API https://novita.ai
+# @see https://novita.ai/docs
+NOVITA_API_KEY=
+
 # Vercel Postgres https://vercel.com/docs/storage/vercel-postgres
 # @see https://vercel.com/docs/storage/vercel-postgres#getting-started
 POSTGRES_DATABASE=

--- a/packages/language-model-registry/src/language-model.test.ts
+++ b/packages/language-model-registry/src/language-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { anthropic } from "./anthropic";
 import { google } from "./google";
 import { parseConfiguration } from "./language-model";
+import { novita } from "./novita";
 import { openai } from "./openai";
 
 describe("parseConfiguration", () => {
@@ -161,5 +162,23 @@ describe("parseConfiguration", () => {
 			expect(result.temperature).toBe(1.0); // default
 			expect(result.thinkingLevel).toBe("high"); // default
 		});
+	});
+});
+
+describe("novita models", () => {
+	it("should have valid model IDs", () => {
+		expect(novita["novita/deepseek/deepseek-v3.2"].id).toBe(
+			"novita/deepseek/deepseek-v3.2",
+		);
+		expect(novita["novita/zai-org/glm-5"].id).toBe("novita/zai-org/glm-5");
+		expect(novita["novita/minimax/minimax-m2.5"].id).toBe(
+			"novita/minimax/minimax-m2.5",
+		);
+	});
+
+	it("should have correct provider", () => {
+		expect(novita["novita/deepseek/deepseek-v3.2"].provider.id).toBe("novita");
+		expect(novita["novita/zai-org/glm-5"].provider.id).toBe("novita");
+		expect(novita["novita/minimax/minimax-m2.5"].provider.id).toBe("novita");
 	});
 });

--- a/packages/language-model-registry/src/language-models.ts
+++ b/packages/language-model-registry/src/language-models.ts
@@ -1,11 +1,13 @@
 import { anthropic } from "./anthropic";
 import { google } from "./google";
+import { novita } from "./novita";
 import { openai } from "./openai";
 
 export const languageModels = [
 	...Object.values(openai),
 	...Object.values(anthropic),
 	...Object.values(google),
+	...Object.values(novita),
 ];
 
 export const languageModelIds = languageModels.map((model) => model.id);

--- a/packages/language-model-registry/src/novita.ts
+++ b/packages/language-model-registry/src/novita.ts
@@ -1,0 +1,66 @@
+import {
+	type AnyLanguageModel,
+	defineLanguageModel,
+	definePricing,
+	type LanguageModelProviderDefinition,
+} from "./language-model";
+
+const novitaProvider = {
+	id: "novita",
+	title: "Novita",
+	metadata: {
+		website: "https://novita.ai",
+		documentationUrl: "https://novita.ai/docs",
+	},
+} as const satisfies LanguageModelProviderDefinition<"novita">;
+
+export const novita = {
+	"novita/deepseek/deepseek-v3.2": defineLanguageModel({
+		provider: novitaProvider,
+		id: "novita/deepseek/deepseek-v3.2",
+		name: "DeepSeek V3.2",
+		description:
+			"DeepSeek V3.2 is a strong language model with improved reasoning and coding capabilities.",
+		contextWindow: 128_000,
+		maxOutputTokens: 8_192,
+		knowledgeCutoff: new Date(2024, 11, 31).getTime(),
+		pricing: {
+			input: definePricing(0.14),
+			output: definePricing(0.28),
+		},
+		requiredTier: "free",
+		url: "https://novita.ai/models/deepseek-ai/deepseek-v3.2",
+	}),
+	"novita/zai-org/glm-5": defineLanguageModel({
+		provider: novitaProvider,
+		id: "novita/zai-org/glm-5",
+		name: "GLM-5",
+		description:
+			"GLM-5 is a large language model developed by Zhipu AI with strong multilingual capabilities.",
+		contextWindow: 128_000,
+		maxOutputTokens: 8_192,
+		knowledgeCutoff: new Date(2024, 6, 31).getTime(),
+		pricing: {
+			input: definePricing(0.5),
+			output: definePricing(0.5),
+		},
+		requiredTier: "free",
+		url: "https://novita.ai/models/zhipu-ai/glm-5",
+	}),
+	"novita/minimax/minimax-m2.5": defineLanguageModel({
+		provider: novitaProvider,
+		id: "novita/minimax/minimax-m2.5",
+		name: "MiniMax M2.5",
+		description:
+			"MiniMax M2.5 is a high-performance language model from MiniMax AI with strong reasoning capabilities.",
+		contextWindow: 32_768,
+		maxOutputTokens: 8_192,
+		knowledgeCutoff: new Date(2024, 9, 31).getTime(),
+		pricing: {
+			input: definePricing(0.5),
+			output: definePricing(0.5),
+		},
+		requiredTier: "free",
+		url: "https://novita.ai/models/MiniMax/MiniMax-M2.5",
+	}),
+} as const satisfies Record<string, AnyLanguageModel>;

--- a/packages/node-registry/src/node-conversion.ts
+++ b/packages/node-registry/src/node-conversion.ts
@@ -13,6 +13,12 @@ import {
 	type TextGenerationNode,
 } from "@giselles-ai/protocol";
 
+// Novita model IDs for TextGenerationNode (without "novita/" prefix)
+type NovitaTextGenerationModelId =
+	| "deepseek/deepseek-v3.2"
+	| "zai-org/glm-5"
+	| "minimax/minimax-m2.5";
+
 // Legacy model IDs that are no longer in the current schema but may exist in stored data
 type LegacyAnthropicModelId =
 	| "claude-opus-4-1-20250805"
@@ -22,7 +28,8 @@ type LegacyOpenAiModelId = "gpt-5-codex";
 type TextGenerationModelIdWithLegacy =
 	| TextGenerationNode["content"]["llm"]["id"]
 	| LegacyAnthropicModelId
-	| LegacyOpenAiModelId;
+	| LegacyOpenAiModelId
+	| NovitaTextGenerationModelId;
 
 function convertTextGenerationLanguageModelIdToContentGenerationLanguageModelId(
 	from: TextGenerationModelIdWithLegacy,
@@ -65,6 +72,12 @@ function convertTextGenerationLanguageModelIdToContentGenerationLanguageModelId(
 			return "openai/gpt-5.1-codex";
 		case "gpt-5-nano":
 			return "openai/gpt-5-nano";
+		case "deepseek/deepseek-v3.2":
+			return "novita/deepseek/deepseek-v3.2";
+		case "zai-org/glm-5":
+			return "novita/zai-org/glm-5";
+		case "minimax/minimax-m2.5":
+			return "novita/minimax/minimax-m2.5";
 		case "sonar":
 		case "sonar-pro":
 			// fallback to gpt-5-nano
@@ -114,9 +127,11 @@ function convertContentGenerationLanguageModelIdToTextGenerationLanguageModelId(
 		case "openai/gpt-5-codex":
 			return "gpt-5.1-codex";
 		case "openai/gpt-5-nano":
-			// When converting back, use gpt-5-nano (not sonar/sonar-pro)
-			// as we cannot determine the original source
 			return "gpt-5-nano";
+		case "novita/deepseek/deepseek-v3.2":
+		case "novita/zai-org/glm-5":
+		case "novita/minimax/minimax-m2.5":
+			return "gpt-5";
 		default: {
 			const _exhaustiveCheck: never = from;
 			throw new Error(`Unknown language model id: ${_exhaustiveCheck}`);
@@ -249,6 +264,20 @@ export function convertContentGenerationToTextGeneration(
 			};
 			break;
 		case "openai":
+			llm = {
+				provider: "openai",
+				id: OpenAILanguageModelId.parse(languageModelId),
+				configurations: {
+					temperature: 0.7,
+					topP: 1.0,
+					presencePenalty: 0.0,
+					frequencyPenalty: 0.0,
+					textVerbosity: "medium",
+					reasoningEffort: "medium",
+				},
+			};
+			break;
+		case "novita":
 			llm = {
 				provider: "openai",
 				id: OpenAILanguageModelId.parse(languageModelId),


### PR DESCRIPTION
## Summary

This PR adds Novita LLM provider integration to Giselle, following the pattern of existing providers.

## What's Changed

- **novita.ts**: New provider implementing 3 Novita models:
  -  - DeepSeek V3.2
  -  - GLM-5 from Zhipu AI
  -  - MiniMax M2.5

- **language-models.ts**: Registered Novita models in the language model registry

- **node-conversion.ts**: Added conversion support for backward compatibility (maps Novita to OpenAI-compatible format)

- **.env.example**: Added NOVITA_API_KEY environment variable

- **language-model.test.ts**: Added tests for Novita model registration

## Notes

- All Novita models use the OpenAI-compatible API (same configuration pattern)
- Model IDs use `/` separator per the codebase convention
- Backward compatibility maintained by mapping to OpenAI format for legacy TextGenerationNode
- No existing providers modified; all changes additive