### PR TITLE
feat: add MiniMax M2.7 + M2.7-highspeed as LLM provider

### DIFF
--- a/packages/giselle/src/generations/generate-content.ts
+++ b/packages/giselle/src/generations/generate-content.ts
@@ -1,7 +1,7 @@
 import { type AnthropicProviderOptions, anthropic } from "@ai-sdk/anthropic";
 import { createGateway } from "@ai-sdk/gateway";
 import { google } from "@ai-sdk/google";
-import { type OpenAIResponsesProviderOptions, openai } from "@ai-sdk/openai";
+import { createOpenAI, type OpenAIResponsesProviderOptions, openai } from "@ai-sdk/openai";
 import type { SharedV2ProviderMetadata } from "@ai-sdk/provider";
 import { githubTools, octokit } from "@giselles-ai/github-tool";
 import {
@@ -567,6 +567,13 @@ function generationModel(
 		case "perplexity": {
 			return gateway(`${llmProvider}/${languageModel.id}`);
 		}
+		case "minimax": {
+			const minimaxOpenAI = createOpenAI({
+				baseURL: "https://api.minimax.io/v1",
+				apiKey: process.env.MINIMAX_API_KEY ?? "",
+			});
+			return minimaxOpenAI(languageModel.id);
+		}
 		default: {
 			const _exhaustiveCheck: never = llmProvider;
 			throw new Error(`Unknown LLM provider: ${_exhaustiveCheck}`);
@@ -624,6 +631,16 @@ function generateContentV2({
 						},
 			);
 
+			const languageModelId = operationNode.content.languageModel.id;
+			const [providerPrefix] = languageModelId.split("/");
+			const resolvedModel =
+				providerPrefix === "minimax"
+					? createOpenAI({
+							baseURL: "https://api.minimax.io/v1",
+							apiKey: process.env.MINIMAX_API_KEY ?? "",
+						})(languageModelId.slice("minimax/".length))
+					: gateway(languageModelId);
+
 			const messages = await buildMessageObject({
 				node: operationNode,
 				contextNodes: generationContext.sourceNodes,
@@ -656,7 +673,7 @@ function generateContentV2({
 				...callOptions,
 				experimental_output: outputOption,
 				abortSignal: abortController.signal,
-				model: gateway(operationNode.content.languageModel.id),
+				model: resolvedModel,
 				messages,
 				tools: toolSet,
 				stopWhen: ({ steps }) => {

--- a/packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts
+++ b/packages/giselle/src/generations/v2/language-model/transform-giselle-to-ai-sdk.ts
@@ -107,6 +107,18 @@ export function transformGiselleLanguageModelToAiSdkLanguageModelCallOptions(
 				},
 			} satisfies Partial<LanguageModelV2CallOptions>;
 		}
+		case "minimax/MiniMax-M2.7":
+		case "minimax/MiniMax-M2.7-highspeed": {
+			const config = parseConfiguration(
+				languageModel,
+				content.languageModel.configuration,
+			);
+			// MiniMax temperature must be in (0.0, 1.0] — clamp to valid range
+			const temperature = Math.min(Math.max(config.temperature, 0.01), 1.0);
+			return {
+				temperature,
+			} satisfies Partial<LanguageModelV2CallOptions>;
+		}
 		default: {
 			const _exhaustiveCheck: never = languageModel;
 			throw new Error(`Unsupported language model: ${_exhaustiveCheck}`);

--- a/packages/language-model-registry/src/language-model.test.ts
+++ b/packages/language-model-registry/src/language-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { anthropic } from "./anthropic";
 import { google } from "./google";
 import { parseConfiguration } from "./language-model";
+import { minimax } from "./minimax";
 import { openai } from "./openai";
 
 describe("parseConfiguration", () => {
@@ -160,6 +161,48 @@ describe("parseConfiguration", () => {
 
 			expect(result.temperature).toBe(1.0); // default
 			expect(result.thinkingLevel).toBe("high"); // default
+		});
+	});
+
+	describe("with minimax/MiniMax-M2.7", () => {
+		const model = minimax["minimax/MiniMax-M2.7"];
+
+		it("should parse valid temperature", () => {
+			const unknownData: Record<string, unknown> = {
+				temperature: 0.5,
+			};
+
+			const result = parseConfiguration(model, unknownData);
+
+			expect(result.temperature).toBe(0.5);
+		});
+
+		it("should fallback to default when temperature is zero (invalid - must be > 0)", () => {
+			const unknownData: Record<string, unknown> = {
+				temperature: 0,
+			};
+
+			const result = parseConfiguration(model, unknownData);
+
+			expect(result.temperature).toBe(0.7); // falls back to default
+		});
+
+		it("should fallback to default when temperature exceeds 1.0", () => {
+			const unknownData: Record<string, unknown> = {
+				temperature: 1.5,
+			};
+
+			const result = parseConfiguration(model, unknownData);
+
+			expect(result.temperature).toBe(0.7); // falls back to default
+		});
+
+		it("should use default when temperature is missing", () => {
+			const unknownData: Record<string, unknown> = {};
+
+			const result = parseConfiguration(model, unknownData);
+
+			expect(result.temperature).toBe(0.7);
 		});
 	});
 });

--- a/packages/language-model-registry/src/language-models.ts
+++ b/packages/language-model-registry/src/language-models.ts
@@ -1,11 +1,13 @@
 import { anthropic } from "./anthropic";
 import { google } from "./google";
+import { minimax } from "./minimax";
 import { openai } from "./openai";
 
 export const languageModels = [
 	...Object.values(openai),
 	...Object.values(anthropic),
 	...Object.values(google),
+	...Object.values(minimax),
 ];
 
 export const languageModelIds = languageModels.map((model) => model.id);

--- a/packages/language-model-registry/src/minimax.ts
+++ b/packages/language-model-registry/src/minimax.ts
@@ -1,0 +1,81 @@
+import * as z from "zod/v4";
+import {
+	type AnyLanguageModel,
+	defineLanguageModel,
+	definePricing,
+	type LanguageModelProviderDefinition,
+} from "./language-model";
+
+const minimaxProvider = {
+	id: "minimax",
+	title: "MiniMax",
+	metadata: {
+		website: "https://www.minimax.io",
+		documentationUrl: "https://platform.minimaxi.com/document/",
+	},
+} as const satisfies LanguageModelProviderDefinition<"minimax">;
+
+export const minimax = {
+	"minimax/MiniMax-M2.7": defineLanguageModel({
+		provider: minimaxProvider,
+		id: "minimax/MiniMax-M2.7",
+		name: "MiniMax M2.7",
+		description:
+			"MiniMax M2.7 is MiniMax's latest flagship model with 204K context window, offering strong performance in reasoning, coding, and multilingual tasks.",
+		contextWindow: 204_000,
+		maxOutputTokens: 8_192,
+		knowledgeCutoff: new Date(2025, 0, 1).getTime(),
+		pricing: {
+			input: definePricing(0.8),
+			output: definePricing(2.4),
+		},
+		requiredTier: "pro",
+		configurationOptions: {
+			temperature: {
+				description:
+					"Amount of randomness injected into the response. Must be greater than 0 and at most 1.",
+				schema: z.number().min(0.01).max(1.0),
+				ui: {
+					min: 0.01,
+					max: 1.0,
+					step: 0.01,
+				},
+			},
+		},
+		defaultConfiguration: {
+			temperature: 0.7,
+		},
+		url: "https://platform.minimaxi.com/document/",
+	}),
+	"minimax/MiniMax-M2.7-highspeed": defineLanguageModel({
+		provider: minimaxProvider,
+		id: "minimax/MiniMax-M2.7-highspeed",
+		name: "MiniMax M2.7 Highspeed",
+		description:
+			"MiniMax M2.7 Highspeed is an optimized variant of M2.7 for faster inference with 204K context window, ideal for latency-sensitive applications.",
+		contextWindow: 204_000,
+		maxOutputTokens: 8_192,
+		knowledgeCutoff: new Date(2025, 0, 1).getTime(),
+		pricing: {
+			input: definePricing(0.6),
+			output: definePricing(1.8),
+		},
+		requiredTier: "pro",
+		configurationOptions: {
+			temperature: {
+				description:
+					"Amount of randomness injected into the response. Must be greater than 0 and at most 1.",
+				schema: z.number().min(0.01).max(1.0),
+				ui: {
+					min: 0.01,
+					max: 1.0,
+					step: 0.01,
+				},
+			},
+		},
+		defaultConfiguration: {
+			temperature: 0.7,
+		},
+		url: "https://platform.minimaxi.com/document/",
+	}),
+} as const satisfies Record<string, AnyLanguageModel>;

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -468,3 +468,37 @@ export const cohereEmbeddingPricing: EmbeddingModelPriceTable = {
 		],
 	},
 };
+
+export const minimaxTokenPricing: ModelPriceTable = {
+	// https://platform.minimaxi.com/document/
+	"MiniMax-M2.7": {
+		prices: [
+			{
+				validFrom: "2025-06-01T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.8,
+					},
+					output: {
+						costPerMegaToken: 2.4,
+					},
+				},
+			},
+		],
+	},
+	"MiniMax-M2.7-highspeed": {
+		prices: [
+			{
+				validFrom: "2025-06-01T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 0.6,
+					},
+					output: {
+						costPerMegaToken: 1.8,
+					},
+				},
+			},
+		],
+	},
+};

