### PR TITLE
feat(studio): support partial and full maintenance modes

### DIFF
--- a/apps/studio.giselles.ai/lib/supabase/middleware.ts
+++ b/apps/studio.giselles.ai/lib/supabase/middleware.ts
@@ -2,11 +2,13 @@ import type { User } from "@supabase/auth-js";
 import { type NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "./create-server-client";
 
+type GuardResult = NextResponse | undefined;
+
 export const supabaseMiddleware = (
 	guardCallback?: (
 		user: User | null,
 		request: NextRequest,
-	) => Promise<NextResponse | undefined>,
+	) => GuardResult | Promise<GuardResult>,
 ) => {
 	return async (request: NextRequest) => {
 		// Dev safeguard: If Supabase env vars are not set locally, skip auth wiring
@@ -52,7 +54,7 @@ export const supabaseMiddleware = (
 		const {
 			data: { user },
 		} = await supabase.auth.getUser();
-		const response = guardCallback?.(user, request);
+		const response = await guardCallback?.(user, request);
 		if (response != null) {
 			return response;
 		}

--- a/apps/studio.giselles.ai/proxy.ts
+++ b/apps/studio.giselles.ai/proxy.ts
@@ -1,27 +1,74 @@
 import { get } from "@vercel/edge-config";
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { supabaseMiddleware } from "./lib/supabase";
 
-export const proxy = supabaseMiddleware(async (user, request) => {
-	const maintenance = await get("maintenance");
-	if (maintenance) {
-		request.nextUrl.pathname = "/maintenance";
+// Paths that continue to serve traffic during `partial` maintenance: webhook
+// receivers, auth flows, public marketing pages, and internal APIs. They also
+// bypass the normal login redirect.
+const PARTIAL_MAINTENANCE_BYPASS_PREFIXES = [
+	"/webhooks",
+	"/legal",
+	"/login",
+	"/signup",
+	"/join",
+	"/pricing",
+	"/password_reset",
+	"/auth",
+	"/api/vector-stores/cron",
+	"/api/apps",
+	"/agent-api",
+];
 
-		// Rewrite to the url
-		return NextResponse.rewrite(request.nextUrl);
+function isPartialMaintenanceBypassed(pathname: string): boolean {
+	return PARTIAL_MAINTENANCE_BYPASS_PREFIXES.some(
+		(prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+	);
+}
+
+type MaintenanceMode = "partial" | "full";
+
+function parseMaintenanceMode(value: unknown): MaintenanceMode | undefined {
+	if (value === "full" || value === "partial") {
+		return value;
 	}
-	if (user == null) {
-		// no user, potentially respond by redirecting the user to the login page
-		const url = request.nextUrl.clone();
-		const returnUrl = request.nextUrl.pathname + request.nextUrl.search;
-		url.pathname = "/login";
-		url.searchParams.set("returnUrl", returnUrl);
-		return NextResponse.redirect(url);
+	return undefined;
+}
+
+function rewriteToMaintenance(request: NextRequest) {
+	request.nextUrl.pathname = "/maintenance";
+	return NextResponse.rewrite(request.nextUrl);
+}
+
+export const proxy = async (request: NextRequest) => {
+	const maintenance = parseMaintenanceMode(await get("maintenance"));
+
+	if (maintenance === "full") {
+		return rewriteToMaintenance(request);
 	}
-});
+
+	const bypassed = isPartialMaintenanceBypassed(request.nextUrl.pathname);
+
+	if (maintenance === "partial" && !bypassed) {
+		return rewriteToMaintenance(request);
+	}
+
+	if (bypassed) {
+		return NextResponse.next();
+	}
+
+	return supabaseMiddleware((user, req) => {
+		if (user == null) {
+			const url = req.nextUrl.clone();
+			const returnUrl = req.nextUrl.pathname + req.nextUrl.search;
+			url.pathname = "/login";
+			url.searchParams.set("returnUrl", returnUrl);
+			return NextResponse.redirect(url);
+		}
+	})(request);
+};
 
 export const config = {
 	matcher: [
-		"/((?!_next/static|_next/image|.well-known|webhooks|legal|login|signup|join|pricing|password_reset|auth|api/vector-stores/cron|api/apps|agent-api|robots\\.txt|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+		"/((?!_next/static|_next/image|.well-known|robots\\.txt|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
 	],
 };


### PR DESCRIPTION
## Summary

- Switch the \`maintenance\` Edge Config key from a boolean toggle to an explicit mode string:
  - \`"partial"\` — keep existing behavior: block the general UI but let auth, webhooks, pricing, legal, and public APIs keep serving traffic.
  - \`"full"\` — rewrite every request (except truly static assets) to the maintenance page, for security-incident responses where even webhooks and auth should be frozen.
- Collapse the two modes into a single middleware: the matcher now only excludes static assets, and the per-path bypass list moves into \`PARTIAL_MAINTENANCE_BYPASS_PREFIXES\` inside \`proxy.ts\`.
- Widen \`supabaseMiddleware\`'s guard callback to accept sync or async returns and \`await\` the result — previously an async callback returning \`undefined\` was coerced to a truthy Promise and the \`supabaseResponse\` fallthrough was unreachable.

## Switching

Edge Config changes are runtime-only (no deploy needed):

- Partial maintenance → set key \`maintenance\` to \`"partial"\`
- Full maintenance → set key \`maintenance\` to \`"full"\`
- Resume → delete the key or set any other value

## Breaking change

A legacy \`maintenance: true\` (boolean) value in Edge Config is now treated as off. Use \`"partial"\` or \`"full"\` strings instead.

## Test plan

- [x] \`pnpm format\`
- [x] \`pnpm check-types\`
- [x] \`pnpm test\`
- [ ] Preview: hit a maintenance-bypassed route (\`/login\`, \`/webhooks/...\`) with no \`maintenance\` key → loads normally
- [ ] Preview: set \`maintenance=partial\` → \`/\` and app routes show maintenance page; \`/login\`, \`/pricing\`, \`/webhooks/...\`, \`/api/apps/...\` still respond
- [ ] Preview: set \`maintenance=full\` → every request (including \`/login\` and webhooks) rewrites to maintenance page; static assets still served
- [ ] Preview: after clearing the key, verify the login redirect for unauthenticated users still fires for protected routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced request middleware architecture with improved callback handling
  * Improved maintenance mode system with selective route bypass capability, allowing critical paths (auth, webhooks, legal pages) to remain accessible during partial maintenance while non-essential routes display maintenance status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->