### PR TITLE
add image format support and SVG handling documentation

### DIFF
--- a/docs/image-formats.md
+++ b/docs/image-formats.md
@@ -1,0 +1,46 @@
+# Image format support
+
+This document will explains supported image formats for vision inputs and limitations such as SVG handling.
+
+## Summary
+
+- Most vision models only support image formats such as PNG, JPEG, GIF, and WebP
+- SVG (`image/svg+xml`) is not supported by LLM providers generally
+- SVG uploads are sometimes accepted in this system however are ignored initially
+- This should be prevented or handled explicitly
+
+## Supported Formats 
+
+Currently the following types are supported:
+- `image/jpeg`
+- `image/png`
+- `image/gif`
+- `image/webp`
+
+These are compatible with major LLMs
+
+## Unsupported Format: SVG and why it is unsupported
+
+- SVG is not supported for vision inputs
+- SVG is a vector based (XML) based, LLMs only support pixel based images (JPEG, PNG etc)
+- If SVG is passed to a vision model it may result in an error
+
+## System behavoir prior to fixes
+
+- SVG files mayy still be uploaded through some UI components
+- In generation pipelines, SVG files are skipped and are not sent to the model
+- A warning may be logged but not visible to feedback
+
+Can result it:
+- file upload appearing succesful whilst the image is silently ignored
+
+## Approach to Fix
+
+- Remove SVG from image handling and handle as a unsupported dtype with a clear message or warning
+- Avoids confusion and ensures only supported formats are used.
+
+## After Fix, SVG Handling
+- SVG is not supported still
+- SVG files are explicitly excluded from image processing and will not be sent to LLMs
+- SVG has been intentionally removed from vision handling due to provider limitations
+

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -51,7 +51,7 @@ class InvalidFileTypeError extends FileUploadError {
 			case "image/png":
 			case "image/gif":
 			case "image/svg+xml":
-				return "Please use Image node to upload this file.";
+				return "SVG is not supported. Please use PNG/JPEG/GIF/WebP instead.";
 			case "application/pdf":
 				return "Please use PDF node to upload this file.";
 			case "text/plain":

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -15,7 +15,7 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 		label: "Text",
 	},
 	image: {
-		accept: ["image/png", "image/jpeg", "image/gif", "image/svg+xml"],
+		accept: ["image/png", "image/jpeg", "image/gif", "image/webp"],
 		label: "Image",
 	},
 };


### PR DESCRIPTION
This PR adds documentation explaining supported image formats for vision inputs and clarifies handling of unsupported SVG files.

Changes
Added docs/image-formats.md
Documented supported MIME types (JPEG, PNG, GIF, WebP)
Explained why SVG (image/svg+xml) is not supported
Provided recommended approaches for handling SVG inputs
Motivation

SVG support was removed from vision input handling due to provider limitations, but this behavior was not clearly documented. This update improves developer understanding and helps prevent common errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation outlining supported image formats (JPEG, PNG, GIF, WebP) and explicitly clarifying that SVG format is not supported by AI models.

* **Bug Fixes**
  * Improved error messaging when SVG files are uploaded, providing clear guidance on supported format alternatives.
  * Updated file upload filters to exclude SVG and enable WebP image support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->