### PR TITLE
fix: prevent SVG files from reaching LLM vision providers

### DIFF
--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx
@@ -51,7 +51,7 @@ class InvalidFileTypeError extends FileUploadError {
 			case "image/png":
 			case "image/gif":
 			case "image/svg+xml":
-				return "Please use Image node to upload this file.";
+				return "SVG files are not supported. Please convert to PNG, JPEG, GIF, or WebP.";
 			case "application/pdf":
 				return "Please use PDF node to upload this file.";
 			case "text/plain":
@@ -226,7 +226,7 @@ export function FilePanel({ node, config }: FilePanelProps) {
 
 			const imageItems: DataTransferItem[] = [];
 			for (const item of items) {
-				if (item.type.startsWith("image/")) {
+				if (config.accept.includes(item.type)) {
 					imageItems.push(item);
 				}
 			}

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -15,7 +15,7 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 		label: "Text",
 	},
 	image: {
-		accept: ["image/png", "image/jpeg", "image/gif", "image/svg+xml"],
+		accept: ["image/png", "image/jpeg", "image/gif", "image/webp"],
 		label: "Image",
 	},
 };

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -1,3 +1,4 @@
+import { SUPPORTED_IMAGE_MIME_TYPES } from "@giselles-ai/protocol";
 import type { FileCategory, FileNode } from "@giselles-ai/protocol";
 import { useDeleteNode, useUpdateNodeData } from "../../../app-designer";
 import { PropertiesPanelContent, PropertiesPanelRoot } from "../ui";
@@ -15,7 +16,7 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 		label: "Text",
 	},
 	image: {
-		accept: ["image/png", "image/jpeg", "image/gif", "image/webp"],
+		accept: [...SUPPORTED_IMAGE_MIME_TYPES],
 		label: "Image",
 	},
 };

--- a/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
+++ b/internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx
@@ -1,4 +1,4 @@
-import { SUPPORTED_IMAGE_MIME_TYPES } from "@giselles-ai/protocol";
+import { supportedImageMimeTypes } from "@giselles-ai/protocol";
 import type { FileCategory, FileNode } from "@giselles-ai/protocol";
 import { useDeleteNode, useUpdateNodeData } from "../../../app-designer";
 import { PropertiesPanelContent, PropertiesPanelRoot } from "../ui";
@@ -16,7 +16,7 @@ const fileType: Record<FileCategory, FileTypeConfig> = {
 		label: "Text",
 	},
 	image: {
-		accept: [...SUPPORTED_IMAGE_MIME_TYPES],
+		accept: [...supportedImageMimeTypes],
 		label: "Image",
 	},
 };

--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -1,4 +1,5 @@
 import { parseConfiguration } from "@giselles-ai/data-store-registry";
