### PR TITLE
fix(deps): bump picomatch to 2.3.2 / 4.0.4 (CVE-2026-33672)

### DIFF
--- a/.continuity/20260518-092854-fix-deps-picomatch-dependabot-alerts.md
+++ b/.continuity/20260518-092854-fix-deps-picomatch-dependabot-alerts.md
@@ -1,0 +1,61 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve open `picomatch` Dependabot alerts #137 and #148 on github.com/giselles-ai/giselle/security/dependabot.
+
+## Goal (incl. success criteria)
+
+- Both alerts close after the bump. They cover the same advisory
+  GHSA-3v7f-55p6-f55p / CVE-2026-33672 (medium) — method injection via
+  POSIX bracket expressions in `POSIX_REGEX_SOURCE`, leading to incorrect
+  glob matching.
+  - #137 targets the 4.x range: `>= 4.0.0, < 4.0.4`, patched in `4.0.4`.
+  - #148 targets the 2.x range: `< 2.3.2`, patched in `2.3.2`.
+
+## Constraints/Assumptions
+
+- `picomatch` is a transitive dev dependency only. Two versions are present in the tree:
+  - `picomatch@2.3.1` — via `@changesets/cli` → `micromatch` and other tooling.
+  - `picomatch@4.0.3` — via `vite`/`turbo`/`vitest` family tools through `fdir`.
+- No application code processes untrusted glob patterns through picomatch; impact in this repo is limited to build/test tooling, but the alerts still need to close.
+
+## Key decisions
+
+- Add two version-range `pnpm.overrides` pins:
+  - `"picomatch@>=4.0.0 <4.0.4": "4.0.4"`
+  - `"picomatch@<2.3.2": "2.3.2"`
+
+  Range overrides avoid forcing the 2.x consumers onto 4.x (potential ESM/CJS breakage) and only upgrade vulnerable versions to the nearest patched release on the same major line.
+
+## State
+
+- Edits applied to root `package.json` `pnpm.overrides`.
+- `pnpm install` updated the lockfile: `picomatch@2.3.1` → `2.3.2`, `picomatch@4.0.3` → `4.0.4`.
+
+## Done
+
+- Updated root `package.json` overrides.
+- `pnpm install` → success.
+- `pnpm format` → clean.
+- `pnpm build-sdk` → 28/28 successful.
+- `pnpm check-types` → 31/31 successful.
+- `pnpm test` → 9/9 tasks pass.
+
+## Now
+
+- Awaiting commit and PR.
+
+## Next
+
+- Commit and open a PR. The `license_finder` workflow will auto-commit `docs/packages-license.md` to the PR branch. Dependabot will auto-close #137 and #148 once merged.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `package.json` (root) — `pnpm.overrides` two new picomatch range pins.
+- `pnpm-lock.yaml` — regenerated.
+- Verification: `pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm test`.

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -10822,7 +10822,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="picomatch"></a>
-### picomatch v2.3.1
+### picomatch v2.3.2
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
 			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2",
 			"express-rate-limit": "8.2.2",
 			"ip-address": "10.1.1",
+			"picomatch@>=4.0.0 <4.0.4": "4.0.4",
+			"picomatch@<2.3.2": "2.3.2",
 			"brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
 			"postcss@<8.5.10": "8.5.12",
 			"uuid@<14.0.0": "14.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,8 @@ overrides:
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
   express-rate-limit: 8.2.2
   ip-address: 10.1.1
+  picomatch@>=4.0.0 <4.0.4: 4.0.4
+  picomatch@<2.3.2: 2.3.2
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
   postcss@<8.5.10: 8.5.12
   uuid@<14.0.0: 14.0.0
@@ -6251,7 +6253,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -7598,12 +7600,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pify@4.0.1:
@@ -11980,10 +11982,10 @@ snapshots:
       '@rollup/pluginutils': 5.1.4(rollup@4.59.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.59.0
 
@@ -11991,7 +11993,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.59.0
 
@@ -14220,9 +14222,9 @@ snapshots:
     dependencies:
       walk-up-path: 4.0.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fflate@0.4.8: {}
 
@@ -14916,7 +14918,7 @@ snapshots:
       minimist: 1.2.8
       oxc-resolver: 11.18.0
       picocolors: 1.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
       typescript: 5.7.3
@@ -15476,7 +15478,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -15848,9 +15850,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pify@4.0.1: {}
 
@@ -16960,8 +16962,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.0.3: {}
 
@@ -17282,8 +17284,8 @@ snapshots:
   vite@7.3.2(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.20.6)(yaml@2.7.0):
     dependencies:
       esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.12
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -17299,8 +17301,8 @@ snapshots:
   vite@7.3.2(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.12
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -17316,8 +17318,8 @@ snapshots:
   vite@7.3.2(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.12
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -17344,7 +17346,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -17384,7 +17386,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -17424,7 +17426,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2


### PR DESCRIPTION
## Summary

- Resolves Dependabot alerts [#137](https://github.com/giselles-ai/giselle/security/dependabot/137) and [#148](https://github.com/giselles-ai/giselle/security/dependabot/148) (GHSA-3v7f-55p6-f55p / CVE-2026-33672), a medium-severity method injection in `POSIX_REGEX_SOURCE` that causes incorrect glob matching.
- Two vulnerable `picomatch` versions are present transitively as dev dependencies: `2.3.1` (via `@changesets/cli` → `micromatch`) and `4.0.3` (via `vite`/`turbo` tooling through `fdir`).
- Adds two range-scoped `pnpm.overrides` so each consumer stays on its existing major line:
  - `picomatch@>=4.0.0 <4.0.4` → `4.0.4`
  - `picomatch@<2.3.2` → `2.3.2`

## Test plan

- [x] `pnpm install` regenerates the lockfile with `picomatch@2.3.2` and `picomatch@4.0.4`
- [x] `pnpm format` clean
- [x] `pnpm build-sdk` (28/28)
- [x] `pnpm check-types` (31/31)
- [x] `pnpm test` (9/9 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `picomatch` dependency with explicit version overrides in package configuration
  * Updated package license documentation to reflect the latest dependency version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/giselles-ai/giselle/pull/2920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->