### PR TITLE
fix(deps): bump nodemailer to 8.0.9 to fix security advisories

### DIFF
--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -82,7 +82,7 @@
 		"motion": "catalog:",
 		"next": "catalog:",
 		"next-themes": "0.3.0",
-		"nodemailer": "8.0.7",
+		"nodemailer": "8.0.9",
 		"nuqs": "catalog:",
 		"openai": "catalog:",
 		"pg": "catalog:",

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -10195,7 +10195,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="nodemailer"></a>
-### nodemailer v8.0.7
+### nodemailer v8.0.9
 #### 
 
 ##### Paths

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,8 +501,8 @@ importers:
         specifier: 0.3.0
         version: 0.3.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       nodemailer:
-        specifier: 8.0.7
-        version: 8.0.7
+        specifier: 8.0.9
+        version: 8.0.9
       nuqs:
         specifier: 'catalog:'
         version: 2.6.0(next@16.2.6(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -7247,8 +7247,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  nodemailer@8.0.7:
-    resolution: {integrity: sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==}
+  nodemailer@8.0.9:
+    resolution: {integrity: sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -15359,7 +15359,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  nodemailer@8.0.7: {}
+  nodemailer@8.0.9: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary

Bumps `nodemailer` from `8.0.7` to `8.0.9` in `apps/studio.giselles.ai` to resolve three medium-severity Dependabot alerts.

## Resolved alerts

- [#226](https://github.com/giselles-ai/giselle/security/dependabot/226) — Improper TLS Certificate Validation in OAuth2 Token Fetch Enables Credential Interception (patched in 8.0.8)
- [#227](https://github.com/giselles-ai/giselle/security/dependabot/227) — jsonTransport bypasses `disableFileAccess` and `disableUrlAccess` during message normalization (patched in 8.0.9)
- [#228](https://github.com/giselles-ai/giselle/security/dependabot/228) — CRLF injection in List-* header comments allows arbitrary message header injection (patched in 8.0.9)

`8.0.9` covers all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email service library to latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->