### PR TITLE
chore: drop stale SIGNOZ_* passthrough entries

### DIFF
--- a/packages/github-tool/turbo.json
+++ b/packages/github-tool/turbo.json
@@ -11,7 +11,6 @@
 				"LANGFUSE_*",
 				"POSTGRES_*",
 				"REDIS_URL",
-				"SIGNOZ_*",
 				"STRIPE_*",
 				"SMTP_*",
 				"SUPABASE_*",

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,6 @@
 				"LANGFUSE_*",
 				"POSTGRES_*",
 				"REDIS_URL",
-				"SIGNOZ_*",
 				"STRIPE_*",
 				"SMTP_*",
 				"SUPABASE_*",


### PR DESCRIPTION
## Summary

- The SigNoz / OpenTelemetry integration was removed in \`caf75cc79\` (\"Remove unused files and dead code\", 2025-07-16) together with the \`lib/opentelemetry\` directory.
- \`.env.example\` was cleaned in \`c44e140a8\` (2025-08-12).
- Nothing in the codebase reads \`process.env.SIGNOZ_*\` any longer, so drop the matching passthrough entries from \`turbo.json\` and \`packages/github-tool/turbo.json\`.

## Test plan

- [x] \`pnpm format\`
- [x] \`pnpm check-types\`
- [x] \`pnpm test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused environment variable configuration from build system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->