### PR TITLE
fix: add missing file size validation in dialog and run-modal upload paths

### DIFF
--- a/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
@@ -101,8 +101,7 @@ export function RunModal({
 				const message =
 					error instanceof Error ? error.message : "Failed to run app.";
 				setSubmitError(message);
-				console.error("Failed to run app:", error);
-			}
+				}
 			return null;
 		},
 		[inputs, flowTriggerData, onClose, client],

--- a/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
@@ -48,12 +48,14 @@ export function RunModal({
 	// Load flow trigger data when modal opens
 	useEffect(() => {
 		if (isOpen && workspaceId) {
+			setSubmitError(null);
 			setIsLoading(true);
 			fetchWorkspaceFlowTrigger(workspaceId)
 				.then(setFlowTriggerData)
 				.finally(() => setIsLoading(false));
 		} else {
 			setFlowTriggerData(null);
+			setSubmitError(null);
 		}
 	}, [isOpen, workspaceId]);
 

--- a/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
@@ -43,6 +43,7 @@ export function RunModal({
 	const [validationErrors, setValidationErrors] = useState<
 		Record<string, string>
 	>({});
+	const [submitError, setSubmitError] = useState<string | null>(null);
 
 	// Load flow trigger data when modal opens
 	useEffect(() => {
@@ -73,6 +74,7 @@ export function RunModal({
 			}
 
 			setValidationErrors({});
+			setSubmitError(null);
 
 			try {
 				const parameterItems = await toParameterItems(inputs, values, {
@@ -94,6 +96,9 @@ export function RunModal({
 				await runWorkspaceApp(flowTriggerData.flowTrigger, parameterItems);
 				onClose();
 			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : "Failed to run app.";
+				setSubmitError(message);
 				console.error("Failed to run app:", error);
 			}
 			return null;
@@ -175,6 +180,9 @@ export function RunModal({
 							</div>
 						) : (
 							<form action={action} className="text-[14px]">
+								{submitError && (
+									<p className="mb-3 text-sm text-red-400">{submitError}</p>
+								)}
 								<FormInputRenderer
 									inputs={inputs}
 									validationErrors={validationErrors}

--- a/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
+++ b/apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx
@@ -83,6 +83,10 @@ export function RunModal({
 						formData.append("fileId", fileId);
 						formData.append("fileName", fileName);
 						formData.append("file", file);
+						const maxFileSize = 1024 * 1024 * 4.5;
+						if (file.size > maxFileSize) {
+							throw new Error(`${fileName}: file size exceeds the 4.5MB limit.`);
+						}
 						await client.uploadFile(formData);
 					},
 				});

--- a/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
@@ -164,7 +164,12 @@ export function AppEntryInputDialog({
 
 						const uploadedFiles: UploadedFileData[] = [];
 
+						const maxFileSize = 1024 * 1024 * 4.5;
 						for (const file of files) {
+							if (file.size > maxFileSize) {
+								errors[parameter.id] = `${parameter.name}: file size exceeds the 4.5MB limit.`;
+								break;
+							}
 							const uploadingFileData = createUploadingFileData({
 								name: file.name,
 								type: file.type || "application/octet-stream",

--- a/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
+++ b/internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx
@@ -165,11 +165,16 @@ export function AppEntryInputDialog({
 						const uploadedFiles: UploadedFileData[] = [];
 
 						const maxFileSize = 1024 * 1024 * 4.5;
+						const hasOversizedFile = files.some(
+							(file) => file.size > maxFileSize,
+						);
+						if (hasOversizedFile) {
+							errors[parameter.id] = `${parameter.name}: file size exceeds the 4.5MB limit.`;
+							values[parameter.id] = [];
+							continue;
+						}
+
 						for (const file of files) {
-							if (file.size > maxFileSize) {
-								errors[parameter.id] = `${parameter.name}: file size exceeds the 4.5MB limit.`;
-								break;
-							}
 							const uploadingFileData = createUploadingFileData({
 								name: file.name,
 								type: file.type || "application/octet-stream",


### PR DESCRIPTION
## Problem

The 4.5MB client-side file size check (required due to Vercel Serverless Function body size limits) was added to `file-panel.tsx` and other upload paths, but was missing from two upload flows:

- `internal-packages/workflow-designer-ui/src/app/app-entry-input-dialog/dialog.tsx`
- `apps/studio.giselles.ai/app/(main)/stage/showcase/[appId]/components/run-modal.tsx`

Users uploading through these paths waste time and bandwidth uploading oversized files, only to have them rejected server-side with no clear feedback.

## Changes

- Added `maxFileSize = 1024 * 1024 * 4.5` check in `dialog.tsx` file upload loop, setting a validation error on the parameter if exceeded
- Added same check in `run-modal.tsx` `uploadFile` callback, throwing before `client.uploadFile` is called

Both checks match the existing pattern in `file-panel.tsx`.

Closes #2623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added per-file upload size validation with a 4.5MB maximum, preventing oversized files from being submitted during workflow execution.
  * Improved the stage “run” experience by capturing submission failures and showing a clearer, user-facing error message in the run modal when a stage can’t be started.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->