### PR TITLE
Fix systeminformation command injection advisory

### DIFF
--- a/.continuity/20260717-000000-agent__fix-systeminformation-cve-2026-50289.md
+++ b/.continuity/20260717-000000-agent__fix-systeminformation-cve-2026-50289.md
@@ -20,7 +20,7 @@
 
 ## State
 
-- Fix implemented and all required verification passed; ready to commit and publish.
+- Fix implemented, verified, and published as draft PR #2958.
 
 ## Done
 
@@ -30,14 +30,16 @@
 - Regenerated `pnpm-lock.yaml`; all resolution edges now use 5.31.7.
 - Installed the frozen lockfile and confirmed the shipped 5.31.7 implementation reads interface files directly with `readFileSync` rather than interpolating the path into a shell command.
 - Passed `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, and `pnpm test` under Node 24.
+- Committed and pushed the fix on `agent/fix-systeminformation-cve-2026-50289`.
+- Opened draft PR https://github.com/giselles-ai/giselle/pull/2958.
 
 ## Now
 
-- Commit and publish the focused change.
+- Awaiting PR review and CI.
 
 ## Next
 
-- Open a draft PR and monitor its initial state.
+- Merge PR #2958 after review and CI; Dependabot alert #253 should then close automatically.
 
 ## Open questions (UNCONFIRMED if needed)
 

--- a/.continuity/20260717-000000-agent__fix-systeminformation-cve-2026-50289.md
+++ b/.continuity/20260717-000000-agent__fix-systeminformation-cve-2026-50289.md
@@ -1,0 +1,52 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Fix GitHub Dependabot alert #253 and create a pull request.
+
+## Goal (incl. success criteria)
+
+- Resolve `systeminformation` GHSA-5xpp-75jx-m839 / CVE-2026-50289 by ensuring the dependency tree uses patched version 5.31.7 or newer.
+- Run the repository-required verification and publish a focused draft PR.
+
+## Constraints/Assumptions
+
+- `systeminformation` is transitive and pinned through the root `pnpm.overrides` field.
+- Keep the change on the existing 5.x release line and preserve all current APIs and runtime behavior.
+
+## Key decisions
+
+- Bump the root override from 5.31.6 to 5.31.7, the advisory's first patched version.
+
+## State
+
+- Fix implemented and all required verification passed; ready to commit and publish.
+
+## Done
+
+- Retrieved Dependabot alert #253 and confirmed the vulnerable range and patched release.
+- Created branch `agent/fix-systeminformation-cve-2026-50289`.
+- Updated `pnpm.overrides.systeminformation` to 5.31.7.
+- Regenerated `pnpm-lock.yaml`; all resolution edges now use 5.31.7.
+- Installed the frozen lockfile and confirmed the shipped 5.31.7 implementation reads interface files directly with `readFileSync` rather than interpolating the path into a shell command.
+- Passed `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, and `pnpm test` under Node 24.
+
+## Now
+
+- Commit and publish the focused change.
+
+## Next
+
+- Open a draft PR and monitor its initial state.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `package.json`
+- `pnpm-lock.yaml`
+- `.continuity/20260717-000000-agent__fix-systeminformation-cve-2026-50289.md`
+- Dependabot alert #253
+- Verification: `pnpm install --frozen-lockfile`, `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, `pnpm test`, `pnpm why systeminformation -r`.

--- a/docs/packages-license.md
+++ b/docs/packages-license.md
@@ -12619,7 +12619,7 @@ Unknown manually approved
 
 
 <a name="systeminformation"></a>
-### systeminformation v5.31.6
+### systeminformation v5.31.7
 #### 
 
 ##### Paths

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 			"@esbuild-kit/core-utils>esbuild": "0.28.1",
 			"esbuild@>=0.17.0 <0.28.1": "0.28.1",
 			"serialize-javascript": "7.0.5",
-			"systeminformation": "5.31.6",
+			"systeminformation": "5.31.7",
 			"socket.io-parser": "4.2.6",
 			"undici@>=7.0.0 <7.28.0": "7.28.0",
 			"@xmldom/xmldom": "0.8.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,7 +285,7 @@ overrides:
   '@esbuild-kit/core-utils>esbuild': 0.28.1
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   serialize-javascript: 7.0.5
-  systeminformation: 5.31.6
+  systeminformation: 5.31.7
   socket.io-parser: 4.2.6
   undici@>=7.0.0 <7.28.0: 7.28.0
   '@xmldom/xmldom': 0.8.13
@@ -8282,8 +8282,8 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  systeminformation@5.31.6:
-    resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
+  systeminformation@5.31.7:
+    resolution: {integrity: sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -10497,7 +10497,7 @@ snapshots:
   '@opentelemetry/host-metrics@0.37.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      systeminformation: 5.31.6
+      systeminformation: 5.31.7
 
   '@opentelemetry/instrumentation-amqplib@0.58.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -16686,7 +16686,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  systeminformation@5.31.6: {}
+  systeminformation@5.31.7: {}
 
   tagged-tag@1.0.0: {}
 


### PR DESCRIPTION
## What changed

- bump the root `systeminformation` override from 5.31.6 to 5.31.7
- regenerate the pnpm lockfile so OpenTelemetry host metrics resolves the patched release

## Why

Dependabot alert #253 reports CVE-2026-50289 / GHSA-5xpp-75jx-m839. In affected releases, `networkInterfaces()` reads a path from Linux `interfaces(5)` configuration and interpolates it into a shell command, allowing command injection. Version 5.31.7 replaces that sink with direct file reading.

This is the smallest repository-native fix because `systeminformation` is a transitive dependency already pinned by the root override.

## Impact

Existing APIs and callers are unchanged. The dependency remains on the 5.x release line, while Linux network-interface collection no longer uses the vulnerable implementation.

## Validation

- `pnpm install --frozen-lockfile`
- confirmed `pnpm why systeminformation -r` resolves only 5.31.7
- confirmed the installed 5.31.7 `checkLinuxDCHPInterfaces()` uses `readFileSync` and contains no `cat ${file}` shell interpolation
- `pnpm format`
- `pnpm build-sdk` (28/28)
- `pnpm check-types` (31/31)
- `pnpm tidy`
- `pnpm test` (9/9 tasks)

Closes Dependabot alert #253.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the system information dependency to a patched version, addressing a known security vulnerability.
  * Refreshed dependency resolution to ensure the patched version is used consistently.

* **Documentation**
  * Updated the recorded package license information to reflect the new dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->