### PR TITLE
fix(deps): bump systeminformation to 5.31.6 (CVE-2026-44724)

### DIFF
--- a/.continuity/20260514-105939-fix-deps-systeminformation-dependabot-alert.md
+++ b/.continuity/20260514-105939-fix-deps-systeminformation-dependabot-alert.md
@@ -1,0 +1,51 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve open `systeminformation` Dependabot alert #208 on github.com/giselles-ai/giselle/security/dependabot.
+
+## Goal (incl. success criteria)
+
+- Alert #208 closes after the bump:
+  - `systeminformation` GHSA-hvx9-hwr7-wjj9 / CVE-2026-44724 (high) — Linux command injection in `networkInterfaces()` via unsanitized NetworkManager connection profile name.
+
+## Constraints/Assumptions
+
+- `systeminformation` is not a direct workspace dependency; it enters the tree transitively via `@opentelemetry/host-metrics` (pulled in by `@trigger.dev/core`). It is already pinned via root `pnpm.overrides`.
+- The advisory only requires bumping to `5.31.6`; this stays on the 5.x line.
+
+## Key decisions
+
+- Bump `pnpm.overrides.systeminformation` from `5.31.5` → `5.31.6` — the first patched version per the advisory.
+
+## State
+
+- Edit applied to root `package.json` `pnpm.overrides`.
+- `pnpm install` updated the lockfile to `systeminformation@5.31.6`.
+
+## Done
+
+- Updated root `package.json` overrides.
+- `pnpm install` → success.
+- `pnpm format` → clean (pre-existing broken-symlink warning in `apps/studio.giselles.ai/out/static`).
+- `pnpm build-sdk` → 28/28 successful (FULL TURBO cache).
+- `pnpm check-types` → 31/31 successful.
+- `pnpm test` → 218/218 tests pass.
+
+## Now
+
+- Awaiting commit and PR.
+
+## Next
+
+- Commit the override bump and open a PR. The `license_finder` workflow will auto-commit `docs/packages-license.md` to the PR branch. Dependabot will auto-close alert #208 once merged.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `package.json` (root) — `pnpm.overrides.systeminformation`.
+- `pnpm-lock.yaml` — regenerated.
+- Verification: `pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm test`.

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -12630,7 +12630,7 @@ Unknown manually approved
 
 
 <a name="systeminformation"></a>
-### systeminformation v5.31.5
+### systeminformation v5.31.6
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 			"js-yaml@>=3.0.0 <4.0.0": "3.14.2",
 			"@esbuild-kit/core-utils>esbuild": "0.25.10",
 			"serialize-javascript": "7.0.3",
-			"systeminformation": "5.31.5",
+			"systeminformation": "5.31.6",
 			"socket.io-parser": "4.2.6",
 			"undici@>=7.0.0 <7.24.0": "7.24.4",
 			"@xmldom/xmldom": "0.8.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,7 +283,7 @@ overrides:
   js-yaml@>=3.0.0 <4.0.0: 3.14.2
   '@esbuild-kit/core-utils>esbuild': 0.25.10
   serialize-javascript: 7.0.3
-  systeminformation: 5.31.5
+  systeminformation: 5.31.6
   socket.io-parser: 4.2.6
   undici@>=7.0.0 <7.24.0: 7.24.4
   '@xmldom/xmldom': 0.8.13
@@ -8360,8 +8360,8 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  systeminformation@5.31.5:
-    resolution: {integrity: sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==}
+  systeminformation@5.31.6:
+    resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -10684,7 +10684,7 @@ snapshots:
   '@opentelemetry/host-metrics@0.37.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      systeminformation: 5.31.5
+      systeminformation: 5.31.6
 
   '@opentelemetry/instrumentation-amqplib@0.58.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -16887,7 +16887,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  systeminformation@5.31.5: {}
+  systeminformation@5.31.6: {}
 
   tagged-tag@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- Bumps the root `pnpm.overrides.systeminformation` pin from `5.31.5` → `5.31.6` to resolve Dependabot alert #208.
- `systeminformation` is not a direct workspace dependency; it enters the tree via `@opentelemetry/host-metrics` (pulled in by `@trigger.dev/core`). Already managed by override, so this is a one-line bump.

## Alert closed

| # | Package | Severity | Advisory |
|---|---|---|---|
| [#208](https://github.com/giselles-ai/giselle/security/dependabot/208) | `systeminformation` | high | GHSA-hvx9-hwr7-wjj9 / CVE-2026-44724 — Linux command injection in `networkInterfaces()` via unsanitized NetworkManager connection profile name |

## Test plan

- [x] `pnpm install` — lockfile updates to `systeminformation@5.31.6`
- [x] `pnpm format` — clean
- [x] `pnpm build-sdk` — 28/28 packages build
- [x] `pnpm check-types` — 31/31 type-check tasks pass
- [x] `pnpm test` — 218/218 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated systeminformation dependency to version 5.31.6.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/giselles-ai/giselle/pull/2917)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->