### PR TITLE
fix(deps): bump socket.io-parser from 4.2.4 to 4.2.6

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -12230,7 +12230,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="socket.io-parser"></a>
-### socket.io-parser v4.2.4
+### socket.io-parser v4.2.6
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
 			"js-yaml@>=3.0.0 <4.0.0": "3.14.2",
 			"@esbuild-kit/core-utils>esbuild": "0.25.10",
 			"serialize-javascript": "7.0.3",
-			"systeminformation": "5.31.5"
+			"systeminformation": "5.31.5",
+			"socket.io-parser": "4.2.6"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,7 @@ overrides:
   '@esbuild-kit/core-utils>esbuild': 0.25.10
   serialize-javascript: 7.0.3
   systeminformation: 5.31.5
+  socket.io-parser: 4.2.6
 
 importers:
 
@@ -8351,8 +8352,8 @@ packages:
     resolution: {integrity: sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.4:
-    resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.7.4:
@@ -16935,16 +16936,16 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.3.7
       engine.io-client: 6.5.4(bufferutil@4.0.9)(utf-8-validate@6.0.5)
-      socket.io-parser: 4.2.4
+      socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.4:
+  socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16956,7 +16957,7 @@ snapshots:
       debug: 4.3.7
       engine.io: 6.5.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       socket.io-adapter: 2.5.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)
-      socket.io-parser: 4.2.4
+      socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16970,7 +16971,7 @@ snapshots:
       debug: 4.3.7
       engine.io: 6.6.4(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       socket.io-adapter: 2.5.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)
-      socket.io-parser: 4.2.4
+      socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
## Summary

- Fixes [Dependabot alert #131](https://github.com/giselles-ai/giselle/security/dependabot/131) (CVE-2026-33151, high severity)
- Bumps `socket.io-parser` from 4.2.4 to 4.2.6 via `pnpm.overrides` to resolve an unbounded binary attachments vulnerability in socket.io
- `socket.io-parser` is a transitive dependency of `socket.io` and `socket.io-client`

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build-sdk` passes
- [x] `pnpm check-types` passes
- [x] CI passes

## Verification

`socket.io-parser` is an internal parser for `socket.io`, used indirectly as the real-time communication layer for Trigger.dev. If workflow execution (content generation / task execution) works correctly, there are no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)