### PR TITLE
fix(deps): bump fast-xml-parser to 5.7.3 (CVE-2026-44665)

### DIFF
--- a/.continuity/20260511-101552-fix-deps-fast-xml-builder-cve-2026-44665.md
+++ b/.continuity/20260511-101552-fix-deps-fast-xml-builder-cve-2026-44665.md
@@ -1,0 +1,47 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/181 (CVE-2026-44665 / GHSA-5wm8-gmm8-39j9) for `fast-xml-builder` (transitive via `fast-xml-parser` → `@aws-sdk/xml-builder`).
+
+## Goal (incl. success criteria)
+
+- Bump transitive `fast-xml-builder` from 1.1.5 to a patched release (>= 1.1.7) so Dependabot alert #181 closes.
+- Keep the change minimal and consistent with prior CVE bumps tracked under `pnpm.overrides`.
+
+## Constraints/Assumptions
+
+- `fast-xml-parser` is already pinned in `pnpm.overrides` at 5.7.2 (previous CVE bump).
+- `fast-xml-parser@5.7.3` declares `fast-xml-builder: ^1.1.7`, so bumping the parser one patch pulls in the patched builder transitively.
+
+## Key decisions
+
+- Bump the existing `fast-xml-parser` override 5.7.2 → 5.7.3 instead of adding a separate `fast-xml-builder` override. Mirrors the pattern in commit 251f061d1 (CVE-2026-41650) and avoids redundant pins.
+
+## State
+
+- `package.json` `pnpm.overrides.fast-xml-parser` set to `5.7.3`.
+- `pnpm install` resolved `fast-xml-builder@1.2.0` and `fast-xml-parser@5.7.3`.
+
+## Done
+
+- Updated override.
+- Ran `pnpm install` to regenerate `pnpm-lock.yaml`.
+
+## Now
+
+- Run quality checks: `pnpm format`, `pnpm check-types`, `pnpm test`.
+
+## Next
+
+- Commit and open PR referencing https://github.com/giselles-ai/giselle/security/dependabot/181.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `package.json` (pnpm.overrides)
+- `pnpm-lock.yaml`
+- Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/181

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2,7 +2,7 @@
 
 
 ## Summary
-* 963 MIT
+* 964 MIT
 * 193 Apache 2.0
 * 43 ISC
 * 24 New BSD
@@ -7577,7 +7577,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="fast-xml-builder"></a>
-### fast-xml-builder v1.1.5
+### fast-xml-builder v1.2.0
 #### 
 
 ##### Paths
@@ -7588,7 +7588,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="fast-xml-parser"></a>
-### fast-xml-parser v5.7.2
+### fast-xml-parser v5.7.3
 #### 
 
 ##### Paths
@@ -13818,6 +13818,17 @@ BlueOak-1.0.0 permitted
 * /home/runner/work/giselle/giselle
 
 <a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
+
+
+
+<a name="xml-naming"></a>
+### xml-naming v0.1.0
+#### 
+
+##### Paths
+* /home/runner/work/giselle/giselle
+
+<a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
 
 
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 			"vite": "7.3.2",
 			"jws": "4.0.1",
 			"glob@>=11.0.0 <11.1.0": "11.1.0",
-			"fast-xml-parser": "5.7.2",
+			"fast-xml-parser": "5.7.3",
 			"protobufjs": "7.5.5",
 			"hono": "4.12.4",
 			"@hono/node-server": "1.19.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ overrides:
   vite: 7.3.2
   jws: 4.0.1
   glob@>=11.0.0 <11.1.0: 11.1.0
-  fast-xml-parser: 5.7.2
+  fast-xml-parser: 5.7.3
   protobufjs: 7.5.5
   hono: 4.12.4
   '@hono/node-server': 1.19.10
@@ -6238,11 +6238,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.5:
-    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.7.2:
-    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -9005,6 +9005,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -9673,7 +9677,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.2':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.7.2
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -14206,14 +14210,15 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.5:
+  fast-xml-builder@1.2.0:
     dependencies:
       path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
 
-  fast-xml-parser@5.7.2:
+  fast-xml-parser@5.7.3:
     dependencies:
       '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.5
+      fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -17610,6 +17615,8 @@ snapshots:
       os-paths: 4.4.0
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert https://github.com/giselles-ai/giselle/security/dependabot/181 (GHSA-5wm8-gmm8-39j9 / CVE-2026-44665, high severity).
- The vulnerability lives in `fast-xml-builder <= 1.1.6`: quote characters inside attribute values escape the value and let an attacker inject additional XML/HTML attributes (e.g. `onClick="alert(1)"`).
- `fast-xml-builder` only enters the tree transitively via `fast-xml-parser` (used by `@aws-sdk/xml-builder`). `fast-xml-parser@5.7.3` declares `fast-xml-builder: ^1.1.7`, so bumping the existing `pnpm.overrides` pin from `5.7.2` -> `5.7.3` pulls the patched builder (`1.2.0`) transitively without needing a redundant `fast-xml-builder` override.

## Test plan

- [x] `pnpm install` (lockfile regenerated; `fast-xml-builder` resolves to `1.2.0`, `fast-xml-parser` to `5.7.3`)
- [x] `pnpm format`
- [x] `pnpm build-sdk`
- [x] `pnpm check-types`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency versions: fast-xml-builder (1.1.5 → 1.2.0) and fast-xml-parser (5.7.2 → 5.7.3)
  * Refreshed package lock file to reflect new dependency versions
  * Updated package documentation with latest dependency information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/giselles-ai/giselle/pull/2909)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->