### PR TITLE
fix: remove commented-out JSX block in glass-button component

### DIFF
--- a/apps/studio.giselles.ai/components/ui/glass-button.tsx
+++ b/apps/studio.giselles.ai/components/ui/glass-button.tsx
@@ -68,15 +68,6 @@ const GlassButton = React.forwardRef<HTMLButtonElement, GlassButtonProps>(
 					style={{ backgroundColor: "#6B8FF0", opacity: 0.08 }}
 				/>
 
-				{/* Main glass background */}
-				{/*<div
-					className="absolute inset-0 rounded-lg backdrop-blur-md"
-					style={{
-						background:
-							"linear-gradient(135deg, rgba(255,255,255,0.15) 0%, rgba(107,143,240,0.1) 50%, rgba(107,143,240,0.2) 100%)",
-					}}
-				/>*/}
-
 				{/* Top reflection */}
 				<div className="absolute top-0 left-4 right-4 h-px bg-gradient-to-r from-transparent via-white/60 to-transparent" />
 


### PR DESCRIPTION
## Summary
Removes the commented-out \"Main glass background\" div from the `GlassButton` component. The block serves no purpose and reduces code clarity.

## Related Issue
Closes #2387

## Changes
- Deleted the commented-out `<div>` block (lines 71–78) in `apps/studio.giselles.ai/components/ui/glass-button.tsx`

## Testing
No functional change — dead code removal only. Verified `biome check` passes with no errors.

## Other Information
The element was flagged as leftover debugging/refactoring artifact. If intentionally removed, the comment block should be deleted rather than left in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up unused code in button component styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->