### PR TITLE
Restore Next.js release age checks

### DIFF
--- a/.continuity/20260722-100842-agent__remove-next-release-age-exclusions.md
+++ b/.continuity/20260722-100842-agent__remove-next-release-age-exclusions.md
@@ -22,7 +22,7 @@
 
 ## State
 
-- Implementation and verification complete; ready to publish.
+- Complete; changes are committed, pushed, and available in draft PR #2960.
 
 ## Done
 
@@ -30,14 +30,15 @@
 - Removed `next`, `@next/env`, and `@next/third-parties` from `minimumReleaseAgeExclude`.
 - Confirmed `pnpm install --frozen-lockfile` succeeds with the normal release-age gate and no lockfile changes.
 - Passed `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, and `pnpm test`.
+- Committed the change as `3064070eb`, pushed the branch, and opened draft PR #2960 against `main`.
 
 ## Now
 
-- Commit and publish the verified change.
+- N/A (complete).
 
 ## Next
 
-- Commit, push, and open a draft PR against `main`.
+- N/A (complete).
 
 ## Open questions (UNCONFIRMED if needed)
 
@@ -48,3 +49,4 @@
 - `pnpm-workspace.yaml`
 - `.continuity/20260722-100842-agent__remove-next-release-age-exclusions.md`
 - `pnpm install --frozen-lockfile`
+- `https://github.com/giselles-ai/giselle/pull/2960`

--- a/.continuity/20260722-100842-agent__remove-next-release-age-exclusions.md
+++ b/.continuity/20260722-100842-agent__remove-next-release-age-exclusions.md
@@ -1,0 +1,50 @@
+# Continuity ledger (per-branch)
+
+## Human intent (must not be overwritten)
+
+- Remove the `next`, `@next/env`, and `@next/third-parties` minimum release-age exclusions.
+- Base the change on the latest `main` and create a pull request.
+
+## Goal (incl. success criteria)
+
+- Restore the normal 24-hour release-age gate for all Next.js packages without changing resolved dependencies.
+- Pass repository verification and publish a draft PR against `main`.
+
+## Constraints/Assumptions
+
+- Follow `AGENTS.md` and keep the change limited to the three requested exclusions.
+- Preserve the remaining Giselle package exclusions.
+
+## Key decisions
+
+- Created `agent/remove-next-release-age-exclusions` from latest `origin/main` (`2b14edfc9`).
+- Remove the three package-wide exclusions entirely; do not replace them with version-specific entries.
+
+## State
+
+- Implementation and verification complete; ready to publish.
+
+## Done
+
+- Updated local `main` to the merged Dependabot PR.
+- Removed `next`, `@next/env`, and `@next/third-parties` from `minimumReleaseAgeExclude`.
+- Confirmed `pnpm install --frozen-lockfile` succeeds with the normal release-age gate and no lockfile changes.
+- Passed `pnpm format`, `pnpm build-sdk`, `pnpm check-types`, `pnpm tidy`, and `pnpm test`.
+
+## Now
+
+- Commit and publish the verified change.
+
+## Next
+
+- Commit, push, and open a draft PR against `main`.
+
+## Open questions (UNCONFIRMED if needed)
+
+- None.
+
+## Working set (files/ids/commands)
+
+- `pnpm-workspace.yaml`
+- `.continuity/20260722-100842-agent__remove-next-release-age-exclusions.md`
+- `pnpm install --frozen-lockfile`

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,9 +95,6 @@ catalog:
 minimumReleaseAge: 1440
 # Use minimumReleaseAgeExclude temporarily for emergency security vulnerability fixes
 minimumReleaseAgeExclude:
-  - next
-  - "@next/env"
-  - "@next/third-parties"
   - "@giselles-ai/browser-tool"
   - "@giselles-ai/agent-runtime"
   - "@giselles-ai/agent-builder"


### PR DESCRIPTION
## What changed

- remove `next`, `@next/env`, and `@next/third-parties` from `minimumReleaseAgeExclude`
- keep the existing Giselle package exclusions unchanged

## Why

The Next.js exclusions are no longer needed. Keeping package-wide exclusions would bypass the repository's 24-hour cooling-off policy for all future releases of those packages.

## Impact

Future Next.js package releases will follow the normal 24-hour minimum release-age gate. Existing resolved dependency versions and the lockfile are unchanged.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm build-sdk`
- `pnpm check-types`
- `pnpm tidy`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the standard 24-hour release-age requirement for Next.js packages.
  * Removed package-specific release-age exclusions while preserving existing exclusions for other packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->