### PR TITLE
fix(ci): add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_issue_security_txt.yml
+++ b/.github/workflows/create_issue_security_txt.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 0 1 6,12 *" # Every year on 6/1 and 12/1 at 9:00am JST
 
+permissions: {}
+
 jobs:
   get_date:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
         description: 'Base URL for Playwright'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Changeset Check


### PR DESCRIPTION
## Summary

- Fixes code scanning alert [#20](https://github.com/giselles-ai/giselle/security/code-scanning/20), [#54](https://github.com/giselles-ai/giselle/security/code-scanning/54), [#55](https://github.com/giselles-ai/giselle/security/code-scanning/55), [#56](https://github.com/giselles-ai/giselle/security/code-scanning/56), [#57](https://github.com/giselles-ai/giselle/security/code-scanning/57) (CodeQL `actions/missing-workflow-permissions`, medium severity)
- Adds explicit `permissions` blocks to 5 workflows that were missing them, following the principle of least privilege:
  - `create_issue_security_txt.yml` — `permissions: {}` at workflow level (job-level permissions already set)
  - `ci.yml` — `contents: read`
  - `e2e.yml` — `contents: read`
  - `release-trigger-dev.yml` — `contents: read`
  - `release.yml` — `contents: write`, `pull-requests: write` (needed by changesets/action)

## Test plan

- [x] CI passes (validates `ci.yml` permissions are correct)
- [x] Verify other workflows still function (no permissions regressions)

## Verification

No user-facing changes. These are CI/CD security hardening changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened security posture in continuous integration workflows by implementing explicit access permission configurations. These changes ensure proper access control across build, test, and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->