### PR TITLE
fix(deps): bump brace-expansion to 5.0.5 (CVE-2026-33750)

### DIFF
--- a/.continuity/20260428-082340-fix__brace-expansion-cve-2026-33750.md
+++ b/.continuity/20260428-082340-fix__brace-expansion-cve-2026-33750.md
@@ -1,0 +1,65 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/142
+  (GHSA-f886-m6hf-6m8v / CVE-2026-33750: brace-expansion zero-step ReDoS hang)
+
+## Goal (incl. success criteria)
+
+- Bump transitive `brace-expansion` past the vulnerable range (>= 4.0.0, < 5.0.5)
+  so the alert closes once merged.
+
+## Constraints/Assumptions
+
+- Only the >= 4.0.0 range is present in our lockfile (was 5.0.2). The < 1.x, 2.x,
+  3.x ranges aren't in the dep tree.
+- `brace-expansion` is a transitive dep (via `minimatch` 9.x and 10.x), so the
+  fix has to live as a pnpm override.
+
+## Key decisions
+
+- Used a scoped pnpm override `"brace-expansion@>=4.0.0 <5.0.5": "5.0.5"` rather
+  than a blanket pin, matching the style of existing scoped overrides
+  (e.g. `glob@>=11.0.0 <11.1.0`, `path-to-regexp@>=8.0.0 <8.4.0`).
+- Considered fixing it via a library update instead of an override:
+  - `minimatch@9.0.8` and `minimatch@10.2.4` already declare `^5.0.2`, which
+    semver-allows `5.0.5` — bumping minimatch is unnecessary; the lockfile was
+    just pinned to the older patch.
+  - `pnpm update -r brace-expansion` does pull 5.0.5, but it cascades through
+    the catalog and bumps `zod` 4.1.12 → 4.3.6. That's out of scope for a
+    security patch, so we kept the override approach.
+  - `pnpm update brace-expansion` (non-recursive) is a no-op (root has no
+    direct dep on it).
+
+## State
+
+- Override added in `package.json`; `pnpm install --lockfile-only` rewrote
+  `pnpm-lock.yaml` so both `minimatch@9.0.8` and `minimatch@10.2.4` now pull
+  `brace-expansion@5.0.5`.
+
+## Done
+
+- `package.json`: added `"brace-expansion@>=4.0.0 <5.0.5": "5.0.5"` to
+  `pnpm.overrides`.
+- `pnpm-lock.yaml`: refreshed; `brace-expansion@5.0.5` is the only version.
+
+## Now
+
+- Running quality gates (`pnpm format`, `build-sdk`, `check-types`, `test`).
+
+## Next
+
+- Open PR titled around the CVE; reference the alert URL in full per repo
+  feedback rule.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- package.json
+- pnpm-lock.yaml
+- Alert: https://github.com/giselles-ai/giselle/security/dependabot/142
+- Advisory: https://github.com/advisories/GHSA-f886-m6hf-6m8v

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -6015,7 +6015,7 @@ Python-2.0 manually approved
 
 
 <a name="brace-expansion"></a>
-### brace-expansion v5.0.2
+### brace-expansion v5.0.5
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
 			"undici@>=7.0.0 <7.24.0": "7.24.4",
 			"@xmldom/xmldom": "0.8.13",
 			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2",
-			"express-rate-limit": "8.2.2"
+			"express-rate-limit": "8.2.2",
+			"brace-expansion@>=4.0.0 <5.0.5": "5.0.5"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,7 @@ overrides:
   '@xmldom/xmldom': 0.8.13
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
   express-rate-limit: 8.2.2
+  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
 
 importers:
 
@@ -5524,9 +5525,9 @@ packages:
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
 
-  brace-expansion@5.0.2:
-    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
-    engines: {node: 20 || >=22}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -13578,7 +13579,7 @@ snapshots:
 
   bowser@2.11.0: {}
 
-  brace-expansion@5.0.2:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.2
 
@@ -15508,11 +15509,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.2
+      brace-expansion: 5.0.5
 
   minimatch@9.0.8:
     dependencies:
-      brace-expansion: 5.0.2
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- Resolve Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/142 (GHSA-f886-m6hf-6m8v / CVE-2026-33750): `brace-expansion` 5.0.2 hangs and allocates ~1.9GB on a zero-step pattern like `{1..2..0}`.
- `brace-expansion` is a transitive via `minimatch@9` (sucrase/tsup chain) and `minimatch@10` (sentry, react-email). Both already declare `^5.0.2`, which semver-allows the patched 5.0.5 — only the lockfile was pinning the older patch.
- Considered `pnpm update -r brace-expansion`: it does pull 5.0.5 but cascades through the catalog and bumps `zod` 4.1.12 → 4.3.6, which is out of scope for a security patch. Used a scoped pnpm override instead, matching existing entries (`glob@>=11.0.0 <11.1.0`, `path-to-regexp@>=8.0.0 <8.4.0`).

## Test plan
- [x] `pnpm install` reproduces a clean lockfile with `brace-expansion@5.0.5` only
- [x] `pnpm format`
- [x] `pnpm build-sdk`
- [x] `pnpm check-types`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated `brace-expansion` dependency to version 5.0.5 using pnpm overrides to ensure consistent dependency resolution across the project.

* **Documentation**
  * Updated `brace-expansion` version in packages licensing documentation from v5.0.2 to v5.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->