### PR TITLE
fix(deps): bump @xmldom/xmldom from 0.8.12 to 0.8.13

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -5560,7 +5560,7 @@ FSL-1.1-MIT manually approved
 
 
 <a name="@xmldom/xmldom"></a>
-### @xmldom/xmldom v0.8.12
+### @xmldom/xmldom v0.8.13
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 			"systeminformation": "5.31.5",
 			"socket.io-parser": "4.2.6",
 			"undici@>=7.0.0 <7.24.0": "7.24.4",
-			"@xmldom/xmldom": "0.8.12",
+			"@xmldom/xmldom": "0.8.13",
 			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2",
 			"express-rate-limit": "8.2.2"
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,7 +285,7 @@ overrides:
   systeminformation: 5.31.5
   socket.io-parser: 4.2.6
   undici@>=7.0.0 <7.24.0: 7.24.4
-  '@xmldom/xmldom': 0.8.12
+  '@xmldom/xmldom': 0.8.13
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
   express-rate-limit: 8.2.2
 
@@ -5326,8 +5326,8 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
@@ -13391,7 +13391,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.8.12':
+  '@xmldom/xmldom@0.8.13':
     optional: true
 
   '@xtuc/ieee754@1.2.0': {}
@@ -15068,7 +15068,7 @@ snapshots:
 
   mathml-to-latex@1.5.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
     optional: true
 
   mdast-util-find-and-replace@3.0.2:


### PR DESCRIPTION
## Summary
Bumps the pinned pnpm override for `@xmldom/xmldom` from `0.8.12` to `0.8.13` to resolve four high-severity advisories. `@xmldom/xmldom` is pulled in only as an optional transitive dependency via `mathml-to-latex`.

## Advisories resolved
- https://github.com/giselles-ai/giselle/security/dependabot/170 — GHSA-f6ww-3ggp-fr8h (CVE-2026-41674) XML injection via `DocumentType` serialization
- https://github.com/giselles-ai/giselle/security/dependabot/171 — GHSA-x6wf-f3px-wcqx (CVE-2026-41675) XML node injection via processing-instruction serialization
- https://github.com/giselles-ai/giselle/security/dependabot/172 — GHSA-j759-j44w-7fr8 (CVE-2026-41672) XML node injection via comment serialization
- https://github.com/giselles-ai/giselle/security/dependabot/173 — GHSA-2v35-w6hq-6mfw (CVE-2026-41673) DoS via uncontrolled recursion during XML serialization

`0.8.13` is the first patched release on the 0.8.x line.

## Test plan
- [x] `pnpm install` (lockfile regenerated — only `@xmldom/xmldom` entries changed)
- [x] `pnpm format`
- [x] `pnpm build-sdk`
- [x] `pnpm check-types`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped XML handling library override from 0.8.12 to 0.8.13; package resolution and documentation now reflect the updated patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->