### PR TITLE
fix(studio): prevent CheckIcon and LoaderIcon from overlapping in TeamSwitchButton

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/ui/header/team-switch-button.tsx
+++ b/apps/studio.giselles.ai/app/(main)/ui/header/team-switch-button.tsx
@@ -46,7 +46,7 @@ export function TeamSwitchButton({
 				</span>
 				{isPro ? <ProTag /> : <FreeTag />}
 			</div>
-			{isCurrentTeam && (
+			{isCurrentTeam && !pending && (
 				<span className="absolute right-2 left-auto flex h-3.5 w-3.5 items-center justify-center">
 					<CheckIcon className="h-4 w-6" />
 				</span>


### PR DESCRIPTION
## Summary
Fixes a visual overlap bug in `TeamSwitchButton` where clicking the already-selected team causes both the `CheckIcon` and `LoaderIcon` to render at the same absolute position (`right-2`), stacking on top of each other during the transition.

## Related Issue
Closes #2385

## Changes
- `apps/studio.giselles.ai/app/(main)/ui/header/team-switch-button.tsx`: add `&& !pending` to the `isCurrentTeam` condition so the `CheckIcon` is hidden while a transition is in progress, making the two icon conditions mutually exclusive

## Testing
Click the currently-active team in the team switcher. The `CheckIcon` disappears and only the `LoaderIcon` spins during the transition. After the transition completes, `CheckIcon` reappears and `LoaderIcon` is gone.

## Other Information
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team selection now correctly displays a loading indicator during team transitions, providing clearer visual feedback when switching teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->