### PR TITLE
fix(deps): bump fast-xml-parser to 5.7.2 (CVE-2026-41650)

### DIFF
--- a/.continuity/20260428-094125-fix__fast-xml-parser-cve-2026-41650.md
+++ b/.continuity/20260428-094125-fix__fast-xml-parser-cve-2026-41650.md
@@ -1,0 +1,59 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/174
+  (GHSA-gh4j-gqv2-49f6 / CVE-2026-41650): fast-xml-parser XMLBuilder does
+  not escape `-->` in comments or `]]>` in CDATA, enabling XML/CDATA
+  injection. Patched in 5.7.0.
+
+## Goal (incl. success criteria)
+
+- Lockfile carries `fast-xml-parser >= 5.7.0` only; alert closes.
+
+## Constraints/Assumptions
+
+- Single vulnerable copy at `5.5.12` (transitive via `@aws-sdk/xml-builder`
+  used by `@aws-sdk/client-s3` and credential providers).
+- The repo already pinned `fast-xml-parser` via `pnpm.overrides` to satisfy
+  earlier security alerts (5.3.6 -> 5.5.12 chain visible in git log). Same
+  override slot, just bumped to a patched version.
+- We don't appear to use `XMLBuilder` from this package directly in our own
+  code; the AWS SDK uses it for request signing. Direct exploit risk is low,
+  but the alert applies because of version range alone.
+
+## Key decisions
+
+- Bump existing override `"fast-xml-parser": "5.5.12"` -> `"5.7.2"` (latest
+  5.7.x). 5.7.0 is the minimum patched version; choosing 5.7.2 picks up
+  follow-up bugfixes.
+
+## State
+
+- Lockfile collapsed to a single `fast-xml-parser@5.7.2`.
+- `pnpm format / build-sdk / check-types / test` all green.
+
+## Done
+
+- package.json: pinned override 5.5.12 -> 5.7.2.
+- pnpm-lock.yaml: regenerated; only `fast-xml-parser@5.7.2` remains.
+
+## Now
+
+- Commit, push, open PR.
+
+## Next
+
+- Watch CI; License Compliance workflow refreshes `docs/packages-license.md`
+  on this branch automatically.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- package.json
+- pnpm-lock.yaml
+- Alert: https://github.com/giselles-ai/giselle/security/dependabot/174
+- Advisory: https://github.com/advisories/GHSA-gh4j-gqv2-49f6

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2,7 +2,7 @@
 
 
 ## Summary
-* 962 MIT
+* 963 MIT
 * 193 Apache 2.0
 * 43 ISC
 * 24 New BSD
@@ -1571,6 +1571,17 @@ BlueOak-1.0.0 permitted
 
 <a name="@noble/hashes"></a>
 ### @noble/hashes v1.7.1
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
+
+
+
+<a name="@nodable/entities"></a>
+### @nodable/entities v2.1.0
 #### 
 
 ##### Paths
@@ -7566,7 +7577,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="fast-xml-builder"></a>
-### fast-xml-builder v1.1.4
+### fast-xml-builder v1.1.5
 #### 
 
 ##### Paths
@@ -7577,7 +7588,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="fast-xml-parser"></a>
-### fast-xml-parser v5.5.12
+### fast-xml-parser v5.7.2
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 			"vite": "7.3.2",
 			"jws": "4.0.1",
 			"glob@>=11.0.0 <11.1.0": "11.1.0",
-			"fast-xml-parser": "5.5.12",
+			"fast-xml-parser": "5.7.2",
 			"protobufjs": "7.5.5",
 			"hono": "4.12.4",
 			"@hono/node-server": "1.19.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ overrides:
   vite: 7.3.2
   jws: 4.0.1
   glob@>=11.0.0 <11.1.0: 11.1.0
-  fast-xml-parser: 5.5.12
+  fast-xml-parser: 5.7.2
   protobufjs: 7.5.5
   hono: 4.12.4
   '@hono/node-server': 1.19.10
@@ -2780,6 +2780,9 @@ packages:
   '@noble/hashes@1.7.1':
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6235,11 +6238,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.5.12:
-    resolution: {integrity: sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==}
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -9670,7 +9673,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.2':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.5.12
+      fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -10496,6 +10499,8 @@ snapshots:
       third-party-capital: 1.0.20
 
   '@noble/hashes@1.7.1': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -14201,13 +14206,14 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.5:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.12:
+  fast-xml-parser@5.7.2:
     dependencies:
-      fast-xml-builder: 1.1.4
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 


### PR DESCRIPTION
## Summary
- Resolve Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/174 (GHSA-gh4j-gqv2-49f6 / CVE-2026-41650): `fast-xml-parser` < 5.7.0 does not escape `-->` in comments or `]]>` in CDATA when its `XMLBuilder` stringifies user-controlled values, enabling XML/CDATA injection (XSS, SOAP injection, RSS poisoning).
- The lockfile carried a single transitive copy at 5.5.12 (via `@aws-sdk/xml-builder` -> `@aws-sdk/client-s3` and the AWS credential providers). The package was already pinned via `pnpm.overrides` from previous security alerts.
- Bumped the existing override `"fast-xml-parser": "5.5.12" -> "5.7.2"` (latest 5.7.x; 5.7.0 is the minimum patched version, 5.7.2 picks up subsequent fixes).
- We don't call `XMLBuilder` from our own code — the AWS SDK uses it internally — so the practical exploit surface here is low, but the override closes the alert and keeps the dependency on a patched line.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build-sdk`
- [x] `pnpm check-types`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved CVE-2026-41650 security vulnerability in fast-xml-parser.

* **Documentation**
  * Updated package license records and added security remediation entry.

* **Chores**
  * Bumped fast-xml-parser dependency to v5.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->