### PR TITLE
docs: reflect external PR non-acceptance policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,35 @@
 # Contributing
 
-Thank you for your interest in this project! Please contribute according to the following guidelines:
+Thank you for your interest in Giselle! This document explains how you can engage with the project.
 
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md); please follow it in all your interactions with the project.
+
+## Our contribution policy
+
+Giselle is developed by the core team, and **we do not accept unsolicited external Pull Requests.** Pull requests opened without a prior invitation from the team will be closed without review.
+
+This is not a judgment on the value of your work. Writing code has become inexpensive, but reviewing it carefully still depends on limited maintainer attention, and every external change widens the project's supply-chain surface. To keep Giselle secure and maintainable, code changes are merged by the core team.
+
+This does **not** mean we don't want to hear from you — quite the opposite. There are many valuable ways to get involved, listed below.
+
+## How you can contribute
+
+- **Report a bug** — [open a bug report](https://github.com/giselles-ai/giselle/issues/new?template=1_bug_report.yml) with clear steps to reproduce.
+- **Share an idea or ask a question** — start a thread on [GitHub Discussions](https://github.com/giselles-ai/giselle/discussions).
+- **Report a security issue** — please follow our [Security Policy](SECURITY.md) rather than opening a public issue.
+- **Spread the word** — star the repo and tell others who might find Giselle useful.
+
+When filing a bug report, please try to make it:
+
+- _Reproducible._ Include steps to reproduce the problem.
+- _Specific._ Include as much detail as possible: which version, what environment, etc.
+- _Unique._ Search the [issue archive](https://github.com/giselles-ai/giselle/issues) first -- your issue may already be addressed.
+- _Scoped to a single bug._ One bug per report.
 
 ## Development environment setup
+
+You're welcome to run Giselle locally for self-hosting or to explore the codebase.
 
 Giselle has both a Cloud version and a Self-hosting version, which can be found in the following directories:
 
 - Cloud: [apps/studio.giselles.ai/](apps/studio.giselles.ai/)
-
-## Issues and feature requests
-
-You've found a bug in the source code, a mistake in the documentation or maybe you'd like a new feature? Take a look at [GitHub Discussions](https://github.com/giselles-ai/giselle/discussions) to see if it's already being discussed. You can help us by [submitting an issue on GitHub](https://github.com/giselles-ai/giselle/issues). Before you create an issue, make sure to search the issue archive -- your issue may have already been addressed!
-
-Please try to create bug reports that are:
-
-- _Reproducible._ Include steps to reproduce the problem.
-- _Specific._ Include as much detail as possible: which version, what environment, etc.
-- _Unique._ Do not duplicate existing opened issues.
-- _Scoped to a Single Bug._ One bug per report.
-
-**Even better: Submit a pull request with a fix or new feature!**
-
-### How to submit a Pull Request
-
-1. Search our repository for open or closed [Pull Requests](https://github.com/giselles-ai/giselle/pulls) that relate to your submission. You don't want to duplicate effort.
-2. Fork the project
-3. Create your feature branch (`git switch -c feat/amazing_feature`)
-4. Commit your changes (`git commit -m 'feat: add amazing_feature'`)
-5. Push to the branch (`git push origin feat/amazing_feature`)
-6. [Open a Pull Request](https://github.com/giselles-ai/giselle/compare?expand=1)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Thanks for your interest in Giselle. Here are a few ways you can engage with the
 - Follow us on social media: [Facebook](https://www.facebook.com/GiselleAI/), [X](https://x.com/Giselles_AI), [Instagram](https://www.instagram.com/giselle_de_ai) and [YouTube](https://www.youtube.com/@Giselle_AI)
 - [Report a bug](https://github.com/giselles-ai/giselle/issues/new?template=1_bug_report.yml) you encounter while using Giselle
 - [Share an idea or question](https://github.com/giselles-ai/giselle/discussions) on GitHub Discussions
-- Before opening a pull request for non-trivial changes, please start a discussion so we can align on scope
 
 For details on contributing, please see our [contributing guide](CONTRIBUTING.md).
 


### PR DESCRIPTION
## Summary

giselle does not accept unsolicited external Pull Requests. This updates the community health docs to match the current operation.

- **CONTRIBUTING.md**: Replace the "submit a Pull Request" fork instructions with an explicit no-external-PR policy (with rationale — review attention is the bottleneck, and external changes widen the supply-chain surface) and redirect contributions to issues, discussions, and the security policy. The development environment setup section is kept for self-hosting.
- **README.md**: Drop the line that prompted readers to open a pull request, keeping the link to the contributing guide. The policy detail lives in CONTRIBUTING.md rather than the README.

`CODE_OF_CONDUCT.md` and `SECURITY.md` were reviewed and left unchanged: their content does not invite code PRs and stays consistent with the policy (security reporting via email / GitHub private vulnerability reporting continues to work independently).

## Changes

- `CONTRIBUTING.md` — rewrite contribution policy and channels
- `README.md` — remove PR prompt line

## Testing

Documentation-only change. No code paths affected; Biome format is a no-op for Markdown.

## Other Information

Refs: route06/giselle-division#5676 (parent: route06/giselle-division#5673)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with clearer pathways to engage, including options for reporting bugs, sharing ideas via GitHub Discussions, and reporting security issues.
  * Revised bug report expectations for better quality contributions.
  * Removed outdated pull request submission instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->