### PR TITLE
chore: remove Google URL Context feature

### DIFF
--- a/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
+++ b/apps/studio.giselles.ai/app/workspaces/[workspaceId]/data-loader.ts
@@ -6,7 +6,6 @@ import {
 	aiGatewayFlag,
 	aiGatewayUnsupportedModelsFlag,
 	generateContentNodeFlag,
-	googleUrlContextFlag,
 	layoutV3Flag,
 	privatePreviewToolsFlag,
 	webSearchActionFlag,
@@ -59,7 +58,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 	const stage = true;
 	const aiGateway = await aiGatewayFlag();
 	const aiGatewayUnsupportedModels = await aiGatewayUnsupportedModelsFlag();
-	const googleUrlContext = await googleUrlContextFlag();
 	const data = await giselle.getWorkspace(workspaceId);
 	const generateContentNode = await generateContentNodeFlag();
 	const privatePreviewTools = await privatePreviewToolsFlag();
@@ -118,7 +116,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 		stage,
 		aiGateway,
 		aiGatewayUnsupportedModels,
-		googleUrlContext,
 		data,
 		documentVectorStores,
 		teamDataStores,
@@ -129,7 +126,6 @@ export async function dataLoader(workspaceId: WorkspaceId) {
 			stage,
 			aiGateway,
 			aiGatewayUnsupportedModels,
-			googleUrlContext,
 			generateContentNode,
 			privatePreviewTools,
 		},

--- a/apps/studio.giselles.ai/flags.ts
+++ b/apps/studio.giselles.ai/flags.ts
@@ -136,26 +136,6 @@ export const aiGatewayUnsupportedModelsFlag = flag<boolean>({
 	defaultValue: false,
 });
 
-export const googleUrlContextFlag = flag<boolean>({
-	key: "google-url-context",
-	async decide() {
-		if (process.env.NODE_ENV === "development") {
-			return takeLocalEnv("GOOGLE_URL_CONTEXT_FLAG");
-		}
-		const edgeConfig = await get(`flag__${this.key}`);
-		if (edgeConfig === undefined) {
-			return false;
-		}
-		return edgeConfig === true || edgeConfig === "true";
-	},
-	description: "Enable Google URL Context tool",
-	options: [
-		{ value: false, label: "disable" },
-		{ value: true, label: "Enable" },
-	],
-	defaultValue: false,
-});
-
 export const newEditorFlag = flag<boolean>({
 	key: "new-editor",
 	async decide() {

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/google.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/google.tsx
@@ -1,30 +1,21 @@
 import { Toggle } from "@giselle-internal/ui/toggle";
 import { GoogleLanguageModelData } from "@giselles-ai/protocol";
-import { useFeatureFlag, useUsageLimits } from "@giselles-ai/react";
-import { InfoIcon } from "lucide-react";
+import { useUsageLimits } from "@giselles-ai/react";
 import { TemperatureSlider, TopPSlider } from "./shared-model-controls";
 
 export function GoogleModelPanel({
 	googleLanguageModel,
 	onModelChange,
 	onSearchGroundingConfigurationChange,
-	onUrlContextConfigurationChange,
 }: {
 	googleLanguageModel: GoogleLanguageModelData;
 	onModelChange: (changedValue: GoogleLanguageModelData) => void;
 	onSearchGroundingConfigurationChange: (enabled: boolean) => void;
-	onUrlContextConfigurationChange: (enabled: boolean) => void;
 }) {
 	useUsageLimits();
-	const { googleUrlContext } = useFeatureFlag();
 
 	const isSearchGroundingEnabled =
 		googleLanguageModel.configurations.searchGrounding;
-	const isUrlContextEnabled =
-		googleUrlContext &&
-		(googleLanguageModel.configurations.urlContext ?? false);
-	const shouldShowMutualExclusionNotice =
-		isSearchGroundingEnabled || isUrlContextEnabled;
 
 	return (
 		<div className="flex flex-col gap-[16px]">
@@ -43,57 +34,16 @@ export function GoogleModelPanel({
 						parseModelData={GoogleLanguageModelData.parse}
 					/>
 				</div>
-				{googleUrlContext && shouldShowMutualExclusionNotice ? (
-					<div className="rounded-[8px] border border-yellow-500/40 bg-yellow-500/10 px-[12px] py-[8px] flex items-start gap-[8px]">
-						<InfoIcon
-							className="size-[16px] text-yellow-200 mt-[2px]"
-							aria-hidden
-						/>
-						<div className="flex flex-col gap-[4px] text-[12px] text-yellow-100">
-							{isSearchGroundingEnabled ? (
-								<span>
-									URL Context is unavailable while Search Grounding is active.
-								</span>
-							) : null}
-							{isUrlContextEnabled ? (
-								<span>
-									Search Grounding is unavailable while URL Context is active.
-								</span>
-							) : null}
-						</div>
-					</div>
-				) : null}
 				<div className="mt-[16px] flex flex-col gap-[16px]">
 					<Toggle
 						name="searchGrounding"
 						checked={isSearchGroundingEnabled}
-						onCheckedChange={(checked) => {
-							if (checked && isUrlContextEnabled) {
-								return;
-							}
-							onSearchGroundingConfigurationChange(checked);
-						}}
+						onCheckedChange={onSearchGroundingConfigurationChange}
 					>
 						<label htmlFor="searchGrounding" className="text-text text-[14px]">
 							Search Grounding
 						</label>
 					</Toggle>
-					{googleUrlContext ? (
-						<Toggle
-							name="urlContext"
-							checked={isUrlContextEnabled}
-							onCheckedChange={(checked) => {
-								if (checked && isSearchGroundingEnabled) {
-									return;
-								}
-								onUrlContextConfigurationChange(checked);
-							}}
-						>
-							<label htmlFor="urlContext" className="text-text text-[14px]">
-								URL Context
-							</label>
-						</Toggle>
-					) : null}
 				</div>
 			</div>
 		</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/google.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/google.tsx
@@ -1,6 +1,5 @@
 import { Toggle } from "@giselle-internal/ui/toggle";
 import { GoogleLanguageModelData } from "@giselles-ai/protocol";
-import { useUsageLimits } from "@giselles-ai/react";
 import { TemperatureSlider, TopPSlider } from "./shared-model-controls";
 
 export function GoogleModelPanel({
@@ -12,8 +11,6 @@ export function GoogleModelPanel({
 	onModelChange: (changedValue: GoogleLanguageModelData) => void;
 	onSearchGroundingConfigurationChange: (enabled: boolean) => void;
 }) {
-	useUsageLimits();
-
 	const isSearchGroundingEnabled =
 		googleLanguageModel.configurations.searchGrounding;
 

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/model-settings.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/model-settings.tsx
@@ -122,11 +122,7 @@ export function ModelSettings({
 
 	const updateOutputForGoogle = useCallback(
 		(googleSearch: boolean) => {
-			const sourceOutput = node.outputs.find((o) => o.accessor === "source");
-			if (googleSearch && sourceOutput) {
-				return;
-			}
-			if (googleSearch && !sourceOutput) {
+			if (googleSearch) {
 				onNodeChange({
 					outputs: [
 						...node.outputs,
@@ -135,6 +131,7 @@ export function ModelSettings({
 				});
 				return;
 			}
+			const sourceOutput = node.outputs.find((o) => o.accessor === "source");
 			for (const connection of connections) {
 				if (connection.outputId !== sourceOutput?.id) {
 					continue;

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/model-settings.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/model/model-settings.tsx
@@ -121,21 +121,12 @@ export function ModelSettings({
 	);
 
 	const updateOutputForGoogle = useCallback(
-		({
-			urlContext,
-			googleSearch,
-		}: {
-			urlContext: boolean;
-			googleSearch: boolean;
-		}) => {
+		(googleSearch: boolean) => {
 			const sourceOutput = node.outputs.find((o) => o.accessor === "source");
-			if (urlContext && googleSearch && sourceOutput) {
+			if (googleSearch && sourceOutput) {
 				return;
 			}
-			if ((urlContext || googleSearch) && sourceOutput) {
-				return;
-			}
-			if ((urlContext || googleSearch) && !sourceOutput) {
+			if (googleSearch && !sourceOutput) {
 				onNodeChange({
 					outputs: [
 						...node.outputs,
@@ -175,38 +166,9 @@ export function ModelSettings({
 					},
 				} satisfies GoogleLanguageModelData,
 			});
-			updateOutputForGoogle({
-				urlContext: result.data.configurations.urlContext,
-				googleSearch,
-			});
+			updateOutputForGoogle(googleSearch);
 		},
 		[node, onTextGenerationContentChange, updateOutputForGoogle],
-	);
-
-	const handleGoogleUrlContextChange = useCallback(
-		(urlContext: boolean) => {
-			const result = GoogleLanguageModelData.safeParse(node.content.llm);
-			if (result.error) {
-				console.warn(
-					`Error parsing GoogleLanguageModelData: ${node.content.llm}`,
-				);
-				return;
-			}
-			onTextGenerationContentChange({
-				llm: {
-					...result.data,
-					configurations: {
-						...result.data.configurations,
-						urlContext,
-					},
-				} satisfies GoogleLanguageModelData,
-			});
-			updateOutputForGoogle({
-				urlContext,
-				googleSearch: result.data.configurations.searchGrounding,
-			});
-		},
-		[node, updateOutputForGoogle, onTextGenerationContentChange],
 	);
 
 	const handleSelect = useCallback(
@@ -254,7 +216,6 @@ export function ModelSettings({
 						onSearchGroundingConfigurationChange={
 							handleGoogleSearchGroundingChange
 						}
-						onUrlContextConfigurationChange={handleGoogleUrlContextChange}
 						onModelChange={(value) =>
 							onTextGenerationContentChange({ llm: value })
 						}

--- a/packages/giselle/src/generations/generate-content.ts
+++ b/packages/giselle/src/generations/generate-content.ts
@@ -244,27 +244,6 @@ export function generateContent({
 				};
 			}
 			if (
-				operationNode.content.llm.provider === "google" &&
-				hasCapability(languageModel, Capability.UrlContext) &&
-				(operationNode.content.llm.configurations.urlContext ?? false)
-			) {
-				preparedToolSet = {
-					...preparedToolSet,
-					toolSet: {
-						...preparedToolSet.toolSet,
-						// Cast needed: urlContext returns Tool<{}, any> but ToolSet expects Tool<any, any>.
-						// This is a type mismatch in AI SDK where {} is not assignable to the ToolSet union type.
-						url_context: google.tools.urlContext({}) as Tool<
-							// biome-ignore lint/suspicious/noExplicitAny: AI SDK type compatibility workaround
-							any,
-							// biome-ignore lint/suspicious/noExplicitAny: AI SDK type compatibility workaround
-							any
-						>,
-					},
-				};
-			}
-
-			if (
 				operationNode.content.llm.provider === "anthropic" &&
 				operationNode.content.tools?.anthropicWebSearch
 			) {

--- a/packages/language-model/src/base.ts
+++ b/packages/language-model/src/base.ts
@@ -10,7 +10,6 @@ export const Capability = {
 	SearchGrounding: 1 << 6,
 	OptionalSearchGrounding: 1 << 7,
 	ImageGenerationInput: 1 << 8,
-	UrlContext: 1 << 9,
 } as const;
 
 export const Tier = z.enum(["free", "pro"]);

--- a/packages/language-model/src/google.ts
+++ b/packages/language-model/src/google.ts
@@ -7,7 +7,6 @@ const GoogleLanguageModelConfigurations = z.object({
 	temperature: z.number(),
 	topP: z.number(),
 	searchGrounding: z.boolean(),
-	urlContext: z.boolean().optional().default(false),
 });
 type GoogleLanguageModelConfigurations = z.infer<
 	typeof GoogleLanguageModelConfigurations
@@ -17,7 +16,6 @@ const defaultConfigurations: GoogleLanguageModelConfigurations = {
 	temperature: 0.7,
 	topP: 1.0,
 	searchGrounding: false,
-	urlContext: false,
 };
 
 const gemini31ProPreviewPattern = /^gemini-3\.1-pro(?:-preview)?(?:-[\w-]+)?$/;
@@ -73,7 +71,6 @@ const gemini31ProPreview: GoogleLanguageModel = {
 		Capability.TextGeneration |
 		Capability.GenericFileInput |
 		Capability.OptionalSearchGrounding |
-		Capability.UrlContext |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
@@ -86,7 +83,6 @@ const gemini3ProPreview: GoogleLanguageModel = {
 		Capability.TextGeneration |
 		Capability.GenericFileInput |
 		Capability.OptionalSearchGrounding |
-		Capability.UrlContext |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
@@ -99,7 +95,6 @@ const gemini3Flash: GoogleLanguageModel = {
 		Capability.TextGeneration |
 		Capability.GenericFileInput |
 		Capability.OptionalSearchGrounding |
-		Capability.UrlContext |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
@@ -112,7 +107,6 @@ const gemini25Pro: GoogleLanguageModel = {
 		Capability.TextGeneration |
 		Capability.GenericFileInput |
 		Capability.OptionalSearchGrounding |
-		Capability.UrlContext |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
@@ -125,7 +119,6 @@ const gemini25Flash: GoogleLanguageModel = {
 		Capability.TextGeneration |
 		Capability.GenericFileInput |
 		Capability.OptionalSearchGrounding |
-		Capability.UrlContext |
 		Capability.Reasoning,
 	tier: Tier.enum.pro,
 	configurations: defaultConfigurations,
@@ -137,7 +130,6 @@ const gemini25FlashLite: GoogleLanguageModel = {
 	capabilities:
 		Capability.TextGeneration |
 		Capability.OptionalSearchGrounding |
-		Capability.UrlContext |
 		Capability.GenericFileInput,
 	tier: Tier.enum.free,
 	configurations: defaultConfigurations,

--- a/packages/node-registry/src/__fixtures__/node-conversion/nodes.ts
+++ b/packages/node-registry/src/__fixtures__/node-conversion/nodes.ts
@@ -222,7 +222,6 @@ export const googleGemini = {
 				temperature: 0.7,
 				topP: 1,
 				searchGrounding: true,
-				urlContext: false,
 			},
 		},
 		prompt:

--- a/packages/node-registry/src/node-conversion.ts
+++ b/packages/node-registry/src/node-conversion.ts
@@ -260,7 +260,6 @@ export function convertContentGenerationToTextGeneration(
 					temperature: 0.7,
 					topP: 1.0,
 					searchGrounding: false,
-					urlContext: false,
 				},
 			};
 			break;

--- a/packages/react/src/feature-flags/context.ts
+++ b/packages/react/src/feature-flags/context.ts
@@ -6,7 +6,6 @@ export interface FeatureFlagContextValue {
 	stage: boolean;
 	aiGateway: boolean;
 	aiGatewayUnsupportedModels: boolean;
-	googleUrlContext: boolean;
 	generateContentNode: boolean;
 	privatePreviewTools: boolean;
 }

--- a/packages/react/src/workspace/provider.tsx
+++ b/packages/react/src/workspace/provider.tsx
@@ -53,7 +53,6 @@ export function WorkspaceProvider({
 				aiGateway: featureFlag?.aiGateway ?? false,
 				aiGatewayUnsupportedModels:
 					featureFlag?.aiGatewayUnsupportedModels ?? false,
-				googleUrlContext: featureFlag?.googleUrlContext ?? false,
 				generateContentNode: featureFlag?.generateContentNode ?? false,
 				privatePreviewTools: featureFlag?.privatePreviewTools ?? false,
 			}}


### PR DESCRIPTION
## Summary

- Delete the Google URL Context tool and its feature flag. The feature will not be released, so the code is removed rather than left gated.
- Scope covers every layer: studio flag + data loader, `@giselles-ai/react` feature-flag context, `@giselles-ai/language-model` capability + Google config schema, `@giselles-ai/giselle` tool wiring, node-registry defaults/fixture, and the workflow-designer Google model panel.
- Existing workspaces persisted with \`configurations.urlContext: true\` silently drop the field on reparse (zod non-strict), so no data migration is needed.

## Test plan

- [x] \`pnpm format\`
- [x] \`pnpm build-sdk\`
- [x] \`pnpm check-types\`
- [x] \`pnpm tidy\`
- [x] \`pnpm test\` (all packages pass)
- [ ] Manual: open a Google (Gemini) text-generation node and confirm only the Search Grounding toggle appears, and that toggling it still adds/removes the \`source\` output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed Google URL Context tool support and related UI controls across the app.
  * Eliminated URL Context options from Google model configurations and capability listings.
  * Simplified Google model settings so Search Grounding is the primary grounding option.
  * Removed the corresponding feature flag and cleaned up exposed feature-flag surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->