--- a/packages/language-model/src/index.ts
+++ b/packages/language-model/src/index.ts
@@ -16,6 +16,10 @@ import {
 	models as googleImageLanguageModels,
 } from "./google-image";
 import {
+	LanguageModel as MiniMaxLanguageModel,
+	models as minimaxLanguageModels,
+} from "./minimax";
+import {
 	LanguageModel as OpenAILanguageModel,
 	models as openaiLanguageModels,
 } from "./openai";
@@ -52,6 +56,7 @@ export const LanguageModel = z.union([
 	OpenAILanguageModel,
 	OpenAIImageLanguageModel,
 	PerplexityLanguageModel,
+	MiniMaxLanguageModel,
 	FalLanguageModel,
 ]);
 export type LanguageModel = z.infer<typeof LanguageModel>;
@@ -63,6 +68,7 @@ export const languageModels = [
 	...openaiLanguageModels,
 	...openaiImageLanguageModels,
 	...perplexityLanguageModels,
+	...minimaxLanguageModels,
 	...falLanguageModels,
 ];
 
@@ -73,12 +79,14 @@ export {
 	OpenAILanguageModel,
 	OpenAIImageLanguageModel,
 	PerplexityLanguageModel,
+	MiniMaxLanguageModel,
 	FalLanguageModel,
 	anthropicLanguageModels,
 	googleLanguageModels,
 	googleImageLanguageModels,
 	openaiLanguageModels,
 	perplexityLanguageModels,
+	minimaxLanguageModels,
 	falLanguageModels,
 };
 
