### PR TITLE
fix(deps): bump serialize-javascript to 7.0.5 (CVE-2026-34043)

### DIFF
--- a/.continuity/20260518-093754-fix-deps-serialize-javascript-dependabot-alert.md
+++ b/.continuity/20260518-093754-fix-deps-serialize-javascript-dependabot-alert.md
@@ -1,0 +1,50 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Resolve open `serialize-javascript` Dependabot alert #146 on github.com/giselles-ai/giselle/security/dependabot.
+
+## Goal (incl. success criteria)
+
+- Alert #146 closes after the bump:
+  - GHSA-qj8w-gfj5-8c6v / CVE-2026-34043 (medium) — CPU-exhaustion DoS when serializing crafted array-like objects with very large `length`. Patched in `7.0.5`.
+
+## Constraints/Assumptions
+
+- `serialize-javascript` is not a direct workspace dependency; it enters the tree transitively (via webpack/terser tooling) and is already pinned via root `pnpm.overrides` at `7.0.3`, which is still on the vulnerable range `< 7.0.5`.
+
+## Key decisions
+
+- Bump `pnpm.overrides.serialize-javascript` from `7.0.3` → `7.0.5` — the first patched version per the advisory.
+
+## State
+
+- Edit applied to root `package.json` `pnpm.overrides`.
+- `pnpm install` updated the lockfile to `serialize-javascript@7.0.5`.
+
+## Done
+
+- Updated root `package.json` overrides.
+- `pnpm install` → success.
+- `pnpm format` → clean.
+- `pnpm build-sdk` → 28/28 successful.
+- `pnpm check-types` → 31/31 successful.
+- `pnpm test` → 9/9 tasks pass.
+
+## Now
+
+- Awaiting commit and PR.
+
+## Next
+
+- Commit and open a PR. The `license_finder` workflow will auto-commit `docs/packages-license.md` to the PR branch. Dependabot will auto-close alert #146 once merged.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `package.json` (root) — `pnpm.overrides.serialize-javascript`.
+- `pnpm-lock.yaml` — regenerated.
+- Verification: `pnpm install`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm test`.

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -12043,7 +12043,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="serialize-javascript"></a>
-### serialize-javascript v7.0.3
+### serialize-javascript v7.0.5
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 			"ajv@>=6.0.0 <7.0.0": "6.14.0",
 			"js-yaml@>=3.0.0 <4.0.0": "3.14.2",
 			"@esbuild-kit/core-utils>esbuild": "0.25.10",
-			"serialize-javascript": "7.0.3",
+			"serialize-javascript": "7.0.5",
 			"systeminformation": "5.31.6",
 			"socket.io-parser": "4.2.6",
 			"undici@>=7.0.0 <7.24.0": "7.24.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ overrides:
   ajv@>=6.0.0 <7.0.0: 6.14.0
   js-yaml@>=3.0.0 <4.0.0: 3.14.2
   '@esbuild-kit/core-utils>esbuild': 0.25.10
-  serialize-javascript: 7.0.3
+  serialize-javascript: 7.0.5
   systeminformation: 5.31.6
   socket.io-parser: 4.2.6
   undici@>=7.0.0 <7.24.0: 7.24.4
@@ -8106,8 +8106,8 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  serialize-javascript@7.0.3:
-    resolution: {integrity: sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
   serve-static@2.2.1:
@@ -16542,7 +16542,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@7.0.3: {}
+  serialize-javascript@7.0.5: {}
 
   serve-static@2.2.1:
     dependencies:
@@ -16919,7 +16919,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 7.0.3
+      serialize-javascript: 7.0.5
       terser: 5.46.0
       webpack: 5.104.1
 


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert [#146](https://github.com/giselles-ai/giselle/security/dependabot/146) (GHSA-qj8w-gfj5-8c6v / CVE-2026-34043), a medium-severity CPU-exhaustion DoS when `serialize-javascript` serializes a crafted array-like object with a very large `length`.
- `serialize-javascript` is transitive; bumps the root `pnpm.overrides` pin from `7.0.3` → `7.0.5`, the first patched version.

## Test plan

- [x] `pnpm install` regenerates the lockfile with `serialize-javascript@7.0.5`
- [x] `pnpm format` clean
- [x] `pnpm build-sdk` (28/28)
- [x] `pnpm check-types` (31/31)
- [x] `pnpm test` (9/9 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `serialize-javascript` to version 7.0.5 with verification complete.

* **Documentation**
  * Updated package license documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/giselles-ai/giselle/pull/2921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->