### PR TITLE
fix(deps): bump path-to-regexp from 8.3.0 to 8.4.2

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -10613,7 +10613,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="path-to-regexp"></a>
-### path-to-regexp v8.3.0
+### path-to-regexp v8.4.2
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
 			"systeminformation": "5.31.5",
 			"socket.io-parser": "4.2.6",
 			"undici@>=7.0.0 <7.24.0": "7.24.4",
-			"@xmldom/xmldom": "0.8.12"
+			"@xmldom/xmldom": "0.8.12",
+			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,7 @@ overrides:
   socket.io-parser: 4.2.6
   undici@>=7.0.0 <7.24.0: 7.24.4
   '@xmldom/xmldom': 0.8.12
+  path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
 
 importers:
 
@@ -7701,8 +7702,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -16056,7 +16057,7 @@ snapshots:
       lru-cache: 11.2.2
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -16738,7 +16739,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

- Fixes [Dependabot alert #144](https://github.com/giselles-ai/giselle/security/dependabot/144) (CVE-2026-4926, high severity)
- Bumps `path-to-regexp` from 8.3.0 to 8.4.2 via `pnpm.overrides` (scoped to `>=8.0.0 <8.4.0`) to resolve a Denial of Service vulnerability via sequential optional groups
- `path-to-regexp` is a transitive dependency of `router`

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build-sdk` passes
- [x] `pnpm check-types` passes
- [x] CI passes

## Verification

`path-to-regexp` is an internal dependency of `router`. There is no direct impact on user-facing features. CI pass is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency to a newer patch release and synchronized documentation to reflect the change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->