+import { SUPPORTED_IMAGE_MIME_TYPES } from "@giselles-ai/protocol";
 import { isClonedFileDataPayload } from "@giselles-ai/node-registry";
 import type {
 	FailedGeneration,

--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -579,7 +579,7 @@ export async function useGenerationExecutor<T>(args: {
 							case "image/jpeg":
 							case "image/png":
 							case "image/gif":
-							case "image/svg+xml":
+							case "image/webp":
 								return {
 									type: "image",
 									image: blob,

--- a/packages/giselle/src/generations/internal/use-generation-executor.ts
+++ b/packages/giselle/src/generations/internal/use-generation-executor.ts
@@ -1,5 +1,5 @@
 import { parseConfiguration } from "@giselles-ai/data-store-registry";
-import { SUPPORTED_IMAGE_MIME_TYPES } from "@giselles-ai/protocol";
+import { supportedImageMimeTypes } from "@giselles-ai/protocol";
 import { isClonedFileDataPayload } from "@giselles-ai/node-registry";
 import type {
 	FailedGeneration,

--- a/packages/giselle/src/generations/utils.ts
+++ b/packages/giselle/src/generations/utils.ts
@@ -1,5 +1,5 @@
 import { hasTierAccess, languageModels } from "@giselles-ai/language-model";
-import { SUPPORTED_IMAGE_MIME_TYPES } from "@giselles-ai/protocol";
+import { supportedImageMimeTypes } from "@giselles-ai/protocol";
 import {
 	type CompletedGeneration,
 	type ContentGenerationNode,
@@ -481,7 +481,7 @@ async function getFileContents(
 						mediaType: file.type,
 					} satisfies FilePart;
 				case "image": {
-					const supportedImageTypes = SUPPORTED_IMAGE_MIME_TYPES;
+					const supportedImageTypes = supportedImageMimeTypes;
 					if (!supportedImageTypes.includes(file.type)) {
 						return null;
 					}

--- a/packages/giselle/src/generations/utils.ts
+++ b/packages/giselle/src/generations/utils.ts
@@ -240,6 +240,8 @@ async function buildGenerationMessageForTextGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						} else {
+							userMessage = userMessage.replace(replaceKeyword, "");
 						}
 						break;
 					}
@@ -314,6 +316,8 @@ async function buildGenerationMessageForTextGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						} else {
+							userMessage = userMessage.replace(replaceKeyword, "");
 						}
 						break;
 					default: {
@@ -592,6 +596,8 @@ async function buildGenerationMessageForImageGeneration(
 						);
 
 						attachedFiles.push(...fileContents);
+						} else {
+							userMessage = userMessage.replace(replaceKeyword, "");
 						}
 						break;
 					}
@@ -639,6 +645,8 @@ async function buildGenerationMessageForImageGeneration(
 						);
 
 						attachedFiles.push(...fileContents);
+						} else {
+							userMessage = userMessage.replace(replaceKeyword, "");
 						}
 						break;
 					default: {
@@ -1095,6 +1103,8 @@ async function buildGenerationMessageForContentGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						} else {
+							userMessage = userMessage.replace(replaceKeyword, "");
 						}
 						break;
 					}
@@ -1149,6 +1159,8 @@ async function buildGenerationMessageForContentGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						} else {
+							userMessage = userMessage.replace(replaceKeyword, "");
 						}
 						break;
 					default: {

--- a/packages/giselle/src/generations/utils.ts
+++ b/packages/giselle/src/generations/utils.ts
@@ -471,12 +471,17 @@ async function getFileContents(
 						filename: file.name,
 						mediaType: file.type,
 					} satisfies FilePart;
-				case "image":
+				case "image": {
+					const SUPPORTED = ["image/jpeg","image/png","image/gif","image/webp"];
+					if (!SUPPORTED.includes(file.type)) {
+						return null;
+					}
 					return {
 						type: "image",
 						image: data,
 						mediaType: file.type,
 					} satisfies ImagePart;
+				}
 				default: {
 					const _exhaustiveCheck: never = fileContent.category;
 					throw new Error(`Unhandled file category: ${_exhaustiveCheck}`);

--- a/packages/giselle/src/generations/utils.ts
+++ b/packages/giselle/src/generations/utils.ts
@@ -1,4 +1,5 @@
 import { hasTierAccess, languageModels } from "@giselles-ai/language-model";
+import { SUPPORTED_IMAGE_MIME_TYPES } from "@giselles-ai/protocol";
 import {
 	type CompletedGeneration,
 	type ContentGenerationNode,
@@ -476,7 +477,7 @@ async function getFileContents(
 						mediaType: file.type,
 					} satisfies FilePart;
 				case "image": {
-					const supportedImageTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+					const supportedImageTypes = SUPPORTED_IMAGE_MIME_TYPES;
 					if (!supportedImageTypes.includes(file.type)) {
 						return null;
 					}

--- a/packages/giselle/src/generations/utils.ts
+++ b/packages/giselle/src/generations/utils.ts
@@ -231,6 +231,7 @@ async function buildGenerationMessageForTextGeneration({
 							contextNode.content,
 							fileResolver,
 						);
+						if (fileContents.length > 0) {
 						userMessage = userMessage.replace(
 							replaceKeyword,
 							getFilesDescription(attachedFiles.length, fileContents.length),
@@ -238,6 +239,7 @@ async function buildGenerationMessageForTextGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						}
 						break;
 					}
 					default: {
@@ -303,6 +305,7 @@ async function buildGenerationMessageForTextGeneration({
 						);
 						break;
 					case "google":
+						if (fileContents.length > 0) {
 						userMessage = userMessage.replace(
 							replaceKeyword,
 							getFilesDescription(attachedFiles.length, fileContents.length),
@@ -310,6 +313,7 @@ async function buildGenerationMessageForTextGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						}
 						break;
 					default: {
 						const _exhaustiveCheck: never = llmProvider;
@@ -472,8 +476,8 @@ async function getFileContents(
 						mediaType: file.type,
 					} satisfies FilePart;
 				case "image": {
-					const SUPPORTED = ["image/jpeg","image/png","image/gif","image/webp"];
-					if (!SUPPORTED.includes(file.type)) {
+					const supportedImageTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+					if (!supportedImageTypes.includes(file.type)) {
 						return null;
 					}
 					return {
@@ -580,12 +584,14 @@ async function buildGenerationMessageForImageGeneration(
 							contextNode.content,
 							fileResolver,
 						);
+						if (fileContents.length > 0) {
 						userMessage = userMessage.replace(
 							replaceKeyword,
 							getFilesDescription(attachedFiles.length, fileContents.length),
 						);
 
 						attachedFiles.push(...fileContents);
+						}
 						break;
 					}
 					default: {
@@ -625,12 +631,14 @@ async function buildGenerationMessageForImageGeneration(
 						);
 						break;
 					case "google":
+						if (fileContents.length > 0) {
 						userMessage = userMessage.replace(
 							replaceKeyword,
 							getFilesDescription(attachedFiles.length, fileContents.length),
 						);
 
 						attachedFiles.push(...fileContents);
+						}
 						break;
 					default: {
 						const _exhaustiveCheck: never = llmProvider;
@@ -1078,6 +1086,7 @@ async function buildGenerationMessageForContentGeneration({
 							contextNode.content,
 							fileResolver,
 						);
+						if (fileContents.length > 0) {
 						userMessage = userMessage.replace(
 							replaceKeyword,
 							getFilesDescription(attachedFiles.length, fileContents.length),
@@ -1085,6 +1094,7 @@ async function buildGenerationMessageForContentGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						}
 						break;
 					}
 					default: {
@@ -1130,6 +1140,7 @@ async function buildGenerationMessageForContentGeneration({
 						);
 						break;
 					case "google":
+						if (fileContents.length > 0) {
 						userMessage = userMessage.replace(
 							replaceKeyword,
 							getFilesDescription(attachedFiles.length, fileContents.length),
@@ -1137,6 +1148,7 @@ async function buildGenerationMessageForContentGeneration({
 
 						attachedFiles.push(...fileContents);
 						attachedFileNodeIds.push(contextNode.id);
+						}
 						break;
 					default: {
 						const _exhaustiveCheck: never = llmProvider;

--- a/packages/protocol/src/node/variables/file.ts
+++ b/packages/protocol/src/node/variables/file.ts
@@ -115,6 +115,14 @@ export const FileData = z.union([
 ]);
 export type FileData = z.infer<typeof FileData>;
 
+export const SUPPORTED_IMAGE_MIME_TYPES = [
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+] as const;
+export type SupportedImageMimeType = (typeof SUPPORTED_IMAGE_MIME_TYPES)[number];
+
 export const FileCategory = z.enum(["pdf", "text", "image"]);
 export type FileCategory = z.infer<typeof FileCategory>;
 export const FileContent = z.object({

--- a/packages/protocol/src/node/variables/file.ts
+++ b/packages/protocol/src/node/variables/file.ts
@@ -115,13 +115,13 @@ export const FileData = z.union([
 ]);
 export type FileData = z.infer<typeof FileData>;
 
-export const SUPPORTED_IMAGE_MIME_TYPES = [
+export const supportedImageMimeTypes = [
 	"image/jpeg",
 	"image/png",
 	"image/gif",
 	"image/webp",
 ] as const;
-export type SupportedImageMimeType = (typeof SUPPORTED_IMAGE_MIME_TYPES)[number];
+export type SupportedImageMimeType = (typeof supportedImageMimeTypes)[number];
 
 export const FileCategory = z.enum(["pdf", "text", "image"]);
 export type FileCategory = z.infer<typeof FileCategory>;


### PR DESCRIPTION
## Problem

SVG files (`image/svg+xml`) can be uploaded as images and are passed to LLM providers as `ImagePart` objects. No provider (OpenAI, Anthropic, Google) supports SVG for vision input, resulting in:

```
UnknownError: Unsupported MIME type: image/svg+xml
```

This is a more complete fix. previous fixes only addressed one of four affected locations. A bot review on that PR identified the remaining gaps.

## Changes

### 1. `packages/giselle/src/generations/utils.ts`
Filter unsupported MIME types inside `getFileContents()` before returning `ImagePart`. This fixes all File/Image node code paths — the function is called from 3 separate generation builders.

### 2. `packages/giselle/src/generations/internal/use-generation-executor.ts`
Remove `image/svg+xml` from the `appEntryResolver` switch and add `image/webp`.

### 3. `internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/index.tsx`
Remove `image/svg+xml` from the UI accept list and add `image/webp`.

### 4. `internal-packages/workflow-designer-ui/src/editor/properties-panel/file-node-properties-panel/file-panel.tsx`
- Fix `handlePaste` which used `item.type.startsWith("image/")` — this accepted any image/* including SVG, bypassing `config.accept` entirely
- Fix `InvalidFileTypeError.suggestion()` which incorrectly told users SVG belongs in the Image node — SVG is not supported anywhere

## Testing

```bash
pnpm -C packages/giselle test
pnpm check-types
pnpm format
```

Closes #2714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded supported image formats across the app to include WebP (alongside JPEG, PNG, and GIF).

* **Bug Fixes**
  * Clipboard paste validation now only accepts the configured MIME types.
  * Image uploads and generation inputs now allow only supported image formats and omit unsupported ones (including SVG).
  * Prevented empty attachments from being included during message preparation.

* **Documentation**
  * Improved invalid file-type messaging with clearer guidance to convert SVG to PNG/JPEG/GIF/WebP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->