### PR TITLE
fix(deps): bump @xmldom/xmldom from 0.8.10 to 0.8.12

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -5571,7 +5571,7 @@ FSL-1.1-MIT manually approved
 
 
 <a name="@xmldom/xmldom"></a>
-### @xmldom/xmldom v0.8.10
+### @xmldom/xmldom v0.8.12
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
 			"serialize-javascript": "7.0.3",
 			"systeminformation": "5.31.5",
 			"socket.io-parser": "4.2.6",
-			"undici@>=7.0.0 <7.24.0": "7.24.4"
+			"undici@>=7.0.0 <7.24.0": "7.24.4",
+			"@xmldom/xmldom": "0.8.12"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,7 @@ overrides:
   systeminformation: 5.31.5
   socket.io-parser: 4.2.6
   undici@>=7.0.0 <7.24.0: 7.24.4
+  '@xmldom/xmldom': 0.8.12
 
 importers:
 
@@ -5484,8 +5485,8 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.8.10':
-    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+  '@xmldom/xmldom@0.8.12':
+    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
@@ -13623,7 +13624,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.8.10':
+  '@xmldom/xmldom@0.8.12':
     optional: true
 
   '@xtuc/ieee754@1.2.0': {}
@@ -15332,7 +15333,7 @@ snapshots:
 
   mathml-to-latex@1.5.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.10
+      '@xmldom/xmldom': 0.8.12
     optional: true
 
   mdast-util-find-and-replace@3.0.2:


### PR DESCRIPTION
## Summary

- Fixes [Dependabot alert #149](https://github.com/giselles-ai/giselle/security/dependabot/149) (CVE-2026-34601, high severity)
- Bumps `@xmldom/xmldom` from 0.8.10 to 0.8.12 via `pnpm.overrides` to resolve an XML injection vulnerability via unsafe CDATA serialization
- `@xmldom/xmldom` is a transitive dependency of `mathml-to-latex`

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build-sdk` passes
- [x] `pnpm check-types` passes
- [x] CI passes

## Verification

`@xmldom/xmldom` is an internal dependency of `mathml-to-latex`. There is no direct impact on user-facing features. CI pass is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)