### PR TITLE
fix(deps): bump postcss to 8.5.12 (CVE-2026-41305)

### DIFF
--- a/.continuity/20260428-084232-fix__postcss-cve-2026-41305.md
+++ b/.continuity/20260428-084232-fix__postcss-cve-2026-41305.md
@@ -1,0 +1,61 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/176
+  (GHSA-qx2v-qp2m-jg93 / CVE-2026-41305: postcss XSS via unescaped `</style>`
+  in stringify output, fixed in 8.5.10).
+
+## Goal (incl. success criteria)
+
+- All postcss copies in the lockfile sit on 8.5.10+; alert closes.
+
+## Constraints/Assumptions
+
+- Three vulnerable copies in the lockfile pre-fix: 8.4.31, 8.5.5, 8.5.6.
+  - 8.4.31 — pulled by `next 16.2.3`
+  - 8.5.5 — direct catalog dep (used by `apps/studio.giselles.ai`,
+    `apps/ui.giselles.ai`)
+  - 8.5.6 — pulled by `vite`, `vitest`, `@tailwindcss/postcss`
+
+## Key decisions
+
+- Two coordinated changes:
+  1. `pnpm-workspace.yaml` catalog: `postcss: 8.5.5` → `8.5.12` (covers the
+     direct consumers; both reference `"postcss": "catalog:"`).
+  2. `package.json` pnpm override: `"postcss@<8.5.10": "8.5.12"` for transitive
+     pulls (next, vite, vitest, tailwind), matching the existing scoped
+     override pattern (e.g. `undici@>=7.0.0 <7.24.0`).
+- Picked 8.5.12 (latest 8.5.x at time of fix); minor patches above 8.5.10 are
+  bug fixes only.
+
+## State
+
+- Lockfile collapsed all three previous postcss versions to 8.5.12.
+- `pnpm format / build-sdk / check-types / test` all green.
+
+## Done
+
+- pnpm-workspace.yaml: postcss catalog 8.5.5 → 8.5.12.
+- package.json: added `"postcss@<8.5.10": "8.5.12"` override.
+- pnpm-lock.yaml: regenerated.
+
+## Now
+
+- Commit, push, open PR.
+
+## Next
+
+- Watch CI (License Compliance auto-updates `docs/packages-license.md`).
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- pnpm-workspace.yaml
+- package.json
+- pnpm-lock.yaml
+- Alert: https://github.com/giselles-ai/giselle/security/dependabot/176
+- Advisory: https://github.com/advisories/GHSA-qx2v-qp2m-jg93

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -10910,7 +10910,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="postcss"></a>
-### postcss v8.4.31
+### postcss v8.5.12
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
 			"@xmldom/xmldom": "0.8.13",
 			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2",
 			"express-rate-limit": "8.2.2",
-			"brace-expansion@>=4.0.0 <5.0.5": "5.0.5"
+			"brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
+			"postcss@<8.5.10": "8.5.12"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ catalogs:
       specifier: 7.0.0
       version: 7.0.0
     postcss:
-      specifier: 8.5.5
-      version: 8.5.5
+      specifier: 8.5.12
+      version: 8.5.12
     prettier:
       specifier: 3.7.4
       version: 3.7.4
@@ -289,6 +289,7 @@ overrides:
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
   express-rate-limit: 8.2.2
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  postcss@<8.5.10: 8.5.12
 
 importers:
 
@@ -588,7 +589,7 @@ importers:
         version: 1.56.1
       postcss:
         specifier: 'catalog:'
-        version: 8.5.5
+        version: 8.5.12
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18
@@ -640,7 +641,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       postcss:
         specifier: 'catalog:'
-        version: 8.5.5
+        version: 8.5.12
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18
@@ -817,7 +818,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/data-store-registry:
     dependencies:
@@ -830,7 +831,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -855,7 +856,7 @@ importers:
         version: 6.0.5
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -952,7 +953,7 @@ importers:
         version: 0.11.6
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1004,7 +1005,7 @@ importers:
         version: 24.10.4
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1029,7 +1030,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/langfuse:
     dependencies:
@@ -1057,7 +1058,7 @@ importers:
         version: 5.0.101(zod@4.3.6)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/language-model:
     dependencies:
@@ -1070,7 +1071,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1086,7 +1087,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1105,7 +1106,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/nextjs:
     dependencies:
