### PR TITLE
fix(deps): bump undici to 7.28.0 to fix security advisories

### DIFF
--- a/.continuity/20260622-000000-fix__undici-dependabot-248-249.md
+++ b/.continuity/20260622-000000-fix__undici-dependabot-248-249.md
@@ -1,0 +1,46 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Fix Dependabot alerts #248 and #249 and open a PR.
+
+## Goal (incl. success criteria)
+
+- Resolve both undici advisories by bumping undici to a non-vulnerable version (>= 7.28.0).
+- Alert #248 (high, GHSA-vmh5-mc38-953g): TLS cert validation bypass via dropped requestTls in SOCKS5 ProxyAgent (>= 7.23.0, < 7.28.0).
+- Alert #249 (medium, GHSA-pr7r-676h-xcf6): cross-user info disclosure via shared cache whitespace bypass (>= 7.0.0, < 7.28.0).
+
+## Constraints/Assumptions
+
+- Stay on undici 7.x (latest 7.x is 7.28.0, which is the patched release). undici 8.x is a major bump, out of scope.
+
+## Key decisions
+
+- Bump catalog `undici` 7.24.4 -> 7.28.0 (pnpm-workspace.yaml).
+- Update root override `undici@>=7.0.0 <7.24.0: 7.24.4` -> `undici@>=7.0.0 <7.28.0: 7.28.0` so any transitive copies in the full vulnerable range are forced to the patched version.
+
+## State
+
+- Changes applied; lockfile regenerated with `pnpm install --lockfile-only`. All undici resolutions now 7.28.0.
+
+## Done
+
+- Edited pnpm-workspace.yaml catalog, package.json override, pnpm-lock.yaml.
+
+## Now
+
+- Commit and open PR.
+
+## Next
+
+- Confirm Dependabot marks both alerts resolved after merge.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- pnpm-workspace.yaml, package.json, pnpm-lock.yaml
+- `pnpm install --lockfile-only`
+- Alerts: dependabot/248, dependabot/249

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -3,7 +3,7 @@
 
 ## Summary
 * 963 MIT
-* 193 Apache 2.0
+* 192 Apache 2.0
 * 42 ISC
 * 24 New BSD
 * 15 Simplified BSD
@@ -125,17 +125,6 @@
 * /home/runner/work/giselle/giselle
 
 <a href="http://opensource.org/licenses/mit-license">MIT</a> permitted
-
-
-
-<a name="@ampproject/remapping"></a>
-### @ampproject/remapping v2.3.0
-#### 
-
-##### Paths
-* /home/runner/work/giselle/giselle
-
-<a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a> permitted
 
 
 
@@ -613,7 +602,7 @@
 
 
 <a name="@babel/compat-data"></a>
-### @babel/compat-data v7.26.5
+### @babel/compat-data v7.29.7
 #### 
 
 ##### Paths
@@ -624,7 +613,7 @@
 
 
 <a name="@babel/core"></a>
-### @babel/core v7.26.7
+### @babel/core v7.29.7
 #### 
 
 ##### Paths
@@ -646,7 +635,7 @@
 
 
 <a name="@babel/helper-compilation-targets"></a>
-### @babel/helper-compilation-targets v7.26.5
+### @babel/helper-compilation-targets v7.29.7
 #### 
 
 ##### Paths
@@ -668,7 +657,7 @@
 
 
 <a name="@babel/helper-module-imports"></a>
-### @babel/helper-module-imports v7.25.9
+### @babel/helper-module-imports v7.29.7
 #### 
 
 ##### Paths
@@ -679,7 +668,7 @@
 
 
 <a name="@babel/helper-module-transforms"></a>
-### @babel/helper-module-transforms v7.26.0
+### @babel/helper-module-transforms v7.29.7
 #### 
 
 ##### Paths
@@ -712,7 +701,7 @@
 
 
 <a name="@babel/helper-validator-option"></a>
