### PR TITLE
refactor: eliminate duplicate code in ImageGeneration and TextGeneration panels

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx
@@ -5,21 +5,11 @@ import { Maximize2 } from "lucide-react";
 import { useCallback } from "react";
 import { useAppDesignerStore } from "../../../app-designer";
 import { GenerateImageIcon } from "../../../icons";
-import { EmptyState } from "../../../ui/empty-state";
 import { GenerationView } from "../../../ui/generation-view";
-
-function Empty() {
-	return (
-		<div className="relative bg-[color-mix(in_srgb,var(--color-text-inverse,#fff)_10%,transparent)] min-h-[250px] rounded-[8px] flex justify-center items-center text-text-muted">
-			<EmptyState
-				icon={<GenerateImageIcon width={24} height={24} />}
-				title="Nothing generated yet."
-				description="Generate or adjust the Prompt to see results."
-				className="text-text-muted"
-			/>
-		</div>
-	);
-}
+import {
+	GenerationEmptyState,
+	GenerationStatusHeader,
+} from "../ui";
 
 export function GenerationPanel({
 	node,
@@ -45,7 +35,13 @@ export function GenerationPanel({
 	}, [onClickGenerateButton]);
 
 	if (currentGeneration === undefined) {
-		return <Empty />;
+		return (
+			<GenerationEmptyState
+				icon={<GenerateImageIcon width={24} height={24} />}
+				minHeight="min-h-[250px]"
+				paddingY=""
+			/>
+		);
 	}
 	return (
 		<div
@@ -64,25 +60,7 @@ export function GenerationPanel({
 					<Maximize2 className="size-[16px] text-inverse group-hover:text-inverse/80" />
 				</button>
 			)}
-			<div
-				className={clsx(
-					"border-b border-white-400/20 py-[4px] px-[16px] flex items-center gap-[8px]",
-					"**:data-header-text:font-[700]",
-				)}
-			>
-				{(currentGeneration.status === "created" ||
-					currentGeneration.status === "queued" ||
-					currentGeneration.status === "running") && (
-					<p data-header-text>Generating...</p>
-				)}
-				{currentGeneration.status === "completed" && (
-					<p data-header-text>Result</p>
-				)}
-				{currentGeneration.status === "failed" && <p data-header-text>Error</p>}
-				{currentGeneration.status === "cancelled" && (
-					<p data-header-text>Result</p>
-				)}
-			</div>
+			<GenerationStatusHeader generation={currentGeneration} />
 			<div className="flex-1 py-[4px] px-[16px] overflow-y-auto">
 				<GenerationView generation={currentGeneration} />
 			</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx
@@ -8,26 +8,15 @@ import {
 	type TextGenerationNode,
 } from "@giselles-ai/protocol";
 import { useNodeGenerations } from "@giselles-ai/react";
-import clsx from "clsx/lite";
 import { ArrowDownIcon, ArrowUpIcon, TimerIcon } from "lucide-react";
 import { useAppDesignerStore } from "../../../app-designer";
 import { TextGenerationIcon } from "../../../icons";
 import ClipboardButton from "../../../ui/clipboard-button";
-import { EmptyState } from "../../../ui/empty-state";
 import { GenerationView } from "../../../ui/generation-view";
-
-function Empty() {
-	return (
-		<div className="relative bg-[color-mix(in_srgb,var(--color-text-inverse,#fff)_10%,transparent)] rounded-[8px] flex justify-center items-center text-text-muted py-[24px]">
-			<EmptyState
-				icon={<TextGenerationIcon width={24} height={24} />}
-				title="Nothing generated yet."
-				description="Generate or adjust the Prompt to see results."
-				className="text-text-muted"
-			/>
-		</div>
-	);
-}
+import {
+	GenerationEmptyState,
+	GenerationStatusHeader,
+} from "../ui";
 
 // Helper function to format execution time
 function formatExecutionTime(startedAt: number, completedAt: number): string {
@@ -120,7 +109,11 @@ export function GenerationPanel({ node }: { node: TextGenerationNode }) {
 	});
 
 	if (currentGeneration === undefined) {
-		return <Empty />;
+		return (
+			<GenerationEmptyState
+				icon={<TextGenerationIcon width={24} height={24} />}
+			/>
+		);
 	}
 	return (
 		<div
@@ -128,88 +121,69 @@ export function GenerationPanel({ node }: { node: TextGenerationNode }) {
 				"relative flex flex-col bg-[color-mix(in_srgb,var(--color-text-inverse,#fff)_10%,transparent)] rounded-[8px] py-[8px]"
 			}
 		>
-			<div
-				className={clsx(
-					"border-b border-white-400/20 py-[4px] px-[16px] flex items-center gap-[8px]",
-					"**:data-header-text:font-[700]",
-				)}
-			>
+			<GenerationStatusHeader generation={currentGeneration}>
 				<div className="flex-1 flex items-center gap-[8px]">
-					{(currentGeneration.status === "created" ||
-						currentGeneration.status === "queued" ||
-						currentGeneration.status === "running") && (
-						<p data-header-text>Generating...</p>
-					)}
 					{currentGeneration.status === "completed" && (
-						<p data-header-text>
-							Result{" "}
-							<span className="text-[12px] font-normal">
-								from {(() => {
-									const modelInfo = getGenerationModelInfo(currentGeneration);
-									return `${getProviderDisplayName(modelInfo.provider)} ${modelInfo.modelId}`;
-								})()}
-							</span>
-						</p>
-					)}
-					{currentGeneration.status === "failed" && (
-						<p data-header-text>Error</p>
+						<span className="text-[12px] font-normal">
+							from {(() => {
+								const modelInfo = getGenerationModelInfo(currentGeneration);
+								return `${getProviderDisplayName(modelInfo.provider)} ${modelInfo.modelId}`;
+							})()}
+						</span>
 					)}
 					{currentGeneration.status === "cancelled" && (
-						<p data-header-text>
-							Result{" "}
-							<span className="text-[12px] font-normal">
-								from {(() => {
-									const modelInfo = getGenerationModelInfo(currentGeneration);
-									return `${getProviderDisplayName(modelInfo.provider)} ${modelInfo.modelId}`;
-								})()}
-							</span>
-						</p>
+						<span className="text-[12px] font-normal">
+							from {(() => {
+								const modelInfo = getGenerationModelInfo(currentGeneration);
+								return `${getProviderDisplayName(modelInfo.provider)} ${modelInfo.modelId}`;
+							})()}
+						</span>
 					)}
 					{currentGeneration.status === "completed" &&
 						currentGeneration.usage && (
-							<div className="flex items-center gap-[10px] text-[11px] text-text-muted font-sans ml-[6px]">
-								{currentGeneration.startedAt &&
-									currentGeneration.completedAt && (
-										<span className="flex items-center gap-[2px]">
-											<TimerIcon className="text-text-muted size-[12px]" />
-											{formatExecutionTime(
-												currentGeneration.startedAt,
-												currentGeneration.completedAt,
-											)}
-										</span>
+						<div className="flex items-center gap-[10px] text-[11px] text-text-muted font-sans ml-[6px]">
+							{currentGeneration.startedAt &&
+								currentGeneration.completedAt && (
+								<span className="flex items-center gap-[2px]">
+									<TimerIcon className="text-text-muted size-[12px]" />
+									{formatExecutionTime(
+										currentGeneration.startedAt,
+										currentGeneration.completedAt,
 									)}
-
-								{currentGeneration.usage.inputTokens && (
-									<span className="flex items-center gap-[2px]">
-										<ArrowUpIcon className="text-text-muted size-[12px]" />
-										{currentGeneration.usage.inputTokens.toLocaleString()}t
-									</span>
+								</span>
 								)}
-								{currentGeneration.usage.outputTokens && (
-									<span className="flex items-center gap-[2px]">
-										<ArrowDownIcon className="text-text-muted size-[12px]" />
-										{currentGeneration.usage.outputTokens.toLocaleString()}t
-									</span>
+
+							{currentGeneration.usage.inputTokens && (
+								<span className="flex items-center gap-[2px]">
+									<ArrowUpIcon className="text-text-muted size-[12px]" />
+									{currentGeneration.usage.inputTokens.toLocaleString()}t
+								</span>
+								)}
+							{currentGeneration.usage.outputTokens && (
+								<span className="flex items-center gap-[2px]">
+									<ArrowDownIcon className="text-text-muted size-[12px]" />
+									{currentGeneration.usage.outputTokens.toLocaleString()}t
+								</span>
 								)}
 							</div>
+							)}
+					</div>
+					{(currentGeneration.status === "completed" ||
+						currentGeneration.status === "cancelled") && (
+						<ClipboardButton
+							text={getGenerationTextContent(currentGeneration)}
+							tooltip="Copy to clipboard"
+							className="text-text-muted hover:text-text/60"
+						/>
 						)}
-				</div>
-				{(currentGeneration.status === "completed" ||
-					currentGeneration.status === "cancelled") && (
-					<ClipboardButton
-						text={getGenerationTextContent(currentGeneration)}
-						tooltip="Copy to clipboard"
-						className="text-text-muted hover:text-text/60"
-					/>
-				)}
-				{currentGeneration.status === "failed" && (
-					<ClipboardButton
-						text={getGenerationErrorContent(currentGeneration)}
-						tooltip="Copy error to clipboard"
-						className="text-text-muted hover:text-text/60"
-					/>
-				)}
-			</div>
+					{currentGeneration.status === "failed" && (
+						<ClipboardButton
+							text={getGenerationErrorContent(currentGeneration)}
+							tooltip="Copy error to clipboard"
+							className="text-text-muted hover:text-text/60"
+						/>
+						)}
+			</GenerationStatusHeader>
 			<div className="flex-1 py-[4px] px-[16px] overflow-y-auto">
 				<GenerationView generation={currentGeneration} />
 			</div>

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/generation-empty-state.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/generation-empty-state.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { EmptyState } from "../../../ui/empty-state";
+
+interface GenerationEmptyStateProps {
+	icon: ReactNode;
+	title?: string;
+	description?: string;
+	minHeight?: string;
+	paddingY?: string;
+}
+
+export function GenerationEmptyState({
+	icon,
+	title = "Nothing generated yet.",
+	description = "Generate or adjust the Prompt to see results.",
+	minHeight,
+	paddingY = "py-[24px]",
+}: GenerationEmptyStateProps) {
+	return (
+		<div
+			className={[
+				"relative bg-[color-mix(in_srgb,var(--color-text-inverse,#fff)_10%,transparent)] rounded-[8px] flex justify-center items-center text-text-muted",
+				minHeight ?? "",
+				paddingY,
+			].join(" ")}
+		>
+			<EmptyState
+				icon={icon}
+				title={title}
+				description={description}
+				className="text-text-muted"
+			/>
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/generation-status-header.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/generation-status-header.tsx
@@ -1,0 +1,35 @@
+import clsx from "clsx/lite";
+import type { Generation } from "@giselles-ai/protocol";
+
+interface GenerationStatusLabelsProps {
+	generation: Generation;
+	children?: React.ReactNode;
+}
+
+export function GenerationStatusHeader({
+	generation,
+	children,
+}: GenerationStatusLabelsProps) {
+	return (
+		<div
+			className={clsx(
+				"border-b border-white-400/20 py-[4px] px-[16px] flex items-center gap-[8px]",
+				"**:data-header-text:font-[700]",
+			)}
+		>
+			{(generation.status === "created" ||
+				generation.status === "queued" ||
+				generation.status === "running") && (
+				<p data-header-text>Generating...</p>
+			)}
+			{generation.status === "completed" && (
+				<p data-header-text>Result</p>
+			)}
+			{generation.status === "failed" && <p data-header-text>Error</p>}
+			{generation.status === "cancelled" && (
+				<p data-header-text>Result</p>
+			)}
+			{children}
+		</div>
+	);
+}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/index.ts
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/index.ts
@@ -10,3 +10,5 @@ export * from "./properties-panel";
 
 export * from "./resizable-section";
 export * from "./select-repository";
+export * from "./generation-empty-state";
+export * from "./generation-status-header";


### PR DESCRIPTION
## What I did
- Extracted shared `GenerationEmptyState` component to replace nearly identical `Empty()` functions in both ImageGeneration and TextGeneration panels
- Extracted shared `GenerationStatusHeader` component for consistent status header rendering across both panels
- Updated both `generation-panel.tsx` files to use the new shared components
- Added exports for the new components in `ui/index.ts`

## Why this works
- Both panels had nearly identical `Empty()` components with only icon and minor styling differences
- Both panels rendered the exact same status labels (Generating..., Result, Error) with identical logic
- By extracting these into reusable components, we reduce code duplication and make future updates easier
- The shared components accept props for the small differences (icon, minHeight, paddingY), keeping them flexible

## Changes made
- **New:** `internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/generation-empty-state.tsx`
- **New:** `internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/generation-status-header.tsx`
- **Modified:** `internal-packages/workflow-designer-ui/src/editor/properties-panel/ui/index.ts` (added exports)
- **Modified:** `internal-packages/workflow-designer-ui/src/editor/properties-panel/image-generation-node-properties-panel/generation-panel.tsx`
- **Modified:** `internal-packages/workflow-designer-ui/src/editor/properties-panel/text-generation-node-properties-panel/generation-panel.tsx`

## Benefits
- Reduced code duplication (~40 lines eliminated)
- Consistent empty state and status header behavior across generation panels
- Easier maintenance - changes to empty state or status rendering only need to be made in one place
- No functional changes - existing behavior is preserved

Fixes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated generation panel UI by extracting shared empty state and status header components across image and text generation interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->