@@ -89,10 +97,12 @@ export const LanguageModelProviders = z.enum([
 	OpenAILanguageModel.shape.provider.value,
 	OpenAIImageLanguageModel.shape.provider.value,
 	PerplexityLanguageModel.shape.provider.value,
+	MiniMaxLanguageModel.shape.provider.value,
 	FalLanguageModel.shape.provider.value,
 ]);
 export type LanguageModelProvider = z.infer<typeof LanguageModelProviders>;
 
 export { AnthropicLanguageModelId } from "./anthropic";
 export { GoogleLanguageModelId } from "./google";
+export { MiniMaxLanguageModelId } from "./minimax";
 export { OpenAILanguageModelId } from "./openai";

--- a/packages/language-model/src/minimax.ts
+++ b/packages/language-model/src/minimax.ts
@@ -1,0 +1,55 @@
+import * as z from "zod/v4";
+import { Capability, LanguageModelBase, Tier } from "./base";
+import { BaseCostCalculator } from "./costs/calculator";
+import { minimaxTokenPricing } from "./costs/model-prices";
+
+const MiniMaxLanguageModelConfigurations = z.object({
+	temperature: z.number(),
+	topP: z.number(),
+});
+type MiniMaxLanguageModelConfigurations = z.infer<
+	typeof MiniMaxLanguageModelConfigurations
+>;
+
+const defaultConfigurations: MiniMaxLanguageModelConfigurations = {
+	temperature: 0.7,
+	topP: 1.0,
+};
+
+export const MiniMaxLanguageModelId = z
+	.enum(["MiniMax-M2.7", "MiniMax-M2.7-highspeed"])
+	.catch("MiniMax-M2.7");
+
+const MiniMaxLanguageModel = LanguageModelBase.extend({
+	id: MiniMaxLanguageModelId,
+	provider: z.literal("minimax"),
+	configurations: MiniMaxLanguageModelConfigurations,
+});
+type MiniMaxLanguageModel = z.infer<typeof MiniMaxLanguageModel>;
+
+const minimaxM27: MiniMaxLanguageModel = {
+	provider: "minimax",
+	id: "MiniMax-M2.7",
+	capabilities: Capability.TextGeneration | Capability.Reasoning,
+	tier: Tier.enum.pro,
+	configurations: defaultConfigurations,
+};
+
+const minimaxM27Highspeed: MiniMaxLanguageModel = {
+	provider: "minimax",
+	id: "MiniMax-M2.7-highspeed",
+	capabilities: Capability.TextGeneration,
+	tier: Tier.enum.pro,
+	configurations: defaultConfigurations,
+};
+
+export const models = [minimaxM27, minimaxM27Highspeed];
+
+export const LanguageModel = MiniMaxLanguageModel;
+export type LanguageModel = MiniMaxLanguageModel;
+
+export class MiniMaxCostCalculator extends BaseCostCalculator {
+	protected getPricingTable() {
+		return minimaxTokenPricing;
+	}
+}


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimax.io) as a first-class LLM provider via its OpenAI-compatible API.

