### PR TITLE
fix(deps): bump fast-uri to 3.1.2 (CVE-2026-6321, CVE-2026-6322)

### DIFF
--- a/.continuity/20260511-102603-fix-deps-fast-uri-cve-2026-6321-6322.md
+++ b/.continuity/20260511-102603-fix-deps-fast-uri-cve-2026-6321-6322.md
@@ -1,0 +1,49 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve Dependabot alerts:
+  - https://github.com/giselles-ai/giselle/security/dependabot/182 (CVE-2026-6321 / GHSA-q3j6-qgpj-74h6) — fast-uri path traversal via percent-encoded dot segments.
+  - https://github.com/giselles-ai/giselle/security/dependabot/186 (CVE-2026-6322 / GHSA-v39h-62p7-jpjc) — fast-uri host confusion via percent-encoded authority delimiters.
+
+## Goal (incl. success criteria)
+
+- Bump transitive `fast-uri` to >= 3.1.2 so both alerts close.
+- Keep the change minimal and consistent with prior CVE bumps tracked under `pnpm.overrides`.
+
+## Constraints/Assumptions
+
+- `fast-uri` enters the tree transitively via `ajv@8.18.0`.
+- Direct override is the simplest fix; no app/package consumes `fast-uri` directly.
+
+## Key decisions
+
+- Add `"fast-uri": "3.1.2"` to `pnpm.overrides`. 3.1.2 is the latest release and covers both #182 (>=3.1.1) and #186 (>=3.1.2).
+
+## State
+
+- `package.json` `pnpm.overrides.fast-uri` set to `3.1.2`.
+- `pnpm install` resolved `fast-uri@3.1.2`.
+
+## Done
+
+- Added override.
+- Ran `pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm test`.
+
+## Now
+
+- Commit and open PR referencing both alerts.
+
+## Next
+
+- Wait for review/merge.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `package.json` (pnpm.overrides)
+- `pnpm-lock.yaml`
+- Dependabot alerts #182, #186

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -7566,7 +7566,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="fast-uri"></a>
-### fast-uri v3.1.0
+### fast-uri v3.1.2
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 			"jws": "4.0.1",
 			"glob@>=11.0.0 <11.1.0": "11.1.0",
 			"fast-xml-parser": "5.7.3",
+			"fast-uri": "3.1.2",
 			"protobufjs": "7.5.5",
 			"hono": "4.12.4",
 			"@hono/node-server": "1.19.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,7 @@ overrides:
   jws: 4.0.1
   glob@>=11.0.0 <11.1.0: 11.1.0
   fast-xml-parser: 5.7.3
+  fast-uri: 3.1.2
   protobufjs: 7.5.5
   hono: 4.12.4
   '@hono/node-server': 1.19.10
@@ -6235,8 +6236,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -13497,7 +13498,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14208,7 +14209,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-xml-builder@1.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves two high-severity Dependabot alerts on `fast-uri` with a single bump to `3.1.2`:

- https://github.com/giselles-ai/giselle/security/dependabot/182 — GHSA-q3j6-qgpj-74h6 / CVE-2026-6321. `fast-uri <= 3.1.0` decodes percent-encoded path separators and dot segments before applying dot-segment removal, so `/public/%2e%2e/admin` normalizes to `/admin` and path-prefix policy checks can be bypassed. Fixed in 3.1.1.
- https://github.com/giselles-ai/giselle/security/dependabot/186 — GHSA-v39h-62p7-jpjc / CVE-2026-6322. `fast-uri <= 3.1.1` decodes percent-encoded authority delimiters (`%40`, `%3A`) inside the host, so `trusted.com%40evil.com` reparses as host `evil.com` with userinfo `trusted.com`, defeating host allowlist checks. Fixed in 3.1.2.

`fast-uri` is only consumed transitively (through `ajv`). Adding it to `pnpm.overrides` at the latest patched version (`3.1.2`) covers both CVEs in one change, consistent with prior CVE bumps in this repo.

## Test plan

- [x] `pnpm install` (lockfile regenerated; `fast-uri` resolves to `3.1.2`)
- [x] `pnpm format`
- [x] `pnpm build-sdk`
- [x] `pnpm check-types`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `fast-uri` transitive dependency to version 3.1.2 to address security vulnerabilities.

* **Documentation**
  * Updated package license documentation to reflect the new dependency version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/giselles-ai/giselle/pull/2910)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->