### PR TITLE
feat: add deploymentId to Langfuse telemetry metadata #2651

### DIFF
--- a/apps/studio.giselles.ai/lib/trace.ts
+++ b/apps/studio.giselles.ai/lib/trace.ts
@@ -42,5 +42,6 @@ export async function traceGenerationForTeam(args: {
 			workspaceId: args.generation.context.origin.workspaceId,
 		},
 		sessionId: args.sessionId,
+		deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
 	});
 }

--- a/packages/langfuse/src/trace-generation.ts
+++ b/packages/langfuse/src/trace-generation.ts
@@ -280,6 +280,7 @@ async function traceContentGeneration(args: {
 	metadata?: Record<string, unknown>;
 	tags?: string[];
 	sessionId?: string;
+	deploymentId?: string;
 }) {
 	const langfuseInput = await prepareLangfuseInput(args.inputMessages);
 
@@ -295,6 +296,7 @@ async function traceContentGeneration(args: {
 	const metadata = {
 		...args.metadata,
 		...extractMetadata(args.operationNode),
+		...(args.deploymentId ? { deploymentId: args.deploymentId } : {}),
 	};
 
 	if (args.generation.status === "failed") {
@@ -371,6 +373,7 @@ export async function traceGeneration(args: {
 	tags?: string[];
 	outputFileBlobs?: OutputFileBlob[];
 	sessionId?: string;
+	deploymentId?: string;
 }) {
 	try {
 		const { operationNode } = args.generation.context;
@@ -390,6 +393,7 @@ export async function traceGeneration(args: {
 				metadata: args.metadata,
 				tags: args.tags,
 				sessionId: args.sessionId,
+				deploymentId: args.deploymentId,
 			});
 			return;
 		}
@@ -422,6 +426,7 @@ export async function traceGeneration(args: {
 		const metadata = {
 			...args.metadata,
 			...extractMetadata(operationNode),
+			...(args.deploymentId ? { deploymentId: args.deploymentId } : {}),
 		};
 
 		const llm = operationNode.content.llm;


### PR DESCRIPTION
Fixes #2651

## Changes
- Added optional `deploymentId` parameter to `traceContentGeneration` and `traceGeneration` in `packages/langfuse/src/trace-generation.ts`
- Included `deploymentId` in the trace metadata payload when the argument is provided
- Passed `process.env.VERCEL_DEPLOYMENT_ID` as `deploymentId` in `apps/studio.giselles.ai/lib/trace.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced trace generation to include a deployment identifier. Traces now capture deployment metadata across general and content-generation telemetry paths, improving observability, filtering, and debugging of deployments without changing external APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->