### PR TITLE
chore(studio): rename GTM_ID to NEXT_PUBLIC_GTM_ID

### DIFF
--- a/apps/studio.giselles.ai/.env.example
+++ b/apps/studio.giselles.ai/.env.example
@@ -17,7 +17,7 @@ FLAGS_SECRET=
 
 # Google Tag Manager https://tagmanager.google.com/
 # @see https://support.google.com/tagmanager/answer/6102821
-GTM_ID=
+NEXT_PUBLIC_GTM_ID=
 
 # Langfuse https://langfuse.com/
 # @see https://langfuse.com/docs/get-started

--- a/apps/studio.giselles.ai/app/layout.tsx
+++ b/apps/studio.giselles.ai/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
 			suppressHydrationWarning
 			className={`${dmSans.variable} ${dmMono.variable}`}
 		>
-			<GoogleTagManager gtmId={process.env.GTM_ID ?? ""} />
+			<GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID ?? ""} />
 			<PHProvider>
 				<body>
 					<ThemeProvider

--- a/packages/github-tool/turbo.json
+++ b/packages/github-tool/turbo.json
@@ -14,7 +14,7 @@
 				"STRIPE_*",
 				"SMTP_*",
 				"SUPABASE_*",
-				"GTM_ID",
+				"NEXT_PUBLIC_GTM_ID",
 				"SENTRY_*",
 				"INTERNAL_USER_EMAIL_DOMAIN",
 				"OFFICIAL_VECTOR_STORE_TEAM_DB_ID",

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
 				"STRIPE_*",
 				"SMTP_*",
 				"SUPABASE_*",
-				"GTM_ID",
+				"NEXT_PUBLIC_GTM_ID",
 				"SENTRY_*",
 				"INTERNAL_USER_EMAIL_DOMAIN",
 				"OFFICIAL_VECTOR_STORE_TEAM_DB_ID",


### PR DESCRIPTION
## Summary
Rename \`GTM_ID\` → \`NEXT_PUBLIC_GTM_ID\` to make the public nature of the Google Tag Manager container ID explicit at the env-var level.

The GTM container ID is embedded into the client HTML via \`<GoogleTagManager gtmId={...} />\` in the root layout — it is a public identifier, not a secret. Matching the \`NEXT_PUBLIC_\` convention aligns it with \`NEXT_PUBLIC_SITE_URL\`, \`NEXT_PUBLIC_SUPABASE_*\`, and the other public env vars in this project.

## Changes
- \`apps/studio.giselles.ai/app/layout.tsx\` — read from \`process.env.NEXT_PUBLIC_GTM_ID\`.
- \`turbo.json\` / \`packages/github-tool/turbo.json\` — update the Turborepo passthrough entry so build-cache invalidation continues to track value changes.

## Deployment sequencing (zero-downtime)
1. ✅ \`NEXT_PUBLIC_GTM_ID\` already added to Vercel for Production / Preview / Development with the same value as the existing \`GTM_ID\`.
2. 🟡 Merge this PR and let the production deploy settle.
3. 🟡 Remove the legacy \`GTM_ID\` entry from Vercel once the new name is confirmed in production.

## Test plan
- [x] \`pnpm format\`
- [x] \`pnpm build-sdk\`
- [x] \`pnpm check-types\`
- [x] \`pnpm test\`
- [ ] Post-deploy: confirm \`window.dataLayer\` and the GTM script load on a production page (sanity check via DevTools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Google Tag Manager environment variable across app, build, and tooling to the NEXT_PUBLIC_ prefixed key, and updated example env template to match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->