-### @babel/helper-validator-option v7.25.9
+### @babel/helper-validator-option v7.29.7
 #### 
 
 ##### Paths
@@ -1845,7 +1834,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="@opentelemetry/core"></a>
-### @opentelemetry/core v2.0.1
+### @opentelemetry/core v2.8.0
 #### 
 
 ##### Paths
@@ -9084,7 +9073,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="linkify-it"></a>
-### linkify-it v5.0.0
+### linkify-it v5.0.1
 #### 
 
 ##### Paths
@@ -9238,7 +9227,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="markdown-it"></a>
-### markdown-it v14.1.1
+### markdown-it v14.2.0
 #### 
 
 ##### Paths
@@ -12685,7 +12674,7 @@ Unknown manually approved
 
 
 <a name="tar"></a>
-### tar v7.5.11
+### tar v7.5.16
 #### 
 
 ##### Paths
@@ -13224,7 +13213,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="undici"></a>
-### undici v7.24.4
+### undici v7.28.0
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 			"serialize-javascript": "7.0.5",
 			"systeminformation": "5.31.6",
 			"socket.io-parser": "4.2.6",
-			"undici@>=7.0.0 <7.24.0": "7.24.4",
+			"undici@>=7.0.0 <7.28.0": "7.28.0",
 			"@xmldom/xmldom": "0.8.13",
 			"path-to-regexp@>=8.0.0 <8.4.0": "8.4.2",
 			"express-rate-limit": "8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ catalogs:
       specifier: 5.7.3
       version: 5.7.3
     undici:
-      specifier: 7.24.4
-      version: 7.24.4
+      specifier: 7.28.0
+      version: 7.28.0
     urql:
       specifier: 4.2.2
       version: 4.2.2
@@ -287,7 +287,7 @@ overrides:
   serialize-javascript: 7.0.5
   systeminformation: 5.31.6
   socket.io-parser: 4.2.6
-  undici@>=7.0.0 <7.24.0: 7.24.4
+  undici@>=7.0.0 <7.28.0: 7.28.0
   '@xmldom/xmldom': 0.8.13
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
   express-rate-limit: 8.2.2
@@ -1581,7 +1581,7 @@ importers:
         version: 2.3.0
       undici:
         specifier: 'catalog:'
-        version: 7.24.4
+        version: 7.28.0
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -8538,8 +8538,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -13083,7 +13083,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.24.4
+      undici: 7.28.0
       xdg-app-paths: 5.1.0
       zod: 3.24.4
     transitivePeerDependencies:
@@ -16944,7 +16944,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.24.4: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,7 +80,7 @@ catalog:
   tsup: 8.5.1
   tsx: 4.20.6
   turndown: 7.2.0
-  undici: 7.24.4
+  undici: 7.28.0
   typescript: 5.7.3
   urql: 4.2.2
   vitest: 4.1.8


### PR DESCRIPTION
## Summary

Resolves two Dependabot alerts for `undici`, both patched in `7.28.0`:

- [Alert 248](https://github.com/giselles-ai/giselle/security/dependabot/248) (high, [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g)) — TLS certificate validation bypass via dropped `requestTls` in SOCKS5 `ProxyAgent` (`>= 7.23.0, < 7.28.0`)
- [Alert 249](https://github.com/giselles-ai/giselle/security/dependabot/249) (medium, [GHSA-pr7r-676h-xcf6](https://github.com/advisories/GHSA-pr7r-676h-xcf6)) — cross-user information disclosure via shared cache whitespace bypass (`>= 7.0.0, < 7.28.0`)

## Changes

- Bump catalog `undici` `7.24.4` → `7.28.0` (`pnpm-workspace.yaml`)
- Widen root override to `undici@>=7.0.0 <7.28.0: 7.28.0` so any transitive copies in the vulnerable range resolve to the patched release
- Regenerate `pnpm-lock.yaml` (all `undici` resolutions now `7.28.0`)

Stays on the `7.x` line — `7.28.0` is the latest `7.x` and the patched release; the `8.x` major is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)