### PR TITLE
fix(deps): bump undici from 7.22.0 to 7.24.4

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -13224,7 +13224,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="undici"></a>
-### undici v7.22.0
+### undici v7.24.4
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
 			"@esbuild-kit/core-utils>esbuild": "0.25.10",
 			"serialize-javascript": "7.0.3",
 			"systeminformation": "5.31.5",
-			"socket.io-parser": "4.2.6"
+			"socket.io-parser": "4.2.6",
+			"undici@>=7.0.0 <7.24.0": "7.24.4"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,7 @@ overrides:
   serialize-javascript: 7.0.3
   systeminformation: 5.31.5
   socket.io-parser: 4.2.6
+  undici@>=7.0.0 <7.24.0: 7.24.4
 
 importers:
 
@@ -8801,10 +8802,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
@@ -13491,7 +13488,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.22.0
+      undici: 7.24.4
       xdg-app-paths: 5.1.0
       zod: 3.24.4
     transitivePeerDependencies:
@@ -17392,8 +17389,6 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.18.2: {}
-
-  undici@7.22.0: {}
 
   undici@7.24.4: {}
 


### PR DESCRIPTION
## Summary

- Fixes [Dependabot alert #121](https://github.com/giselles-ai/giselle/security/dependabot/121) (CVE-2026-1528, high severity) — malicious WebSocket 64-bit length overflows parser and crashes the client
- Fixes [Dependabot alert #125](https://github.com/giselles-ai/giselle/security/dependabot/125) (CVE-2026-2229, high severity) — unhandled exception in WebSocket client due to invalid `server_max_window_bits` validation
- Bumps `undici` from 7.22.0 to 7.24.4 via `pnpm.overrides` (scoped to `>=7.0.0 <7.24.0` to avoid affecting already-patched instances)
- `undici` is a transitive dependency of `@vercel/sandbox`

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build-sdk` passes
- [x] `pnpm check-types` passes
- [x] CI passes

## Verification

`undici` is an HTTP client library and an internal dependency of `@vercel/sandbox`. There is no direct impact on user-facing features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)