@@ -1139,7 +1140,7 @@ importers:
         version: 19.2.7
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1173,7 +1174,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1216,7 +1217,7 @@ importers:
         version: link:../utils
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1238,7 +1239,7 @@ importers:
         version: 1.0.22
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.20.6)(typescript@5.7.3)(yaml@2.7.0)
       tsx:
         specifier: 'catalog:'
         version: 4.20.6
@@ -1290,7 +1291,7 @@ importers:
         version: 8.16.0
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -1333,7 +1334,7 @@ importers:
         version: 19.2.7
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1355,7 +1356,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1371,7 +1372,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/stream:
     dependencies:
@@ -1387,7 +1388,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/supabase-driver:
     dependencies:
@@ -1412,7 +1413,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/text-editor:
     dependencies:
@@ -1461,7 +1462,7 @@ importers:
         version: 19.2.7
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/text-editor-utils:
     dependencies:
@@ -1501,7 +1502,7 @@ importers:
         version: 5.0.5
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/trigger-registry:
     dependencies:
@@ -1517,7 +1518,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/utils:
     dependencies:
@@ -1536,7 +1537,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/vault:
     dependencies:
@@ -1549,7 +1550,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/web-search:
     dependencies:
@@ -1577,7 +1578,7 @@ importers:
         version: 24.10.4
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -1596,7 +1597,7 @@ importers:
         version: link:../../tools/tsconfig
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.9(bufferutil@4.0.9)(utf-8-validate@6.0.5))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0)
@@ -7664,7 +7665,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: 8.5.12
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -7677,16 +7678,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.5:
-    resolution: {integrity: sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -8548,7 +8541,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: 8.5.12
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -12791,7 +12784,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
-      postcss: 8.5.6
+      postcss: 8.5.12
       tailwindcss: 4.1.18
 
   '@tiptap/core@2.11.5(@tiptap/pm@2.11.5)':
@@ -15583,7 +15576,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001774
-      postcss: 8.4.31
+      postcss: 8.5.12
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       styled-jsx: 5.1.6(@babel/core@7.26.7)(react@19.2.1)
@@ -15923,37 +15916,25 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.7.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.20.6)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.6
+      postcss: 8.5.12
       tsx: 4.20.6
       yaml: 2.7.0
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.7.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.6
+      postcss: 8.5.12
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.5:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -17042,7 +17023,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.7.3)(yaml@2.7.0):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.20.6)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -17053,7 +17034,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.7.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.20.6)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -17062,7 +17043,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.12
       typescript: 5.7.3
     transitivePeerDependencies:
       - jiti
@@ -17070,7 +17051,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -17081,7 +17062,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.7.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -17090,7 +17071,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.12
       typescript: 5.7.3
     transitivePeerDependencies:
       - jiti
@@ -17303,7 +17284,7 @@ snapshots:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.12
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -17320,7 +17301,7 @@ snapshots:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.12
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -17337,7 +17318,7 @@ snapshots:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.12
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   pgvector: 0.2.1
   pino: 9.9.0
   pngjs: 7.0.0
-  postcss: 8.5.5
+  postcss: 8.5.12
   radix-ui: 1.4.3
   react: 19.2.1
   react-dom: 19.2.1


### PR DESCRIPTION
## Summary
- Resolve Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/176 (GHSA-qx2v-qp2m-jg93 / CVE-2026-41305): PostCSS < 8.5.10 does not escape `</style>` in its stringify output, opening an XSS path when user CSS is re-stringified into an HTML `<style>` tag.
- The lockfile carried three vulnerable copies: 8.4.31 (next), 8.5.5 (catalog), and 8.5.6 (vite / vitest / @tailwindcss/postcss).
- Bumped the catalog `postcss: 8.5.5 → 8.5.12` (covers `apps/studio.giselles.ai` and `apps/ui.giselles.ai`, which both use `"postcss": "catalog:"`) and added a scoped pnpm override `"postcss@<8.5.10": "8.5.12"` to collapse the transitive pulls. Lockfile now has a single `postcss@8.5.12`.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build-sdk`
- [x] `pnpm check-types`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PostCSS to version 8.5.12 to address a security vulnerability.

* **Documentation**
  * Updated package documentation to reflect the latest dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->