### PR TITLE
fix(deps): bump systeminformation from 5.23.8 to 5.31.5

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -12619,7 +12619,7 @@ Unknown manually approved
 
 
 <a name="systeminformation"></a>
-### systeminformation v5.23.8
+### systeminformation v5.31.5
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 			"ajv@>=6.0.0 <7.0.0": "6.14.0",
 			"js-yaml@>=3.0.0 <4.0.0": "3.14.2",
 			"@esbuild-kit/core-utils>esbuild": "0.25.10",
-			"serialize-javascript": "7.0.3"
+			"serialize-javascript": "7.0.3",
+			"systeminformation": "5.31.5"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,7 @@ overrides:
   js-yaml@>=3.0.0 <4.0.0: 3.14.2
   '@esbuild-kit/core-utils>esbuild': 0.25.10
   serialize-javascript: 7.0.3
+  systeminformation: 5.31.5
 
 importers:
 
@@ -8519,8 +8520,8 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  systeminformation@5.23.8:
-    resolution: {integrity: sha512-Osd24mNKe6jr/YoXLLK3k8TMdzaxDffhpCxgkfgBHcapykIkd50HXThM3TCEuHO2pPuCsSx2ms/SunqhU5MmsQ==}
+  systeminformation@5.31.5:
+    resolution: {integrity: sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -10920,7 +10921,7 @@ snapshots:
   '@opentelemetry/host-metrics@0.37.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      systeminformation: 5.23.8
+      systeminformation: 5.31.5
 
   '@opentelemetry/instrumentation-amqplib@0.58.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -17146,7 +17147,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  systeminformation@5.23.8: {}
+  systeminformation@5.31.5: {}
 
   tagged-tag@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- Fixes [Dependabot alert #167](https://github.com/giselles-ai/giselle/security/dependabot/167) (CVE-2026-26318, high severity)
- Bumps `systeminformation` from 5.23.8 to 5.31.5 via `pnpm.overrides` to resolve a command injection vulnerability via unsanitized `locate` output in `versions()`
- `systeminformation` is a transitive dependency of `@opentelemetry/host-metrics` (from `@trigger.dev/core`)

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build-sdk` passes
- [x] `pnpm check-types` passes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency pinning to lock the system information library at v5.31.5 for consistent installs.
* **Documentation**
  * Updated package licensing docs to reflect the system information library version change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->