### PR TITLE
refactor(studio): wire Sentry source-map uploads to env vars

### DIFF
--- a/apps/studio.giselles.ai/next.config.ts
+++ b/apps/studio.giselles.ai/next.config.ts
@@ -110,9 +110,6 @@ const sentryBuildOptions: SentryBuildOptions = {
 	// For all available options, see:
 	// https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
-	org: "route06cojp",
-	project: "edge",
-
 	// Only print logs for uploading source maps in CI
 	silent: !process.env.CI,
 

--- a/apps/studio.giselles.ai/next.config.ts
+++ b/apps/studio.giselles.ai/next.config.ts
@@ -110,6 +110,13 @@ const sentryBuildOptions: SentryBuildOptions = {
 	// For all available options, see:
 	// https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
+	// Source-map upload targets — read from env so deployments opt in by
+	// providing SENTRY_ORG / SENTRY_PROJECT / SENTRY_AUTH_TOKEN. Undefined
+	// values skip upload (plugin emits a warning, build continues).
+	org: process.env.SENTRY_ORG,
+	project: process.env.SENTRY_PROJECT,
+	authToken: process.env.SENTRY_AUTH_TOKEN,
+
 	// Only print logs for uploading source maps in CI
 	silent: !process.env.CI,
 


### PR DESCRIPTION
## Summary
Replaces the hardcoded \`org: \"route06cojp\"\` and \`project: \"edge\"\` in \`apps/studio.giselles.ai/next.config.ts\` with env-driven reads. Also adds explicit \`authToken: process.env.SENTRY_AUTH_TOKEN\` so all three build-time inputs are visible in the config.

## Why
- The Vercel-side \`SENTRY_ORG\`, \`SENTRY_PROJECT\`, and \`SENTRY_AUTH_TOKEN\` values were removed as part of the broader Sentry env-var cleanup. With the values hardcoded but no token, source-map upload would silently skip — the code's intent and the deployment reality diverged.
- The Sentry webpack plugin already falls back to these env vars implicitly, but relying on implicit behavior makes the config harder to read. This change makes the env dependency explicit.

## Behavior after this PR
- \`SENTRY_ENABLE=true\` **+** \`SENTRY_ORG\` / \`SENTRY_PROJECT\` / \`SENTRY_AUTH_TOKEN\` all set → source-map upload works as before.
- \`SENTRY_ENABLE=true\` **+** any of org/project/token missing → upload skipped with a warning, build continues, runtime error capture via the hardcoded DSN is unaffected.
- \`SENTRY_ENABLE\` unset or not \`\"true\"\` → Sentry integration bypassed entirely, as before.

## Test plan
- [x] \`pnpm format\`
- [x] \`pnpm build-sdk\`
- [x] \`pnpm check-types\`
- [x] \`pnpm test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Sentry configuration now reads organization, project, and auth token from environment variables. Source-map upload behavior is now deployment-dependent; if those values are absent, uploads are skipped but builds continue normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->