### PR TITLE
fix(studio): only set stripe-restricted-access-key header when env var is present

### DIFF
--- a/apps/studio.giselles.ai/app/giselle.ts
+++ b/apps/studio.giselles.ai/app/giselle.ts
@@ -422,8 +422,10 @@ const callbacks: GiselleCallbacks = {
 		};
 		if (stripeCustomerId !== undefined) {
 			aiGatewayHeaders["stripe-customer-id"] = stripeCustomerId;
-			aiGatewayHeaders["stripe-restricted-access-key"] =
-				process.env.STRIPE_AI_GATEWAY_RESTRICTED_ACCESS_KEY ?? "";
+			if (process.env.STRIPE_AI_GATEWAY_RESTRICTED_ACCESS_KEY) {
+				aiGatewayHeaders["stripe-restricted-access-key"] =
+					process.env.STRIPE_AI_GATEWAY_RESTRICTED_ACCESS_KEY;
+			}
 		} else if (teamPlan === "pro" || teamPlan === "team") {
 			logger.warn(
 				`Stripe customer ID not found for generation ${generation.id}`,

--- a/apps/studio.giselles.ai/lib/vector-stores/shared/ai-gateway-headers.ts
+++ b/apps/studio.giselles.ai/lib/vector-stores/shared/ai-gateway-headers.ts
@@ -17,8 +17,10 @@ export function buildAiGatewayHeaders(
 	const stripeCustomerId = team?.activeCustomerId ?? undefined;
 	if (stripeCustomerId !== undefined) {
 		headers["stripe-customer-id"] = stripeCustomerId;
-		headers["stripe-restricted-access-key"] =
-			process.env.STRIPE_AI_GATEWAY_RESTRICTED_ACCESS_KEY ?? "";
+		if (process.env.STRIPE_AI_GATEWAY_RESTRICTED_ACCESS_KEY) {
+			headers["stripe-restricted-access-key"] =
+				process.env.STRIPE_AI_GATEWAY_RESTRICTED_ACCESS_KEY;
+		}
 	} else if (team?.plan === "pro" || team?.plan === "team") {
 		console.warn(
 			`Stripe customer ID not found for vector store ingest (team: ${team?.id})`,


### PR DESCRIPTION
## Summary
Guards the `stripe-restricted-access-key` AI Gateway header so it is only set when `STRIPE_AI_GATEWAY_RESTRICTED_ACCESS_KEY` has an actual value. Previously, using `?? ""` sent an empty authentication header when the env var was absent, which could cause authentication failures or unexpected behavior at the gateway.

## Related Issue
Closes #2255

## Changes
- `apps/studio.giselles.ai/app/giselle.ts`: wrap `stripe-restricted-access-key` assignment in a truthiness check, consistent with the conditional pattern already used for `stripe-customer-id`

## Testing
No behaviour change when the env var is set. When absent, the header is now omitted rather than sent as an empty string.

## Other Information
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API request headers no longer include an empty Stripe restricted-access header when the corresponding environment variable is unset; only populated headers with valid values are sent, while existing Stripe customer ID behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->