### PR TITLE
Complete SVG handling for vision inputs (follow-up to #2728)

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -51,7 +51,7 @@ class InvalidFileTypeError extends FileUploadError {
 			case "image/png":
 			case "image/gif":
 			case "image/svg+xml":
-				return "Please use Image node to upload this file.";
+				return "SVG is not supported. Please use PNG/JPEG/GIF/WebP instead..";
 			case "application/pdf":
 				return "Please use PDF node to upload this file.";
 			case "text/plain":

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -47,20 +47,25 @@ class InvalidFileTypeError extends FileUploadError {
 		}
 
 		switch (this.actualType) {
-			case "image/jpeg":
-			case "image/png":
-			case "image/gif":
-				 return "Please use the Image node to upload this file";
+  			case "image/jpeg":
+ 			case "image/png":
+  			case "image/gif":
+  			case "image/webp":
+    			return "Please use the Image node to upload this file.";
+
 			case "image/svg+xml":
-				return "SVG is not supported. Please use PNG/JPEG/GIF/WebP instead.";
-			case "application/pdf":
-				return "Please use PDF node to upload this file.";
-			case "text/plain":
-			case "text/markdown":
-				return "Please use Text node to upload this file.";
-			default:
-				return `${this.actualType} is not supported.`;
-		}
+    			return "SVG is not supported. Please use PNG/JPEG/GIF/WebP instead.";
+
+  			case "application/pdf":
+    			return "Please use PDF node to upload this file.";
+
+  			case "text/plain":
+  			case "text/markdown":
+    			return "Please use Text node to upload this file.";
+
+  default:
+    return `${this.actualType} is not supported.`;
+}
 	}
 }
 

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -50,8 +50,9 @@ class InvalidFileTypeError extends FileUploadError {
 			case "image/jpeg":
 			case "image/png":
 			case "image/gif":
+				 return "Please use the Image node to upload this file";
 			case "image/svg+xml":
-				return "SVG is not supported. Please use PNG/JPEG/GIF/WebP instead..";
+				return "SVG is not supported. Please use PNG/JPEG/GIF/WebP instead.";
 			case "application/pdf":
 				return "Please use PDF node to upload this file.";
 			case "text/plain":

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -15,7 +15,7 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 		label: "Text",
 	},
 	image: {
-		accept: ["image/png", "image/jpeg", "image/gif", "image/svg+xml"],
+		accept: ["image/png", "image/jpeg", "image/gif", "image/webp"],
 		label: "Image",
 	},
 };

--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -567,11 +567,19 @@ export async function useGenerationExecutor<T>(args: {
 							case "image/jpeg":
 							case "image/png":
 							case "image/gif":
-							case "image/svg+xml":
+							case "image/webp":
 								return {
 									type: "image",
 									image: blob,
 								} as ImagePart;
+
+							case "image/svg+xml":
+								args.context.logger.warn(
+									{ id: fileParameter.id, type: fileParameter.type, name: fileParameter.name },
+									"SVG is not supported for vision input. Please upload PNG/JPEG/GIF/WebP instead.",
+								);
+								return undefined;
+								
 							case "application/pdf":
 								return {
 									type: "file",

--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -579,7 +579,6 @@ export async function useGenerationExecutor<T>(args: {
 									"SVG is not supported for vision input. Please upload PNG/JPEG/GIF/WebP instead.",
 								);
 								return undefined;
-								
 							case "application/pdf":
 								return {
 									type: "file",


### PR DESCRIPTION
This PR builds on #2728 and completes the remaining requested changes.

### Fixes
- Prevent SVG from reaching vision via all code paths
- Remove `image/svg+xml` from UI accept list
- Add `image/webp` to UI accept list
- Update misleading validation message for SVG uploads
- Remove trailing whitespace

### Why
SVG files could still reach vision models in some cases, causing:
`Unsupported MIME type: image/svg+xml`

Additionally, the UI allowed SVG uploads even though they were silently ignored by the backend, leading to a confusing user experience.

### Notes
- Original work by @KerwinLarrobis in #2728
- This PR completes the requested review changes after inactivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebP image format support for uploads and vision inputs.

* **Bug Fixes**
  * Improved error messaging for unsupported SVG files, explicitly stating SVG is not accepted and recommending PNG, JPEG, GIF, or WebP.
  * SVG files are now rejected for vision processing with a clear warning and are no longer included in processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->