### PR TITLE
fix(deps): bump express-rate-limit from 8.2.1 to 8.2.2

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -7434,7 +7434,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="express-rate-limit"></a>
-### express-rate-limit v8.2.1
+### express-rate-limit v8.2.2
 #### 
 
 ##### Paths
@@ -8512,7 +8512,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="ip-address"></a>
-### ip-address v10.0.1
+### ip-address v10.1.0
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
 			"socket.io-parser": "4.2.6",
 			"undici@>=7.0.0 <7.24.0": "7.24.4",
 			"@xmldom/xmldom": "0.8.12",
-			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2"
+			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2",
+			"express-rate-limit": "8.2.2"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,7 @@ overrides:
   undici@>=7.0.0 <7.24.0: 7.24.4
   '@xmldom/xmldom': 0.8.12
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
+  express-rate-limit: 8.2.2
 
 importers:
 
@@ -6350,8 +6351,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.2.1:
-    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+  express-rate-limit@8.2.2:
+    resolution: {integrity: sha512-Ybv7bqtOgA914MLwaHWVFXMpMYeR1MQu/D+z2MaLYteqBsTIp9sY3AU7mGNLMJv8eLg8uQMpE20I+L2Lv49nSg==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -6783,8 +6784,8 @@ packages:
     resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -10688,7 +10689,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
+      express-rate-limit: 8.2.2(express@5.2.1)
       hono: 4.12.4
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -14409,10 +14410,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.2.1(express@5.2.1):
+  express-rate-limit@8.2.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.0.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -15018,7 +15019,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.0.1: {}
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary

- Fixes [Dependabot alert #116](https://github.com/giselles-ai/giselle/security/dependabot/116) (CVE-2026-30827, high severity)
- Bumps `express-rate-limit` from 8.2.1 to 8.2.2 via `pnpm.overrides` to resolve an IPv4-mapped IPv6 address bypass vulnerability in per-client rate limiting on dual-stack networks
- `express-rate-limit` is a transitive dependency of `@modelcontextprotocol/sdk`

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build-sdk` passes
- [x] `pnpm check-types` passes
- [x] CI passes

## Verification

`express-rate-limit` is an internal dependency of `@modelcontextprotocol/sdk`. There is no direct impact on user-facing features. CI pass is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documented dependency versions in package licensing documentation.
  * Updated dependency override configuration for `express-rate-limit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->