### Models added
- `MiniMax-M2.7` — 204K context, flagship model (pricing: $0.8/M in, $2.4/M out)
- `MiniMax-M2.7-highspeed` — 204K context, optimized for low latency (pricing: $0.6/M in, $1.8/M out)

### Changes

**`packages/language-model-registry`** (V2 registry)
- Add `src/minimax.ts` with provider definition + two models, temperature-only config (clamped to (0.01, 1.0])
- Register MiniMax in `language-models.ts`
- Add 4 tests to `language-model.test.ts`

**`packages/language-model`** (V1 model package)
- Add `src/minimax.ts` with Zod schema + `MiniMaxCostCalculator`
- Export MiniMax types + models from `index.ts`
- Add pricing entry in `costs/model-prices.ts`

**`packages/giselle`** (generation engine)
- `generate-content.ts`: route `minimax` provider to `createOpenAI({ baseURL: "https://api.minimax.io/v1", apiKey: MINIMAX_API_KEY })` in both V1 (`generationModel()`) and V2 (`generateContentV2()`)
- `transform-giselle-to-ai-sdk.ts`: add MiniMax cases with temperature clamping to (0.01, 1.0]

### Configuration
Set `MINIMAX_API_KEY` environment variable to enable MiniMax models.

## Test plan
- [x] `@giselles-ai/language-model-registry` tests: 16/16 pass (includes 4 new MiniMax tests)
- [x] `@giselles-ai/language-model` tests: 68/68 pass
- [x] `@giselles-ai/giselle` tests: all pre-existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for MiniMax language models (MiniMax-M2.7 and MiniMax-M2.7-highspeed)
  * MiniMax-M2.7 supports text generation and reasoning; MiniMax-M2.7-highspeed optimized for text generation
  * Configurable temperature parameter (0.01–1.0 range, default 0.7)

* **Tests**
  * Added validation tests for MiniMax model configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->