### PR TITLE
fix(deps): bump nodemailer to 9.0.1 to fix file read / SSRF advisory

### DIFF
--- a/.continuity/20260622-010000-fix__nodemailer-dependabot-250-251.md
+++ b/.continuity/20260622-010000-fix__nodemailer-dependabot-250-251.md
@@ -17,18 +17,21 @@
 ## Key decisions
 
 - Bump nodemailer 8.0.9 -> 9.0.1 in apps/studio.giselles.ai/package.json.
+- Also bump @types/nodemailer 6.4.17 -> 8.0.1 (latest; no 9.x typings exist) to track the v9 runtime, after coderabbit flagged a type mismatch. NOTE: real check-types passed even at 6.4.17 once nodemailer@9 was actually installed (the first check-types ran lockfile-only, so node_modules still had v8 — corrected by running full `pnpm install`).
 
 ## State
 
-- Edited package.json, regenerated pnpm-lock.yaml (nodemailer@9.0.1). `pnpm -F studio.giselles.ai check-types` passes.
+- PR #2950 open. CI all green. Two bot comments handled (replies posted):
+  - qodo (packages-license.md stale): auto-resolved by License Compliance CI commit 8878702.
+  - coderabbit (@types/nodemailer incompatible, Critical): not an actual failure for our usage, but bumped to 8.0.1 anyway.
 
 ## Done
 
-- Version bump + lockfile + type-check.
+- nodemailer 8.0.9 -> 9.0.1, @types/nodemailer 6.4.17 -> 8.0.1, lockfile, type-check pass. Replied to both bots.
 
 ## Now
 
-- Commit and open PR.
+- Awaiting review/merge.
 
 ## Next
 

--- a/.continuity/20260622-010000-fix__nodemailer-dependabot-250-251.md
+++ b/.continuity/20260622-010000-fix__nodemailer-dependabot-250-251.md
@@ -1,0 +1,46 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Fix Dependabot alerts #250 and #251 and open a PR.
+
+## Goal (incl. success criteria)
+
+- Resolve the nodemailer advisory by bumping to the patched version (9.0.1).
+- Alerts #250 (manifest: apps/studio.giselles.ai/package.json) and #251 (manifest: pnpm-lock.yaml) are the SAME advisory GHSA-p6gq-j5cr-w38f (high): message-level `raw` option bypasses disableFileAccess/disableUrlAccess, enabling arbitrary file read and full-response SSRF. Vulnerable `<= 9.0.0`, patched `9.0.1`.
+
+## Constraints/Assumptions
+
+- nodemailer is a direct dep of apps/studio.giselles.ai only (was 8.0.9).
+- Our only usage is services/external/email/send-email.ts: standard createTransport + sendMail (from/to/subject/text/html). No `raw` option, no file/url attachments — so the 8 -> 9 major bump is low risk.
+
+## Key decisions
+
+- Bump nodemailer 8.0.9 -> 9.0.1 in apps/studio.giselles.ai/package.json.
+
+## State
+
+- Edited package.json, regenerated pnpm-lock.yaml (nodemailer@9.0.1). `pnpm -F studio.giselles.ai check-types` passes.
+
+## Done
+
+- Version bump + lockfile + type-check.
+
+## Now
+
+- Commit and open PR.
+
+## Next
+
+- Confirm Dependabot marks both alerts resolved after merge.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- apps/studio.giselles.ai/package.json, pnpm-lock.yaml
+- apps/studio.giselles.ai/services/external/email/send-email.ts (usage check)
+- `pnpm install --lockfile-only`; `pnpm -F studio.giselles.ai check-types`
+- Alerts: dependabot/250, dependabot/251

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -82,7 +82,7 @@
 		"motion": "catalog:",
 		"next": "catalog:",
 		"next-themes": "0.3.0",
-		"nodemailer": "8.0.9",
+		"nodemailer": "9.0.1",
 		"nuqs": "catalog:",
 		"openai": "catalog:",
 		"pg": "catalog:",

--- a/apps/studio.giselles.ai/package.json
+++ b/apps/studio.giselles.ai/package.json
@@ -110,7 +110,7 @@
 		"@react-email/preview-server": "5.0.5",
 		"@tailwindcss/postcss": "catalog:",
 		"@types/node": "catalog:",
-		"@types/nodemailer": "6.4.17",
+		"@types/nodemailer": "8.0.1",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",
 		"drizzle-kit": "catalog:",

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -10184,7 +10184,7 @@ BlueOak-1.0.0 permitted
 
 
 <a name="nodemailer"></a>
-### nodemailer v8.0.9
+### nodemailer v9.0.1
 #### 
 
 ##### Paths

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -5087,7 +5087,7 @@ FSL-1.1-MIT manually approved
 
 
 <a name="@types/nodemailer"></a>
-### @types/nodemailer v6.4.17
+### @types/nodemailer v8.0.1
 #### 
 
 ##### Paths

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,8 +507,8 @@ importers:
         specifier: 0.3.0
         version: 0.3.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       nodemailer:
-        specifier: 8.0.9
-        version: 8.0.9
+        specifier: 9.0.1
+        version: 9.0.1
       nuqs:
         specifier: 'catalog:'
         version: 2.6.0(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -7274,8 +7274,8 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  nodemailer@8.0.9:
-    resolution: {integrity: sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -15418,7 +15418,7 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  nodemailer@8.0.9: {}
+  nodemailer@9.0.1: {}
 
   normalize-path@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,8 +586,8 @@ importers:
         specifier: 'catalog:'
         version: 24.10.4
       '@types/nodemailer':
-        specifier: 6.4.17
-        version: 6.4.17
+        specifier: 8.0.1
+        version: 8.0.1
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.7
@@ -5069,8 +5069,8 @@ packages:
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
-  '@types/nodemailer@6.4.17':
-    resolution: {integrity: sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==}
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
 
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
@@ -12981,9 +12981,9 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/nodemailer@6.4.17':
+  '@types/nodemailer@8.0.1':
     dependencies:
-      '@types/node': 24.10.4
+      '@types/node': 25.3.0
 
   '@types/pg-pool@2.0.7':
     dependencies:


### PR DESCRIPTION
## Summary

Resolves two Dependabot alerts for `nodemailer` (same advisory, two manifests), patched in `9.0.1`:

- [Alert 250](https://github.com/giselles-ai/giselle/security/dependabot/250) (high, [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f)) — manifest `apps/studio.giselles.ai/package.json`
- [Alert 251](https://github.com/giselles-ai/giselle/security/dependabot/251) (high, same GHSA) — manifest `pnpm-lock.yaml`

The message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read and full-response SSRF in the delivered message (vulnerable `<= 9.0.0`).

## Changes

- Bump `nodemailer` `8.0.9` → `9.0.1` in `apps/studio.giselles.ai/package.json`
- Regenerate `pnpm-lock.yaml` (`nodemailer@9.0.1`)

## Notes

`nodemailer` is a direct dependency only in `apps/studio.giselles.ai`. The sole usage (`services/external/email/send-email.ts`) is a standard `createTransport` + `sendMail` with `from`/`to`/`subject`/`text`/`html` — it does not use the vulnerable `raw` option or file/url attachments, so the 8 → 9 major bump is low risk. `pnpm -F studio.giselles.ai check-types` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated email delivery dependencies to patched versions to address security vulnerabilities and reduce exposure from Dependabot-reported alerts.
  * Refreshed the related TypeScript typings to match the updated email library and keep development-time compatibility.
  * Updated the project’s license/dependency documentation to reflect the new package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->