### PR TITLE
fix(deps): bump nodemailer to 8.0.7 (GHSA-c7w3-x93f-qmm8, GHSA-vvjj-xcjg-gr5g)

### DIFF
--- a/.continuity/20260518-092032-fix-deps-nodemailer-dependabot-alerts.md
+++ b/.continuity/20260518-092032-fix-deps-nodemailer-dependabot-alerts.md
@@ -1,0 +1,53 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve open `nodemailer` Dependabot alerts #140, #141, #161, #162 on github.com/giselles-ai/giselle/security/dependabot.
+
+## Goal (incl. success criteria)
+
+- All four alerts close after the bump. They reduce to two underlying advisories:
+  - GHSA-c7w3-x93f-qmm8 (low) — SMTP command injection via unsanitized `envelope.size` (#140 lockfile / #141 direct dep). Patched in `8.0.4`.
+  - GHSA-vvjj-xcjg-gr5g (medium) — SMTP command injection via unsanitized transport `name` (EHLO/HELO) (#161 lockfile / #162 direct dep). Patched in `8.0.5`.
+
+## Constraints/Assumptions
+
+- `nodemailer` is a direct dependency declared in `apps/studio.giselles.ai/package.json` (was pinned at `7.0.11`).
+- Only one call site uses `nodemailer`: `apps/studio.giselles.ai/services/external/email/send-email.ts`. It calls `createTransport({ host, port, secure, auth })` and `sendMail({ from, to, subject, text, html })`. It does NOT use the vulnerable `envelope.size` field or a custom transport `name`, so real-world exposure is negligible — but the alerts still need to close.
+- Latest stable is `8.0.7`. Major bump `7.x → 8.x` but the public API surface used in `send-email.ts` is unchanged.
+
+## Key decisions
+
+- Bump `nodemailer` directly in `apps/studio.giselles.ai/package.json` from `7.0.11` → `8.0.7` (latest, > 8.0.5 patched threshold). No root `pnpm.overrides` entry needed because it is a direct dep.
+
+## State
+
+- Edit applied to `apps/studio.giselles.ai/package.json`.
+- `pnpm install` updated the lockfile to `nodemailer@8.0.7`.
+
+## Done
+
+- Updated direct dep version.
+- `pnpm install` → success.
+- `pnpm format` → clean.
+- `pnpm build-sdk` → 28/28 successful.
+- `pnpm check-types` → 31/31 successful (cache miss only on `studio.giselles.ai:check-types`).
+- `pnpm test` → 9/9 tasks, all suites pass.
+
+## Now
+
+- Awaiting commit and PR.
+
+## Next
+
+- Commit and open a PR. The `license_finder` workflow will auto-commit `docs/packages-license.md` to the PR branch. Dependabot will auto-close alerts #140, #141, #161, #162 once merged.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `apps/studio.giselles.ai/package.json` — `dependencies.nodemailer`.
+- `pnpm-lock.yaml` — regenerated.
+- Verification: `pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm test`.

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -82,7 +82,7 @@
 		"motion": "catalog:",
 		"next": "catalog:",
 		"next-themes": "0.3.0",
-		"nodemailer": "7.0.11",
+		"nodemailer": "8.0.7",
 		"nuqs": "catalog:",
 		"openai": "catalog:",
 		"pg": "catalog:",

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -10217,7 +10217,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="nodemailer"></a>
-### nodemailer v7.0.11
+### nodemailer v8.0.7
 #### 
 
 ##### Paths

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,8 +494,8 @@ importers:
         specifier: 0.3.0
         version: 0.3.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       nodemailer:
-        specifier: 7.0.11
-        version: 7.0.11
+        specifier: 8.0.7
+        version: 8.0.7
       nuqs:
         specifier: 'catalog:'
         version: 2.6.0(next@16.2.6(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -7338,8 +7338,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  nodemailer@7.0.11:
-    resolution: {integrity: sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==}
+  nodemailer@8.0.7:
+    resolution: {integrity: sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -15604,7 +15604,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  nodemailer@7.0.11: {}
+  nodemailer@8.0.7: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary

- Resolves Dependabot alerts [#140](https://github.com/giselles-ai/giselle/security/dependabot/140), [#141](https://github.com/giselles-ai/giselle/security/dependabot/141), [#161](https://github.com/giselles-ai/giselle/security/dependabot/161), [#162](https://github.com/giselles-ai/giselle/security/dependabot/162) — two underlying `nodemailer` SMTP command-injection advisories (CRLF):
  - **GHSA-c7w3-x93f-qmm8** (low) — `envelope.size` injected into `MAIL FROM` (patched in 8.0.4)
  - **GHSA-vvjj-xcjg-gr5g** (medium) — transport `name` injected into `EHLO`/`HELO` (patched in 8.0.5)
- `nodemailer` is a direct dependency in `apps/studio.giselles.ai`; bumped from `7.0.11` to `8.0.7` (latest).
- The single call site (`apps/studio.giselles.ai/services/external/email/send-email.ts`) does not pass `envelope.size` nor a custom transport `name`, so real-world exposure was negligible — the bump is to close the alerts.

## Test plan

- [x] `pnpm install` regenerates the lockfile with `nodemailer@8.0.7`
- [x] `pnpm format` clean
- [x] `pnpm build-sdk` (28/28)
- [x] `pnpm check-types` (31/31)
- [x] `pnpm test` (9/9 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Nodemailer library updated to version 8.0.7 and documentation refreshed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/giselles-ai/giselle/pull/2919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->