### PR TITLE
fix(deps): bump protobufjs to 7.6.3 to fix DoS and property shadowing

### DIFF
--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -2384,7 +2384,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="@protobufjs/eventemitter"></a>
-### @protobufjs/eventemitter v1.1.0
+### @protobufjs/eventemitter v1.1.1
 #### 
 
 ##### Paths
@@ -2395,7 +2395,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="@protobufjs/fetch"></a>
-### @protobufjs/fetch v1.1.0
+### @protobufjs/fetch v1.1.1
 #### 
 
 ##### Paths
@@ -2417,7 +2417,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="@protobufjs/inquire"></a>
-### @protobufjs/inquire v1.1.1
+### @protobufjs/inquire v1.1.2
 #### 
 
 ##### Paths
@@ -9172,7 +9172,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="long"></a>
-### long v5.2.4
+### long v5.3.2
 #### 
 
 ##### Paths
@@ -11295,7 +11295,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="protobufjs"></a>
-### protobufjs v7.5.8
+### protobufjs v7.6.3
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 			"glob@>=11.0.0 <11.1.0": "11.1.0",
 			"fast-xml-parser": "5.7.3",
 			"fast-uri": "3.1.2",
-			"protobufjs": "7.5.8",
+			"protobufjs": "7.6.3",
 			"hono": "4.12.21",
 			"@hono/node-server": "1.19.14",
 			"ajv@>=6.0.0 <7.0.0": "6.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,11 +271,12 @@ overrides:
   '@react-email/preview-server>next': 16.2.6
   '@babel/helpers': 7.26.10
   '@babel/runtime': 7.26.10
+  vite: 7.3.5
   jws: 4.0.1
   glob@>=11.0.0 <11.1.0: 11.1.0
   fast-xml-parser: 5.7.3
   fast-uri: 3.1.2
-  protobufjs: 7.5.8
+  protobufjs: 7.6.3
   hono: 4.12.21
   '@hono/node-server': 1.19.14
   ajv@>=6.0.0 <7.0.0: 6.14.0
@@ -300,7 +301,6 @@ overrides:
   ws@>=8.0.0 <8.21.0: 8.21.0
   ws@>=7.0.0 <7.5.11: 7.5.11
   qs@>=6.11.1 <6.15.2: 6.15.2
-  vite: 7.3.5
 
 importers:
 
@@ -3164,17 +3164,17 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.1':
-    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -6848,8 +6848,8 @@ packages:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
-  long@5.2.4:
-    resolution: {integrity: sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==}
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -7714,8 +7714,8 @@ packages:
   prosemirror-view@1.38.0:
     resolution: {integrity: sha512-O45kxXQTaP9wPdXhp8TKqCR+/unS/gnfg9Q93svQcB3j0mlp2XSPAmsPefxHADwzC+fbNS404jqRxm3UQaGvgw==}
 
-  protobufjs@7.5.8:
-    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
+  protobufjs@7.6.3:
+    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -10683,7 +10683,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.8
+      protobufjs: 7.6.3
 
   '@opentelemetry/redis-common@0.38.2': {}
 
@@ -10836,16 +10836,15 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.1
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.1': {}
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -14774,7 +14773,7 @@ snapshots:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.1.2
 
-  long@5.2.4: {}
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -15851,20 +15850,20 @@ snapshots:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.2
 
-  protobufjs@7.5.8:
+  protobufjs@7.6.3:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
       '@types/node': 25.3.0
-      long: 5.2.4
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:


### PR DESCRIPTION
## Summary

Bumps the `protobufjs` pnpm override from `7.5.8` to `7.6.3` to resolve two Dependabot alerts. `protobufjs` is a transitive dependency pinned via the root `pnpm.overrides`.

## Resolved alerts

- [#237](https://github.com/giselles-ai/giselle/security/dependabot/237) (high) — DoS through unbounded `Any` expansion during JSON conversion, vulnerable `<= 7.6.0` (patched 7.6.1)
- [#236](https://github.com/giselles-ai/giselle/security/dependabot/236) (medium) — schema-derived names can shadow runtime-significant properties, vulnerable `<= 7.6.2` (patched 7.6.3)

`7.6.3` covers both.

## Notes

- Lockfile resolves `protobufjs@7.6.3` everywhere; no `7.5.8` remains.
- Diff is scoped to protobufjs.
- Verified `pnpm install --frozen-lockfile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded protobufjs and related package dependencies to newer versions for improved stability.
* **Documentation**
  * Updated license documentation to reflect the latest versions of project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->