### PR TITLE
fix(studio): validate parseInt results to guard against NaN in stripe webhook

### DIFF
--- a/apps/studio.giselles.ai/app/webhooks/stripe/handle-pricing-plan-subscription.ts
+++ b/apps/studio.giselles.ai/app/webhooks/stripe/handle-pricing-plan-subscription.ts
@@ -94,7 +94,7 @@ export async function handlePricingPlanServicingActivated(event: Stripe.Event) {
 				);
 				if (Number.isNaN(teamDbId)) {
 					throw new Error(
-						`Invalid teamDbId in metadata: ${metadata[UPGRADING_TEAM_DB_ID_KEY]}`,
+						`Invalid teamDbId in metadata[${UPGRADING_TEAM_DB_ID_KEY}]: ${metadata[UPGRADING_TEAM_DB_ID_KEY]}`,
 					);
 				}
 				await upgradeExistingTeam(
@@ -115,7 +115,7 @@ export async function handlePricingPlanServicingActivated(event: Stripe.Event) {
 				);
 				if (Number.isNaN(userDbId)) {
 					throw new Error(
-						`Invalid userDbId in metadata: ${metadata[DRAFT_TEAM_USER_DB_ID_METADATA_KEY]}`,
+						`Invalid userDbId in metadata[${DRAFT_TEAM_USER_DB_ID_METADATA_KEY}]: ${metadata[DRAFT_TEAM_USER_DB_ID_METADATA_KEY]}`,
 					);
 				}
 				await createNewProTeam(

--- a/apps/studio.giselles.ai/app/webhooks/stripe/handle-pricing-plan-subscription.ts
+++ b/apps/studio.giselles.ai/app/webhooks/stripe/handle-pricing-plan-subscription.ts
@@ -92,6 +92,11 @@ export async function handlePricingPlanServicingActivated(event: Stripe.Event) {
 					metadata[UPGRADING_TEAM_DB_ID_KEY],
 					10,
 				);
+				if (Number.isNaN(teamDbId)) {
+					throw new Error(
+						`Invalid teamDbId in metadata: ${metadata[UPGRADING_TEAM_DB_ID_KEY]}`,
+					);
+				}
 				await upgradeExistingTeam(
 					tx,
 					subscription,
@@ -108,6 +113,11 @@ export async function handlePricingPlanServicingActivated(event: Stripe.Event) {
 					metadata[DRAFT_TEAM_USER_DB_ID_METADATA_KEY],
 					10,
 				);
+				if (Number.isNaN(userDbId)) {
+					throw new Error(
+						`Invalid userDbId in metadata: ${metadata[DRAFT_TEAM_USER_DB_ID_METADATA_KEY]}`,
+					);
+				}
 				await createNewProTeam(
 					tx,
 					subscription,


### PR DESCRIPTION
## Summary
Adds `Number.isNaN` validation after `Number.parseInt` calls in the Stripe pricing plan subscription webhook handler. Without this guard, malformed metadata strings silently propagate `NaN` into DB operations.

## Related Issue
Closes #2294

## Changes
- `apps/studio.giselles.ai/app/webhooks/stripe/handle-pricing-plan-subscription.ts`: after parsing `teamDbId` and `userDbId`, throw a descriptive error when `Number.isNaN` returns `true`, including the metadata key name and raw value

## Testing
Existing webhook tests cover the happy path. The new guards throw before any DB call when metadata values are non-numeric, preventing silent corruption.

## Other Information
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for subscription activation flows: the system now verifies parsed team and user identifiers from payment metadata and halts processing with clearer error messages if values are invalid, preventing downstream operations on malformed subscription data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->