### PR TITLE
chore: drop unused NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY from .env.example

### DIFF
--- a/apps/studio.giselles.ai/.env.example
+++ b/apps/studio.giselles.ai/.env.example
@@ -51,7 +51,6 @@ SENTRY_AUTH_TOKEN=
 # Stripe https://stripe.com/
 # @see https://docs.stripe.com/keys
 STRIPE_SECRET_KEY=
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_PRO_PLAN_PRICE_ID=
 # Stripe Pricing Plans v2 (preview API)
 STRIPE_PRO_PRICING_PLAN_ID=


### PR DESCRIPTION
## Summary

- No client-side Stripe.js (\`@stripe/stripe-js\`) is installed — the subscription flow uses Stripe-hosted Checkout via a server-triggered redirect, which never needs a publishable key on the browser.
- Nothing in the codebase reads \`NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\`.
- Drop the entry from \`.env.example\` so new contributors do not provision a Vercel env var nothing consumes.

## Test plan

- [x] \`pnpm format\`
- [x] \`pnpm check-types\`
- [x] \`pnpm test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused environment variable configuration from the application setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->