### PR TITLE
fix(deps): bump protobufjs to 7.5.6 (8 high/medium CVEs)

### DIFF
--- a/.continuity/20260514-104919-fix-deps-protobufjs-dependabot-alerts.md
+++ b/.continuity/20260514-104919-fix-deps-protobufjs-dependabot-alerts.md
@@ -1,0 +1,59 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve open `protobufjs` / `@protobufjs/utf8` Dependabot alerts #200–#207 on github.com/giselles-ai/giselle/security/dependabot.
+
+## Goal (incl. success criteria)
+
+- All 8 protobufjs-family Dependabot alerts close after the bump:
+  - #200 `@protobufjs/utf8` GHSA-q6x5-8v7m-xcrf / CVE-2026-44288 (overlong UTF-8 decoding)
+  - #201 `protobufjs` GHSA-q6x5-8v7m-xcrf / CVE-2026-44288 (overlong UTF-8 decoding)
+  - #202 `protobufjs` GHSA-jvwf-75h9-cwgg / CVE-2026-44290 (process-wide DoS via unsafe option paths)
+  - #203 `protobufjs` GHSA-75px-5xx7-5xc7 / CVE-2026-44291 (codegen gadget after prototype pollution)
+  - #204 `protobufjs` GHSA-fx83-v9x8-x52w / CVE-2026-44292 (prototype injection in generated constructors)
+  - #205 `protobufjs` GHSA-2pr8-phx7-x9h3 / CVE-2026-44294 (DoS from crafted field names)
+  - #206 `protobufjs` GHSA-66ff-xgx4-vchm / CVE-2026-44293 (code injection through bytes field defaults)
+  - #207 `protobufjs` GHSA-685m-2w69-288q / CVE-2026-44289 (DoS via unbounded recursion)
+
+## Constraints/Assumptions
+
+- `protobufjs` is not a direct workspace dependency; it enters the tree transitively via `@opentelemetry/otlp-*` (pulled in by `@trigger.dev/core`). It is already pinned via root `pnpm.overrides`.
+- Staying on the 7.x line avoids a major-version bump (8.x exists but isn't needed; 7.5.6 is the patched 7.x release).
+- `@protobufjs/utf8` upgrades automatically as a transitive of `protobufjs@7.5.6` (1.1.0 → 1.1.1).
+
+## Key decisions
+
+- Bump `pnpm.overrides.protobufjs` from `7.5.5` → `7.5.6` — the first patched 7.x version covering all 8 advisories.
+
+## State
+
+- Edit applied to root `package.json` `pnpm.overrides`.
+- `pnpm install` replaced 4 packages; lockfile now resolves `protobufjs@7.5.6` and `@protobufjs/utf8@1.1.1` (also pulls `@protobufjs/codegen@2.0.5`, `@protobufjs/inquire@1.1.1`).
+
+## Done
+
+- Updated root `package.json` overrides.
+- `pnpm install` → success.
+- `pnpm format` → clean (pre-existing broken-symlink warning in `apps/studio.giselles.ai/out/static`).
+- `pnpm build-sdk` → 28/28 successful (FULL TURBO cache hit; no source touched).
+- `pnpm check-types` → 31/31 successful.
+- `pnpm test` → 218/218 tests pass.
+
+## Now
+
+- Awaiting commit and PR.
+
+## Next
+
+- Commit the override bump and open a PR. Dependabot will auto-close alerts #200–#207 once the change reaches the default branch.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `package.json` (root) — `pnpm.overrides.protobufjs`.
+- `pnpm-lock.yaml` — regenerated.
+- Verification: `pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm test`.

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2373,7 +2373,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="@protobufjs/codegen"></a>
-### @protobufjs/codegen v2.0.4
+### @protobufjs/codegen v2.0.5
 #### 
 
 ##### Paths
@@ -2417,7 +2417,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="@protobufjs/inquire"></a>
-### @protobufjs/inquire v1.1.0
+### @protobufjs/inquire v1.1.1
 #### 
 
 ##### Paths
@@ -2450,7 +2450,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="@protobufjs/utf8"></a>
-### @protobufjs/utf8 v1.1.0
+### @protobufjs/utf8 v1.1.1
 #### 
 
 ##### Paths
@@ -11295,7 +11295,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="protobufjs"></a>
-### protobufjs v7.5.5
+### protobufjs v7.5.6
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 			"glob@>=11.0.0 <11.1.0": "11.1.0",
 			"fast-xml-parser": "5.7.3",
 			"fast-uri": "3.1.2",
-			"protobufjs": "7.5.5",
+			"protobufjs": "7.5.6",
 			"hono": "4.12.18",
 			"@hono/node-server": "1.19.14",
 			"ajv@>=6.0.0 <7.0.0": "6.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,7 +276,7 @@ overrides:
   glob@>=11.0.0 <11.1.0: 11.1.0
   fast-xml-parser: 5.7.3
   fast-uri: 3.1.2
-  protobufjs: 7.5.5
+  protobufjs: 7.5.6
   hono: 4.12.18
   '@hono/node-server': 1.19.14
   ajv@>=6.0.0 <7.0.0: 6.14.0
@@ -3308,8 +3308,8 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
@@ -3320,8 +3320,8 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -3329,8 +3329,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -7821,8 +7821,8 @@ packages:
   prosemirror-view@1.38.0:
     resolution: {integrity: sha512-O45kxXQTaP9wPdXhp8TKqCR+/unS/gnfg9Q93svQcB3j0mlp2XSPAmsPefxHADwzC+fbNS404jqRxm3UQaGvgw==}
 
-  protobufjs@7.5.5:
-    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -10928,7 +10928,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
 
   '@opentelemetry/redis-common@0.38.2': {}
 
@@ -11079,24 +11079,24 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
   '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.1': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.1': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -16111,18 +16111,18 @@ snapshots:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.2
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/codegen': 2.0.5
       '@protobufjs/eventemitter': 1.1.0
       '@protobufjs/fetch': 1.1.0
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 25.3.0
       long: 5.2.4
 


### PR DESCRIPTION
## Summary

- Bumps the root `pnpm.overrides.protobufjs` pin from `7.5.5` → `7.5.6` to resolve 8 open Dependabot alerts. `@protobufjs/utf8` upgrades transitively from `1.1.0` → `1.1.1`.
- `protobufjs` is not a direct workspace dependency; it enters the tree via `@opentelemetry/otlp-*` (pulled in by `@trigger.dev/core`). Already managed by override, so this is a one-line bump.

## Alerts closed

| # | Package | Severity | Advisory |
|---|---|---|---|
| [#200](https://github.com/giselles-ai/giselle/security/dependabot/200) | `@protobufjs/utf8` | medium | GHSA-q6x5-8v7m-xcrf — overlong UTF-8 decoding |
| [#201](https://github.com/giselles-ai/giselle/security/dependabot/201) | `protobufjs` | medium | GHSA-q6x5-8v7m-xcrf — overlong UTF-8 decoding |
| [#202](https://github.com/giselles-ai/giselle/security/dependabot/202) | `protobufjs` | high | GHSA-jvwf-75h9-cwgg — process-wide DoS via unsafe option paths |
| [#203](https://github.com/giselles-ai/giselle/security/dependabot/203) | `protobufjs` | high | GHSA-75px-5xx7-5xc7 — codegen gadget after prototype pollution |
| [#204](https://github.com/giselles-ai/giselle/security/dependabot/204) | `protobufjs` | medium | GHSA-fx83-v9x8-x52w — prototype injection in generated constructors |
| [#205](https://github.com/giselles-ai/giselle/security/dependabot/205) | `protobufjs` | medium | GHSA-2pr8-phx7-x9h3 — DoS from crafted field names |
| [#206](https://github.com/giselles-ai/giselle/security/dependabot/206) | `protobufjs` | high | GHSA-66ff-xgx4-vchm — code injection through bytes field defaults |
| [#207](https://github.com/giselles-ai/giselle/security/dependabot/207) | `protobufjs` | high | GHSA-685m-2w69-288q — DoS via unbounded recursion |

## Test plan

- [x] `pnpm install` — lockfile updates to `protobufjs@7.5.6`, `@protobufjs/utf8@1.1.1`
- [x] `pnpm format` — clean
- [x] `pnpm build-sdk` — 28/28 packages build
- [x] `pnpm check-types` — 31/31 type-check tasks pass
- [x] `pnpm test` — 218/218 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated protobufjs and related packages to resolve eight security vulnerabilities
  * Updated dependency documentation with new package versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/giselles-ai/giselle/pull/2916)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->